### PR TITLE
feat(docs): promote Opus 4.8 landing to Pages

### DIFF
--- a/docs/handoff/opus-48-landing-pages.md
+++ b/docs/handoff/opus-48-landing-pages.md
@@ -1,0 +1,38 @@
+# Handoff: Opus 4.8 landing page on GitHub Pages
+
+## Outcome
+
+The GitHub Pages root at `/hikyo/` now implements the visual direction and page
+structure of `prototype/landing-opus-4.8/2/` from the `wayfinder-docs` branch.
+The Starlight documentation overview moved from `/hikyo/` to `/hikyo/docs/`.
+
+## Production corrections
+
+The frozen prototype predated the flat-value and MPL-2.0 decisions. The public
+implementation keeps its graphite/linen theme, teal accent, environment matrix,
+asymmetric feature rows, self-hosting band, and compact footer while replacing:
+
+- inherited/default value states with explicit `set` and `absent` states;
+- MIT wording with Mozilla Public License 2.0 wording;
+- placeholder install, pricing, sign-in, star-count, and community links with
+  real GitHub and generated documentation routes;
+- unimplemented `run`/`render` demonstrations with current write validation and
+  the catalogue/classification/presence-only machine-fetch boundary.
+
+## Files
+
+- `docs/site/src/pages/index.astro` — standalone landing route.
+- `docs/site/src/styles/landing.css` — responsive dual-theme landing styles.
+- `docs/site/src/content/docs/docs.mdx` — relocated documentation overview.
+- `docs/site/astro.config.mjs` — overview sidebar route.
+- `scripts/ci/check-oss-policy.sh` — generated landing assertions.
+
+## Verification
+
+- `fnm exec --using 24 ./scripts/ci/verify-docs.sh` passes.
+- Astro check reports zero errors, warnings, or hints.
+- Generated `/hikyo/`, `/hikyo/docs/`, and `/hikyo/security/` routes return 200.
+- Generated links retain the GitHub Pages `/hikyo/` base path.
+- T3 preview navigation loaded the landing page title at 1280×800. Snapshot and
+  DOM automation timed out, so this handoff does not claim screenshot-based
+  desktop or mobile verification.

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -23,7 +23,7 @@ export default defineConfig({
         { icon: 'github', label: 'GitHub', href: 'https://github.com/Dunky13/hikyo' },
       ],
       sidebar: [
-        { label: 'Overview', slug: 'index' },
+        { label: 'Overview', slug: 'docs' },
         {
           label: 'Project policy',
           items: [

--- a/docs/site/src/content/docs/docs.mdx
+++ b/docs/site/src/content/docs/docs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hikyo documentation
-description: Fully open-source secrets and configuration across environments.
+description: Project policies and release trust for Hikyo.
 template: splash
 hero:
   tagline: Explicit values. Audited disclosure. No enterprise tier.

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -1,0 +1,331 @@
+---
+import '../styles/landing.css';
+
+const base = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/`;
+const repository = 'https://github.com/Dunky13/hikyo';
+const links = {
+  contributing: `${base}contributing/`,
+  docs: `${base}docs/`,
+  governance: `${base}governance/`,
+  license: `${base}license/`,
+  security: `${base}security/`,
+  support: `${base}support/`,
+};
+---
+
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta
+      name="description"
+      content="Hikyo is a fully open-source, self-hosted control plane for validated secrets and configuration across environments."
+    />
+    <meta name="theme-color" content="#1b2225" />
+    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
+    <link rel="canonical" href="https://dunky13.github.io/hikyo/" />
+    <title>Hikyo — fully open secrets and configuration</title>
+    <script is:inline>
+      (() => {
+        const stored = localStorage.getItem('starlight-theme');
+        document.documentElement.dataset.theme = stored === 'light' ? 'light' : 'dark';
+      })();
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="wrap nav" aria-label="Primary navigation">
+        <a class="brand" href={base} aria-label="Hikyo home">
+          <span class="brand-glyph" aria-hidden="true">h</span>
+          <span>hikyo</span>
+        </a>
+        <div class="nav-links">
+          <a href="#matrix">Product</a>
+          <a href="#self-host">Self-hosting</a>
+          <a href="#why">Why Hikyo</a>
+          <a href={links.docs}>Docs</a>
+        </div>
+        <div class="nav-actions">
+          <button class="theme-toggle" type="button" aria-label="Switch to light theme">
+            <span class="theme-icon" aria-hidden="true">◐</span>
+            <span class="theme-label">Light</span>
+          </button>
+          <a class="button button-primary header-cta" href={repository}>View on GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero">
+        <div class="wrap">
+          <p class="eyebrow"><span class="live" aria-hidden="true"></span> 0.x · one Go binary · self-hosted</p>
+          <h1>See every value.<br /><span>Trust every decision.</span></h1>
+          <p class="lede">
+            Hikyo is a self-hosted control plane for validated secrets and configuration across environments.
+            Every value is explicit, every disclosure is deliberate, and production features stay open.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href={repository}>Follow development <span aria-hidden="true">↗</span></a>
+            <a class="button button-line" href={links.docs}>Read the docs</a>
+          </div>
+          <p class="subtrust">
+            <strong>Mozilla Public License 2.0.</strong> No account required. No enterprise-only directory.
+          </p>
+
+          <div class="surface" id="matrix">
+            <div class="surface-bar">
+              <div class="crumb"><span class="avatar">AC</span> <strong>acme</strong><span>/</span> payments-api</div>
+              <div class="environment-chips" aria-label="Visible environments">
+                <span>development</span><span>staging</span><span>production</span>
+              </div>
+            </div>
+            <div class="matrix-scroll">
+              <table class="matrix">
+                <caption class="sr-only">Explicit configuration values for three environments</caption>
+                <thead>
+                  <tr><th>Key</th><th>development</th><th>staging</th><th>production</th></tr>
+                </thead>
+                <tbody>
+                  <tr class="group"><th colspan="4">database <span>3</span></th></tr>
+                  <tr>
+                    <th>DATABASE_URL</th>
+                    <td><span class="state masked">● set · secret</span></td>
+                    <td><span class="state masked">● set · secret</span></td>
+                    <td><span class="state masked">● set · secret</span></td>
+                  </tr>
+                  <tr>
+                    <th>DATABASE_POOL_MAX</th>
+                    <td><span class="state set">✓ 10</span></td>
+                    <td><span class="state set">✓ 20</span></td>
+                    <td><span class="state set">✓ 40</span></td>
+                  </tr>
+                  <tr>
+                    <th>DATABASE_SSLMODE</th>
+                    <td><span class="state set">✓ disable</span></td>
+                    <td><span class="state set">✓ verify-full</span></td>
+                    <td><span class="state set">✓ verify-full</span></td>
+                  </tr>
+                  <tr class="group"><th colspan="4">observability <span>2</span></th></tr>
+                  <tr>
+                    <th>LOG_LEVEL</th>
+                    <td><span class="state set">✓ debug</span></td>
+                    <td><span class="state set">✓ info</span></td>
+                    <td><span class="state set">✓ info</span></td>
+                  </tr>
+                  <tr>
+                    <th>SENTRY_DSN</th>
+                    <td><span class="state absent">○ absent</span></td>
+                    <td><span class="state masked">● set · secret</span></td>
+                    <td><span class="state missing">! required · absent</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="surface-foot" aria-label="Value state legend">
+              <span><i class="dot set-dot"></i> set here</span>
+              <span><i class="dot absent-dot"></i> absent</span>
+              <span><i class="dot masked-dot"></i> secret set</span>
+              <span><i class="dot missing-dot"></i> required, absent</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="stack">
+        <div class="wrap stack-inner">
+          <p>Built for infrastructure you own</p>
+          <div><span>Go</span><span>SQLite</span><span>PostgreSQL</span><span>Helm</span><span>OpenAPI</span></div>
+        </div>
+      </div>
+
+      <section class="block" aria-labelledby="product-heading">
+        <div class="wrap">
+          <p class="kicker">// explicit state, deliberate access</p>
+          <h2 id="product-heading">A dense surface that stays honest.</h2>
+          <p class="section-lede">
+            Fifty keys across four environments should stay scannable. Hikyo makes absence visible and keeps
+            secret material behind a separate disclosure path.
+          </p>
+
+          <article class="feature-row">
+            <div class="feature-copy">
+              <h3>Every environment answers for itself.</h3>
+              <p>
+                Values never fall through a hidden inheritance chain. Each cell is explicitly set or absent, so
+                production cannot quietly borrow a development default.
+              </p>
+              <p class="feature-note"><span>▸</span> Flat values: no inheritance, no hidden fallback.</p>
+            </div>
+            <div class="artifact frame">
+              <div class="frame-head"><i></i><i></i><i></i><span>DATABASE_POOL_MAX · coverage</span></div>
+              <div class="frame-body coverage">
+                <div><span>development</span><code>10</code><b>set ✓</b></div>
+                <div><span>staging</span><code>20</code><b>set ✓</b></div>
+                <div class="active"><span>production</span><code>40</code><b>set ✓</b></div>
+                <p>3 environments · 3 explicit values · 0 fallbacks</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="feature-row flip">
+            <div class="feature-copy">
+              <h3>Revealing a secret is a ceremony.</h3>
+              <p>
+                Secrets stay masked until you deliberately re-authenticate. Reveal windows remask automatically,
+                and clipboard copies become individual audited disclosures.
+              </p>
+              <p class="feature-note"><span>▸</span> Write-only replacement never needs the current plaintext.</p>
+            </div>
+            <div class="artifact frame">
+              <div class="frame-head"><i></i><i></i><i></i><span>STRIPE_SECRET_KEY · production</span></div>
+              <div class="frame-body reveal">
+                <div class="gate"><span>⌾</span> Re-authentication required <small>protected environment</small></div>
+                <div class="secret-stage"><span>before</span><code>••••••••••••••••</code></div>
+                <div class="secret-stage"><span>after</span><code class="shown">sk_live_51Kp…9aQ</code><b>remask 0:18</b></div>
+              </div>
+            </div>
+          </article>
+
+          <article class="feature-row">
+            <div class="feature-copy">
+              <h3>Invalid changes stop at write time.</h3>
+              <p>
+                Key declarations distinguish config from secrets and attach validation rules. Invalid values are
+                refused, and a value required in an environment cannot be cleared there.
+              </p>
+              <p class="feature-note"><span>▸</span> The server validates the value and presence rule together.</p>
+            </div>
+            <div class="artifact frame">
+              <div class="frame-head"><i></i><i></i><i></i><span>SENTRY_DSN · production · clear</span></div>
+              <div class="frame-body checks">
+                <div><b class="ok">✓</b><span>current value is set</span><code>secret</code></div>
+                <div><b class="bad">!</b><span>clear requested in <strong>production</strong></span><code>change</code></div>
+                <div><b class="ok">✓</b><span>presence rule is required</span><code>required_in</code></div>
+                <div><b class="bad">×</b><span>clear refused; value unchanged</span><code>fail-closed</code></div>
+              </div>
+            </div>
+          </article>
+
+          <article class="feature-row flip">
+            <div class="feature-copy">
+              <h3>Machine access has an honest boundary.</h3>
+              <p>
+                Today, workload fetch returns the authorized key catalogue, classification, and declared presence.
+                It does not return plaintext values. Every request still reaches the same authorization chokepoint.
+              </p>
+              <p class="feature-note"><span>▸</span> Unauthorized resources remain indistinguishable from nonexistent ones.</p>
+            </div>
+            <div class="artifact frame terminal">
+              <div class="frame-head"><i></i><i></i><i></i><span>catalogue fetch · production</span></div>
+              <pre><span># workload presents its own identity</span>
+<b>authorize</b> payments-api / production
+  <em>✓</em> identity verified
+  <em>✓</em> grant constrained to project + environment
+  <em>✓</em> 18 key declarations returned
+  <span>→ required 4 · optional 13 · forbidden 1</span>
+  <strong>!</strong> no plaintext on this surface</pre>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="self-host" id="self-host" aria-labelledby="self-host-heading">
+        <div class="wrap self-host-grid">
+          <div>
+            <p class="kicker">// runs where you do</p>
+            <h2 id="self-host-heading">Own the keys. Own the data.</h2>
+            <p class="section-lede">
+              Self-hosting is the product, not a paid tier. Run one binary with its embedded web UI, choose SQLite
+              or PostgreSQL, and hold the root key outside the datastore it protects.
+            </p>
+            <div class="section-actions">
+              <a class="button button-primary" href={repository}>Inspect the source</a>
+              <a class="button button-line" href={links.security}>Read the security policy</a>
+            </div>
+          </div>
+          <dl class="specs">
+            <div><dt>runtime</dt><dd><strong>One Go binary</strong> with an embedded web interface.</dd></div>
+            <div><dt>storage</dt><dd><strong>SQLite or PostgreSQL</strong>, selected explicitly.</dd></div>
+            <div><dt>encryption</dt><dd>Envelope encryption with <strong>operator-held root key material</strong>.</dd></div>
+            <div><dt>deploy</dt><dd>A first-party <strong>Helm chart</strong> for Kubernetes and K3s.</dd></div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="block" id="why" aria-labelledby="why-heading">
+        <div class="wrap why">
+          <p class="kicker">// why hikyo exists</p>
+          <h2 id="why-heading">Operational capability should not be an enterprise upsell.</h2>
+          <div class="why-body">
+            <p>
+              Secrets products often make audit, SSO, SCIM, or recovery the reason to upgrade. Hikyo keeps the
+              production path in the same open repository under the Mozilla Public License 2.0.
+            </p>
+            <p>
+              The environment matrix is the core idea: <strong>explicit state you can inspect</strong>, disclosure
+              you must intend, and refusals that name the safe next action.
+            </p>
+            <p>No badge wall. No hidden operational tier. Infrastructure you can reason about.</p>
+          </div>
+          <p class="signature">Built in the open · MPL-2.0 · no <code>/ee</code></p>
+        </div>
+      </section>
+
+      <section class="final-cta" aria-labelledby="final-heading">
+        <div class="wrap">
+          <h2 id="final-heading">Config you can reason about.</h2>
+          <p>Hikyo is under active 0.x development. Read the code, inspect the decisions, and follow the road to 1.0.</p>
+          <div class="section-actions">
+            <a class="button button-primary" href={repository}>View on GitHub <span aria-hidden="true">↗</span></a>
+            <a class="button button-line" href={links.docs}>Read project docs</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="wrap footer-grid">
+        <div class="footer-brand">
+          <a class="brand" href={base}><span class="brand-glyph" aria-hidden="true">h</span><span>hikyo</span></a>
+          <p>Fully open-source secrets and configuration across environments.</p>
+        </div>
+        <div>
+          <h3>Project</h3>
+          <a href={links.docs}>Documentation</a><a href={links.governance}>Governance</a><a href={links.license}>License</a>
+        </div>
+        <div>
+          <h3>Operate</h3>
+          <a href={links.security}>Security</a><a href={links.support}>Support</a><a href={`${base}release/signing/`}>Release trust</a>
+        </div>
+        <div>
+          <h3>Contribute</h3>
+          <a href={repository}>GitHub</a><a href={links.contributing}>Contributing</a><a href={`${repository}/issues`}>Issues</a>
+        </div>
+      </div>
+      <div class="wrap footer-bar">
+        <span>© 2026 Hikyo contributors</span><span>MPL-2.0 · self-hosted</span>
+      </div>
+    </footer>
+
+    <script>
+      const button = document.querySelector<HTMLButtonElement>('.theme-toggle');
+      const label = button?.querySelector<HTMLElement>('.theme-label');
+
+      const renderTheme = (theme: 'dark' | 'light') => {
+        document.documentElement.dataset.theme = theme;
+        if (label) label.textContent = theme === 'dark' ? 'Light' : 'Dark';
+        button?.setAttribute('aria-label', `Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`);
+      };
+
+      renderTheme(document.documentElement.dataset.theme === 'light' ? 'light' : 'dark');
+      button?.addEventListener('click', () => {
+        const theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+        localStorage.setItem('starlight-theme', theme);
+        renderTheme(theme);
+      });
+    </script>
+  </body>
+</html>

--- a/docs/site/src/styles/landing.css
+++ b/docs/site/src/styles/landing.css
@@ -1,0 +1,1094 @@
+@import '@fontsource/archivo/400.css';
+@import '@fontsource/archivo/500.css';
+@import '@fontsource/archivo/700.css';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
+
+:root {
+  --bg: oklch(0.19 0.012 220);
+  --bg-raised: oklch(0.225 0.014 220);
+  --bg-sunken: oklch(0.165 0.011 220);
+  --line: oklch(0.34 0.016 220);
+  --line-soft: oklch(0.27 0.014 220);
+  --text: oklch(0.94 0.008 200);
+  --text-dim: oklch(0.77 0.01 210);
+  --text-faint: oklch(0.62 0.012 215);
+  --accent: oklch(0.82 0.09 195);
+  --accent-quiet: oklch(0.82 0.09 195 / 0.12);
+  --on-accent: oklch(0.2 0.02 220);
+  --danger: oklch(0.72 0.13 25);
+  --danger-quiet: oklch(0.72 0.13 25 / 0.14);
+  --warning: oklch(0.82 0.1 85);
+  --mono: 'IBM Plex Mono', ui-monospace, monospace;
+  --sans: 'Archivo', sans-serif;
+  --max-width: 70rem;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  color-scheme: dark;
+}
+
+:root[data-theme='light'] {
+  --bg: oklch(0.965 0.008 200);
+  --bg-raised: oklch(0.995 0.004 200);
+  --bg-sunken: oklch(0.93 0.008 200);
+  --line: oklch(0.82 0.015 210);
+  --line-soft: oklch(0.88 0.012 210);
+  --text: oklch(0.25 0.03 225);
+  --text-dim: oklch(0.4 0.025 220);
+  --text-faint: oklch(0.52 0.025 218);
+  --accent: oklch(0.5 0.1 205);
+  --accent-quiet: oklch(0.55 0.09 205 / 0.1);
+  --on-accent: oklch(0.99 0.01 200);
+  --danger: oklch(0.48 0.16 30);
+  --danger-quiet: oklch(0.5 0.15 30 / 0.1);
+  --warning: oklch(0.52 0.13 75);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
+}
+
+body {
+  min-width: 20rem;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 1rem;
+  line-height: 1.55;
+  letter-spacing: -0.006em;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  font: inherit;
+}
+
+::selection {
+  background: var(--accent-quiet);
+  color: var(--text);
+}
+
+.wrap {
+  width: min(100%, var(--max-width));
+  margin-inline: auto;
+  padding-inline: clamp(1.125rem, 4vw, 2.5rem);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  inset-block-start: 0.75rem;
+  inset-inline-start: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 1rem;
+  transform: translateY(-150%);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.site-header {
+  position: sticky;
+  z-index: 50;
+  inset-block-start: 0;
+  border-block-end: 1px solid var(--line-soft);
+  background: color-mix(in oklab, var(--bg) 90%, transparent);
+  backdrop-filter: saturate(1.25) blur(8px);
+}
+
+.nav {
+  display: flex;
+  min-height: 3.75rem;
+  align-items: center;
+  gap: 1.4rem;
+}
+
+.brand {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.brand-glyph {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--accent);
+  color: var(--on-accent);
+  font-family: var(--mono);
+  font-size: 0.875rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.4rem;
+  color: var(--text-dim);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.nav-links a {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+}
+
+.nav-links a,
+.site-footer a,
+.theme-toggle {
+  transition: color 160ms ease;
+}
+
+.nav-links a:hover,
+.site-footer a:hover,
+.theme-toggle:hover {
+  color: var(--text);
+}
+
+.nav-actions {
+  display: flex;
+  margin-inline-start: auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.45rem;
+  padding-inline: 0.75rem;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+
+.theme-icon {
+  color: var(--accent);
+  font-size: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  transition:
+    transform 160ms var(--ease-out),
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.button-line {
+  border-color: var(--line);
+  background: transparent;
+  color: var(--text);
+}
+
+.button-line:hover {
+  border-color: var(--accent);
+}
+
+.hero {
+  padding-block: clamp(3.5rem, 9vw, 6.5rem) clamp(2rem, 5vw, 3rem);
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin: 0 0 1.5rem;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  background: var(--bg-raised);
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.live {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-block-start: 0;
+}
+
+h1 {
+  max-width: 15ch;
+  margin-block-end: 0;
+  font-size: clamp(2.5rem, 6.4vw, 4.25rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.015;
+}
+
+h1 span {
+  color: var(--text-dim);
+}
+
+.lede {
+  max-width: 62ch;
+  margin-block: 1.4rem 0;
+  color: var(--text-dim);
+  font-size: clamp(1rem, 2vw, 1.1875rem);
+  line-height: 1.62;
+}
+
+.hero-actions,
+.section-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-actions {
+  margin-block-start: 2rem;
+}
+
+.hero-actions .button {
+  padding-inline: 1.2rem;
+  font-size: 0.9375rem;
+}
+
+.subtrust {
+  margin-block: 1rem 0;
+  color: var(--text-faint);
+  font-size: 0.8125rem;
+}
+
+.subtrust strong {
+  color: var(--text-dim);
+}
+
+.surface,
+.frame,
+.specs {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-raised);
+}
+
+.surface {
+  margin-block-start: clamp(2.25rem, 5vw, 3.5rem);
+}
+
+.surface-bar,
+.frame-head {
+  display: flex;
+  align-items: center;
+  border-block-end: 1px solid var(--line);
+  background: var(--bg-sunken);
+}
+
+.surface-bar {
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding: 0.65rem 1rem;
+}
+
+.crumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+
+.crumb strong {
+  color: var(--text);
+}
+
+.avatar {
+  display: grid;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--accent-quiet);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  font-weight: 700;
+}
+
+.environment-chips {
+  display: flex;
+  margin-inline-start: auto;
+  gap: 0.375rem;
+}
+
+.environment-chips span {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+}
+
+.matrix-scroll {
+  overflow-x: auto;
+}
+
+.matrix {
+  width: 100%;
+  min-width: 44rem;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.matrix th,
+.matrix td {
+  padding: 0.62rem 1rem;
+  border-block-end: 1px solid var(--line-soft);
+  text-align: start;
+  white-space: nowrap;
+}
+
+.matrix thead th {
+  background: var(--bg-raised);
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.matrix tbody th {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 400;
+}
+
+.matrix tbody tr:not(.group):hover {
+  background: color-mix(in oklab, var(--accent) 4%, transparent);
+}
+
+.matrix .group th {
+  background: var(--bg-sunken);
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.matrix .group span {
+  display: inline-grid;
+  min-width: 1.125rem;
+  height: 1rem;
+  margin-inline-start: 0.45rem;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--line);
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.625rem;
+}
+
+.state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
+.state.set {
+  background: var(--accent);
+  color: var(--on-accent);
+  font-weight: 500;
+}
+
+.state.absent {
+  border: 1px solid var(--line);
+  color: var(--text-dim);
+}
+
+.state.masked {
+  border: 1px solid var(--line);
+  background: var(--bg-sunken);
+  color: var(--text-dim);
+}
+
+.state.missing {
+  background: var(--danger-quiet);
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.surface-foot {
+  display: flex;
+  min-height: 2.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.55rem 1rem;
+  background: var(--bg-sunken);
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+}
+
+.surface-foot span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+}
+
+.set-dot { background: var(--accent); }
+.absent-dot { border: 1px solid var(--line); }
+.masked-dot { background: var(--text-faint); }
+.missing-dot { background: var(--danger); }
+
+.stack {
+  margin-block-start: clamp(3rem, 7vw, 5rem);
+  border-block: 1px solid var(--line-soft);
+}
+
+.stack-inner {
+  display: flex;
+  min-height: 4.25rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(1rem, 4vw, 2.6rem);
+}
+
+.stack p {
+  margin: 0;
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.stack-inner div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.9rem, 3vw, 1.8rem);
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.8125rem;
+}
+
+.block {
+  padding-block: clamp(3.5rem, 9vw, 6.5rem);
+}
+
+.kicker {
+  margin-block-end: 0.9rem;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+h2 {
+  max-width: 21ch;
+  margin-block-end: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.625rem);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+}
+
+.section-lede {
+  max-width: 57ch;
+  margin-block: 0.9rem 0;
+  color: var(--text-dim);
+  font-size: clamp(0.9375rem, 1.7vw, 1.0625rem);
+  line-height: 1.65;
+}
+
+.feature-row {
+  display: grid;
+  grid-template-columns: 1fr 1.05fr;
+  align-items: center;
+  gap: clamp(1.75rem, 5vw, 4.25rem);
+  padding-block: clamp(2.5rem, 6vw, 4.5rem);
+  border-block-start: 1px solid var(--line-soft);
+}
+
+.feature-row:first-of-type {
+  margin-block-start: clamp(2.5rem, 6vw, 4rem);
+}
+
+.feature-row.flip .feature-copy {
+  order: 2;
+}
+
+.feature-row h3 {
+  margin-block-end: 0;
+  font-size: clamp(1.3rem, 2.6vw, 1.7rem);
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.feature-copy > p:not(.feature-note) {
+  max-width: 46ch;
+  margin-block: 0.75rem 0;
+  color: var(--text-dim);
+  font-size: 0.96875rem;
+  line-height: 1.65;
+}
+
+.feature-note {
+  display: flex;
+  margin-block: 1rem 0;
+  align-items: flex-start;
+  gap: 0.55rem;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.feature-note span {
+  color: var(--accent);
+}
+
+.frame-head {
+  min-height: 2.5rem;
+  gap: 0.35rem;
+  padding-inline: 0.8rem;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+}
+
+.frame-head i {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.frame-head span {
+  margin-inline-start: 0.25rem;
+}
+
+.frame-body {
+  padding: 1rem;
+}
+
+.coverage {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.coverage > div,
+.checks > div {
+  display: grid;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  background: var(--bg-sunken);
+}
+
+.coverage > div {
+  grid-template-columns: 1fr auto auto;
+}
+
+.coverage > div.active {
+  border-color: var(--accent);
+  background: var(--accent-quiet);
+}
+
+.coverage span,
+.coverage code,
+.coverage b,
+.coverage p,
+.secret-stage,
+.checks,
+.terminal pre,
+.signature {
+  font-family: var(--mono);
+}
+
+.coverage span {
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+}
+
+.coverage code {
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.coverage b {
+  color: var(--accent);
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.coverage p {
+  margin: 0.15rem 0 0;
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+}
+
+.reveal {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.gate,
+.secret-stage {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  background: var(--bg-sunken);
+}
+
+.gate {
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+
+.gate > span {
+  color: var(--accent);
+}
+
+.gate small {
+  margin-inline-start: auto;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.625rem;
+}
+
+.secret-stage span {
+  margin-inline-end: auto;
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+}
+
+.secret-stage code {
+  color: var(--text-faint);
+  font-size: 0.75rem;
+}
+
+.secret-stage code.shown {
+  color: var(--accent);
+}
+
+.secret-stage b {
+  color: var(--warning);
+  font-size: 0.625rem;
+  font-weight: 400;
+}
+
+.checks {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.checks > div {
+  grid-template-columns: auto 1fr auto;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+}
+
+.checks b {
+  display: grid;
+  width: 1.125rem;
+  height: 1.125rem;
+  place-items: center;
+  border-radius: 3px;
+}
+
+.checks b.ok {
+  background: var(--accent-quiet);
+  color: var(--accent);
+}
+
+.checks b.bad {
+  background: var(--danger-quiet);
+  color: var(--danger);
+}
+
+.checks code {
+  color: var(--text-faint);
+  font-size: 0.625rem;
+}
+
+.terminal pre {
+  min-height: 15.5rem;
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  line-height: 1.85;
+}
+
+.terminal pre span { color: var(--text-faint); }
+.terminal pre b { color: var(--text); font-weight: 500; }
+.terminal pre em { color: var(--accent); font-style: normal; }
+.terminal pre strong { color: var(--warning); font-weight: 500; }
+
+.self-host {
+  border-block: 1px solid var(--line);
+  background: var(--bg-sunken);
+}
+
+.self-host-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  align-items: center;
+  gap: clamp(1.75rem, 5vw, 3.75rem);
+  padding-block: clamp(3rem, 8vw, 5.6rem);
+}
+
+.section-actions {
+  margin-block-start: 1.5rem;
+}
+
+.specs {
+  display: grid;
+  gap: 1px;
+  margin: 0;
+  border-color: var(--line-soft);
+  background: var(--line-soft);
+}
+
+.specs div {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: 0.9rem;
+  align-items: baseline;
+  padding: 0.9rem 1.1rem;
+  background: var(--bg-raised);
+}
+
+.specs dt {
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.specs dd {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.875rem;
+}
+
+.specs strong {
+  color: var(--text);
+}
+
+.why {
+  max-width: 46rem;
+}
+
+.why h2 {
+  max-width: 24ch;
+}
+
+.why-body {
+  display: grid;
+  gap: 1rem;
+  margin-block-start: 1.4rem;
+  color: var(--text-dim);
+  font-size: clamp(1rem, 1.9vw, 1.15rem);
+  line-height: 1.68;
+}
+
+.why-body p {
+  margin: 0;
+}
+
+.why-body strong {
+  color: var(--text);
+}
+
+.signature {
+  margin-block: 1.6rem 0;
+  color: var(--text-faint);
+  font-size: 0.8125rem;
+}
+
+.signature code {
+  color: var(--accent);
+  font-family: inherit;
+}
+
+.final-cta {
+  padding-block: clamp(4rem, 10vw, 7.5rem);
+  text-align: center;
+}
+
+.final-cta h2 {
+  margin-inline: auto;
+}
+
+.final-cta p {
+  max-width: 48ch;
+  margin: 1.1rem auto 0;
+  color: var(--text-dim);
+}
+
+.final-cta .section-actions {
+  justify-content: center;
+}
+
+.site-footer {
+  border-block-start: 1px solid var(--line);
+  background: var(--bg-sunken);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1.6fr repeat(3, 1fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding-block: clamp(2.5rem, 6vw, 4rem) 1.875rem;
+}
+
+.footer-brand p {
+  max-width: 34ch;
+  margin-block: 0.8rem 0;
+  color: var(--text-faint);
+  font-size: 0.8125rem;
+}
+
+.footer-grid h3 {
+  margin: 0 0 0.75rem;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer-grid > div:not(.footer-brand) a {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  padding-block: 0.35rem;
+  color: var(--text-dim);
+  font-size: 0.875rem;
+}
+
+.footer-bar {
+  display: flex;
+  min-height: 3.75rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-block-start: 1px solid var(--line-soft);
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+}
+
+@media (max-width: 56.25rem) {
+  .feature-row,
+  .self-host-grid,
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-row.flip .feature-copy {
+    order: 0;
+  }
+
+  .feature-row .artifact {
+    order: 2;
+  }
+
+  .footer-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .footer-brand {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 43rem) {
+  .nav-links,
+  .theme-label {
+    display: none;
+  }
+
+  .nav {
+    gap: 0.5rem;
+  }
+
+  .nav-actions {
+    gap: 0.2rem;
+  }
+
+  .theme-toggle {
+    width: 2.75rem;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .header-cta {
+    padding-inline: 0.75rem;
+  }
+
+  h1 {
+    font-size: clamp(2.15rem, 10vw, 2.75rem);
+  }
+
+  .environment-chips span {
+    display: none;
+  }
+
+  .environment-chips::after {
+    content: '3 environments';
+    color: var(--text-faint);
+    font-family: var(--mono);
+    font-size: 0.6875rem;
+  }
+
+  .hero-actions .button,
+  .section-actions .button {
+    flex: 1 1 auto;
+  }
+
+  .stack-inner {
+    padding-block: 1rem;
+  }
+
+  .gate {
+    align-items: flex-start;
+  }
+
+  .gate small {
+    text-align: end;
+  }
+
+  .secret-stage {
+    flex-wrap: wrap;
+  }
+
+  .secret-stage code {
+    order: 3;
+    width: 100%;
+  }
+
+  .specs div {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .footer-brand {
+    grid-column: 1 / -1;
+  }
+
+  .footer-bar {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    padding-block: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/scripts/ci/check-oss-policy.sh
+++ b/scripts/ci/check-oss-policy.sh
@@ -117,6 +117,7 @@ require_text "$repo_root/SUPPORT.md" 'Prereleases are never supported.'
 
 for path in \
 	.well-known/security.txt \
+	index.html \
 	security/index.html \
 	support/index.html \
 	governance/index.html \
@@ -125,6 +126,12 @@ for path in \
 	license/index.html; do
 	require_file "$site_root/$path"
 done
+
+require_text "$site_root/index.html" 'Every value is explicit'
+require_text "$site_root/index.html" 'Mozilla Public License 2.0'
+require_text "$site_root/index.html" 'href="/hikyo/docs/"'
+reject_text "$site_root/index.html" 'validated, inherited secrets'
+reject_text "$site_root/index.html" 'MIT licensed'
 
 cmp "$security_txt" "$site_root/.well-known/security.txt" >/dev/null || {
 	printf 'OSS policy gate: served security.txt differs from its canonical source\n' >&2


### PR DESCRIPTION
## Summary

- promote the latest Opus 4.8 landing direction to the GitHub Pages root
- keep the existing Starlight documentation at `/hikyo/docs/`
- replace stale prototype claims with current flat-value, MPL-2.0, and machine-fetch semantics
- add generated-site assertions for the landing route and Pages base paths

## Validation

- `fnm exec --using 24 ./scripts/ci/verify-docs.sh`
- Astro check: 0 errors, 0 warnings, 0 hints
- generated `/hikyo/`, `/hikyo/docs/`, and `/hikyo/security/`: HTTP 200
- standards review: CLEAN
- spec review: CLEAN

## Visual evidence

T3 preview navigation and viewport resize succeeded. Snapshot, DOM evaluation, and recording automation timed out, so this PR does not claim current-build screenshot verification. The frozen Opus 4.8 desktop/mobile reference screenshots were inspected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR promotes a standalone landing page to the GitHub Pages root while relocating the Starlight overview to `/hikyo/docs/`.
- Adds a responsive, theme-aware landing page and associated styles.
- Updates Starlight navigation for the relocated documentation overview.
- Extends generated-site policy checks for landing-page content and base-path links.
- Documents the implementation and validation handoff.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/site/src/pages/index.astro | Adds the Pages-root landing route, base-aware navigation, static product messaging, and persisted theme selection. |
| docs/site/src/styles/landing.css | Adds responsive dark/light landing-page styling with accessibility and reduced-motion accommodations. |
| docs/site/astro.config.mjs | Points the Starlight overview navigation item to the relocated `docs` route. |
| docs/site/src/content/docs/docs.mdx | Relocates and retitles the documentation overview beneath `/hikyo/docs/`. |
| scripts/ci/check-oss-policy.sh | Adds generated landing-page existence, content, stale-copy, and Pages-link assertions. |
| docs/handoff/opus-48-landing-pages.md | Records the landing-page outcome, production corrections, affected files, and validation status. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Root["/hikyo/"] --> Landing["Standalone Astro landing page"]
  Landing --> Docs["/hikyo/docs/"]
  Landing --> Policies["Policy and release-trust routes"]
  Build["Astro build"] --> Root
  Build --> Docs
  Build --> Policies
  Checks["OSS policy checks"] --> Build
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(docs): promote Opus 4.8 landing to ..."](https://github.com/dunky13/hikyo/commit/4a74ede1521c474d737408b4357d7d279c06e597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52929629)</sub>

<!-- /greptile_comment -->