### PR TITLE
Complete SAML SP synthesis spellings

### DIFF
--- a/docs/adr/saml-sp.md
+++ b/docs/adr/saml-sp.md
@@ -25,7 +25,7 @@ Granularity note: this is the wayfinding-level SAML ADR. It fixes the library an
 | #219: assertion sig unverified when response-signed | Assertion signature mandatory + the structural verification algorithm (§ *The validation algorithm*) binding verification to extraction |
 | Unsigned LogoutRequest/Response acceptance history | SLO excluded from profile — no logout endpoint exists |
 | IdP-initiated SSO accepted implicitly | Unsolicited responses refused by name (`InResponseTo` mandatory) |
-| Audience/Conditions violations returned as warnings | Wrapper promotes **every** `WarningInfo` to a hard error — an empty warning set is a precondition of login |
+| Audience/Conditions violations returned as warnings | The exact-node wrapper independently re-enforces every condition represented by gosaml2 `WarningInfo` as a hard error on the verifier-returned assertion; no warning-only result can reach extraction |
 | `Destination` checked only if present | Wrapper requires `Destination` present and exact |
 | No `InResponseTo` validation | Wrapper binds to the server-side transaction store (§ *The SAML transaction*) |
 | No replay cache | Wrapper maintains a durable one (§ *The validation algorithm*) |
@@ -68,7 +68,7 @@ An algorithm or transform not on the list is **refused, not evaluated** — the 
 
 ## The validation algorithm
 
-The wrapper's acceptance decision is one closed conjunction over the single parse tree; every clause is a hard error with a distinct, enumerated, audited cause. Library validation runs first and the wrapper promotes **every** `WarningInfo` to a hard error (an empty warning set is a precondition); the wrapper then asserts, in order:
+The wrapper's acceptance decision is one closed conjunction over the single parse tree; every clause is a hard error with a distinct, enumerated, audited cause. Wenv deliberately does **not** call gosaml2's public response-validation path: that path reparses and returns detached typed values, breaking the parse-once and verification-to-extraction binding. The wrapper invokes goxmldsig verification on the exact detached assertion node, consumes the verifier-returned node, and independently re-enforces every condition represented by gosaml2 `WarningInfo` as a hard error before extraction. There is therefore no warning channel to promote and no warning-only result that can reach extraction. The wrapper then asserts, in order:
 
 **Structural XSW defence — verification bound to extraction:**
 
@@ -96,7 +96,7 @@ The wrapper's acceptance decision is one closed conjunction over the single pars
 
 **Values** (defaults fixed here; catalogued as tunable ops-spec entries at synthesis): clock skew 60 s (the machine-identity precedent), transaction TTL 10 min, `IssueInstant` max age 5 min, document bounds as § *XML processing*.
 
-**Refusals are enumerated, not generic**: unsolicited response, unknown/consumed transaction, initiator mismatch, purpose mismatch, issuer mismatch (each leg), wrong ACS, destination mismatch, structural-XSW refusals (duplicate ID, assertion cardinality, reference shape, extra signature invalid), unknown certificate, disallowed algorithm/transform/canonicalization, audience missing/mismatched, confirmation-method unsupported, missing `NotOnOrAfter` (either), stale/early conditions, stale `IssueInstant`, replayed assertion, AuthnStatement cardinality, encrypted-assertion present, DTD present, document bounds exceeded, warning-set nonempty. Each maps to a distinct audited failure cause (§ *Audit*), because "SAML login failed" is not a diagnosable event.
+**Refusals are enumerated, not generic**: unsolicited response, unknown/consumed transaction, initiator mismatch, purpose mismatch, issuer mismatch (each leg), wrong ACS, destination mismatch, structural-XSW refusals (duplicate ID, assertion cardinality, reference shape, extra signature invalid), unknown certificate, disallowed algorithm/transform/canonicalization, audience missing/mismatched, confirmation-method unsupported, missing `NotOnOrAfter` (either), stale/early conditions, stale `IssueInstant`, replayed assertion, AuthnStatement cardinality, encrypted-assertion present, DTD present, document bounds exceeded, and every warning-equivalent audience/conditions violation independently enforced by the wrapper. Each maps to a distinct audited failure cause (§ *Audit*), because "SAML login failed" is not a diagnosable event.
 
 **`SessionNotOnOrAfter` is ignored, and the ADR says so plainly.** Without SLO, Wenv does not track IdP session state; honouring one field of it would claim a coupling that does not exist. The Wenv session minted from a SAML login lives under Wenv's own lifetimes ([ops-spec.md](./ops-spec.md)), exactly like an OIDC-minted session.
 

