### PR TITLE
ci: shorten validation critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # PR updates supersede the same PR; every main push stays independently
+  # queued so a burst cannot discard the middle commit's CI/cache seed.
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,6 +28,21 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Restore lint Go cache
+        id: lint-go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-lint-v1.7.12-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            go-lint-v1.7.12-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-lint-v1.7.12-${{ runner.os }}-
       - name: Shellcheck (pinned archive)
         env:
           SHELLCHECK_VERSION: v0.11.0
@@ -37,6 +58,12 @@ jobs:
             scripts/lib/*.sh scripts/ci/*.sh scripts/release/*.sh install/install.sh.in
       - name: Actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Save lint Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.lint-go-cache.outputs.cache-primary-key }}
 
   dco:
     if: github.event_name == 'pull_request'
@@ -53,7 +80,7 @@ jobs:
           "${{ github.event.pull_request.base.sha }}"
           "${{ github.event.pull_request.head.sha }}"
 
-  supply-chain-fixtures:
+  supply-chain-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -65,23 +92,6 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v4.2.3
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version-file: .nvmrc
-      - name: Enable pnpm
-        run: corepack enable
-      # working-directory matters: corepack resolves the packageManager pin
-      # from the CWD's package.json — from the repo root (which has none) it
-      # falls back to its default pnpm and the pinned project refuses it.
-      - name: Build the SPA (the `ui` build tag embeds it)
-        working-directory: web
-        run: |
-          pnpm --dir ../clients/ts install --frozen-lockfile
-          pnpm install --frozen-lockfile
-          pnpm build
       - name: Chart renders and carries release substitution anchors
         run: |
           grep -Fx "  repository: ghcr.io/dunky13/hikyo" chart/hikyo/values.yaml
@@ -100,6 +110,8 @@ jobs:
         run: ./scripts/release/create-manifest_test.sh
       - name: DCO fixture
         run: ./scripts/ci/check-dco_test.sh
+      - name: Required-jobs fixture
+        run: ./scripts/ci/check-required-jobs_test.sh
       - name: Immutable-tag probe fixture
         run: ./scripts/release/probe-tag-move_test.sh
       - name: Release-tag guard fixture
@@ -110,6 +122,44 @@ jobs:
         run: ./scripts/release/release-channel_test.sh
       - name: Pinned installer fixture
         run: ./scripts/release/render-installer_test.sh
+
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Restore release-snapshot Go cache
+        id: release-snapshot-go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-release-snapshot-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            go-release-snapshot-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-release-snapshot-${{ runner.os }}-
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Enable pnpm
+        run: corepack enable
+      # GoReleaser builds with the `ui` tag, so its isolated job must produce
+      # the embedded SPA before compiling all six release targets.
+      - name: Build the SPA (the `ui` build tag embeds it)
+        working-directory: web
+        run: |
+          pnpm --dir ../clients/ts install --frozen-lockfile
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: GoReleaser configuration and snapshot
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -118,6 +168,52 @@ jobs:
           args: release --snapshot --clean --skip=publish
       - name: Classify complete snapshot manifest
         run: ./scripts/release/snapshot-manifest_test.sh
+      - name: Save release-snapshot Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.release-snapshot-go-cache.outputs.cache-primary-key }}
+
+  generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Restore generated-code Go cache
+        id: generated-go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-generated-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            go-generated-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-generated-${{ runner.os }}-
+      - name: Format
+        run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
+      - name: Generated code is fresh
+        run: |
+          go tool sqlc generate
+          go tool oapi-codegen --config api/oapi-codegen.yaml api/openapi.yaml
+          git diff --exit-code -- internal/store/sqlitegen internal/store/pggen api/apigen
+          # git diff misses newly generated untracked files
+          test -z "$(git status --porcelain --untracked-files=all -- internal/store/sqlitegen internal/store/pggen api/apigen)"
+      - name: Save generated-code Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.generated-go-cache.outputs.cache-primary-key }}
 
   # The TypeScript half of the contract chain. It is a separate job because it
   # needs a different toolchain, and because a Go-only change must not be able
@@ -179,6 +275,21 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Restore web Go cache
+        id: web-go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-web-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            go-web-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-web-${{ runner.os }}-
       - name: Enable pnpm
         run: corepack enable
 
@@ -215,7 +326,9 @@ jobs:
         run: go build -tags ui ./...
 
       - name: Go tests (transport, serving rules, browser session)
-        run: go test -tags ui ./internal/server/... ./internal/webui/...
+        # Restored GOCACHE may contain passing test results. Compile from cache,
+        # but always execute this job's tests against its fresh build.
+        run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
 
       - name: Install Chromium
         working-directory: web
@@ -231,6 +344,12 @@ jobs:
           name: playwright-traces
           path: web/test-results/
           retention-days: 7
+      - name: Save web Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.web-go-cache.outputs.cache-primary-key }}
 
   test:
     runs-on: ubuntu-latest
@@ -255,6 +374,25 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod # exact toolchain pinned by go.mod's go directive
+          cache: false
+      - name: Restore shared Go module cache
+        id: go-module-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Restore test Go cache
+        id: test-go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-test-${{ runner.os }}-
+
+      - name: Populate shared Go module cache
+        run: go mod download
 
       - name: Build
         run: go build ./...
@@ -262,18 +400,65 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Format
-        run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
-
-      - name: Generated code is fresh
-        run: |
-          go tool sqlc generate
-          go tool oapi-codegen --config api/oapi-codegen.yaml api/openapi.yaml
-          git diff --exit-code -- internal/store/sqlitegen internal/store/pggen api/apigen
-          # git diff misses newly generated untracked files
-          test -z "$(git status --porcelain --untracked-files=all -- internal/store/sqlitegen internal/store/pggen api/apigen)"
-
       - name: Test (sqlite + postgres conformance)
         env:
           HIKYO_TEST_POSTGRES_DSN: postgres://hikyo:hikyo@127.0.0.1:5432/hikyo_test
-        run: go test ./...
+        # Compile from restored GOCACHE, but never replay results: PostgreSQL
+        # conformance must exercise this run's fresh service container.
+        run: go test -count=1 ./...
+      - name: Save test Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.test-go-cache.outputs.cache-primary-key }}
+      # One trusted writer avoids the setup-go race where the first, smallest
+      # job permanently won the shared module key for this dependency graph.
+      - name: Save shared Go module cache
+        if: >-
+          success() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          steps.go-module-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.go-module-cache.outputs.cache-primary-key }}
+
+  # The permanent required context. Every validation job is named here so a
+  # future job split cannot accidentally weaken branch protection.
+  ci-required:
+    if: always()
+    needs:
+      - client
+      - dco
+      - docs
+      - generated
+      - lint
+      - release-snapshot
+      - supply-chain-checks
+      - test
+      - web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Require every validation job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: ./scripts/ci/check-required-jobs.sh "$GITHUB_EVENT_NAME" "$NEEDS_JSON"
+
+  # Compatibility context for ruleset 20539346. Keep it until ci-required has
+  # reported on main and the live ruleset requires ci-required instead.
+  supply-chain-fixtures:
+    if: always()
+    needs:
+      - ci-required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Forward permanent required context
+        env:
+          CI_REQUIRED_RESULT: ${{ needs.ci-required.result }}
+        run: test "$CI_REQUIRED_RESULT" = success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc

--- a/docs/handoff/46-release-signing.md
+++ b/docs/handoff/46-release-signing.md
@@ -39,8 +39,8 @@ this work: `8bfeef1`.
   proves signed commits pass and unsigned commits block.
 - Live repository policy is active: ruleset `20539249` forbids `v*` update and
   deletion with no bypass; ruleset `20539250` restricts `v*` creation to the
-  admin repository role; main ruleset `20539346` requires an
-  up-to-date PR with `lint`, `dco`, `supply-chain-fixtures`, and `test`;
+  admin repository role; the checked-in desired state for main ruleset
+  `20539346` requires an up-to-date PR with the aggregate `ci-required` context;
   immutable releases and full-SHA-only Actions are enabled. The permanent
   `v-ruleset-probe` tag is pinned at `8bfeef1a80cceae0aea178cfda12bed1819e36c8`;
   a real changed-SHA update was refused by ruleset `20539249`.

--- a/docs/handoff/56-ui-shell.md
+++ b/docs/handoff/56-ui-shell.md
@@ -281,7 +281,7 @@ name**, at org scope or below. Decisions, each argued rather than assumed:
 
 `.goreleaser.yaml`'s build carries `-tags=ui`, so a released binary serves the
 SPA. Both pipelines that invoke GoReleaser build the frontend first —
-`release.yml`'s `build-unsigned-draft` and `ci.yml`'s `supply-chain-fixtures`
+`release.yml`'s `build-unsigned-draft` and `ci.yml`'s `release-snapshot`
 (which runs the snapshot) each gain Node from `.nvmrc`, `corepack enable`, and
 `pnpm --dir web install --frozen-lockfile && pnpm --dir web build` before the
 GoReleaser step. `Dockerfile.release` needs no change: it copies the binary,

--- a/docs/handoff/ci-speed-phases-1-4.md
+++ b/docs/handoff/ci-speed-phases-1-4.md
@@ -1,0 +1,50 @@
+# CI speed phases 1–4 handoff
+
+## Scope
+
+This change keeps every existing CI assertion while shortening the critical
+path and preventing obsolete pull-request runs from consuming runners.
+
+- `ci-required` is the permanent aggregate status. It requires `client`,
+  `dco`, `docs`, `generated`, `lint`, `release-snapshot`,
+  `supply-chain-checks`, `test`, and `web`.
+- The old required `supply-chain-fixtures` context temporarily forwards
+  `ci-required`. This keeps ruleset 20539346 safe during the migration.
+- Pull-request updates cancel older runs of the same PR. Main pushes use their
+  run ID as the concurrency key, so none are discarded while pending.
+- Go build caches are isolated by job. Pull requests restore them; successful
+  `main` runs save rolling caches. All Go CI jobs restore one dependency-keyed
+  module cache, while only `test` saves it on trusted `main`. Tagged releases
+  build without a restored Go cache.
+- Full six-target GoReleaser output and its manifest classifier run together
+  in `release-snapshot`, parallel to the release shell fixtures.
+- Go formatting and generated-code freshness run in `generated`, parallel to
+  the full build, vet, SQLite, and PostgreSQL test job.
+- Restored build caches never make tests vacuous: Go test commands use
+  `-count=1`.
+
+## Required post-merge gate migration
+
+Do not change the live ruleset before this commit merges under the old required
+contexts.
+
+1. Verify the post-merge `main` run reports a successful `ci-required` status.
+2. Confirm `release/repository/main-ci-gate.json` still requires only
+   `ci-required`.
+3. Apply that repository configuration with
+   `scripts/release/configure-repository.sh`.
+4. Re-read live ruleset 20539346 and confirm strict mode plus exactly one
+   required context: `ci-required`.
+5. Remove the compatibility `supply-chain-fixtures` job in a later PR.
+
+## Validation before commit
+
+- Actionlint and ShellCheck passed.
+- Required-job positive and negative fixtures passed.
+- Generated Go and TypeScript clients were fresh.
+- Go build, vet, tagged UI build/tests, and the full PostgreSQL-backed suite
+  passed. `internal/isolation` executed against PostgreSQL rather than skipping.
+- Client tests: 4 passed. Web unit tests: 20 passed. Playwright desktop/mobile
+  flow tests: 36 passed.
+- Docs verification passed.
+- GoReleaser produced and classified all six OS/architecture archives.

--- a/release/repository/main-ci-gate.json
+++ b/release/repository/main-ci-gate.json
@@ -28,11 +28,7 @@
         "do_not_enforce_on_create": false,
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
-          {"context": "lint"},
-          {"context": "dco"},
-          {"context": "supply-chain-fixtures"},
-          {"context": "docs"},
-          {"context": "test"}
+          {"context": "ci-required"}
         ]
       }
     }

--- a/scripts/ci/check-oss-policy.sh
+++ b/scripts/ci/check-oss-policy.sh
@@ -52,7 +52,7 @@ require_text "$security_channel_workflow" 'Fallback security channel health chec
 
 main_gate="$repo_root/release/repository/main-ci-gate.json"
 require_file "$main_gate"
-require_text "$main_gate" '{"context": "docs"}'
+require_text "$main_gate" '{"context": "ci-required"}'
 
 license_sha=$(sha256sum "$repo_root/LICENSE" | awk '{print $1}')
 [ "$license_sha" = '3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04' ] || {

--- a/scripts/ci/check-oss-policy_test.sh
+++ b/scripts/ci/check-oss-policy_test.sh
@@ -75,6 +75,19 @@ fi
 
 cp "$repo_root/.github/ISSUE_TEMPLATE/config.yml" \
 	"$fixture_dir/.github/ISSUE_TEMPLATE/config.yml"
+sed 's/ci-required/removed-required-context/' \
+	"$fixture_dir/release/repository/main-ci-gate.json" \
+	>"$fixture_dir/main-ci-gate-missing-aggregate.json"
+mv "$fixture_dir/main-ci-gate-missing-aggregate.json" \
+	"$fixture_dir/release/repository/main-ci-gate.json"
+
+if "$repo_root/scripts/ci/check-oss-policy.sh" "$fixture_dir" "$fixture_dir/site" >/dev/null 2>&1; then
+	printf 'OSS policy fixture failed: missing ci-required context was accepted\n' >&2
+	exit 1
+fi
+
+cp "$repo_root/release/repository/main-ci-gate.json" \
+	"$fixture_dir/release/repository/main-ci-gate.json"
 sed '/issues: write/d' "$fixture_dir/.github/workflows/security-channel.yml" \
 	>"$fixture_dir/security-channel-unprivileged.yml"
 mv "$fixture_dir/security-channel-unprivileged.yml" \

--- a/scripts/ci/check-required-jobs.sh
+++ b/scripts/ci/check-required-jobs.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+	printf 'usage: %s EVENT NEEDS_JSON\n' "$0" >&2
+	exit 2
+fi
+
+event=$1
+results=$2
+expected='["client","dco","docs","generated","lint","release-snapshot","supply-chain-checks","test","web"]'
+
+case "$event" in
+	pull_request)
+		allowed='all(to_entries[]; .value.result == "success")'
+		;;
+	push)
+		allowed='all(to_entries[];
+			.value.result == "success" or
+			(.key == "dco" and .value.result == "skipped")
+		)'
+		;;
+	*)
+		printf 'required jobs: unsupported event %s\n' "$event" >&2
+		exit 2
+		;;
+esac
+
+if ! printf '%s\n' "$results" | jq -e --argjson expected "$expected" \
+	"type == \"object\" and (keys == (\$expected | sort)) and ($allowed)" >/dev/null; then
+	printf 'required jobs: one or more jobs did not succeed\n' >&2
+	printf '%s\n' "$results" | jq -r \
+		'to_entries[] | select(.value.result != "success") | "  \(.key): \(.value.result)"' \
+		>&2 2>/dev/null || true
+	exit 1
+fi
+
+printf 'required jobs: all validation jobs passed\n'

--- a/scripts/ci/check-required-jobs_test.sh
+++ b/scripts/ci/check-required-jobs_test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+checker="$script_dir/check-required-jobs.sh"
+
+expect_accept() {
+	label=$1
+	event=$2
+	results=$3
+	if ! "$checker" "$event" "$results" >/dev/null; then
+		printf 'required-jobs fixture failed: %s was rejected\n' "$label" >&2
+		exit 1
+	fi
+}
+
+expect_reject() {
+	label=$1
+	event=$2
+	results=$3
+	if "$checker" "$event" "$results" >/dev/null 2>&1; then
+		printf 'required-jobs fixture failed: %s was accepted\n' "$label" >&2
+		exit 1
+	fi
+}
+
+all_success='{
+	"client":{"result":"success"},
+	"dco":{"result":"success"},
+	"docs":{"result":"success"},
+	"generated":{"result":"success"},
+	"lint":{"result":"success"},
+	"release-snapshot":{"result":"success"},
+	"supply-chain-checks":{"result":"success"},
+	"test":{"result":"success"},
+	"web":{"result":"success"}
+}'
+
+expect_accept 'successful pull request' pull_request "$all_success"
+expect_accept 'main push with skipped DCO' push \
+	"$(printf '%s' "$all_success" | jq '.dco.result = "skipped"')"
+
+for result in failure cancelled skipped; do
+	expect_reject "pull request with $result client" pull_request \
+		"$(printf '%s' "$all_success" | jq --arg result "$result" '.client.result = $result')"
+done
+
+expect_reject 'main push with skipped validation' push \
+	"$(printf '%s' "$all_success" | jq '.web.result = "skipped" | .dco.result = "skipped"')"
+expect_reject 'main push with failed DCO' push \
+	"$(printf '%s' "$all_success" | jq '.dco.result = "failure"')"
+expect_reject 'unsupported event' workflow_dispatch "$all_success"
+expect_reject 'empty job set' pull_request '{}'
+expect_reject 'missing required job' pull_request \
+	"$(printf '%s' "$all_success" | jq 'del(.web)')"
+expect_reject 'unknown job' pull_request \
+	"$(printf '%s' "$all_success" | jq '.unexpected.result = "success"')"
+expect_reject 'malformed results' pull_request 'not-json'
+
+printf 'required-jobs fixture: success accepted; failure, cancellation, and skip refused\n'


### PR DESCRIPTION
## Summary

- cancel superseded PR runs while preserving every main push
- split release snapshot and generated-code checks onto parallel paths
- replace competing setup-go caches with exact-key, single-writer Go caches
- add permanent `ci-required` aggregate plus safe legacy-context forwarding

## Validation

- actionlint and ShellCheck
- exact required-job and OSS-policy positive/negative fixtures
- Go build, vet, generated-code freshness, and PostgreSQL-backed full suite
- TypeScript client, web unit, Playwright desktop/mobile, docs, and six-target GoReleaser snapshot
- three-round native Claude adversarial review

## Migration

Merge under existing required contexts. After post-merge `main` reports green `ci-required`, apply `release/repository/main-ci-gate.json` and verify ruleset 20539346 requires only `ci-required`.