### PR TITLE
ci: retry ShellCheck archive downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           archive="$RUNNER_TEMP/shellcheck.tar.xz"
           curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error \
+            --retry 4 --retry-delay 2 --retry-all-errors \
             "https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.x86_64.tar.xz" \
             --output "$archive"
           printf '%s  %s\n' "$SHELLCHECK_SHA256" "$archive" | sha256sum --check --strict


### PR DESCRIPTION
## Cause

Post-merge main run 31640977513 received HTTP 503 from the pinned ShellCheck release asset on both attempt 1 and attempt 2. PR #99 had passed the same URL.

## Fix

Add four bounded curl retries with a two-second delay for transient HTTP/network failures. Existing HTTPS-only transport, TLS floor, pinned SHA-256 verification, and fail-closed behavior remain unchanged.

## Validation

- actionlint v1.7.12
- git diff --check
- native Claude Opus high-effort review: CLEAN