--- a/docs/spec/api-cli-spellings.md
+++ b/docs/spec/api-cli-spellings.md
@@ -36,6 +36,7 @@ Joins the **existing `instance-config` verb surface** — no new top-level verb 
 
 ```
 wenv instance-config provider create --kind saml --name <name> \
+    --entity-id <byte-exact-entityID> \
     (--metadata-file <xml> | --metadata-url <url>)    # URL fetch runs the fingerprint ceremony
 wenv instance-config provider list
 wenv instance-config provider show    <name>
@@ -43,12 +44,27 @@ wenv instance-config provider update  <name> …
 wenv instance-config provider disable <name>
 wenv instance-config provider remove  <name>
 wenv instance-config provider refresh-metadata <name>   # diff-and-confirm ceremony
+
+wenv instance-config saml-sp-key list
+wenv instance-config saml-sp-key rotate                 # old active becomes retiring; both publish
+wenv instance-config saml-sp-key retire <fingerprint>   # retiring only; erases the private key
+wenv instance-config saml-sp-key compromise-retire <fingerprint> # active only; replace atomically
 ```
 
-All under `instance-config` capability, grant-evaluated `InstanceProof`, network path — never the local-admin class. `refresh-metadata` is the ADR's "action on the provider resource".
+All under `instance-config` capability, grant-evaluated `InstanceProof`, network path — never the local-admin class. `refresh-metadata` is the ADR's "action on the provider resource". SP keys are instance-wide, so their noun is deliberately a sibling of `provider`, not a provider subresource. Fingerprints are `sha256:` plus URL-safe unpadded base64 of SubjectPublicKeyInfo, so the exact value is safe as one path segment. `rotate` atomically marks the active key retiring and mints its replacement. Ordinary `retire` accepts only a retiring fingerprint; `compromise-retire` accepts only the active fingerprint and atomically erases and replaces it without an overlap window.
+
+Admin REST resources (ordinary `/api/v1` grammar, proof-carrying):
+
+- `GET /api/v1/instance/saml-sp-keys`
+- `POST /api/v1/instance/saml-sp-keys/rotate`
+- `DELETE /api/v1/instance/saml-sp-keys/{fingerprint}`
+- `POST /api/v1/instance/saml-sp-keys/{fingerprint}/compromise-retire`
+
+Provider list/show responses carry a required `warnings` array. Its closed warning codes are `metadata_expires_soon`, `metadata_expired`, `signing_certificate_not_yet_valid`, and `signing_certificate_expired`; each item carries `severity`, the relevant timestamp, a server-authored message, and a certificate fingerprint where applicable. The 30-day metadata threshold is server-authoritative. Provider table output names warnings, JSON preserves the structured array, and the existing top-level `wenv doctor [--instance REF] [-o table|json]` reports the same server-authoritative items (no second warning calculation and no additional endpoint). Doctor returns success for no findings or warning-severity findings; metadata-expired is error severity and returns the stable refused exit code after rendering the findings.
 
 Identity-protocol endpoints (exception class, per-provider, parity-exempt):
 
+- Start: `POST /api/v1/auth/saml/{provider}/start` (server-mints the AuthnRequest, RelayState transaction and path-scoped initiator binding)
 - ACS: `POST /api/v1/auth/saml/{provider}/acs`
 - SP metadata: `GET /api/v1/auth/saml/{provider}/metadata` (unauthenticated, documentation-class, pre-auth admission)
 


### PR DESCRIPTION
## Summary

- correct the locked SAML wrapper wording to match the parse-once exact-node verification mechanism
- add deferred exact CLI and REST spellings for SP-key lifecycle and SAML start
- define structured provider warnings and doctor behavior
- add the required byte-exact entity ID input

## Scope

This does not weaken or remove any SAML acceptance criterion. It completes deferred synthesis details required to implement #72.

## Validation

- markdown diff check clean
- isolated one-commit branch based on current wayfinder-docs

Refs #37
Refs #72