### PR TITLE
feat(machine-access): tabbed inventory, display-once mint, federation surfaces (#67)

### DIFF
--- a/docs/handoff/67-machine-access.md
+++ b/docs/handoff/67-machine-access.md
@@ -1,0 +1,275 @@
+# Handoff: #67 Machine access UI
+
+Parent #41. Binds the frozen prototype `prototype/machine-access/` —
+**iteration 3, locked** (Marc, 2026-08-05, ticket #31: tabbed inventory, row
+expansion leading with credentials and bindings, journey full-width **below**)
+— plus [machine-identities.md](https://github.com/Dunky13/hikyo/blob/wayfinder-docs/docs/adr/machine-identities.md)
+(#17), the Compose (#18) and Kubernetes (#19) ADRs, and mvp-boundary row **S3**
+(`machine access: all three tabs + row expansion + display-once mint`, desktop
+and mobile, pinned assertion set).
+
+Blockers #56 (UI shell) and #62 (OIDC federation + conditional-fetch cursor)
+were merged before this landed.
+
+## What shipped
+
+**A project surface at `/orgs/:org/projects/:project/machine-access`**, added to
+the router's own surface table (`web/src/app/navigation.ts`) — the closed flow
+registry reads that table, so the route could not exist without a flow.
+`section: null` for the same reason `values` is: it addresses ONE project and a
+static sidebar entry cannot know which. The project-scoped navigation the
+prototype draws around it is the shell's ticket, not this one.
+
+- **Tabbed inventory** — Service accounts / Federation / Kubernetes targets,
+  with a live count in each tab label.
+- **Policy strip** above the table: the per-project machine-reveal opt-in,
+  **stated, not offered** (see gaps).
+- **Write-only credential rows**: prefix hint, kind, expiry in words, last used
+  — never a value. There is no route that returns one after the mint, so there
+  is nothing the row could render.
+- **Row expansion**: credentials and federated bindings on the left, delivery
+  targets and the three actions on the right, the five-step setup journey
+  full-width underneath — iteration 3's resolution exactly.
+- **Display-once mint**: a step-up naming the post-state formula and the
+  environments it ranges over, then the value **exactly once**, with a
+  stored-confirmation checkbox gating dismissal — including Escape, which must
+  not be a way to lose a value nothing can return. Rotation is the same flow
+  with the "the prior value is never returned, the predecessor keeps working
+  until you revoke it" sentence added.
+- **Grant-mutation warning**: names the live-credential count (the server's own
+  `live_credentials`, which applies revocation, the credential epoch and
+  expiry — a client filtering on `revoked_at` would count credentials that
+  stopped authenticating weeks ago), states the formula, and enumerates exactly
+  what becomes reachable. It is **fail-closed**: until the key catalogue has
+  actually loaded, the grant button stays disabled and says why, because
+  "nothing becomes reachable" is the one answer a pending or failed read does
+  not have and the one that makes the grant look harmless. The catalogue comes
+  from `listKeys`, not `listValues`, on purpose (PR review, aikido): a value
+  listing is authorized for the human reading it and carries **config
+  plaintext** this dialog never renders, and a fetch is a copy the query cache
+  keeps — `listKeys` answers the only question asked (name, classification)
+  with no value member anywhere in its schema.
+- **Federation form**: three presets carrying the per-platform pin rules the
+  server enforces at creation (Kubernetes' `/kubernetes.io/serviceaccount/uid`,
+  Forgejo's `repository` + `event_name`, GitHub Actions' `repository_id` +
+  `repository_owner_id` + `event_name`), a **binding lifetime** (instance
+  default / 30 / 90 days, with `indefinite` present-and-disabled naming the
+  instance opt-in that admits it — renewal is a mint, never an edit), a
+  mandatory audience refused before the request rather than as a 400, and the
+  **pull-request refusal**: pinning `pull_request` or `pull_request_target`
+  raises a `role="alert"` refusal and is held back until a deliberate
+  acknowledgement is ticked. Submission runs the same reauthentication leg as
+  the credential mint (PR review, aikido): a binding **is** a mint (#62), so
+  one passkey ceremony per post-state environment precedes
+  `createFederatedBinding` — vacuous today exactly like the mint's, but the
+  form will not start failing with a bare 403 when the reveal opt-in lands.
+- **Every write on this surface is commit-aware, not just the mint** (PR
+  review, aikido round 2). Binding and grant submissions track the same
+  `issued` line the mint draws: an in-flight write blocks Escape, Back and
+  unload (`useNavigationGuard(busy)` + the dialog cancel gate), and a failure
+  after the request left refreshes the rows / scope column and says the act
+  *may still have landed* (`bindingFailureText` / `grantFailureText`) rather
+  than reporting "nothing happened" over a committed external login path or a
+  committed widening.
+- **Typed claim pins are parsed, not coerced.** A numeric pin takes digits only,
+  non-empty, inside the range JSON carries exactly. `Number()` would turn an
+  empty field into repository id **0**, accept `1e3` and `4242.7`, and round
+  anything past 2^53 to a *neighbouring* repository id — each of which binds a
+  production service account to a repository nobody chose, while looking like it
+  worked.
+- **Restore quarantine**: a binding carrying `reactivated_at` renders the
+  permanent iat-floor refusal in words. It is real state, not a simulation.
+
+## Three properties of the mint that are not obvious from the screen
+
+1. **The plaintext exists in exactly one place.** The mint is deliberately NOT a
+   `useMutation`: TanStack keeps a mutation's result in a global cache until
+   garbage collection, so a mint run through it would leave the credential
+   reachable from the query client long after the dialog closed — a second copy
+   of a value whose whole contract is that there is one. It is a plain async
+   call, and only `MintDialog`'s own state holds the result.
+2. **The response is parsed down to what may be kept.** `zMintCredentialResult`
+   is `.pick`ed to `{ value, clamped }` rather than parsed whole, so a drift in
+   the nested credential metadata cannot throw away the one member nothing can
+   ever return again. The row metadata is re-read from the listing instead.
+3. **A mint that was ISSUED and then failed is reported as such.** Once the
+   request leaves, a failure says nothing about whether the server committed —
+   so that path invalidates the credential list and says *a credential may still
+   have been minted; check the rows and revoke anything you did not expect*,
+   rather than the guess ("the mint failed") that leaves a live credential
+   nobody is looking for. And **dismissal is refused entirely while the mint is
+   in flight**: Escape reaches a native `<dialog>` even when Cancel is disabled,
+   and unmounting mid-flight loses a committed value as thoroughly as never
+   minting it (`dismissDecision`, unit-tested, plus a flow test that delays the
+   real mint and presses Escape). Navigation gets the same treatment
+   (`useNavigationGuard`): `beforeunload` guards reload/close while a mint is
+   in flight or a value is unstored, and a history sentinel turns the Back
+   button into a dismissal attempt routed through the same gate — the route
+   never pops out from under the dialog (flow test: Back mid-flight and Back
+   with the value on screen).
+
+## The one backend change, and why it is here
+
+**`listMachineCredentials` dropped every binding member.** The wire schema has
+always said an `oidc-federation` row "carries the binding members instead" of a
+prefix hint; the generated Zod schema has `issuer`, `subject`, `audience`,
+`required_claims` and `reactivated_at`; the store layer already returned all of
+them on `MachineCredential.Binding`; and `server.wireCredential` rendered none.
+Since a binding **is** a credential row and is listed only through that route
+(#62's own decision), an operator could see that a binding existed and not
+which external identity it admitted — and the quarantine field was invisible
+for the same reason.
+
+That is a server failing its published contract rather than a feature that does
+not exist yet, so it is fixed here rather than worked around. **The change is
+read-path only and three files:**
+
+- `internal/service/identities.go` — `CredentialView` gains the binding
+  members; `ListCredentials` populates them for `oidc-federation` rows,
+  resolving the byte-exact issuer STRING once per distinct configuration (not
+  once per row) via `az.FederationIssuerByID`, and decoding the pins through
+  the existing `DecodeClaimPins`.
+- `internal/server/identities.go` — `wireCredential` renders them, reusing
+  `wireClaimPins`. All zero for a bearer credential, so `optional` renders them
+  absent. The mint path goes through the same function with zero values and is
+  unchanged.
+- `internal/isolation/federation_e2e_test.go` —
+  `TestFederationBindingIsListedWithItsIdentity{SQLite,Postgres}` pins it in
+  both directions through the SERVICE: a listed binding carries
+  issuer/subject/audience byte-exact plus its `event_name` pin and no prefix
+  hint, and a bearer row on the same account carries no binding members at all.
+- `internal/server/identities_wire_test.go` — and the same two directions
+  through the RENDER, which is where the defect actually was: a service-level
+  test passes with the wire still empty. It asserts the pins' scalar **values**
+  (not merely their presence — `event_name` is the whole CI rule) and that the
+  discriminated scalar is not folded, that `reactivated_at` round-trips, and
+  that a bearer row renders every binding member *absent* rather than as an
+  empty string, which a client cannot tell from "unset".
+
+Nothing on the authentication or verifier path was touched. **Flagged for the
+reviewer as its own item**: it is separable from the UI work and revertible on
+its own, at the cost of the Federation tab.
+
+A second, smaller backend change followed from the first during PR review
+(aikido): now that the credential listing carries the issuer string byte-exact
+to project-level `manage-identities`, an issuer configured as
+`https://user:secret@host` would disclose those embedded credentials on a
+lower-privileged surface. `checkIssuerRequest`
+(`internal/service/federation.go`) therefore enforces the OIDC issuer grammar
+at creation — https, a host, and no userinfo, query or fragment — refused
+before a row exists, because byte-exact matching forbids sanitising later.
+Pinned by `TestFederationIssuerGrammarRefusesNonIssuerURLs`.
+
+## What a `read` grant actually reaches — the decision behind the warning
+
+Read off `internal/service/delivery.go` (`deliveryRows`) and the `fetchDelivery`
+contract rather than assumed. A machine holding `read` on an environment gets
+**the whole key catalogue for that environment** — every key's name, its
+classification and its declared presence rule — and **no value of any
+classification, config included**: `DeliveredKey` has no value member at all.
+
+So the grant warning enumerates *every* key with its classification, not only
+`classification === 'secret' && set`. The narrower filter would have understated
+the blast radius twice over: it hid the config keys, and it hid the secret keys
+that are declared but unset — whose presence state is itself delivered, and
+whose names are exactly what an attacker with a stolen credential would want.
+
+## Gaps: where the prototype is ahead of the server
+
+Each of these renders the state that exists and says what is missing. None of
+them mocks a data path.
+
+| Prototype surface | Server today | What ships |
+|---|---|---|
+| Per-project machine-reveal opt-in, as a toggle with a ceremony both ways | No opt-in exists. #55's machine allowlist admits `read` and **nothing else** on a workload principal (`internal/domain/permission.go`), so `reveal` on a machine is refused by the grant API | A `role="status"` policy strip stating the opt-in is off in this build and why. A toggle would be a control whose only outcome is a refusal; the repo's own precedent is the ceremony's TOTP cap — absent with the reason given, never disabled. **Ships with #17/#18.** |
+| Journey step 5, "Grant `reveal`" | Same refusal | Step renders `not in this build`, naming the allowlist. No button. |
+| Journey step 3's verbatim delivery refusal (`hikyo run` / `UndeliverableKeys`) | Delivery never refuses: it delivers config and secret **presence**, with no plaintext path at all (`fetchDelivery`) | Step 3 says delivery succeeds as configuration and secret presence. **Rendering the refusal would fabricate a state the server does not produce.** |
+| Kubernetes delivery targets and the four CR conditions in both voices | No operator (#64), no target state, no condition rows | Empty state saying nothing is reporting and that an empty list here is **not** "everything is healthy". The condition vocabulary is deliberately NOT rendered as a static reference: it is documentation with no data source and would drift the day #64 lands. |
+| Restore reconciliation: recovery banner, per-SA re-activation, no bulk-accept | No recovery-mode signal and no per-SA re-activation route. `Federation.Reactivate` exists as the write #76's ceremony will call, and `reactivated_at` is on the wire | The quarantine badge and its permanent-floor sentence render from the real field. The banner and the re-activation ceremony are **not** built. |
+| Scenario simulator (normal / expiring / post-restore) | — | Not built. It is a prototype affordance for showing states, not a product surface. |
+| Mint step-up's passkey leg | Reachable, but never exercised: the disclosure conjunct ranges over environments the account can decrypt, and no machine can hold `reveal` today, so the post-state reach is always empty and the server asks for no reauthentication (ratified, #61 handoff item 5) | The code path is there and correct — one `reauthPasskeyStart({operation: 'mint', …})` per reachable environment, mirroring `RequireDisclosureAuthority` — but it cannot be exercised end to end until the opt-in lands. The panel says in words that the conjunct is vacuous rather than performing a ceremony that authorises nothing. **Covered by a unit test (`postStateReach`), not by the flow.** |
+| Grant-mutation step-up's passkey leg | Same, one level along: `checkMachineWidening` gates a grant on the same conjunct, but over the **delta** rather than the whole post-state — and a `read` grant on a principal that cannot hold `reveal` widens nothing | Same treatment as the mint's, deliberately: the dialog states the formula, runs one ceremony per newly-decryptable environment, and says *this grant newly decrypts nothing, so the disclosure conjunct is vacuous* when — as today — the delta is empty. The delta is computed by `grantWideningReach`, which is unit-tested against the non-vacuous case the server will one day produce. |
+
+**Partial reads are not rendered as zeroes.** Every act on this surface is
+gated on all four of its inputs — accounts, grants, environments and
+credentials — having actually loaded: each dialog's warning is an assertion
+about that state, and a query that failed answers "how many credentials does
+this re-scope" with a confident 0. A failed listing therefore shows the tab
+count as `—` rather than `(0)`, the scope column as `unknown` rather than
+`no environment`, and holds the mint, bind and grant actions back with the
+reason stated.
+
+Also noted, not a gap in this ticket: the shell's breadcrumb resolves a
+parameterised path to "Not found" (pre-existing; `values` has it too), and the
+teardown's `--grep` escape hatch does not actually trigger for a CLI `--grep` in
+the pinned Playwright version, so a filtered run still fails the execution
+check. Neither was touched — `e2e/global-teardown.ts` is #56's locked harness.
+
+## Files
+
+| File | |
+|---|---|
+| `web/src/api/identities.ts` | new — Zod-parsed hooks plus every derivation as a pure function |
+| `web/src/api/identities.test.ts` | new — unit tests over those derivations, including the three whose failure modes are invisible on screen: `parseClaimNumber`, `grantWideningReach` and `dismissDecision` |
+| `web/src/routes/MachineAccess.tsx` | new — the surface and its three native `<dialog>` ceremonies |
+| `web/src/app/navigation.ts`, `web/src/app/App.tsx` | the surface entry and its element |
+| `web/src/api/values.ts` | `PasskeyCeremonyInput.operation` widened with `mint` (the contract already has it) |
+| `web/src/styles/app.css` | tabs, inventory, expansion, journey, binding card, token box, checkbox |
+| `web/e2e/registry.ts`, `web/e2e/registry.test.ts` | the flow, and the closure test's counts derived rather than restated |
+| `web/e2e/fixtures/seed.ts`, `web/e2e/fixtures/instance.ts` | the machine fixture |
+| `web/e2e/flows/machine-access.spec.ts` | new — 10 tests × 2 viewport projects |
+| `internal/service/identities.go`, `internal/server/identities.go` | the contract-conformance fix above |
+| `internal/isolation/federation_e2e_test.go`, `internal/server/identities_wire_test.go` | its two tests, at the service and at the render |
+
+## Endpoints each surface consumes
+
+| Surface | Route |
+|---|---|
+| Inventory rows | `listServiceAccounts` (`manage-identities@project`) |
+| Read scope column, journey, grant dialog's grantable set | `listProjectGrants` (`manage-members@project` — a **separate** authority; its absence renders an honest "no scope is shown", not a blank column) |
+| Environment names | `listEnvironments` |
+| Credential rows, binding cards, tab counts | `listMachineCredentials`, one query per account |
+| Display-once mint | `reauthPasskeyStart`/`finish` with `operation: mint`, per reachable environment, then `mintMachineCredential` |
+| Revoke | `revokeMachineCredential` |
+| Federated binding | `createFederatedBinding` |
+| Environment grant | `createEnvGrant` |
+| Grant warning's newly-reachable key set | `listValues` for the chosen environment (presence only — the surface never asks for plaintext) |
+
+## The e2e fixture
+
+`seedTenant` now also creates, **inside the stepped-up TOTP session** (because
+`instance-config` and `manage-members` are MFA-mandatory and the `reveal` grant
+at the end kills that session):
+
+- a federation issuer, `kubernetes` type, static JWKS, with the API server's own
+  audience in `refused_audiences`;
+- three service accounts — `web-api` (workload, `read` on development, one
+  federated binding), `nightly-export` (automation, no journey), `batch-worker`
+  (workload, no grants, the one the mint tests mint on);
+- `manage-identities` added to the break-glass grant list.
+
+The binding's service account reaches no plaintext, so its own mint formula's
+disclosure conjunct is vacuous and seeding needs no reauthentication.
+
+**Each minting test revokes what it minted.** The instance caps live
+credentials per account at five and this file mints three times per viewport
+project; without the revoke the sixth mint is refused by the cap and reads as a
+broken mint rather than as a test that littered.
+
+## How to verify
+
+```bash
+pnpm --dir web typecheck
+pnpm --dir web test                     # 37 unit tests, incl. the closed-registry checks
+pnpm --dir web build                    # the flows run against the EMBEDDED bundle
+pnpm --dir web e2e                      # unfiltered: a filtered run fails the execution check
+go build ./... && go vet ./...
+go test ./internal/service/... ./internal/server/... ./internal/isolation/ ./internal/conformance/
+```
+
+Last run on this branch: `pnpm e2e` **84 passed** across both viewport
+projects with the registry's execution check satisfied; `vitest` 48 passed;
+`go build`/`go vet` clean and 722 passed across `internal/server` and
+`internal/isolation` (sqlite only — set `HIKYO_TEST_POSTGRES_DSN` for the
+Postgres leg of `TestFederationBindingIsListedWithItsIdentityPostgres`, which
+has never executed here).

--- a/internal/isolation/federation_e2e_test.go
+++ b/internal/isolation/federation_e2e_test.go
@@ -1449,3 +1449,139 @@ func runFederationLifecycle(t *testing.T, db *store.DB) {
 	}
 	r.idp.SetOffline(false)
 }
+
+func TestFederationBindingIsListedWithItsIdentitySQLite(t *testing.T) {
+	runBindingListedWithIdentity(t, seededDB(t, openSQLite))
+}
+
+func TestFederationBindingIsListedWithItsIdentityPostgres(t *testing.T) {
+	runBindingListedWithIdentity(t, seededDB(t, openPostgres))
+}
+
+// runBindingListedWithIdentity pins what the credential LISTING carries for a
+// binding row.
+//
+// A binding is a credential row and is listed through the credential route
+// rather than a second pair of routes, which is what makes this the only place
+// an operator can read back the `(issuer, subject)` pair a binding matches. The
+// wire schema has always said so — an `oidc-federation` row "carries the binding
+// members instead" of a prefix hint — and the transport dropped every one of
+// them until #67, so a federation surface could show that a binding existed and
+// not which external identity it admitted.
+//
+// The issuer is asserted as the byte-exact STRING rather than the configuration
+// id: nothing folds case, resolves the URL or strips a trailing slash anywhere
+// on this path, and the id is not what the external authority presents.
+func runBindingListedWithIdentity(t *testing.T, db *store.DB) {
+	r := newFedRig(t, db)
+	const instance = "https://git.example.test"
+	shape := oidctest.ForgejoShape(instance, "acme/service", "refs/heads/main", "push")
+	r.configureIssuer(t, domain.IssuerForgejo, []string{shape.DefaultAudience})
+	sa, binding := r.bindShape(t, "listed-binding", shape, hikyoAudience)
+
+	// A bearer credential on the SAME account, so the discriminator is exercised
+	// in both directions by one listing.
+	if _, err := r.ident.MintCredential(t.Context(), service.LocalPrincipal(identAdmin),
+		prjScope(), sa.ID, service.MintRequest{}); err != nil {
+		t.Fatalf("mint bearer credential: %v", err)
+	}
+
+	rows, err := r.ident.ListCredentials(t.Context(), service.LocalPrincipal(identAdmin),
+		prjScope(), sa.ID)
+	if err != nil {
+		t.Fatalf("list credentials: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("listed %d credentials, want the binding and the bearer", len(rows))
+	}
+
+	var listed, bearer *service.CredentialView
+	for i := range rows {
+		switch rows[i].Kind {
+		case domain.CredentialOIDCFederation:
+			listed = &rows[i]
+		case domain.CredentialHikyoToken:
+			bearer = &rows[i]
+		}
+	}
+	if listed == nil || bearer == nil {
+		t.Fatal("the listing did not carry one row of each kind")
+	}
+
+	if listed.ID != binding.CredentialID {
+		t.Fatalf("listed binding id %q, want %q", listed.ID, binding.CredentialID)
+	}
+	if listed.Issuer != r.idp.Issuer() {
+		t.Fatalf("listed issuer %q, want the byte-exact %q", listed.Issuer, r.idp.Issuer())
+	}
+	if listed.Subject != shape.Subject {
+		t.Fatalf("listed subject %q, want %q", listed.Subject, shape.Subject)
+	}
+	if listed.Audience != hikyoAudience {
+		t.Fatalf("listed audience %q, want %q", listed.Audience, hikyoAudience)
+	}
+	// The pins travel too, and the discriminated scalar is not folded on the way
+	// out: `event_name` is the whole CI rule, and an operator auditing a binding
+	// has to be able to see which event it admits.
+	pinned := map[string]bool{}
+	for _, pin := range listed.RequiredClaims {
+		pinned[pin.Claim] = true
+	}
+	if !pinned[oidcfed.EventNameClaim] {
+		t.Fatalf("listed pins %v, want the event_name pin among them", pinned)
+	}
+	if listed.PrefixHint != "" {
+		t.Fatalf("a binding has no minted value to hint at, got %q", listed.PrefixHint)
+	}
+
+	// And the other direction: a bearer row carries no binding members at all,
+	// so nothing on the read surface can read one into a credential that has none.
+	if bearer.Issuer != "" || bearer.Subject != "" || bearer.Audience != "" ||
+		len(bearer.RequiredClaims) != 0 || !bearer.ReactivatedAt.IsZero() {
+		t.Fatalf("a bearer credential carried binding members: %+v", *bearer)
+	}
+	if bearer.PrefixHint == "" {
+		t.Fatal("a bearer credential must carry its prefix hint")
+	}
+}
+
+// TestFederationIssuerGrammarRefusesNonIssuerURLs pins the issuer identifier
+// grammar at creation: an https URL with a host and NOTHING that is not part
+// of an identity namespace. The load-bearing case is userinfo — an issuer
+// stored as `https://user:secret@host` would be listed byte-exact by the
+// credential route to project-level `manage-identities` (#67), turning an
+// instance-config mistake into plaintext exposure on a project surface. The
+// refusal has to happen here, before a row exists, because byte-exact
+// matching forbids sanitising it later.
+func TestFederationIssuerGrammarRefusesNonIssuerURLs(t *testing.T) {
+	r := newFedRig(t, seededDB(t, openSQLite))
+	for _, tc := range []struct {
+		name   string
+		issuer string
+	}{
+		{"userinfo", "https://user:secret@issuer.example.test"},
+		{"userinfo without password", "https://user@issuer.example.test"},
+		{"query", "https://issuer.example.test/path?x=1"},
+		{"fragment", "https://issuer.example.test#frag"},
+		{"http", "http://issuer.example.test"},
+		{"no host", "https:///path"},
+		{"opaque", "https:issuer.example.test"},
+		{"empty", ""},
+	} {
+		if _, err := r.fed.CreateIssuer(t.Context(), service.LocalPrincipal(root), service.IssuerRequest{
+			Issuer: tc.issuer, Type: domain.IssuerForgejo, Mode: domain.JWKSDiscovery,
+			RefusedAudiences: []string{"https://forgejo.example.test"},
+		}); !errors.Is(err, service.ErrIssuerValue) {
+			t.Errorf("%s: CreateIssuer(%q) = %v, want the issuer-grammar refusal", tc.name, tc.issuer, err)
+		}
+	}
+
+	// And the well-formed shapes stay admitted: a port and a path are both
+	// part of real issuer identifiers (kind clusters, tenant paths).
+	if _, err := r.fed.CreateIssuer(t.Context(), service.LocalPrincipal(root), service.IssuerRequest{
+		Issuer: "https://issuer.example.test:6443/tenant", Type: domain.IssuerForgejo,
+		Mode: domain.JWKSDiscovery, RefusedAudiences: []string{"https://forgejo.example.test"},
+	}); err != nil {
+		t.Fatalf("a host:port/path issuer must stay admitted, got %v", err)
+	}
+}

--- a/internal/server/identities.go
+++ b/internal/server/identities.go
@@ -147,6 +147,13 @@ func wireServiceAccount(sa service.ServiceAccountView) apigen.ServiceAccount {
 
 // wireCredential renders metadata and nothing else. There is no branch here
 // that could add a value: the generated type has no member for one.
+//
+// The binding members ride along for an `oidc-federation` row, which is what
+// the schema has always said this row carries in place of a prefix hint: a
+// binding IS a credential row, listed through this route, and an operator who
+// cannot see the byte-exact `(issuer, subject)` pair cannot audit it. Every one
+// of them is the zero value for a bearer credential, so `optional` renders them
+// absent rather than empty.
 func wireCredential(c service.CredentialView) apigen.MachineCredential {
 	out := apigen.MachineCredential{
 		Id: c.ID, Kind: apigen.CredentialKind(c.Kind),
@@ -158,6 +165,13 @@ func wireCredential(c service.CredentialView) apigen.MachineCredential {
 	out.ExpiresAt = optionalTime(c.ExpiresAt)
 	out.RevokedAt = optionalTime(c.RevokedAt)
 	out.LastUsedAt = optionalTime(c.LastUsedAt)
+	out.Issuer = optional(c.Issuer)
+	out.Subject = optional(c.Subject)
+	out.Audience = optional(c.Audience)
+	out.ReactivatedAt = optionalTime(c.ReactivatedAt)
+	if pins := wireClaimPins(c.RequiredClaims); len(pins) > 0 {
+		out.RequiredClaims = &pins
+	}
 	return out
 }
 

--- a/internal/server/identities_wire_test.go
+++ b/internal/server/identities_wire_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Dunky13/hikyo/internal/domain"
+	"github.com/Dunky13/hikyo/internal/service"
+)
+
+// The credential RENDER function, tested where the bug was.
+//
+// #67 found `listMachineCredentials` dropping every binding member the schema
+// says an `oidc-federation` row carries — issuer, subject, audience, the pinned
+// claims and the restore predicate's instant — while the service layer beneath
+// it had them all. That is a transport defect, so a service-level test can pass
+// with the wire still empty; this one runs the render itself.
+//
+// It is an INTERNAL test (`package server`) because `wireCredential` is
+// unexported, which it should stay: it is the single place the never-return-a-
+// value rule is kept, and a second caller is exactly what would let a value
+// escape.
+
+func TestWireCredentialCarriesTheBindingMembers(t *testing.T) {
+	reactivated := time.Date(2026, 8, 4, 2, 0, 0, 0, time.UTC)
+	event := "pull_request_target"
+	repo := int64(4242)
+	view := service.CredentialView{
+		ID:        "mcr_00000000-0000-0000-0000-000000000001",
+		Kind:      domain.CredentialOIDCFederation,
+		Lifetime:  domain.LifetimeFinite,
+		ExpiresAt: time.Date(2026, 11, 1, 0, 0, 0, 0, time.UTC),
+		CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		CreatedBy: domain.PrincipalID("pr_00000000-0000-0000-0000-000000000002"),
+		Issuer:    "https://token.actions.githubusercontent.com",
+		Subject:   "repo:acme/service:ref:refs/heads/main",
+		Audience:  "hikyo.example.org/main",
+		RequiredClaims: []service.ClaimPin{
+			{Claim: "event_name", String: &event},
+			{Claim: "repository_id", Number: &repo},
+		},
+		ReactivatedAt: reactivated,
+	}
+
+	out := wireCredential(view)
+
+	if out.Issuer == nil || *out.Issuer != view.Issuer {
+		t.Fatalf("issuer = %v, want the byte-exact %q", out.Issuer, view.Issuer)
+	}
+	if out.Subject == nil || *out.Subject != view.Subject {
+		t.Fatalf("subject = %v, want %q", out.Subject, view.Subject)
+	}
+	if out.Audience == nil || *out.Audience != view.Audience {
+		t.Fatalf("audience = %v, want %q", out.Audience, view.Audience)
+	}
+	// The restore predicate's instant is the reason a workload stopped
+	// authenticating; a surface that cannot see it cannot explain the outage.
+	if out.ReactivatedAt == nil || !out.ReactivatedAt.Equal(reactivated) {
+		t.Fatalf("reactivated_at = %v, want %v", out.ReactivatedAt, reactivated)
+	}
+	// A binding has no minted value to hint at.
+	if out.PrefixHint != nil {
+		t.Fatalf("prefix_hint = %q on a binding row, want absent", *out.PrefixHint)
+	}
+
+	if out.RequiredClaims == nil {
+		t.Fatal("required_claims absent, want both pins")
+	}
+	pins := map[string]struct {
+		str *string
+		num *int64
+	}{}
+	for _, pin := range *out.RequiredClaims {
+		pins[pin.Claim] = struct {
+			str *string
+			num *int64
+		}{pin.StringValue, pin.NumberValue}
+	}
+	// The VALUE, not merely the presence of the pin: `event_name` is the whole
+	// CI rule, and an operator auditing a binding has to see which event it
+	// admits — a render that carried the claim names and dropped the scalars
+	// would look complete and say nothing.
+	if got := pins["event_name"].str; got == nil || *got != event {
+		t.Fatalf("event_name pin = %v, want %q", got, event)
+	}
+	// And the discriminated scalar is not folded: `repository_id` is the number
+	// 4242 and must never arrive as the string "4242".
+	if got := pins["repository_id"].num; got == nil || *got != repo {
+		t.Fatalf("repository_id pin = %v, want the number %d", got, repo)
+	}
+	if pins["repository_id"].str != nil {
+		t.Fatalf("repository_id arrived as a string %q; the scalar was folded", *pins["repository_id"].str)
+	}
+}
+
+func TestWireCredentialLeavesABearerRowWithoutBindingMembers(t *testing.T) {
+	// The other direction. Every binding member is the zero value on a bearer
+	// credential, and `optional` must render each one ABSENT rather than as an
+	// empty string — a client cannot tell "" from "the issuer is unset", and
+	// only one of those is a fact.
+	out := wireCredential(service.CredentialView{
+		ID:         "mcr_00000000-0000-0000-0000-000000000003",
+		Kind:       domain.CredentialHikyoToken,
+		PrefixHint: "hik_1_wl_9fK2mQ",
+		Lifetime:   domain.LifetimeFinite,
+		CreatedAt:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		CreatedBy:  domain.PrincipalID("pr_00000000-0000-0000-0000-000000000002"),
+	})
+
+	if out.Issuer != nil || out.Subject != nil || out.Audience != nil {
+		t.Fatalf("a bearer credential carried binding members: %+v", out)
+	}
+	if out.RequiredClaims != nil {
+		t.Fatalf("a bearer credential carried pinned claims: %+v", *out.RequiredClaims)
+	}
+	if out.ReactivatedAt != nil {
+		t.Fatalf("a bearer credential carried a restore predicate: %v", *out.ReactivatedAt)
+	}
+	if out.PrefixHint == nil || *out.PrefixHint != "hik_1_wl_9fK2mQ" {
+		t.Fatalf("prefix_hint = %v, want the bearer row's hint", out.PrefixHint)
+	}
+	// And still no value member exists to render — the generated type has none,
+	// which is what makes the rule structural rather than a convention.
+}

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -939,10 +940,18 @@ func (s *Federation) recordKeyState(ctx context.Context, issuer string, state oi
 // checkIssuerRequest validates the whole configuration before any row is
 // written.
 func checkIssuerRequest(req IssuerRequest) error {
-	if req.Issuer == "" || !strings.HasPrefix(req.Issuer, "https://") {
-		// https only, and not as ceremony: discovery and JWKS are fetched from
-		// this URL, and an http issuer means the instance's whole federation
-		// trust rests on whoever holds the network path.
+	// The OIDC issuer grammar exactly: an https URL with a host and nothing
+	// that is not part of an identity namespace. https only, and not as
+	// ceremony — discovery and JWKS are fetched from this URL, and an http
+	// issuer means the instance's whole federation trust rests on whoever
+	// holds the network path. Userinfo is the load-bearing refusal: an issuer
+	// stored as `https://user:secret@host` would be disclosed byte-exact on
+	// every credential listing, turning an instance-config mistake into
+	// plaintext exposure on a project surface (#67 review). Query and fragment
+	// are refused with it — no issuer identifier carries either, and byte-exact
+	// matching means a junk component would live forever.
+	if u, err := url.Parse(req.Issuer); err != nil || u.Scheme != "https" ||
+		u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
 		return ErrIssuerValue
 	}
 	if !domain.IsIssuerType(req.Type) {

--- a/internal/service/identities.go
+++ b/internal/service/identities.go
@@ -134,6 +134,26 @@ type CredentialView struct {
 	// before any transport. It is computed, never stored: a stored flag would
 	// be stale the moment the clock moved past it.
 	ExpiringSoon bool
+	// The binding half, populated only for an `oidc-federation` row and the
+	// zero value for a bearer credential — the kind discriminates, so there is
+	// no second boolean saying which half of the view is meaningful.
+	//
+	// A binding IS a credential row (#62), listed and revoked through these
+	// routes, so its identity has to travel on the listing: an operator cannot
+	// audit a byte-exact `(issuer, subject)` pair they cannot see, and the
+	// contract has always said this row "carries the binding members instead"
+	// of a prefix hint. `Issuer` is the byte-exact string rather than the
+	// configuration's id, because the id is not what the external authority
+	// presents and not what an operator compares against a cluster.
+	Issuer         string
+	Subject        string
+	Audience       string
+	RequiredClaims []ClaimPin
+	// ReactivatedAt is the restore predicate's instant, zero unless this
+	// binding has been through a restore. It is a permanent refusal floor, not
+	// a quarantine window, and the surface that hides it hides the reason a
+	// workload stopped authenticating.
+	ReactivatedAt time.Time
 }
 
 // ExpiryWarningWindow is how far ahead a live finite credential is flagged
@@ -509,12 +529,37 @@ func (s *Identities) ListCredentials(ctx context.Context, actor Actor, scope dom
 		if err != nil {
 			return err
 		}
+		// Issuer strings are resolved once per DISTINCT configuration rather
+		// than once per row: a service account's bindings usually name the
+		// same issuer, and a lookup per row would make the listing's cost
+		// scale with the fleet rather than with the instance's configuration.
+		issuers := map[string]string{}
 		out = make([]CredentialView, 0, len(creds))
 		for _, c := range creds {
 			view := CredentialView{
 				ID: c.ID, Kind: c.Kind, PrefixHint: c.PrefixHint, Lifetime: c.Lifetime,
 				ExpiresAt: c.ExpiresAt, CreatedAt: c.CreatedAt, CreatedBy: c.CreatedBy,
 				RevokedAt: c.RevokedAt, LastUsedAt: c.LastUsedAt,
+			}
+			if c.Kind == domain.CredentialOIDCFederation {
+				issuer, ok := issuers[c.Binding.IssuerID]
+				if !ok {
+					configured, err := az.FederationIssuerByID(ctx, c.Binding.IssuerID)
+					if err != nil {
+						return err
+					}
+					issuer = configured.Issuer
+					issuers[c.Binding.IssuerID] = issuer
+				}
+				pins, err := DecodeClaimPins(c.Binding.RequiredClaimsJSON)
+				if err != nil {
+					return err
+				}
+				view.Issuer = issuer
+				view.Subject = c.Binding.Subject
+				view.Audience = c.Binding.Audience
+				view.RequiredClaims = pins
+				view.ReactivatedAt = c.Binding.ReactivatedAt
 			}
 			view.ExpiringSoon = expiringSoon(view, now)
 			out = append(out, view)

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -243,6 +243,14 @@ const zSeeded = z.object({
   principal: z.string(),
   otpauth: z.string(),
   lastTotpStep: z.number(),
+  machine: z.object({
+    workload: z.string(),
+    automation: z.string(),
+    mintable: z.string(),
+    issuer: z.string(),
+    subject: z.string(),
+    audience: z.string(),
+  }),
   /**
    * The instance's sqlite file. Playwright runs global setup and the workers
    * in SEPARATE PROCESSES, so a worker cannot reach the setup process's

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -69,6 +69,29 @@ export type Seeded = {
    * or be refused as a replay, which looks exactly like a wrong code.
    */
   lastTotpStep: number;
+  /**
+   * The machine-access fixture (#67).
+   *
+   * Three service accounts because the surface has three shapes to show: a
+   * workload that has been granted `read` (its journey is under way), a
+   * workload with no grants at all (whose mint therefore needs no disclosure
+   * ceremony, and whose credential count the mint flow may move), and an
+   * automation principal (which has no setup journey at all).
+   */
+  machine: {
+    /** The workload holding `read` on development, with a federated binding. */
+    workload: string;
+    /** The automation principal — no journey, different allowlist. */
+    automation: string;
+    /** The workload the mint flow mints on, so counts stay predictable. */
+    mintable: string;
+    /** The configured issuer, byte-exact. */
+    issuer: string;
+    /** The bound subject, byte-exact. */
+    subject: string;
+    /** The bound audience, which is never the issuer's default. */
+    audience: string;
+  };
 };
 
 const BASE32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
@@ -121,6 +144,7 @@ type Json = Record<string, unknown>;
 
 /** zCreated is every create response this fixture reads: it needs the id. */
 const zCreated = z.object({ id: z.string() });
+const zServiceAccount = z.object({ id: z.string(), principal_id: z.string() });
 const zEnrolStart = z.object({ otpauth_uri: z.string() });
 const zRotated = z.object({ session_token: z.string() });
 const zWhoAmI = z.object({ principal: z.object({ id: z.string() }) });
@@ -232,6 +256,24 @@ async function signIn(): Promise<string> {
 /** REVEAL_GRANT is the instance-scope `reveal` row the write-only flow toggles. */
 export const REVEAL_GRANT = { capability: 'reveal', scope: 'instance' } as const;
 
+/**
+ * MACHINE is the machine-access fixture's fixed vocabulary (#67).
+ *
+ * The issuer, subject and audience are byte-exact strings the flow asserts on
+ * screen: the whole federation rule is that nothing folds case, resolves a URL
+ * or strips a slash, so what is seeded and what is rendered must be one string.
+ */
+export const MACHINE = {
+  workload: 'web-api',
+  automation: 'nightly-export',
+  mintable: 'batch-worker',
+  issuer: 'https://kubernetes.default.svc.cluster.local',
+  subject: 'system:serviceaccount:hikyo-system:hikyo-fetch',
+  // Never the issuer's default: a token minted for the API server must not
+  // authenticate here, which is what the refused-audience list enforces.
+  audience: 'hikyo.example.org/main',
+} as const;
+
 /** grantReveal creates the revocable instance-scope `reveal` grant. */
 export async function grantReveal(token: string, principal: string): Promise<void> {
   await call(token, 'POST', '/api/v1/instance/grants', zIgnored, {
@@ -277,6 +319,10 @@ export async function seedTenant(
     'manage-projects',
     'definitions-edit',
     'project-settings',
+    // The machine-access surface's own authority (#67): listing service
+    // accounts, minting and binding are all `manage-identities`, which is a
+    // separate atom from administering members.
+    'manage-identities',
   ]) {
     runAdminGrant(['--principal', principal, '--capability', capability]);
   }
@@ -306,16 +352,19 @@ export async function seedTenant(
     name: 'Ceremonies',
   });
 
-  // `reveal` through the API, under the instance `manage-members` the operator
-  // template seeds — the ADR's own unheld-capability granting power, at the
-  // scope where the threat model actually extends that trust.
-  await grantReveal(token, principal);
-
-  // That grant killed the session with it. Nothing left to seed is
-  // MFA-mandatory — `manage-projects`, `definitions-edit`, `edit`, `publish`
-  // and `project-settings` are all ordinary capabilities — so a plain password
-  // session finishes the job with no further codes.
-  token = await signIn();
+  // The federation issuer is instance-scoped configuration, so it is
+  // `instance-config` and belongs in this same stepped-up session. Static JWKS
+  // rather than discovery: nothing in this fixture presents a token, and a
+  // discovery issuer would make setup depend on an unreachable network host.
+  await call(token, 'POST', '/api/v1/instance/federation-issuers', zCreated, {
+    issuer: MACHINE.issuer,
+    issuer_type: 'kubernetes',
+    jwks_mode: 'static',
+    static_jwks: '{"keys":[]}',
+    // The API server's own audience, which no binding may name and no token may
+    // carry — the rule the mandatory audience exists to enforce.
+    refused_audiences: ['https://kubernetes.default.svc'],
+  });
 
   const { id: project } = await call(token, 'POST', `/api/v1/orgs/${org}/projects`, zCreated, {
     name: 'payments',
@@ -334,6 +383,57 @@ export async function seedTenant(
     zCreated,
     { name: 'production' },
   );
+
+  // The machine-identity fixture, still on the stepped-up session: granting a
+  // capability to the service account is `manage-members`, which is
+  // MFA-mandatory, so it cannot wait for the plain session below.
+  const created = async (name: string, kind: 'workload' | 'automation') =>
+    call(
+      token,
+      'POST',
+      `/api/v1/orgs/${org}/projects/${project}/service-accounts`,
+      zServiceAccount,
+      { name, kind },
+    );
+  const workload = await created(MACHINE.workload, 'workload');
+  await created(MACHINE.automation, 'automation');
+  await created(MACHINE.mintable, 'workload');
+
+  await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${project}/environments/${dev}/grants`,
+    zIgnored,
+    { principal: workload.principal_id, capability: 'read' },
+  );
+  // A binding whose service account reaches no plaintext: `read` delivers
+  // configuration and secret presence, so the mint formula's disclosure
+  // conjunct is vacuous and no reauthentication is required here.
+  await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${project}/service-accounts/${workload.id}/bindings`,
+    zIgnored,
+    {
+      issuer: MACHINE.issuer,
+      subject: MACHINE.subject,
+      audience: MACHINE.audience,
+      required_claims: [
+        { claim: '/kubernetes.io/serviceaccount/uid', string_value: '9f2c-fixture-uid' },
+      ],
+    },
+  );
+
+  // `reveal` through the API, under the instance `manage-members` the operator
+  // template seeds — the ADR's own unheld-capability granting power, at the
+  // scope where the threat model actually extends that trust.
+  await grantReveal(token, principal);
+
+  // That grant killed the session with it. Nothing left to seed is
+  // MFA-mandatory — `manage-projects`, `definitions-edit`, `edit`, `publish`
+  // and `project-settings` are all ordinary capabilities — so a plain password
+  // session finishes the job with no further codes.
+  token = await signIn();
 
   const secrets = ['DB_PASSWORD', 'STRIPE_SECRET_KEY', 'ROTATE_ME'];
   const rotatable = 'ROTATE_ME';
@@ -413,5 +513,6 @@ export async function seedTenant(
     principal,
     otpauth: uri,
     lastTotpStep: lastStep,
+    machine: MACHINE,
   };
 }

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -1,0 +1,528 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
+import {
+  establishSession,
+  parseCredential,
+  readPasskey,
+  readSeed,
+  writePasskey,
+} from '../fixtures/instance.ts';
+
+/**
+ * Flow: machine access (registry surface `machine-access`) — mvp-boundary S3's
+ * "all three tabs + row expansion + display-once mint", against the locked
+ * prototype #31 iteration 3.
+ *
+ * What this flow proves, in the ADRs' own terms:
+ *
+ *  - the inventory is a TABBED one — service accounts, federation, Kubernetes
+ *    targets — and each tab renders the state this build actually holds;
+ *  - a credential row is METADATA ONLY: prefix hint, kind, expiry in words,
+ *    last used, and never a value;
+ *  - expanding a service account shows credentials and federated bindings on
+ *    the left, delivery targets and actions on the right, and the five-step
+ *    setup journey full-width below;
+ *  - the mint is DISPLAY-ONCE: the step-up names the post-state formula, the
+ *    value appears exactly once, a stored-confirmation checkbox gates dismiss,
+ *    and after dismissal the value is nowhere on the page while the new row is;
+ *  - a federated binding renders byte-exactly, and the form REFUSES a
+ *    pull-request event until it is deliberately bound.
+ *
+ * The passkey machinery is here for the session, not for the mint: a
+ * `manage-members` read of the grant rows is MFA-mandatory, so the surface's
+ * scope column needs a stepped-up session to exist at all.
+ */
+
+const seed = readSeed();
+const PATH = `/orgs/${seed.org}/projects/${seed.project}/machine-access`;
+
+/**
+ * installAuthenticator attaches Chromium's virtual authenticator preloaded with
+ * the passkey global setup enrolled — never a fresh one. Enrolment is an
+ * account-security mutation that deletes every other session the principal
+ * holds, so a flow that enrolled would invalidate the suite's shared session.
+ */
+async function installAuthenticator(page: Page): Promise<() => Promise<void>> {
+  const session = await page.context().newCDPSession(page);
+  await session.send('WebAuthn.enable');
+  const { authenticatorId } = await session.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+  await session.send('WebAuthn.addCredential', { authenticatorId, credential: readPasskey() });
+  // Hand the ADVANCED signature counter back: the next Playwright project's
+  // authenticator must carry on from here or the server sees a clone.
+  return async () => {
+    const { credentials } = await session.send('WebAuthn.getCredentials', { authenticatorId });
+    const advanced: unknown = credentials[0];
+    if (advanced !== undefined) {
+      writePasskey(parseCredential(advanced));
+    }
+  };
+}
+
+/** accountRow is the disclosure button that expands one service account. */
+function accountRow(page: Page, name: string) {
+  return page.getByRole('button', { name, exact: false }).first();
+}
+
+/**
+ * revokeMinted retires everything this flow minted, and it is not tidiness.
+ *
+ * The instance caps concurrent live credentials per service account at five,
+ * and this file mints three times per Playwright project across two viewport
+ * projects — so without revoking, the sixth mint is refused by the cap and the
+ * failure reads as a broken mint rather than as a test that littered. Revoking
+ * is also the second half of the rotation the ADR describes: mint, distribute,
+ * then revoke.
+ */
+async function revokeMinted(page: Page) {
+  const expansion = page.locator('.machine__sub');
+  const buttons = expansion.getByRole('button', { name: /^Revoke hik_1_wl_/ });
+  for (let remaining = await buttons.count(); remaining > 0; remaining--) {
+    await buttons.first().click();
+    await expect(expansion.locator('.cred')).toHaveCount(remaining - 1);
+  }
+  await expect(expansion.locator('.cred')).toHaveCount(0);
+}
+
+test.describe('machine access', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let context: BrowserContext;
+  let page: Page;
+  let persistPasskey: () => Promise<void>;
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
+    page = await context.newPage();
+    persistPasskey = await installAuthenticator(page);
+  });
+
+  test.afterAll(async () => {
+    await persistPasskey();
+    await context.close();
+  });
+
+  test.beforeEach(async () => {
+    await context.clearCookies();
+    await page.goto(PATH);
+    await establishSession(page);
+    await page.goto(PATH);
+    await expect(page.getByRole('heading', { name: 'Machine access', level: 1 })).toBeVisible();
+  });
+
+  test('the inventory has three tabs, and every one of them says what it holds', async () => {
+    const tabs = page.getByRole('tab');
+    await expect(tabs).toHaveCount(3);
+    await expect(tabs.nth(0)).toHaveText(/Service accounts \(3\)/);
+    await expect(tabs.nth(1)).toHaveText(/Federation \(1\)/);
+    await expect(tabs.nth(2)).toHaveText(/Kubernetes targets \(0\)/);
+
+    // The policy strip: the per-project opt-in is stated, not offered as a
+    // control whose only outcome would be a refusal.
+    const policy = page.locator('.machine__policy');
+    await expect(policy).toContainText('per-project opt-in): off in this build');
+    await expectStatusIsTextAndAria(page, policy);
+
+    // The inventory itself: every seeded account, with its immutable kind.
+    for (const name of [seed.machine.workload, seed.machine.automation, seed.machine.mintable]) {
+      await expect(page.getByRole('button', { name, exact: false })).toBeVisible();
+    }
+    await expect(page.getByRole('row').filter({ hasText: seed.machine.workload })).toContainText(
+      'development',
+    );
+    await expect(page.getByRole('row').filter({ hasText: seed.machine.automation })).toContainText(
+      'automation',
+    );
+
+    // The federation tab renders the binding BYTE-EXACTLY. Nothing folds case,
+    // resolves the URL or strips a slash, so what was seeded is what is here.
+    await page.getByRole('tab', { name: 'Federation' }).click();
+    await expect(page.getByText(seed.machine.issuer, { exact: true })).toBeVisible();
+    await expect(page.getByText(seed.machine.subject, { exact: true })).toBeVisible();
+    await expect(page.getByText(seed.machine.audience, { exact: true })).toBeVisible();
+
+    // The Kubernetes tab is EMPTY and says why. An empty list here must not
+    // read as "everything is healthy".
+    await page.getByRole('tab', { name: 'Kubernetes targets' }).click();
+    const empty = page.getByRole('status').filter({ hasText: 'No delivery targets are reported' });
+    await expect(empty).toContainText('never that everything is healthy');
+    await expectStatusIsTextAndAria(page, empty);
+  });
+
+  test('expanding a row shows credentials, bindings, targets and the journey below', async () => {
+    const toggle = accountRow(page, seed.machine.workload);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const expansion = page.locator('.machine__sub');
+    await expect(expansion.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+    await expect(expansion.getByRole('heading', { name: 'Federated bindings' })).toBeVisible();
+    await expect(expansion.getByRole('heading', { name: 'Delivery targets' })).toBeVisible();
+    await expect(expansion.getByRole('heading', { name: 'Setup journey' })).toBeVisible();
+
+    // The journey is five steps, and the two this build cannot perform say so
+    // in words rather than offering a control the server refuses.
+    const steps = expansion.locator('.journey__step');
+    await expect(steps).toHaveCount(5);
+    await expect(steps.nth(1)).toContainText(`read granted — development`);
+    await expect(steps.nth(3)).toContainText('not in this build');
+    await expect(steps.nth(3)).toContainText('per-project opt-in');
+    await expect(steps.nth(4)).toContainText('not in this build');
+
+    // An automation principal has no journey at all: it never delivers to a
+    // workload.
+    await toggle.click();
+    await accountRow(page, seed.machine.automation).click();
+    await expect(page.locator('.machine__sub')).toContainText('has no setup journey');
+    await expect(page.locator('.journey__step')).toHaveCount(0);
+  });
+
+  test('the mint shows the value exactly once, and the confirmation gates dismiss', async () => {
+    await accountRow(page, seed.machine.mintable).click();
+    await page
+      .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+      .click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { level: 2 })).toHaveText(
+      `mint credential · ${seed.machine.mintable}`,
+    );
+    // The step-up names the POST-STATE formula, not what the mint adds — and
+    // says honestly that this account reaches no plaintext, so nothing is
+    // reauthenticated for a disclosure that cannot happen.
+    await expect(dialog).toContainText('resulting post-state');
+    await expect(dialog).toContainText('reaches no plaintext');
+
+    await dialog.getByRole('button', { name: 'Mint credential' }).click();
+
+    // The value, exactly once, in the credential grammar.
+    const token = dialog.locator('.machine__token');
+    await expect(token).toHaveText(/^hik_1_wl_/);
+    const value = (await token.textContent()) ?? '';
+    expect(value.length, 'the minted value').toBeGreaterThan(20);
+    await expect(dialog).toContainText('never retrievable again');
+
+    // Dismissal is GATED. Pressing Done without the confirmation refuses, in
+    // words, and the value stays on screen rather than being lost.
+    await dialog.getByRole('button', { name: 'Done' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('there is no second look');
+    await expect(token).toBeVisible();
+
+    await dialog.getByRole('checkbox').check();
+    await dialog.getByRole('button', { name: 'Done' }).click();
+    await expect(dialog).toBeHidden();
+
+    // And it is gone: nothing on this page can return it, which is the whole
+    // point of display-once. The row shows the PREFIX HINT instead.
+    await expect(page.getByText(value)).toHaveCount(0);
+    const expansion = page.locator('.machine__sub');
+    await expect(expansion.locator('.cred')).toHaveCount(1);
+    await expect(expansion.locator('.cred code')).toHaveText(/^hik_1_wl_.*…$/);
+    await expect(expansion.locator('.cred')).toContainText('expires in');
+    await expect(expansion.locator('.cred')).toContainText('never used');
+    // The row shows a PREFIX, not the value: what is on screen is a strict,
+    // short prefix of what was minted and nothing more.
+    const hint = ((await expansion.locator('.cred code').textContent()) ?? '').replace('…', '');
+    expect(value.startsWith(hint), 'the row shows a prefix of the minted value').toBe(true);
+    expect(hint.length, 'the hint is far shorter than the value').toBeLessThan(value.length / 2);
+
+    // Revoking is the other half of rotation, and it bites at the next request
+    // rather than at expiry.
+    await revokeMinted(page);
+    await expect(
+      page.getByRole('status').filter({ hasText: 'stops authenticating at the next request' }),
+    ).toBeVisible();
+  });
+
+  test('escape does not throw away a value nothing can return', async () => {
+    await accountRow(page, seed.machine.mintable).click();
+    await page
+      .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+      .click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Mint credential' }).click();
+    await expect(dialog.locator('.machine__token')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('alert')).toContainText('there is no second look');
+
+    await dialog.getByRole('checkbox').check();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await revokeMinted(page);
+  });
+
+  test('escape while the mint is in flight does not unmount the value', async () => {
+    // The window this closes: Escape reaches a native <dialog> even when Cancel
+    // is disabled, so a dismissal mid-flight would unmount the component the
+    // server is about to hand a credential to — losing a value nothing can
+    // return while leaving a live credential behind.
+    //
+    // The mint is delayed rather than stubbed: the request, the commit and the
+    // response are all real, only slower, so what is asserted is the real
+    // ordering rather than a fixture's.
+    await page.route('**/service-accounts/*/credentials', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      await route.continue();
+    });
+    try {
+      await accountRow(page, seed.machine.mintable).click();
+      await page
+        .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+        .click();
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Mint credential' }).click();
+      await expect(dialog.getByRole('button', { name: 'Minting…' })).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeVisible();
+
+      // And the value still arrives, at the component that is still there.
+      await expect(dialog.locator('.machine__token')).toHaveText(/^hik_1_wl_/, { timeout: 10_000 });
+    } finally {
+      await page.unroute('**/service-accounts/*/credentials');
+    }
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('checkbox').check();
+    await dialog.getByRole('button', { name: 'Done' }).click();
+    await expect(dialog).toBeHidden();
+    await revokeMinted(page);
+  });
+
+  test('browser Back is a dismissal attempt, not a way to lose the value', async () => {
+    // Escape goes through the dialog's own cancel event; Back pops the ROUTE,
+    // which would unmount the component and everything it holds. The guard
+    // turns the pop into the same gated dismissal attempt: mid-flight it is
+    // ignored, with an unstored value it holds back, and the URL never moves.
+    await page.route('**/service-accounts/*/credentials', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      await route.continue();
+    });
+    try {
+      await accountRow(page, seed.machine.mintable).click();
+      await page
+        .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+        .click();
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Mint credential' }).click();
+      await expect(dialog.getByRole('button', { name: 'Minting…' })).toBeVisible();
+
+      // Back mid-flight: ignored, the mint completes where it started.
+      await page.goBack();
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator('.machine__token')).toHaveText(/^hik_1_wl_/, { timeout: 10_000 });
+      expect(new URL(page.url()).pathname).toBe(PATH);
+
+      // Back with the unstored value on screen: held back, in words.
+      await page.goBack();
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByRole('alert')).toContainText('there is no second look');
+      expect(new URL(page.url()).pathname).toBe(PATH);
+
+      await dialog.getByRole('checkbox').check();
+      await dialog.getByRole('button', { name: 'Done' }).click();
+      await expect(dialog).toBeHidden();
+    } finally {
+      await page.unroute('**/service-accounts/*/credentials');
+    }
+    await revokeMinted(page);
+  });
+
+  test('the binding form refuses a pull-request event until it is deliberately bound', async () => {
+    await page.getByRole('tab', { name: 'Federation' }).click();
+    await page.getByRole('button', { name: 'New binding' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    // The Kubernetes preset fills the byte-exact issuer and the UID pin the
+    // server refuses a binding without.
+    await expect(dialog.getByLabel('Issuer')).toHaveValue(seed.machine.issuer);
+    await expect(dialog.getByLabel(/ServiceAccount UID/)).toBeVisible();
+
+    // A binding expires on the same terms as a bearer credential, and the
+    // indefinite option is present-and-disabled with its reason rather than
+    // absent — the instance opt-in that admits it is off by default.
+    const lifetime = dialog.getByLabel('Binding lifetime');
+    await expect(lifetime).toHaveValue('default');
+    await expect(lifetime.getByRole('option', { name: /Indefinite/ })).toBeDisabled();
+    await lifetime.selectOption('90d');
+
+    await dialog.getByRole('button', { name: 'GitHub Actions' }).click();
+    await expect(dialog.getByLabel(/Repository id/)).toBeVisible();
+    // `push` is not a refusal.
+    await expect(dialog.getByRole('alert')).toHaveCount(0);
+
+    // A numeric pin is refused BEFORE the request when it is not a whole number
+    // the issuer could have minted: an empty field would bind repository 0, and
+    // anything past 2^53 rounds to a neighbouring repository id.
+    await dialog.getByLabel(/Repository id \(repository_id\)/).fill('4242.7');
+    await dialog.getByLabel(/Repository owner id/).fill('99');
+    await dialog.getByLabel('Audience').fill(seed.machine.audience);
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('must be a whole number');
+    await dialog.getByLabel(/Repository id \(repository_id\)/).fill('4242');
+
+    // The audience is mandatory, and refused here rather than as a 400.
+    await dialog.getByLabel('Audience').fill('');
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('An audience is mandatory');
+    await dialog.getByLabel('Audience').fill(seed.machine.audience);
+
+    await dialog.getByLabel('Event name').selectOption('pull_request_target');
+    const refusal = dialog.getByRole('alert');
+    await expect(refusal).toContainText('pull_request_target');
+    await expect(refusal).toContainText("this service account's fetch authority");
+    await expectStatusIsTextAndAria(page, refusal.first());
+
+    // The refusal HOLDS: pressing bind without the acknowledgement is refused
+    // by the surface, before the server is asked anything.
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog).toContainText('Acknowledge deliberately below');
+
+    // And the acknowledgement is a deliberate act, not a default.
+    const deliberate = dialog.getByRole('checkbox');
+    await expect(deliberate).not.toBeChecked();
+    await deliberate.check();
+    await expect(deliberate).toBeChecked();
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('the grant warning names the live credentials and the newly reachable keys', async () => {
+    await accountRow(page, seed.machine.workload).click();
+    await page
+      .getByRole('button', { name: `Add environment grant to ${seed.machine.workload}` })
+      .click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Grants attach to the service account, never to a credential');
+    // The two numbers nothing else on the surface says: how many credentials
+    // this re-scopes, and exactly what becomes reachable. The count is the
+    // SERVER's `live_credentials`, so an expired credential is not counted as
+    // one this grant re-scopes.
+    await expect(dialog).toContainText('re-scopes every credential already in circulation');
+    await expect(dialog).toContainText('1 live credential');
+
+    // The formula, and the honest statement that its disclosure conjunct is
+    // vacuous here — the same sentence the mint makes, for the same reason.
+    await expect(dialog).toContainText('the delta, not the whole post-state');
+    await expect(dialog).toContainText('newly decrypts nothing');
+
+    // What a `read` grant actually delivers: the whole key catalogue by name,
+    // classification and presence — config keys included, unset keys included
+    // — and no value of any classification.
+    const keys = dialog.getByRole('list', { name: 'Keys this grant makes reachable' });
+    for (const key of [...seed.secrets, seed.config]) {
+      await expect(keys).toContainText(key);
+    }
+    await expect(keys).toContainText('config');
+    await expect(keys).toContainText('secret');
+    await expect(dialog).toContainText('No value of any classification is delivered');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  for (const scheme of ['dark', 'light'] as const) {
+    test(`meets the pinned assertion set on the inventory (${scheme})`, async () => {
+      await page.emulateMedia({ colorScheme: scheme });
+      try {
+        await page.reload();
+        await expect(page.getByRole('heading', { name: 'Machine access', level: 1 })).toBeVisible();
+        // Expanded, because the expansion is most of this surface: the
+        // credential rows, the binding card and the journey rail are all only
+        // reachable through it.
+        await accountRow(page, seed.machine.workload).click();
+
+        const heading = page.getByRole('heading', { name: 'Machine access', level: 1 });
+        const well = page.locator('.card');
+        const badge = page.locator('.badge').first();
+        const mint = page.getByRole('button', {
+          name: `Mint credential for ${seed.machine.workload}`,
+        });
+
+        await expectPinnedAssertionSet(page, {
+          flow: 'machine-access',
+          surface: 'machine-access',
+          theme: scheme,
+          text: [heading, page.locator('.machine__policy'), page.locator('.journey__step').first()],
+          radii: [
+            [well, 'container'],
+            [mint, 'control'],
+            [badge, 'badge'],
+          ],
+          fonts: [
+            [heading, 'ui'],
+            [page.locator('.kv dd').first(), 'mono'],
+          ],
+          colours: [
+            [heading, 'color', '--tx'],
+            [well, 'backgroundColor', '--bg-raise'],
+            [well, 'borderTopColor', '--line'],
+          ],
+          hairlines: [well],
+          density: [[mint, '--touch']],
+        });
+      } finally {
+        await page.emulateMedia({ colorScheme: null });
+      }
+    });
+  }
+
+  test('meets the pinned assertion set with the display-once value on screen', async () => {
+    // The mint dialog is the component this ticket exists for, and it is the
+    // only place in the SPA a credential value is ever rendered. Asserting only
+    // the resting surface would leave it, its confirmation checkbox and its
+    // refusal unchecked.
+    await accountRow(page, seed.machine.mintable).click();
+    await page
+      .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+      .click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Mint credential' }).click();
+    await expect(dialog.locator('.machine__token')).toBeVisible();
+
+    await expectPinnedAssertionSet(page, {
+      flow: 'machine-access',
+      surface: 'machine-access',
+      theme: 'dark',
+      text: [dialog.getByRole('heading', { level: 2 }), dialog.locator('.machine__token')],
+      radii: [
+        [dialog, 'container'],
+        [dialog.locator('.machine__token'), 'control'],
+      ],
+      fonts: [[dialog.locator('.machine__token'), 'mono']],
+      colours: [[dialog, 'backgroundColor', '--bg-raise']],
+      hairlines: [dialog],
+      density: [[dialog.getByRole('button', { name: 'Done' }), '--touch']],
+    });
+
+    await dialog.getByRole('checkbox').check();
+    await dialog.getByRole('button', { name: 'Done' }).click();
+    await expect(dialog).toBeHidden();
+    await revokeMinted(page);
+  });
+});

--- a/web/e2e/registry.test.ts
+++ b/web/e2e/registry.test.ts
@@ -110,6 +110,7 @@ describe('the execution half of closure', () => {
           'shell\tprojects\tlight',
           'shell\tsettings\tdark',
           'reveal\tvalues\tdark',
+          'machine-access\tmachine-access\tdark',
         ),
       ),
     ).toEqual([]);
@@ -117,7 +118,12 @@ describe('the execution half of closure', () => {
 
   it('fails a surface that was claimed but never asserted', () => {
     const problems = unexecutedClaims(
-      log('login\tlogin\tdark', 'shell\toverview\tdark', 'reveal\tvalues\tdark'),
+      log(
+        'login\tlogin\tdark',
+        'shell\toverview\tdark',
+        'reveal\tvalues\tdark',
+        'machine-access\tmachine-access\tdark',
+      ),
     );
     expect(problems).toHaveLength(2);
     expect(problems.join(' ')).toContain('claims surface "projects" but the pinned assertion set never ran');
@@ -125,7 +131,10 @@ describe('the execution half of closure', () => {
   });
 
   it('fails everything when nothing ran at all', () => {
-    expect(unexecutedClaims('')).toHaveLength(5);
+    // One line per (flow, surface) pair in the registry.
+    expect(unexecutedClaims('')).toHaveLength(
+      FLOWS.reduce((total, flow) => total + flow.surfaces.length, 0),
+    );
   });
 
   it('does not accept another flow\'s execution as this one\'s', () => {

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -38,6 +38,11 @@ export const FLOWS: readonly Flow[] = [
   { id: 'login', spec: 'flows/login.spec.ts', surfaces: ['login'] },
   { id: 'shell', spec: 'flows/shell.spec.ts', surfaces: ['overview', 'projects', 'settings'] },
   { id: 'reveal', spec: 'flows/reveal.spec.ts', surfaces: ['values'] },
+  {
+    id: 'machine-access',
+    spec: 'flows/machine-access.spec.ts',
+    surfaces: ['machine-access'],
+  },
 ];
 
 /**

--- a/web/src/api/identities.test.ts
+++ b/web/src/api/identities.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dismissDecision,
+  expiryLabel,
+  grantWideningReach,
+  lastUsedLabel,
+  parseClaimNumber,
+  postStateReach,
+  pullRequestRefusal,
+  scopeOf,
+  setupJourney,
+  type Grant,
+  type MachineCredential,
+} from './identities.ts';
+
+/**
+ * The machine-access surface's derivations (#67).
+ *
+ * These are the pieces where a wrong answer is a SECURITY statement rather than
+ * a layout bug: which environments a service account reaches, whether the mint
+ * needs a disclosure ceremony, and whether a pull-request identity is being
+ * bound. Each is a pure function precisely so it can be pinned here rather than
+ * inferred from a screenshot.
+ */
+
+const ENVS = [
+  { id: 'env_dev', name: 'development' },
+  { id: 'env_prod', name: 'production' },
+];
+
+const grant = (
+  principal: string,
+  capability: string,
+  scope: { project_id?: string; environment_id?: string },
+): Grant => ({
+  id: 'gr_00000000-0000-0000-0000-000000000000',
+  principal_id: principal,
+  capability,
+  scope: { org_id: 'org_x', project_id: 'prj_x', ...scope },
+  origins: [],
+  created_at: '2026-08-13T00:00:00Z',
+});
+
+describe('scopeOf', () => {
+  it('reads one environment-scoped grant as reach on that environment only', () => {
+    const scope = scopeOf([grant('mp_a', 'read', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    expect(scope).toEqual([
+      { id: 'env_dev', name: 'development', read: true, reveal: false },
+      { id: 'env_prod', name: 'production', read: false, reveal: false },
+    ]);
+  });
+
+  it('lets a project-scoped grant reach every environment beneath it', () => {
+    // The ordinary downward inheritance. A listing confined to one project has
+    // no wider row, so an absent environment_id can only mean project scope.
+    const scope = scopeOf([grant('mp_a', 'read', {})], 'mp_a', ENVS);
+    expect(scope.every((s) => s.read)).toBe(true);
+  });
+
+  it('never reads another principal\'s grant as this one\'s', () => {
+    const scope = scopeOf([grant('mp_other', 'read', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    expect(scope.some((s) => s.read)).toBe(false);
+  });
+});
+
+describe('postStateReach', () => {
+  it('is empty without reveal, however read is granted', () => {
+    // The state every workload principal is in today: the permission model's
+    // machine allowlist admits `read` and nothing else, so nothing this
+    // account holds reaches plaintext and the mint's disclosure conjunct is
+    // vacuous.
+    const scope = scopeOf([grant('mp_a', 'read', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    expect(postStateReach(scope)).toEqual([]);
+  });
+
+  it('is empty with reveal but no read: no delivery means no plaintext', () => {
+    const scope = scopeOf([grant('mp_a', 'reveal', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    expect(postStateReach(scope)).toEqual([]);
+  });
+
+  it('names the environment when both are held', () => {
+    const scope = scopeOf(
+      [
+        grant('mp_a', 'read', { environment_id: 'env_dev' }),
+        grant('mp_a', 'reveal', { environment_id: 'env_dev' }),
+      ],
+      'mp_a',
+      ENVS,
+    );
+    expect(postStateReach(scope).map((s) => s.name)).toEqual(['development']);
+  });
+});
+
+describe('grantWideningReach', () => {
+  // The mint's conjunct for a GRANT is the DELTA, not the whole post-state:
+  // `checkMachineWidening` computes exactly that server-side, so a client
+  // asking for a ceremony over everything the account already reaches would
+  // prompt for authority the server never consumes.
+  it('is empty for a read grant on an account that cannot decrypt', () => {
+    // The state of every workload principal today.
+    expect(grantWideningReach(scopeOf([], 'mp_a', ENVS), 'env_dev', 'read')).toEqual([]);
+  });
+
+  it('names the environment when the read grant completes an existing reveal', () => {
+    // `reveal` without `read` reaches nothing; adding `read` is what turns it
+    // into a working path to plaintext, and that IS a widening.
+    const scope = scopeOf([grant('mp_a', 'reveal', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    expect(grantWideningReach(scope, 'env_dev', 'read').map((s) => s.name)).toEqual(['development']);
+  });
+
+  it('is empty when the environment was already reachable', () => {
+    const scope = scopeOf(
+      [
+        grant('mp_a', 'read', { environment_id: 'env_dev' }),
+        grant('mp_a', 'reveal', { environment_id: 'env_dev' }),
+      ],
+      'mp_a',
+      ENVS,
+    );
+    expect(grantWideningReach(scope, 'env_dev', 'read')).toEqual([]);
+  });
+
+  it('never widens an environment the grant does not name', () => {
+    const scope = scopeOf([grant('mp_a', 'reveal', {})], 'mp_a', ENVS);
+    expect(grantWideningReach(scope, 'env_dev', 'read').map((s) => s.id)).toEqual(['env_dev']);
+  });
+});
+
+describe('parseClaimNumber', () => {
+  // An immutable repository id is what stops a renamed-and-reused path
+  // inheriting a production binding. Every case below is a way `Number()`
+  // silently binds the wrong repository.
+  it('takes a plain integer', () => {
+    expect(parseClaimNumber('4242')).toBe(4242);
+    expect(parseClaimNumber(' 4242 ')).toBe(4242);
+    expect(parseClaimNumber('-7')).toBe(-7);
+  });
+
+  it('refuses an empty field rather than binding repository 0', () => {
+    expect(parseClaimNumber('')).toBeNull();
+    expect(parseClaimNumber('   ')).toBeNull();
+  });
+
+  it('refuses anything that is not digits', () => {
+    expect(parseClaimNumber('1e3')).toBeNull();
+    expect(parseClaimNumber('4242.7')).toBeNull();
+    expect(parseClaimNumber('0x10')).toBeNull();
+    expect(parseClaimNumber('42abc')).toBeNull();
+  });
+
+  it('refuses a value past the range JSON carries exactly', () => {
+    // 2^53 + 1 rounds to 2^53 — a DIFFERENT, existing repository id.
+    expect(parseClaimNumber('9007199254740993')).toBeNull();
+    expect(parseClaimNumber('9007199254740991')).toBe(9_007_199_254_740_991);
+  });
+});
+
+describe('dismissDecision', () => {
+  it('ignores a dismissal while the mint is in flight', () => {
+    // Escape reaches a native <dialog> even when Cancel is disabled. Unmounting
+    // here would lose a value the server may already have committed.
+    expect(dismissDecision({ busy: true, hasValue: false, stored: false })).toBe('ignore');
+    expect(dismissDecision({ busy: true, hasValue: true, stored: true })).toBe('ignore');
+  });
+
+  it('holds the dialog open until the value is confirmed stored', () => {
+    expect(dismissDecision({ busy: false, hasValue: true, stored: false })).toBe('hold-back');
+  });
+
+  it('closes once there is nothing to lose', () => {
+    expect(dismissDecision({ busy: false, hasValue: false, stored: false })).toBe('close');
+    expect(dismissDecision({ busy: false, hasValue: true, stored: true })).toBe('close');
+  });
+});
+
+describe('setupJourney', () => {
+  it('has no journey for an automation principal', () => {
+    expect(setupJourney('automation', [])).toBeNull();
+  });
+
+  it('waits on the read grant before anything else', () => {
+    const steps = setupJourney('workload', scopeOf([], 'mp_a', ENVS)) ?? [];
+    expect(steps.map((s) => s.state)).toEqual(['done', 'next', 'next', 'unavailable', 'unavailable']);
+  });
+
+  it('marks delivery done once read is granted, and never invents a refusal', () => {
+    const scope = scopeOf([grant('mp_a', 'read', { environment_id: 'env_dev' })], 'mp_a', ENVS);
+    const steps = setupJourney('workload', scope) ?? [];
+    expect(steps[1]?.title).toBe('read granted — development');
+    expect(steps[2]?.state).toBe('done');
+    // The two steps this build cannot perform say so rather than offering a
+    // control the server refuses every time.
+    expect(steps[3]?.state).toBe('unavailable');
+    expect(steps[4]?.state).toBe('unavailable');
+  });
+});
+
+const credential = (over: Partial<MachineCredential>): MachineCredential => ({
+  id: 'mcr_00000000-0000-0000-0000-000000000000',
+  kind: 'hikyo-token',
+  lifetime: 'finite',
+  created_at: '2026-08-01T00:00:00Z',
+  created_by: 'pr_00000000-0000-0000-0000-000000000000',
+  expiring_soon: false,
+  ...over,
+});
+
+describe('expiryLabel', () => {
+  const now = new Date('2026-08-13T00:00:00Z');
+
+  it('counts the days left', () => {
+    expect(expiryLabel(credential({ expires_at: '2026-08-27T00:00:00Z' }), now)).toBe(
+      'expires in 14 days',
+    );
+  });
+
+  it('says expired rather than a negative count', () => {
+    expect(expiryLabel(credential({ expires_at: '2026-08-01T00:00:00Z' }), now)).toBe('expired');
+  });
+
+  it('says revoked first, whatever the expiry says', () => {
+    const dead = credential({ expires_at: '2026-12-01T00:00:00Z', revoked_at: '2026-08-02T00:00:00Z' });
+    expect(expiryLabel(dead, now)).toBe('revoked');
+  });
+
+  it('states an indefinite lifetime as a fact, not as a large number', () => {
+    expect(expiryLabel(credential({ lifetime: 'indefinite' }), now)).toBe('no expiry');
+  });
+});
+
+describe('lastUsedLabel', () => {
+  it('keeps never-used and used-at-the-epoch different facts', () => {
+    expect(lastUsedLabel(credential({}))).toBe('never used');
+    expect(lastUsedLabel(credential({ last_used_at: '1970-01-01T00:00:00Z' }))).toBe(
+      'last used 1970-01-01',
+    );
+  });
+});
+
+describe('pullRequestRefusal', () => {
+  it('refuses both pull-request events by name', () => {
+    expect(pullRequestRefusal('pull_request')).toContain('pull_request');
+    expect(pullRequestRefusal('pull_request_target')).toContain('pull_request_target');
+  });
+
+  it('passes the ordinary events', () => {
+    expect(pullRequestRefusal('push')).toBeNull();
+    expect(pullRequestRefusal('workflow_dispatch')).toBeNull();
+  });
+
+  it('is not fooled by an event that merely contains the word', () => {
+    // The rule is about the pinned event being one of exactly two values, not
+    // about the string looking pull-request-ish.
+    expect(pullRequestRefusal('pull_request_review')).toBeNull();
+  });
+});

--- a/web/src/api/identities.ts
+++ b/web/src/api/identities.ts
@@ -1,0 +1,719 @@
+import {
+  createEnvGrant,
+  createFederatedBinding,
+  listKeys,
+  listMachineCredentials,
+  listProjectGrants,
+  listServiceAccounts,
+  mintMachineCredential,
+  revokeMachineCredential,
+  type FederatedClaimPin,
+} from '@hikyo/client';
+import {
+  zFederatedBinding,
+  zGrantList,
+  zGrantResult,
+  zKeyList,
+  zMachineCredentialList,
+  zMintCredentialResult,
+  zServiceAccountList,
+} from '@hikyo/zod';
+import { useMutation, useQueries, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import type { z } from 'zod';
+
+import { ApiError, parsed } from './client.ts';
+
+/**
+ * The machine-access surface, as the SPA sees it (#67, locked prototype #31
+ * iteration 3).
+ *
+ * Everything here crosses its generated schema before a component sees it, and
+ * two of this file's rules exist because the ADRs put them here rather than in
+ * the component:
+ *
+ *  - **A credential value exists in exactly one response.** `MachineCredential`
+ *    has no value member and no route returns one after the mint, so the only
+ *    place plaintext can enter the SPA is `useMintCredential`'s result — which
+ *    is why the mint dialog is the only component that ever holds one.
+ *  - **The post-state reach is what the mint's formula ranges over**, not what
+ *    the mint adds. A mint adds no grants, so the post-state IS the current
+ *    state: the environments the service account can already decrypt. That set
+ *    decides whether the human must reauthenticate, and it is computed from the
+ *    server's grant rows rather than guessed.
+ */
+
+export type ServiceAccount = z.infer<typeof zServiceAccountList>['items'][number];
+export type MachineCredential = z.infer<typeof zMachineCredentialList>['items'][number];
+export type Grant = z.infer<typeof zGrantList>['items'][number];
+/**
+ * ClaimPin is the READ shape — the parsed one, whose `number_value` is a bigint
+ * because an int64 repository id does not survive a float. The REQUEST shape is
+ * the generated `FederatedClaimPin`, which carries a plain number: they are two
+ * different types on purpose and neither is re-declared here.
+ */
+export type ClaimPin = NonNullable<MachineCredential['required_claims']>[number];
+
+export type ProjectRef = { org: string; project: string };
+
+const accountsKey = (p: ProjectRef) => ['service-accounts', p.org, p.project] as const;
+const credentialsKey = (p: ProjectRef, sa: string) =>
+  ['machine-credentials', p.org, p.project, sa] as const;
+const projectGrantsKey = (p: ProjectRef) => ['project-grants', p.org, p.project] as const;
+
+/** useServiceAccounts lists the project's machine principals. Metadata only. */
+export function useServiceAccounts(
+  p: ProjectRef,
+): UseQueryResult<z.infer<typeof zServiceAccountList>> {
+  return useQuery({
+    queryKey: accountsKey(p),
+    queryFn: () =>
+      parsed(listServiceAccounts({ path: { org: p.org, project: p.project } }), zServiceAccountList),
+    retry: false,
+  });
+}
+
+/**
+ * useProjectGrants is how the surface learns each service account's SCOPE.
+ *
+ * It is a separate query from the account listing because it is a separate
+ * authority: listing accounts is `manage-identities`, and the membership
+ * surface is `manage-members`. A principal who administers identities but not
+ * members gets the accounts and an honest "scope unavailable" rather than a
+ * blank column that reads like "no grants".
+ */
+export function useProjectGrants(p: ProjectRef): UseQueryResult<z.infer<typeof zGrantList>> {
+  return useQuery({
+    queryKey: projectGrantsKey(p),
+    queryFn: () =>
+      parsed(listProjectGrants({ path: { org: p.org, project: p.project } }), zGrantList),
+    retry: false,
+  });
+}
+
+/**
+ * useKeyCatalogue is the grant warning's blast-radius source: every key's name
+ * and classification, and NOTHING with a value member.
+ *
+ * Deliberately `listKeys`, not `listValues`: a value listing is authorized for
+ * the HUMAN reading it, so it carries config plaintext this surface never
+ * renders — and a fetch is a copy, cached by the query client where any
+ * same-page script can read it. The catalogue endpoint answers the only
+ * question the warning asks (what exists, of which classification) without
+ * ever holding a value of any kind.
+ */
+export function useKeyCatalogue(p: ProjectRef): UseQueryResult<z.infer<typeof zKeyList>> {
+  return useQuery({
+    queryKey: ['key-catalogue', p.org, p.project] as const,
+    queryFn: () => parsed(listKeys({ path: { org: p.org, project: p.project } }), zKeyList),
+    retry: false,
+  });
+}
+
+type CredentialsByAccount = {
+  readonly byAccount: ReadonlyMap<string, readonly MachineCredential[]>;
+  readonly isPending: boolean;
+  readonly isError: boolean;
+};
+
+/**
+ * useCredentials fetches every account's credential rows.
+ *
+ * All of them, not just the expanded row: the Federation tab is the same rows
+ * filtered by kind, and the tab counts are the sizes of those sets — so a
+ * fetch-on-expand would leave the tabs unable to say how much they hold.
+ */
+export function useCredentials(
+  p: ProjectRef,
+  accounts: readonly ServiceAccount[],
+): CredentialsByAccount {
+  return useQueries({
+    queries: accounts.map((sa) => ({
+      queryKey: credentialsKey(p, sa.id),
+      queryFn: () =>
+        parsed(
+          listMachineCredentials({
+            path: { org: p.org, project: p.project, serviceAccount: sa.id },
+          }),
+          zMachineCredentialList,
+        ),
+      retry: false,
+    })),
+    combine: (results) => ({
+      byAccount: new Map(
+        accounts.map((sa, index) => [sa.id, results[index]?.data?.items ?? []] as const),
+      ),
+      isPending: results.some((r) => r.isPending),
+      isError: results.some((r) => r.isError),
+    }),
+  });
+}
+
+/**
+ * zMinted is the mint result NARROWED to what a caller may keep.
+ *
+ * Deliberately not the whole `MintCredentialResult`: the nested credential
+ * metadata is re-read from the listing a moment later anyway, and parsing it
+ * here would let a drift in an unrelated member throw away the one member
+ * nothing in the system can ever return again. `clamped` stays because the
+ * operator has to be told the ceiling shortened what they asked for rather than
+ * discover it when the credential dies early.
+ */
+const zMinted = zMintCredentialResult.pick({ value: true, clamped: true });
+
+/**
+ * mintCredential is the display-once mint, and it is deliberately NOT a
+ * `useMutation`.
+ *
+ * TanStack keeps a mutation's result in a global cache until garbage
+ * collection, so a mint run through it would leave the plaintext credential
+ * reachable from the query client long after the dialog that showed it closed —
+ * a second copy of a value whose whole contract is that there is one. A plain
+ * async call leaves the value in exactly one place: the component that renders
+ * it once.
+ */
+export async function mintCredential(
+  p: ProjectRef,
+  serviceAccount: string,
+): Promise<z.infer<typeof zMinted>> {
+  return parsed(
+    mintMachineCredential({
+      path: { org: p.org, project: p.project, serviceAccount },
+      body: {},
+    }),
+    zMinted,
+  );
+}
+
+/**
+ * useRefreshAccount re-reads what a mint changed.
+ *
+ * It exists because the mint above is not a mutation and therefore has no
+ * `onSuccess` — and because a mint whose response never arrived may still have
+ * COMMITTED, so the caller has to be able to refresh on the failure path too.
+ */
+export function useRefreshAccount(p: ProjectRef): (serviceAccount: string) => void {
+  const queries = useQueryClient();
+  return (serviceAccount: string) => {
+    void queries.invalidateQueries({ queryKey: credentialsKey(p, serviceAccount) });
+    void queries.invalidateQueries({ queryKey: accountsKey(p) });
+  };
+}
+
+/**
+ * useRefreshGrants re-reads the scope surface, for the same reason
+ * useRefreshAccount exists: a grant whose response never arrived may still
+ * have COMMITTED, and a committed widening must show in the scope column even
+ * when the dialog reports a failure.
+ */
+export function useRefreshGrants(p: ProjectRef): () => void {
+  const queries = useQueryClient();
+  return () => {
+    void queries.invalidateQueries({ queryKey: projectGrantsKey(p) });
+  };
+}
+
+/**
+ * useRevokeCredential retires one credential. It is NOT deprovisioning: grants
+ * are untouched and siblings keep working, which is what makes rotation
+ * (mint, distribute, then revoke) a sequence of two deliberate acts.
+ */
+export function useRevokeCredential(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { serviceAccount: string; credential: string }) => {
+      const result = await revokeMachineCredential({
+        path: {
+          org: p.org,
+          project: p.project,
+          serviceAccount: input.serviceAccount,
+          credential: input.credential,
+        },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, `revoke failed with ${result.response.status}`);
+      }
+    },
+    onSuccess: (_void, input) => {
+      void queries.invalidateQueries({ queryKey: credentialsKey(p, input.serviceAccount) });
+      void queries.invalidateQueries({ queryKey: accountsKey(p) });
+    },
+  });
+}
+
+/** useCreateBinding mints a federated `(issuer, subject)` binding. */
+export function useCreateBinding(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      serviceAccount: string;
+      issuer: string;
+      subject: string;
+      audience: string;
+      requiredClaims: readonly FederatedClaimPin[];
+      lifetimeSeconds?: number;
+    }) =>
+      parsed(
+        createFederatedBinding({
+          path: { org: p.org, project: p.project, serviceAccount: input.serviceAccount },
+          body: {
+            issuer: input.issuer,
+            subject: input.subject,
+            audience: input.audience,
+            required_claims: input.requiredClaims.map((pin) => ({ ...pin })),
+            ...(input.lifetimeSeconds === undefined
+              ? {}
+              : { lifetime_seconds: input.lifetimeSeconds }),
+          },
+        }),
+        zFederatedBinding,
+      ),
+    onSuccess: (_result, input) => {
+      void queries.invalidateQueries({ queryKey: credentialsKey(p, input.serviceAccount) });
+      // A binding IS a live credential, so the account's `live_credentials` —
+      // the number the grant warning quotes — moved too.
+      void queries.invalidateQueries({ queryKey: accountsKey(p) });
+    },
+  });
+}
+
+/**
+ * useGrantEnvironment adds one capability to a machine principal on one
+ * environment. The warning the caller shows first is not decoration: the grant
+ * attaches to the SERVICE ACCOUNT, so every credential already in circulation
+ * is re-scoped the moment it lands.
+ */
+export function useGrantEnvironment(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environment: string; principal: string; capability: string }) =>
+      parsed(
+        createEnvGrant({
+          path: { org: p.org, project: p.project, environment: input.environment },
+          body: { principal: input.principal, capability: input.capability },
+        }),
+        zGrantResult,
+      ),
+    onSuccess: () => queries.invalidateQueries({ queryKey: projectGrantsKey(p) }),
+  });
+}
+
+// --- derivation, all of it pure --------------------------------------------
+
+export type EnvironmentRef = { readonly id: string; readonly name: string };
+
+/** MachineEnvScope is what one service account reaches in one environment. */
+export type MachineEnvScope = {
+  readonly id: string;
+  readonly name: string;
+  /** `read` delivers configuration and secret PRESENCE — never plaintext. */
+  readonly read: boolean;
+  /** `reveal` is the standing decryption capability, the ◆ in the prototype. */
+  readonly reveal: boolean;
+};
+
+/**
+ * scopeOf resolves a principal's grant rows into per-environment reach.
+ *
+ * A row with no `environment_id` is PROJECT-scoped and reaches every
+ * environment beneath it — the ordinary downward inheritance. The listing this
+ * reads is already confined to one project, so there is no wider row to
+ * mistake for a narrow one.
+ */
+export function scopeOf(
+  grants: readonly Grant[],
+  principalId: string,
+  environments: readonly EnvironmentRef[],
+): MachineEnvScope[] {
+  const mine = grants.filter((g) => g.principal_id === principalId);
+  const holds = (capability: string, environment: string) =>
+    mine.some(
+      (g) =>
+        g.capability === capability &&
+        (g.scope.environment_id === undefined || g.scope.environment_id === environment),
+    );
+  return environments.map((env) => ({
+    id: env.id,
+    name: env.name,
+    read: holds('read', env.id),
+    reveal: holds('reveal', env.id),
+  }));
+}
+
+/**
+ * postStateReach is the environments a credential of this account can decrypt
+ * — the set the mint's disclosure conjunct ranges over.
+ *
+ * `read` is required as well as `reveal`, mirroring the server: no read means
+ * no delivery at all, so neither disclosure capability reaches plaintext
+ * however it is granted.
+ */
+export function postStateReach(scope: readonly MachineEnvScope[]): MachineEnvScope[] {
+  return scope.filter((s) => s.read && s.reveal);
+}
+
+/**
+ * grantWideningReach is the mint's conjunct for a GRANT: the environments the
+ * account would newly decrypt, not the whole post-state.
+ *
+ * The difference is the ADR's, not a nuance: a mint adds no grants, so its
+ * formula ranges over everything the account already reaches; a grant adds one,
+ * so its formula ranges over the DELTA. `checkMachineWidening` computes exactly
+ * this server-side, and a client that asked for a ceremony over the whole
+ * post-state would prompt for authority the server never consumes.
+ *
+ * For a `read` grant the delta is empty unless the account already holds
+ * `reveal` there — which is why it is vacuous today: the machine allowlist
+ * admits `read` and nothing else on a workload principal.
+ */
+export function grantWideningReach(
+  scope: readonly MachineEnvScope[],
+  environmentId: string,
+  capability: 'read' | 'reveal',
+): MachineEnvScope[] {
+  const after = scope.map((s) =>
+    s.id === environmentId
+      ? { ...s, read: s.read || capability === 'read', reveal: s.reveal || capability === 'reveal' }
+      : s,
+  );
+  const before = new Set(postStateReach(scope).map((s) => s.id));
+  return postStateReach(after).filter((s) => !before.has(s.id));
+}
+
+/**
+ * parseClaimNumber turns a typed int64 pin into a number, or refuses.
+ *
+ * `Number()` is not usable here and the failures are not cosmetic: an empty
+ * field becomes 0, which is a valid-looking repository id nobody owns; `1e3`
+ * and `4242.7` are accepted; and anything past 2^53 silently rounds to a
+ * NEIGHBOURING repository id — which would bind a production service account to
+ * whatever repository happens to hold that number. Digits only, and inside the
+ * range JSON can carry losslessly.
+ */
+export function parseClaimNumber(raw: string): number | null {
+  if (!/^-?[0-9]+$/.test(raw.trim())) {
+    return null;
+  }
+  const value = Number(raw.trim());
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
+ * dismissDecision is what a dismissal attempt on the mint dialog does.
+ *
+ * Three outcomes, and the first is the one that is easy to miss: **while the
+ * mint is in flight there is no dismissal at all.** Escape reaches a native
+ * `<dialog>` even when the Cancel button is disabled, and unmounting mid-flight
+ * would let a value the server DID commit arrive at a component that no longer
+ * exists — losing it exactly as thoroughly as never minting it, while leaving a
+ * live credential behind. After that, a shown value holds the dialog open until
+ * the operator confirms they stored it, because there is no second look.
+ *
+ * It is a function rather than three `if`s in a handler so the rule can be
+ * checked without a DOM: the failure it guards against is invisible in a
+ * screenshot.
+ */
+export function dismissDecision(input: {
+  busy: boolean;
+  hasValue: boolean;
+  stored: boolean;
+}): 'ignore' | 'hold-back' | 'close' {
+  if (input.busy) {
+    return 'ignore';
+  }
+  if (input.hasValue && !input.stored) {
+    return 'hold-back';
+  }
+  return 'close';
+}
+
+/** isoDay renders an instant as the calendar day, which is all these surfaces show. */
+export function isoDay(timestamp: string): string {
+  return timestamp.slice(0, 10);
+}
+
+export type JourneyState = 'done' | 'next' | 'unavailable';
+
+export type JourneyStep = {
+  readonly title: string;
+  readonly note: string;
+  readonly state: JourneyState;
+};
+
+/**
+ * setupJourney is the five-step workload-integration journey (#18, the locked
+ * prototype's rail), told against what this build can actually do.
+ *
+ * Steps 4 and 5 are `unavailable` rather than `next`, and that is the honest
+ * rendering: the per-project machine-reveal opt-in has no server surface yet,
+ * and the permission model's machine allowlist admits `read` and nothing else
+ * on a workload principal — so a "grant reveal" button would be a control that
+ * is refused every time it is pressed. The prototype's verbatim delivery
+ * refusal is left out for the same reason: this build's delivery never refuses,
+ * it delivers configuration and secret presence, and rendering a refusal would
+ * describe a state the server does not produce.
+ *
+ * `null` for an automation principal: automation never delivers to a workload,
+ * so it has no setup journey at all.
+ */
+export function setupJourney(
+  kind: 'workload' | 'automation',
+  scope: readonly MachineEnvScope[],
+): JourneyStep[] | null {
+  if (kind === 'automation') {
+    return null;
+  }
+  const read = scope.filter((s) => s.read);
+  const named = read.map((s) => s.name).join(', ');
+  return [
+    {
+      title: 'Service account minted',
+      note: 'kind: workload — immutable at creation',
+      state: 'done',
+    },
+    {
+      title:
+        read.length === 0
+          ? 'Grant read on an environment'
+          : `read granted — ${named}`,
+      note: 'delivers configuration and secret presence only',
+      state: read.length === 0 ? 'next' : 'done',
+    },
+    {
+      title:
+        read.length === 0
+          ? 'First delivery'
+          : 'First delivery succeeds — configuration and secret presence',
+      note: 'a fetch that delivers no values is still an audited access record',
+      state: read.length === 0 ? 'next' : 'done',
+    },
+    {
+      title: 'Project machine-reveal opt-in',
+      note: 'not part of this build: the per-project opt-in that admits a standing decryption capability has no server surface yet (#17/#18)',
+      state: 'unavailable',
+    },
+    {
+      title: 'Grant reveal',
+      note: 'not part of this build: a workload principal may hold read and nothing else until the opt-in lands, so no credential here reaches plaintext',
+      state: 'unavailable',
+    },
+  ];
+}
+
+/**
+ * expiryLabel is the in-product-first expiry signal (#17): the product says so
+ * before any email does, and it says it in words rather than in a colour.
+ */
+export function expiryLabel(credential: MachineCredential, now: Date): string {
+  if (credential.revoked_at !== undefined) {
+    return 'revoked';
+  }
+  if (credential.lifetime === 'indefinite') {
+    return 'no expiry';
+  }
+  if (credential.expires_at === undefined) {
+    return 'expiry unknown';
+  }
+  const days = Math.ceil((new Date(credential.expires_at).getTime() - now.getTime()) / 86_400_000);
+  if (days <= 0) {
+    return 'expired';
+  }
+  return `expires in ${String(days)} ${days === 1 ? 'day' : 'days'}`;
+}
+
+/** lastUsedLabel keeps "never used" and "used at the epoch" different facts. */
+export function lastUsedLabel(credential: MachineCredential): string {
+  return credential.last_used_at === undefined
+    ? 'never used'
+    : `last used ${isoDay(credential.last_used_at)}`;
+}
+
+export type IssuerPlatform = 'kubernetes' | 'forgejo' | 'github-actions';
+
+export type ClaimField = {
+  readonly claim: string;
+  readonly label: string;
+  readonly kind: 'string' | 'number' | 'event';
+};
+
+export type FederationPreset = {
+  readonly id: IssuerPlatform;
+  readonly label: string;
+  readonly issuer: string;
+  readonly subject: string;
+  readonly audience: string;
+  /**
+   * The claims this platform's bindings MUST pin, which the server refuses a
+   * binding without. They are fields rather than fixed values because the
+   * immutable identifiers are per-repository and per-cluster.
+   */
+  readonly claims: readonly ClaimField[];
+};
+
+/**
+ * FEDERATION_PRESETS carry the per-platform pin rules the server enforces at
+ * binding creation, so the form asks for them rather than letting the operator
+ * discover them as a 400.
+ *
+ * Kubernetes pins the ServiceAccount UID through its JSON Pointer — a
+ * recreated ServiceAccount with the same name has a different UID, which is
+ * precisely what the pin closes. The two CI platforms must pin `event_name`,
+ * and GitHub Actions additionally pins the numeric repository ids, because a
+ * renamed-and-reused repository path would otherwise inherit the binding.
+ */
+export const KUBERNETES_PRESET: FederationPreset = {
+  id: 'kubernetes',
+  label: 'Kubernetes ServiceAccount token',
+  issuer: 'https://kubernetes.default.svc.cluster.local',
+  subject: 'system:serviceaccount:hikyo-system:hikyo-fetch',
+  audience: '',
+  claims: [
+    { claim: '/kubernetes.io/serviceaccount/uid', label: 'ServiceAccount UID', kind: 'string' },
+  ],
+};
+
+const FORGEJO_PRESET: FederationPreset = {
+  id: 'forgejo',
+  label: 'Forgejo Actions',
+  issuer: 'https://git.example.org',
+  subject: 'repo:owner/repository:ref:refs/heads/main',
+  audience: '',
+  claims: [
+    { claim: 'repository', label: 'Repository', kind: 'string' },
+    { claim: 'event_name', label: 'Event name', kind: 'event' },
+  ],
+};
+
+const GITHUB_ACTIONS_PRESET: FederationPreset = {
+  id: 'github-actions',
+  label: 'GitHub Actions',
+  issuer: 'https://token.actions.githubusercontent.com',
+  subject: 'repo:owner/repository:ref:refs/heads/main',
+  audience: '',
+  claims: [
+    { claim: 'repository_id', label: 'Repository id', kind: 'number' },
+    { claim: 'repository_owner_id', label: 'Repository owner id', kind: 'number' },
+    { claim: 'event_name', label: 'Event name', kind: 'event' },
+  ],
+};
+
+export const FEDERATION_PRESETS: readonly FederationPreset[] = [
+  KUBERNETES_PRESET,
+  FORGEJO_PRESET,
+  GITHUB_ACTIONS_PRESET,
+];
+
+/** presetFieldId keeps a JSON-Pointer claim usable as an element id. */
+export function presetFieldId(claim: string): string {
+  return `binding-${claim.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '')}`;
+}
+
+/**
+ * BINDING_LIFETIMES is the binding's own lifetime, which is #17's rule rather
+ * than a convenience: a binding is a standing permission to present tokens and
+ * expires on the same terms as a bearer credential — renewal is a mint, never
+ * an edit, because bindings are immutable.
+ *
+ * `indefinite` is present and DISABLED with its reason, exactly as the frozen
+ * prototype has it: the instance opt-in that admits it is off by default, and a
+ * missing option would leave an operator wondering whether the product has the
+ * concept at all.
+ */
+export const BINDING_LIFETIMES: ReadonlyArray<{
+  readonly id: string;
+  readonly label: string;
+  readonly seconds?: number;
+  readonly disabled?: boolean;
+}> = [
+  { id: 'default', label: 'Instance default' },
+  { id: '30d', label: '30 days', seconds: 30 * 24 * 60 * 60 },
+  { id: '90d', label: '90 days', seconds: 90 * 24 * 60 * 60 },
+  {
+    id: 'indefinite',
+    label: 'Indefinite — requires the instance allow_indefinite opt-in',
+    disabled: true,
+  },
+];
+
+/** The events a CI binding can pin. The last two are the refused pair. */
+export const CI_EVENTS = ['push', 'workflow_dispatch', 'pull_request', 'pull_request_target'] as const;
+
+/**
+ * pullRequestRefusal names why a pull-request binding is refused.
+ *
+ * The protection comes from the PINNED EVENT, never from the subject's shape:
+ * a `pull_request_target` token carries the ordinary ref-form subject — the
+ * default branch's, the one a production binding names — so a binding that
+ * pinned only the subject would already be reachable from a pull request.
+ * Returning the sentence rather than a boolean keeps what is shown and what is
+ * refused as one thing.
+ */
+export function pullRequestRefusal(eventName: string): string | null {
+  if (eventName !== 'pull_request' && eventName !== 'pull_request_target') {
+    return null;
+  }
+  return (
+    `Refused: this binding pins event_name ${eventName}. A pull-request workflow runs ` +
+    `third-party code, so binding it hands every pull-request author this service ` +
+    `account's fetch authority.`
+  );
+}
+
+/**
+ * identityRefusalText names what actually happened, in the vocabulary of the
+ * act that failed. A machine-identity refusal is never "your access may have
+ * changed" — the caller holds `manage-identities` or they never saw the page.
+ */
+export function identityRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return 'The server refused that as malformed. Check the issuer, subject, audience and the pinned claims — every one of them is matched byte-for-byte.';
+      case 403:
+        return 'The server refused this act. Minting or binding needs a disclosure capability over every environment the account reaches in the resulting state, plus a fresh reauthentication.';
+      case 404:
+        return 'That service account is no longer here.';
+      case 409:
+        return 'The server refused this as a conflict: the live-credential ceiling, or an identical binding that already exists.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The act could not be completed (server error ${String(error.status)}).`;
+    }
+  }
+  if (error instanceof Error && error.name === 'NotAllowedError') {
+    return 'The passkey prompt was dismissed or timed out. Nothing was minted.';
+  }
+  return 'The act could not be completed.';
+}
+
+/**
+ * mintFailureText is the refusal for a mint request that WAS ISSUED.
+ *
+ * It is a different sentence from `identityRefusalText` because the honest
+ * answer is different: once the request left, a failure carries no information
+ * about whether the server committed — a transport that dropped the response,
+ * or a body this build could not parse, both leave a credential that may exist
+ * and whose value is gone forever. Saying "the mint failed" there would be a
+ * guess, and the wrong one leaves a live credential nobody is looking for.
+ */
+export function mintFailureText(error: unknown): string {
+  return `${identityRefusalText(error)} A credential may still have been minted: its value is not recoverable, so check the rows below and revoke anything you did not expect.`;
+}
+
+/**
+ * bindingFailureText is the same issued-not-confirmed honesty for a binding: a
+ * lost response may still have created a live external login path, and the row
+ * list is the only place it would show.
+ */
+export function bindingFailureText(error: unknown): string {
+  return `${identityRefusalText(error)} The binding may still have been created: check the account's rows and revoke anything you did not expect.`;
+}
+
+/**
+ * grantFailureText: a lost response may still have widened every live
+ * credential's reach, which is exactly the change the warning existed to make
+ * deliberate — so it must not be reported as "nothing happened".
+ */
+export function grantFailureText(error: unknown): string {
+  return `${identityRefusalText(error)} The grant may still have landed: the scope column shows what the account reaches now, so check it before acting again.`;
+}

--- a/web/src/api/values.ts
+++ b/web/src/api/values.ts
@@ -160,8 +160,12 @@ export type PasskeyCeremonyInput = {
    * The decision this ceremony authorizes. It goes into the SIGNED binding, so
    * an assertion given to `reveal` cannot be spent on `publish` over the same
    * environment and keys — the same unit, a different decision.
+   *
+   * `mint` is the machine-identity row (#61/#67): the credential mint and the
+   * grant-widening gate both consume a window opened under this purpose, over
+   * each environment the service account reaches in the resulting post-state.
    */
-  operation: 'reveal' | 'copy' | 'publish';
+  operation: 'reveal' | 'copy' | 'publish' | 'mint';
   environmentId: string;
   /** The enumerated unit: exactly the keys this one decision covers. */
   keyIds: readonly string[];

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 
 import { useSession } from '../api/session.ts';
 import { Login } from '../routes/Login.tsx';
+import { MachineAccess } from '../routes/MachineAccess.tsx';
 import { NotFound, Overview, Projects, Settings } from '../routes/Placeholder.tsx';
 import { Shell } from '../routes/Shell.tsx';
 import { Values } from '../routes/Values.tsx';
@@ -24,6 +25,7 @@ const ELEMENTS: Record<SurfaceId, ReactElement> = {
   projects: <Projects />,
   settings: <Settings />,
   values: <Values />,
+  'machine-access': <MachineAccess />,
 };
 
 const signedInSurfaces: readonly Surface[] = SURFACES.filter((s) => s.id !== 'login');

--- a/web/src/app/navigation.ts
+++ b/web/src/app/navigation.ts
@@ -12,7 +12,13 @@
  * login page is reached by not being signed in, never by choosing it).
  */
 
-export type SurfaceId = 'login' | 'overview' | 'projects' | 'settings' | 'values';
+export type SurfaceId =
+  | 'login'
+  | 'overview'
+  | 'projects'
+  | 'settings'
+  | 'values'
+  | 'machine-access';
 
 export type Surface = {
   readonly id: SurfaceId;
@@ -34,6 +40,17 @@ export const SURFACES: readonly Surface[] = [
     id: 'values',
     path: '/orgs/:org/projects/:project/environments/:environment/values',
     label: 'Values',
+    section: null,
+  },
+  // The machine-access surface (#67). `section: null` for the same reason
+  // `values` is: it addresses ONE project, and a static sidebar entry could not
+  // know which. It is reached from the project and by deep link. The
+  // project-scoped navigation the prototype draws around it is the shell's own
+  // ticket, not this one.
+  {
+    id: 'machine-access',
+    path: '/orgs/:org/projects/:project/machine-access',
+    label: 'Machine access',
     section: null,
   },
 ];

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1,0 +1,1688 @@
+import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react';
+import { useParams } from 'react-router';
+
+import type { FederatedClaimPin } from '@hikyo/client';
+
+import {
+  BINDING_LIFETIMES,
+  bindingFailureText,
+  CI_EVENTS,
+  dismissDecision,
+  expiryLabel,
+  FEDERATION_PRESETS,
+  grantFailureText,
+  grantWideningReach,
+  identityRefusalText,
+  isoDay,
+  KUBERNETES_PRESET,
+  lastUsedLabel,
+  mintCredential,
+  mintFailureText,
+  parseClaimNumber,
+  postStateReach,
+  presetFieldId,
+  pullRequestRefusal,
+  scopeOf,
+  setupJourney,
+  useCreateBinding,
+  useCredentials,
+  useGrantEnvironment,
+  useKeyCatalogue,
+  useProjectGrants,
+  useRefreshAccount,
+  useRefreshGrants,
+  useRevokeCredential,
+  useServiceAccounts,
+  type ClaimPin,
+  type FederationPreset,
+  type MachineCredential,
+  type MachineEnvScope,
+  type ProjectRef,
+  type ServiceAccount,
+} from '../api/identities.ts';
+import { runPasskeyCeremony, useEnvironments } from '../api/values.ts';
+
+/**
+ * The machine-access surface (#67, locked prototype #31 iteration 3).
+ *
+ * The structure is the prototype's, and each part of it is a rule rather than a
+ * layout preference:
+ *
+ *  - **A tabbed inventory** — service accounts, federation, Kubernetes targets
+ *    — with the per-project machine-reveal policy stated above the table.
+ *  - **Write-only credential rows.** Prefix hint, kind, expiry in words,
+ *    last used. Never the value: no route returns one after the mint, so there
+ *    is nothing here that could render it.
+ *  - **Row expansion leads with credentials and bindings (left), delivery
+ *    targets and actions (right), and the five-step setup journey full-width
+ *    below** — iteration 3's resolution, journey underneath rather than on top.
+ *  - **Display-once mint.** A step-up naming the post-state formula, then the
+ *    value exactly once, with a stored-confirmation checkbox gating dismiss.
+ *    Rotation is the same flow: the prior value is never returned.
+ *
+ * Where the prototype is ahead of the server this surface says so instead of
+ * pretending. The three places, each recorded in `docs/handoff/67-machine-access.md`:
+ * the per-project reveal opt-in has no server surface, Kubernetes delivery
+ * targets have no operator reporting them, and restore reconciliation has no
+ * recovery-mode signal — only the binding's own quarantine field, which IS
+ * rendered because it is real.
+ */
+
+type Tab = 'accounts' | 'federation' | 'kubernetes';
+
+type Dialog =
+  | { kind: 'mint'; account: ServiceAccount; rotating: boolean }
+  | { kind: 'binding'; account: ServiceAccount }
+  | { kind: 'grant'; account: ServiceAccount };
+
+const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
+  { id: 'accounts', label: 'Service accounts' },
+  { id: 'federation', label: 'Federation' },
+  { id: 'kubernetes', label: 'Kubernetes targets' },
+];
+
+export function MachineAccess() {
+  const params = useParams();
+  const project: ProjectRef = {
+    org: params['org'] ?? '',
+    project: params['project'] ?? '',
+  };
+
+  const accountsQuery = useServiceAccounts(project);
+  const grantsQuery = useProjectGrants(project);
+  const environmentsQuery = useEnvironments({ ...project, environment: '' });
+
+  const accounts = useMemo(() => accountsQuery.data?.items ?? [], [accountsQuery.data]);
+  const environments = useMemo(
+    () => environmentsQuery.data?.items ?? [],
+    [environmentsQuery.data],
+  );
+  const grants = useMemo(() => grantsQuery.data?.items ?? [], [grantsQuery.data]);
+  const credentials = useCredentials(project, accounts);
+
+  const [tab, setTab] = useState<Tab>('accounts');
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [dialog, setDialog] = useState<Dialog | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const revoke = useRevokeCredential(project);
+  const now = useMemo(() => new Date(), []);
+
+  const scopeFor = (sa: ServiceAccount): MachineEnvScope[] =>
+    scopeOf(grants, sa.principal_id, environments);
+  const credentialsFor = (sa: ServiceAccount): readonly MachineCredential[] =>
+    credentials.byAccount.get(sa.id) ?? [];
+  // Un-revoked, which is NOT the same as live: an expired credential is
+  // revoked_at-less and authenticates nothing. The count an operator is told is
+  // the server's own `live_credentials`, which applies the whole liveness
+  // predicate — epoch, revocation and expiry. This filter only decides which
+  // rows are worth showing.
+  const showable = (rows: readonly MachineCredential[]) =>
+    rows.filter((c) => c.revoked_at === undefined);
+  const bearers = (rows: readonly MachineCredential[]) =>
+    showable(rows).filter((c) => c.kind === 'hikyo-token');
+  const bindings = (rows: readonly MachineCredential[]) =>
+    showable(rows).filter((c) => c.kind === 'oidc-federation');
+
+  const allBindings = accounts.flatMap((sa) =>
+    bindings(credentialsFor(sa)).map((credential) => ({ account: sa, credential })),
+  );
+
+  /**
+   * inputsReady gates every act on the surface.
+   *
+   * Each dialog's warning is an assertion about state — how many credentials a
+   * grant re-scopes, which environments a mint's formula ranges over — and a
+   * query that failed answers those questions with a confident zero. Refusing
+   * to act on a half-read surface is the only honest option: the alternative is
+   * a warning that understates what the operator is about to do.
+   */
+  const inputsReady =
+    accountsQuery.isSuccess &&
+    grantsQuery.isSuccess &&
+    environmentsQuery.isSuccess &&
+    !credentials.isPending &&
+    !credentials.isError;
+
+  const tabCount: Record<Tab, string> = {
+    accounts: accountsQuery.isSuccess ? String(accounts.length) : '—',
+    // Unknown is rendered as unknown: "Federation (0)" on a failed listing
+    // reads as "there are none", which is the one thing it does not know.
+    federation: credentials.isPending || credentials.isError ? '—' : String(allBindings.length),
+    kubernetes: '0',
+  };
+
+  const doRevoke = (account: ServiceAccount, credential: MachineCredential) => {
+    setRefusal(null);
+    revoke.mutate(
+      { serviceAccount: account.id, credential: credential.id },
+      {
+        onSuccess: () =>
+          setNotice(
+            'Revoked. It stops authenticating at the next request, never at expiry — grants and sibling credentials are untouched.',
+          ),
+        onError: (error) => setRefusal(identityRefusalText(error)),
+      },
+    );
+  };
+
+  return (
+    <section className="card card--wide machine" aria-labelledby="machine-title">
+      <header className="values__head">
+        <h1 id="machine-title">Machine access</h1>
+      </header>
+
+      {accountsQuery.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            The service accounts could not be listed. Listing them needs manage-identities on this
+            project.
+          </span>
+        </p>
+      ) : null}
+
+      {grantsQuery.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            The grant rows could not be read, so no scope is shown below. Reading the membership
+            surface needs manage-members on this project — a separate authority from administering
+            identities.
+          </span>
+        </p>
+      ) : null}
+
+      {environmentsQuery.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            The project&apos;s environments could not be read, so no scope is shown below — an empty
+            scope column here would say &ldquo;this account reaches nothing&rdquo;, which is not
+            something this page knows.
+          </span>
+        </p>
+      ) : null}
+
+      {credentials.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            At least one service account&apos;s credentials could not be listed. Counts and the
+            federation tab are incomplete, and the actions are held back until the listing succeeds.
+          </span>
+        </p>
+      ) : null}
+
+      {refusal !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{refusal}</span>
+        </p>
+      ) : null}
+
+      {credentials.isPending && !credentials.isError && accounts.length > 0 ? (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            ⋯
+          </span>
+          <span>Reading credentials…</span>
+        </p>
+      ) : null}
+
+      {notice !== null ? (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            ✓
+          </span>
+          <span>{notice}</span>
+        </p>
+      ) : null}
+
+      <div className="tabs" role="tablist" aria-label="Machine access sections">
+        {TABS.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            role="tab"
+            id={`machine-tab-${entry.id}`}
+            className="tab"
+            aria-selected={tab === entry.id}
+            aria-controls="machine-panel"
+            onClick={() => setTab(entry.id)}
+          >
+            {`${entry.label} (${tabCount[entry.id]})`}
+          </button>
+        ))}
+      </div>
+
+      <div className="tabpanel" role="tabpanel" id="machine-panel" aria-labelledby={`machine-tab-${tab}`}>
+        {tab === 'accounts' ? (
+          <>
+            <PolicyStrip />
+            <table className="values__table machine__table">
+              <caption className="visually-hidden">
+                The project&apos;s service accounts. Credential values are never listed: a value is
+                displayed once, at mint.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Service account</th>
+                  <th scope="col">Kind</th>
+                  <th scope="col">Read scope (◆ = reveal)</th>
+                  <th scope="col" className="col-secondary">
+                    Credentials
+                  </th>
+                  <th scope="col" className="col-secondary">
+                    Last used
+                  </th>
+                  <th scope="col">Setup</th>
+                </tr>
+              </thead>
+              <tbody>
+                {accounts.map((sa) => {
+                  const rows = credentialsFor(sa);
+                  const scope = scopeFor(sa);
+                  const open = expanded === sa.id;
+                  const newest = showable(rows)
+                    .map((c) => c.last_used_at)
+                    .filter((at): at is string => at !== undefined)
+                    .sort()
+                    .at(-1);
+                  return (
+                    <ExpandableRow
+                      key={sa.id}
+                      account={sa}
+                      scope={scope}
+                      open={open}
+                      scopeKnown={grantsQuery.isSuccess && environmentsQuery.isSuccess}
+                      lastUsed={newest === undefined ? 'never' : isoDay(newest)}
+                      onToggle={() => setExpanded(open ? null : sa.id)}
+                    >
+                      <ExpansionBody
+                        account={sa}
+                        scope={scope}
+                        bearers={bearers(rows)}
+                        bindings={bindings(rows)}
+                        now={now}
+                        ready={inputsReady}
+                        onMint={(rotating) => setDialog({ kind: 'mint', account: sa, rotating })}
+                        onBind={() => setDialog({ kind: 'binding', account: sa })}
+                        onGrant={() => setDialog({ kind: 'grant', account: sa })}
+                        onRevoke={(credential) => doRevoke(sa, credential)}
+                      />
+                    </ExpandableRow>
+                  );
+                })}
+              </tbody>
+            </table>
+            {accounts.length === 0 && !accountsQuery.isPending && !accountsQuery.isError ? (
+              <p role="status">No service accounts on this project yet.</p>
+            ) : null}
+            <p className="machine__footnote">
+              The credential list is metadata only — prefix, kind, scope, expiry, last used. Values
+              are write-only: displayed exactly once at mint, never retrievable, and rotation never
+              returns the prior value.
+            </p>
+          </>
+        ) : null}
+
+        {tab === 'federation' ? (
+          <>
+            <h2>Federated bindings</h2>
+            <p className="machine__lede">
+              An external OIDC identity is bound to exactly one service account by a byte-exact
+              (issuer, subject) pair — no wildcards, no case folding, no just-in-time provisioning.
+              An unbound identity is not a login. A binding expires on the same terms as a bearer
+              credential and is immutable: renewal is a mint.
+            </p>
+            {accounts.length > 0 ? (
+              <p className="machine__actions">
+                <button
+                  className="btn btn--primary"
+                  type="button"
+                  disabled={!inputsReady}
+                  onClick={() => {
+                    const first = accounts[0];
+                    if (first !== undefined) {
+                      setDialog({ kind: 'binding', account: first });
+                    }
+                  }}
+                >
+                  New binding
+                </button>
+              </p>
+            ) : null}
+            {credentials.isPending || credentials.isError ? (
+              <p role="status">
+                {credentials.isError
+                  ? 'The bindings could not be listed, so none are shown. This is not the same as there being none.'
+                  : 'Reading bindings…'}
+              </p>
+            ) : allBindings.length === 0 ? (
+              <p role="status">
+                No federated bindings on this project. Add one from a service account&apos;s row.
+              </p>
+            ) : (
+              <ul className="machine__bindings">
+                {allBindings.map(({ account, credential }) => (
+                  <li key={credential.id}>
+                    <BindingCard account={account} credential={credential} now={now} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        ) : null}
+
+        {tab === 'kubernetes' ? (
+          <>
+            <h2>Kubernetes delivery targets</h2>
+            <p className="machine__lede">
+              One managed Secret per delivery target, each reporting its state as a condition that
+              reads the same in kubectl and here.
+            </p>
+            <p role="status">
+              No delivery targets are reported. The Kubernetes operator that reconciles them and
+              publishes their conditions is not part of this build, so this instance holds no target
+              state to show — an empty list here means nothing is reporting, never that everything
+              is healthy.
+            </p>
+          </>
+        ) : null}
+      </div>
+
+      {dialog?.kind === 'mint' ? (
+        <MintDialog
+          project={project}
+          account={dialog.account}
+          rotating={dialog.rotating}
+          reach={postStateReach(scopeFor(dialog.account))}
+          onClose={() => setDialog(null)}
+        />
+      ) : null}
+
+      {dialog?.kind === 'binding' ? (
+        <BindingDialog
+          project={project}
+          accounts={accounts}
+          initial={dialog.account}
+          reachFor={(accountId) => {
+            const sa = accounts.find((candidate) => candidate.id === accountId);
+            return sa === undefined ? [] : postStateReach(scopeFor(sa));
+          }}
+          onClose={() => setDialog(null)}
+          onCreated={(subject) => {
+            setDialog(null);
+            setNotice(`Bound. The binding matches ${subject} byte-for-byte and nothing else.`);
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'grant' ? (
+        <GrantDialog
+          project={project}
+          account={dialog.account}
+          scope={scopeFor(dialog.account)}
+          // The SERVER's count, which applies the whole liveness predicate —
+          // revocation, the credential epoch and expiry. Counting un-revoked
+          // rows here would tell an operator that a grant re-scopes credentials
+          // that stopped authenticating weeks ago.
+          liveCredentials={dialog.account.live_credentials}
+          onClose={() => setDialog(null)}
+          onGranted={(environment) => {
+            setDialog(null);
+            setNotice(
+              `Granted. Every credential this service account already holds now reads ${environment}.`,
+            );
+          }}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * PolicyStrip is the per-project machine-reveal opt-in, stated rather than
+ * offered.
+ *
+ * A toggle here would be a control whose only outcome is a refusal: the opt-in
+ * has no server surface, and the permission model's machine allowlist admits
+ * `read` and nothing else on a workload principal until it lands. The repo's
+ * own precedent is the ceremony's TOTP cap — absent with the reason given, not
+ * disabled — and for the same reason: a greyed-out switch invites a support
+ * ticket that a sentence answers.
+ */
+function PolicyStrip() {
+  return (
+    <p className="notice machine__policy" role="status">
+      <span className="alert__glyph" aria-hidden="true">
+        ◆
+      </span>
+      <span>
+        <strong>Machine secret delivery (per-project opt-in): off in this build.</strong> Every
+        workload delivery on this project is configuration and secret presence only. A credential
+        holding reveal would be a standing decryption capability, so the acknowledgement that admits
+        one is a deliberate per-project act — and it is not part of this build yet.
+      </span>
+    </p>
+  );
+}
+
+function ExpandableRow({
+  account,
+  scope,
+  open,
+  scopeKnown,
+  lastUsed,
+  onToggle,
+  children,
+}: {
+  account: ServiceAccount;
+  scope: readonly MachineEnvScope[];
+  open: boolean;
+  /** False when the grants or the environments could not be read: unknown is not "none". */
+  scopeKnown: boolean;
+  lastUsed: string;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  const reading = scope.filter((s) => s.read);
+  const journey = setupJourney(account.kind, scope);
+  const outstanding = journey?.findIndex((step) => step.state !== 'done') ?? -1;
+  return (
+    <>
+      <tr>
+        <th scope="row">
+          <button
+            className="values__keyname mono"
+            type="button"
+            aria-expanded={open}
+            onClick={onToggle}
+          >
+            {`${open ? '▾' : '▸'} ${account.name}`}
+          </button>
+        </th>
+        <td>
+          <span className="badge">{account.kind}</span>
+        </td>
+        <td>
+          {!scopeKnown ? (
+            <span className="machine__none">unknown</span>
+          ) : reading.length === 0 ? (
+            <span className="machine__none">no environment</span>
+          ) : (
+            <span className="machine__chips">
+              {reading.map((s) => (
+                <span className="badge" key={s.id}>
+                  {s.reveal ? `${s.name} ◆` : s.name}
+                </span>
+              ))}
+            </span>
+          )}
+        </td>
+        {/* The SERVER's live count: it applies revocation, the credential epoch
+            and expiry, none of which a client filtering on `revoked_at` sees. */}
+        <td className="col-secondary">{String(account.live_credentials)}</td>
+        <td className="col-secondary">{lastUsed}</td>
+        <td>
+          <span className="badge">
+            {journey === null
+              ? 'not applicable'
+              : !scopeKnown
+                ? 'unknown'
+                : outstanding === -1
+                  ? 'complete'
+                  : `step ${String(outstanding + 1)} of 5`}
+          </span>
+        </td>
+      </tr>
+      {open ? (
+        <tr className="machine__sub">
+          <td colSpan={6}>{children}</td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+function ExpansionBody({
+  account,
+  scope,
+  bearers,
+  bindings,
+  now,
+  ready,
+  onMint,
+  onBind,
+  onGrant,
+  onRevoke,
+}: {
+  account: ServiceAccount;
+  scope: readonly MachineEnvScope[];
+  bearers: readonly MachineCredential[];
+  bindings: readonly MachineCredential[];
+  now: Date;
+  /** Every query this surface's warnings are computed from has succeeded. */
+  ready: boolean;
+  onMint: (rotating: boolean) => void;
+  onBind: () => void;
+  onGrant: () => void;
+  onRevoke: (credential: MachineCredential) => void;
+}) {
+  const journey = setupJourney(account.kind, scope);
+  return (
+    <>
+      <div className="machine__grid">
+        <div>
+          <h2 className="machine__subhead">Credentials</h2>
+          {bearers.length === 0 ? (
+            <p className="machine__none">
+              No bearer credentials. This account authenticates by federation only, or not at all
+              until one is minted.
+            </p>
+          ) : (
+            <ul className="machine__creds">
+              {bearers.map((credential) => (
+                <li className="cred" key={credential.id}>
+                  <code className="mono">{`${credential.prefix_hint ?? 'unknown'}…`}</code>
+                  <span className="badge">bearer</span>
+                  <span className="badge">{expiryLabel(credential, now)}</span>
+                  <span className="cred__meta">{lastUsedLabel(credential)}</span>
+                  <button
+                    className="btn"
+                    type="button"
+                    disabled={!ready}
+                    onClick={() => onMint(true)}
+                  >
+                    {`Rotate ${account.name}`}
+                  </button>
+                  <button className="btn" type="button" onClick={() => onRevoke(credential)}>
+                    {`Revoke ${credential.prefix_hint ?? credential.id}`}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {bindings.length > 0 ? (
+            <>
+              <h2 className="machine__subhead">Federated bindings</h2>
+              <ul className="machine__bindings">
+                {bindings.map((credential) => (
+                  <li key={credential.id}>
+                    <BindingCard account={account} credential={credential} now={now} />
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </div>
+
+        <div>
+          <h2 className="machine__subhead">Delivery targets</h2>
+          <p role="status" className="machine__none">
+            No Kubernetes delivery targets are reported for this account. The operator that publishes
+            them is not part of this build.
+          </p>
+          {ready ? null : (
+            <p className="machine__none" role="status">
+              The actions are held back until the accounts, grants, environments and credentials
+              have all been read: every one of their warnings is a statement about that state, and a
+              query that failed would make it an understatement.
+            </p>
+          )}
+          <div className="machine__actions">
+            <button
+              className="btn btn--primary"
+              type="button"
+              disabled={!ready}
+              onClick={() => onMint(false)}
+            >
+              {`Mint credential for ${account.name}`}
+            </button>
+            <button className="btn" type="button" disabled={!ready} onClick={onBind}>
+              {`Add federated binding to ${account.name}`}
+            </button>
+            <button className="btn" type="button" disabled={!ready} onClick={onGrant}>
+              {`Add environment grant to ${account.name}`}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <h2 className="machine__subhead">Setup journey</h2>
+      {journey === null ? (
+        <p className="machine__none">
+          Automation principal — it runs off-box, on a schedule or in CI, and never delivers to a
+          workload, so it has no setup journey. Its capability allowlist admits read, edit, publish
+          and definitions-edit; never any manage- or instance capability.
+        </p>
+      ) : (
+        <ol className="journey">
+          {journey.map((step) => (
+            <li className={`journey__step journey__step--${step.state}`} key={step.title}>
+              <span className="journey__state">
+                {step.state === 'done'
+                  ? 'done'
+                  : step.state === 'next'
+                    ? 'next'
+                    : 'not in this build'}
+              </span>
+              <span className="journey__body">
+                <span className="journey__title">{step.title}</span>
+                <span className="journey__note">{step.note}</span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </>
+  );
+}
+
+function BindingCard({
+  account,
+  credential,
+  now,
+}: {
+  account: ServiceAccount;
+  credential: MachineCredential;
+  now: Date;
+}) {
+  return (
+    <div className="bindrow">
+      <p className="bindrow__head">
+        <code className="mono">{account.name}</code>
+        <span className="badge">federated</span>
+        <span className="badge">{expiryLabel(credential, now)}</span>
+        <span className="cred__meta">
+          matched byte-for-byte — no wildcards, no case folding; renewal is a mint
+        </span>
+      </p>
+      {/* Every pair is wrapped: a `dl` takes either dt/dd children or `div`
+          children, never a mixture, and axe checks exactly that. */}
+      <dl className="kv">
+        {[
+          { term: 'issuer', value: credential.issuer ?? 'unknown' },
+          { term: 'subject', value: credential.subject ?? 'unknown' },
+          { term: 'audience', value: credential.audience ?? 'unknown' },
+          ...(credential.required_claims ?? []).map((pin) => ({
+            term: pin.claim,
+            value: claimText(pin),
+          })),
+        ].map((pair) => (
+          <div className="kv__pair" key={pair.term}>
+            <dt>{pair.term}</dt>
+            <dd className="mono">{pair.value}</dd>
+          </div>
+        ))}
+      </dl>
+      {credential.reactivated_at === undefined ? null : (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            {`Quarantined since the restore on ${isoDay(credential.reactivated_at)}: this binding permanently refuses any token issued at or before that instant plus the accepted clock skew.`}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function claimText(pin: ClaimPin): string {
+  if (pin.string_value !== undefined) {
+    return pin.string_value;
+  }
+  if (pin.number_value !== undefined) {
+    return String(pin.number_value);
+  }
+  if (pin.bool_value !== undefined) {
+    return String(pin.bool_value);
+  }
+  return 'unpinned';
+}
+
+/**
+ * useModalDialog opens a native `<dialog>` with `showModal()`.
+ *
+ * The platform gives a real focus trap, an inert document behind it, Escape and
+ * the top layer — every part of which a hand-rolled `role="dialog"` has to
+ * reimplement, and the focus trap is the part everyone gets wrong.
+ */
+function useModalDialog() {
+  const ref = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    const element = ref.current;
+    if (element !== null && !element.open) {
+      element.showModal();
+    }
+  }, []);
+  return ref;
+}
+
+/**
+ * useNavigationGuard keeps navigation from destroying what dismissal is not
+ * allowed to.
+ *
+ * `dismissDecision` gates Escape and the buttons, but the browser has two more
+ * ways to unmount this dialog: unload (reload, tab close, external navigation)
+ * and the Back button, which pops the route out from under the component. The
+ * first gets the platform's `beforeunload` confirmation; the second gets a
+ * history sentinel — a duplicate entry pushed while the guard is active, so a
+ * Back press consumes the sentinel instead of the route, the URL never changes,
+ * and the press is surfaced as a dismissal ATTEMPT routed through the same
+ * gate as Escape. Deactivating consumes the sentinel again so Back is not a
+ * double-press afterwards.
+ */
+function useNavigationGuard(active: boolean, onAttempt: () => void) {
+  const attempt = useRef(onAttempt);
+  attempt.current = onAttempt;
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+    const onPopState = () => {
+      history.pushState(null, '', window.location.href);
+      attempt.current();
+    };
+    history.pushState(null, '', window.location.href);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    window.addEventListener('popstate', onPopState);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      window.removeEventListener('popstate', onPopState);
+      history.back();
+    };
+  }, [active]);
+}
+
+/**
+ * MintDialog is the display-once ceremony, and it is the only component in the
+ * SPA that ever holds a credential value.
+ *
+ * The step-up names the POST-STATE formula rather than what the mint adds: a
+ * mint adds no grants, so a replacement credential is not a smaller act than a
+ * new one — it hands the same reach to a fresh value. When the account reaches
+ * no plaintext the disclosure conjunct is vacuous and the server asks for no
+ * reauthentication, which the panel says in words rather than performing a
+ * ceremony that authorises nothing.
+ */
+function MintDialog({
+  project,
+  account,
+  rotating,
+  reach,
+  onClose,
+}: {
+  project: ProjectRef;
+  account: ServiceAccount;
+  rotating: boolean;
+  reach: readonly MachineEnvScope[];
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  const refresh = useRefreshAccount(project);
+  const [value, setValue] = useState<string | null>(null);
+  const [clamped, setClamped] = useState(false);
+  const [stored, setStored] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [heldBack, setHeldBack] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const confirmation = useRef<HTMLInputElement>(null);
+
+  // The panel the value arrives on replaces the control that was focused, so
+  // focus goes to the one decision left: the stored-confirmation checkbox.
+  useEffect(() => {
+    if (value !== null) {
+      confirmation.current?.focus();
+    }
+  }, [value]);
+
+  const run = async () => {
+    setBusy(true);
+    setFailure(null);
+    // `issued` is the difference between "nothing happened" and "something may
+    // have". Once the request leaves, a failure says nothing about whether the
+    // server committed — and a mint that committed and whose response was lost
+    // is a live credential whose value is gone forever.
+    let issued = false;
+    try {
+      // One reauthentication per environment the account reaches in the
+      // post-state, which is exactly the set the server will consume. An empty
+      // reach runs no ceremony because there is no disclosure to authorise.
+      for (const environment of reach) {
+        await runPasskeyCeremony({
+          operation: 'mint',
+          environmentId: environment.id,
+          keyIds: [],
+        });
+      }
+      issued = true;
+      const minted = await mintCredential(project, account.id);
+      setValue(minted.value);
+      setClamped(minted.clamped);
+      refresh(account.id);
+    } catch (error) {
+      if (issued) {
+        // Re-read the rows so the operator can see — and revoke — whatever may
+        // have landed.
+        refresh(account.id);
+        setFailure(mintFailureText(error));
+      } else {
+        setFailure(identityRefusalText(error));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const dismiss = () => {
+    switch (dismissDecision({ busy, hasValue: value !== null, stored })) {
+      case 'ignore':
+        return;
+      case 'hold-back':
+        setHeldBack(true);
+        return;
+      default:
+        onClose();
+    }
+  };
+
+  // Back, reload and tab close are dismissals too — an in-flight mint or an
+  // unstored value must not be lost to a navigation the buttons would refuse.
+  useNavigationGuard(busy || (value !== null && !stored), dismiss);
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="mint-title"
+      ref={dialog}
+      onCancel={(event) => {
+        // Escape must not be a way to lose a value nothing can return.
+        event.preventDefault();
+        dismiss();
+      }}
+    >
+      {value === null ? (
+        <>
+          <h2 className="ceremony__title" id="mint-title">
+            {`${rotating ? 'rotate' : 'mint'} credential · ${account.name}`}
+          </h2>
+          <p className="ceremony__stepup">
+            <span className="alert__glyph" aria-hidden="true">
+              ⚿
+            </span>
+            <span>
+              <strong>Confirm it&apos;s you.</strong> The value is delivered display-once, to you.
+              The formula is manage-identities on this project and a disclosure capability over
+              every environment this account reaches in the resulting post-state — not only the ones
+              a mint adds, because a mint adds none.
+            </span>
+          </p>
+          <p className="ceremony__scope">
+            {reach.length === 0
+              ? 'This account reaches no plaintext in the resulting post-state, so no disclosure capability and no reauthentication are required. Its deliveries stay configuration and secret presence only.'
+              : `This account decrypts ${reach.map((r) => r.name).join(', ')}. Each takes its own passkey reauthentication before the value is minted.`}
+          </p>
+          {rotating ? (
+            <p className="ceremony__lede">
+              The prior value is never returned. The predecessor keeps authenticating until you
+              revoke it — rotation and revocation are separate, deliberate acts, so a mint that
+              lands and a revoke that does not leaves two live credentials rather than none.
+            </p>
+          ) : null}
+          {failure !== null ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>{failure}</span>
+            </p>
+          ) : null}
+          <div className="ceremony__actions">
+            <button
+              className="btn btn--primary"
+              type="button"
+              disabled={busy}
+              onClick={() => void run()}
+            >
+              {busy
+                ? 'Minting…'
+                : reach.length === 0
+                  ? 'Mint credential'
+                  : 'Use a passkey and mint'}
+            </button>
+            <button className="btn" type="button" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <h2 className="ceremony__title" id="mint-title">
+            Credential minted — shown exactly once
+          </h2>
+          <p className="mono machine__token">{value}</p>
+          {clamped ? (
+            <p className="notice" role="status">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>
+                The instance lifetime ceiling shortened this credential. It expires earlier than the
+                default asked for — said now rather than discovered when it dies.
+              </span>
+            </p>
+          ) : null}
+          <p className="ceremony__cap" role="status">
+            <span className="alert__glyph" aria-hidden="true">
+              !
+            </span>
+            <span>
+              This value is never retrievable again. The list shows metadata only and rotation never
+              returns it. Store it in the consuming system now; if it is lost, revoke this
+              credential and mint a fresh one.
+            </span>
+          </p>
+          <button
+            className="btn"
+            type="button"
+            onClick={() => {
+              void navigator.clipboard
+                .writeText(value)
+                .then(() =>
+                  setCopied(
+                    'Copied. The clipboard is now the only copy outside its target system.',
+                  ),
+                )
+                .catch(() => setCopied('This browser refused clipboard access, so nothing was copied.'));
+            }}
+          >
+            Copy to clipboard
+          </button>
+          {copied === null ? null : (
+            <p className="notice" role="status">
+              <span className="alert__glyph" aria-hidden="true">
+                ⧉
+              </span>
+              <span>{copied}</span>
+            </p>
+          )}
+          <div className="field chk">
+            <input
+              id="mint-stored"
+              type="checkbox"
+              ref={confirmation}
+              checked={stored}
+              onChange={(event) => {
+                setStored(event.target.checked);
+                setHeldBack(false);
+              }}
+            />
+            <label htmlFor="mint-stored">I have stored this credential in its target system.</label>
+          </div>
+          {heldBack ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>Confirm you have stored it — there is no second look at this value.</span>
+            </p>
+          ) : null}
+          <div className="ceremony__actions">
+            <button className="btn btn--primary" type="button" onClick={dismiss}>
+              Done
+            </button>
+          </div>
+        </>
+      )}
+    </dialog>
+  );
+}
+
+/**
+ * BindingDialog is the federation form.
+ *
+ * Two of its rules come straight off the server and are asked for HERE so an
+ * operator meets them as a form rather than as a 400: the audience is mandatory
+ * and may not be the issuer's default, and each platform's immutable
+ * identifiers must be pinned. The third — the pull-request refusal — is the
+ * load-bearing one: the protection comes from the pinned `event_name`, never
+ * from the subject's shape, because a `pull_request_target` token carries the
+ * ordinary ref-form subject a production binding names.
+ */
+function BindingDialog({
+  project,
+  accounts,
+  initial,
+  reachFor,
+  onClose,
+  onCreated,
+}: {
+  project: ProjectRef;
+  accounts: readonly ServiceAccount[];
+  initial: ServiceAccount;
+  /**
+   * The selected account's post-state reach. A binding is a mint (#62), so the
+   * server demands the same disclosure formula the credential mint does: one
+   * fresh window per environment the account can decrypt in the resulting
+   * state. Vacuous today for the same reason the mint's is — nothing a machine
+   * can hold reaches plaintext — but the leg exists so the form does not start
+   * failing with a bare 403 the day the reveal opt-in lands.
+   */
+  reachFor: (accountId: string) => readonly MachineEnvScope[];
+  onClose: () => void;
+  onCreated: (subject: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const create = useCreateBinding(project);
+  const refresh = useRefreshAccount(project);
+  const [account, setAccount] = useState(initial.id);
+  const [preset, setPreset] = useState<FederationPreset>(KUBERNETES_PRESET);
+  const [issuer, setIssuer] = useState(KUBERNETES_PRESET.issuer);
+  const [subject, setSubject] = useState(KUBERNETES_PRESET.subject);
+  const [audience, setAudience] = useState('');
+  const [claims, setClaims] = useState<Record<string, string>>(() => blankClaims(KUBERNETES_PRESET));
+  const [lifetime, setLifetime] = useState('default');
+  const [deliberate, setDeliberate] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // A refusal describes the form as it was when it was refused. Editing any
+  // field makes it stale, and a stale refusal sitting beside a fresh one is two
+  // alerts saying different things about one form.
+  const edited = () => setFailure(null);
+
+  const choose = (next: FederationPreset) => {
+    setPreset(next);
+    setIssuer(next.issuer);
+    setSubject(next.subject);
+    setClaims(blankClaims(next));
+    setDeliberate(false);
+    edited();
+  };
+
+  const eventName = claims['event_name'] ?? '';
+  const refusal = pullRequestRefusal(eventName);
+
+  /**
+   * pinsOrRefusal builds the pinned claims, or names the first field that
+   * cannot be one.
+   *
+   * The numeric fields are the ones worth refusing over: an immutable
+   * repository id is what stops a renamed-and-reused path inheriting this
+   * binding, and a field that quietly became 0 — or rounded to a neighbouring
+   * id past 2^53 — would bind this service account to somebody else's
+   * repository while looking like it worked.
+   */
+  const pinsOrRefusal = (): FederatedClaimPin[] | string => {
+    const pins: FederatedClaimPin[] = [];
+    for (const field of preset.claims) {
+      const raw = claims[field.claim] ?? '';
+      if (field.kind === 'number') {
+        const value = parseClaimNumber(raw);
+        if (value === null) {
+          return `${field.label} (${field.claim}) must be a whole number the issuer actually mints — digits only, and inside the range this contract can carry exactly. Nothing was bound.`;
+        }
+        pins.push({ claim: field.claim, number_value: value });
+        continue;
+      }
+      if (raw.trim() === '') {
+        return `${field.label} (${field.claim}) is required: this issuer's bindings must pin it, and the server refuses a binding without it. Nothing was bound.`;
+      }
+      pins.push({ claim: field.claim, string_value: raw });
+    }
+    return pins;
+  };
+
+  const submit = async () => {
+    if (refusal !== null && !deliberate) {
+      setFailure(
+        'This binding pins a pull-request event. Acknowledge deliberately below, or pin another event.',
+      );
+      return;
+    }
+    // Mandatory, and refused HERE rather than as a 400: a token minted for
+    // another consumer must not authenticate here, and an empty field is the
+    // most likely way to end up with no such constraint at all.
+    if (audience.trim() === '') {
+      setFailure(
+        'An audience is mandatory, and it may never be the issuer’s default. A token minted for another consumer must not authenticate here. Nothing was bound.',
+      );
+      return;
+    }
+    const pins = pinsOrRefusal();
+    if (typeof pins === 'string') {
+      setFailure(pins);
+      return;
+    }
+    setBusy(true);
+    setFailure(null);
+    // Same issued-vs-nothing-happened line the mint draws: once the request
+    // leaves, a failure says nothing about whether a live external login path
+    // now exists, and the row list is the only place it would show.
+    let issued = false;
+    try {
+      // A binding is a mint: one reauthentication per environment the account
+      // decrypts in the post-state, in the same purpose the server consumes.
+      // Empty today — no machine reaches plaintext — so no ceremony runs.
+      for (const environment of reachFor(account)) {
+        await runPasskeyCeremony({
+          operation: 'mint',
+          environmentId: environment.id,
+          keyIds: [],
+        });
+      }
+      const seconds = BINDING_LIFETIMES.find((entry) => entry.id === lifetime)?.seconds;
+      issued = true;
+      await create.mutateAsync({
+        serviceAccount: account,
+        issuer,
+        subject,
+        audience,
+        requiredClaims: pins,
+        ...(seconds === undefined ? {} : { lifetimeSeconds: seconds }),
+      });
+      onCreated(subject);
+    } catch (error) {
+      if (issued) {
+        refresh(account);
+        setFailure(bindingFailureText(error));
+      } else {
+        setFailure(identityRefusalText(error));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // An in-flight binding is not dismissible: Escape, Back or unload here would
+  // hide a mutation that may commit — the operator stays until it resolves.
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog className="ceremony" aria-labelledby="binding-title" ref={dialog} onCancel={(e) => {
+      e.preventDefault();
+      if (!busy) {
+        onClose();
+      }
+    }}>
+      <h2 className="ceremony__title" id="binding-title">
+        Add federated binding
+      </h2>
+      <p className="ceremony__lede">
+        A byte-exact (issuer, subject) pair naming exactly one service account. The audience is
+        mandatory and may not be the issuer&apos;s default: a token minted for another consumer must
+        not authenticate here.
+      </p>
+
+      {/* One native latch for the whole target: an issued request is for the
+          form as submitted, so nothing here may change until it resolves —
+          otherwise the success or failure sentence describes one account while
+          the operator is looking at another. */}
+      <fieldset className="machine__lock" disabled={busy}>
+      <div className="machine__presets">
+        {FEDERATION_PRESETS.map((entry) => (
+          <button
+            key={entry.id}
+            className="btn"
+            type="button"
+            aria-pressed={preset.id === entry.id}
+            onClick={() => choose(entry)}
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="field">
+        <label htmlFor="binding-account">Service account</label>
+        <select
+          id="binding-account"
+          value={account}
+          onChange={(event) => {
+            // The acknowledgement is consent for ONE account's fetch authority.
+            // A different target is a different decision, so it does not carry.
+            setAccount(event.target.value);
+            setDeliberate(false);
+            edited();
+          }}
+        >
+          {accounts.map((sa) => (
+            <option key={sa.id} value={sa.id}>
+              {sa.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="field">
+        <label htmlFor="binding-issuer">Issuer</label>
+        <input
+          id="binding-issuer"
+          className="mono"
+          value={issuer}
+          onChange={(event) => {
+            setIssuer(event.target.value);
+            edited();
+          }}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor="binding-subject">Subject, matched byte-for-byte</label>
+        <input
+          id="binding-subject"
+          className="mono"
+          value={subject}
+          onChange={(event) => {
+            setSubject(event.target.value);
+            edited();
+          }}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor="binding-audience">Audience</label>
+        <input
+          id="binding-audience"
+          className="mono"
+          value={audience}
+          onChange={(event) => {
+            setAudience(event.target.value);
+            edited();
+          }}
+        />
+      </div>
+
+      {preset.claims.map((field) =>
+        field.kind === 'event' ? (
+          <div className="field" key={field.claim}>
+            <label htmlFor="binding-event">{field.label}</label>
+            <select
+              id="binding-event"
+              value={eventName}
+              onChange={(event) => {
+                setClaims((current) => ({ ...current, event_name: event.target.value }));
+                setDeliberate(false);
+                edited();
+              }}
+            >
+              {CI_EVENTS.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <div className="field" key={field.claim}>
+            <label htmlFor={presetFieldId(field.claim)}>{`${field.label} (${field.claim})`}</label>
+            <input
+              id={presetFieldId(field.claim)}
+              className="mono"
+              inputMode={field.kind === 'number' ? 'numeric' : 'text'}
+              value={claims[field.claim] ?? ''}
+              onChange={(event) => {
+                setClaims((current) => ({ ...current, [field.claim]: event.target.value }));
+                edited();
+              }}
+            />
+          </div>
+        ),
+      )}
+
+      <div className="field">
+        <label htmlFor="binding-lifetime">Binding lifetime</label>
+        <select
+          id="binding-lifetime"
+          value={lifetime}
+          onChange={(event) => {
+            setLifetime(event.target.value);
+            edited();
+          }}
+        >
+          {BINDING_LIFETIMES.map((entry) => (
+            <option key={entry.id} value={entry.id} disabled={entry.disabled === true}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {refusal === null ? null : (
+        <>
+          <p className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">
+              !
+            </span>
+            <span>{refusal}</span>
+          </p>
+          <div className="field chk">
+            <input
+              id="binding-deliberate"
+              type="checkbox"
+              checked={deliberate}
+              onChange={(event) => setDeliberate(event.target.checked)}
+            />
+            <label htmlFor="binding-deliberate">
+              I am deliberately binding a pull-request identity and accept that pull-request authors
+              reach this account&apos;s scope.
+            </label>
+          </div>
+        </>
+      )}
+      </fieldset>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <p className="machine__footnote">
+        No wildcards, no namespace patterns, no case folding — canonicalisation merges distinct
+        external identities. Bindings are immutable and expire on the same terms as a bearer
+        credential: renewal is a mint, never an edit.
+      </p>
+
+      <div className="ceremony__actions">
+        <button className="btn btn--primary" type="button" disabled={busy} onClick={() => void submit()}>
+          {busy ? 'Binding…' : 'Bind this identity'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * GrantDialog is the grant-mutation warning.
+ *
+ * A grant attaches to the SERVICE ACCOUNT, never to a credential, so it
+ * re-scopes every credential already in circulation the moment it lands. The
+ * warning therefore names two numbers the operator cannot see anywhere else:
+ * how many live credentials that is, and exactly which keys become reachable.
+ *
+ * Only `read` is offered, and that is the permission model rather than a
+ * simplification: a workload principal's allowlist admits `read` and nothing
+ * else, so a `reveal` control here would be refused every time it was pressed.
+ */
+function GrantDialog({
+  project,
+  account,
+  scope,
+  liveCredentials,
+  onClose,
+  onGranted,
+}: {
+  project: ProjectRef;
+  account: ServiceAccount;
+  scope: readonly MachineEnvScope[];
+  liveCredentials: number;
+  onClose: () => void;
+  onGranted: (environment: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const grantable = scope.filter((s) => !s.read);
+  // The in-flight latch lives here because the <dialog>'s cancel event does,
+  // while the mutation lives in GrantBody — a ref, because the gate needs the
+  // truth at event time, not a render.
+  const inFlight = useRef(false);
+
+  return (
+    <dialog className="ceremony" aria-labelledby="grant-title" ref={dialog} onCancel={(e) => {
+      e.preventDefault();
+      if (!inFlight.current) {
+        onClose();
+      }
+    }}>
+      <h2 className="ceremony__title" id="grant-title">
+        {`Add environment grant · ${account.name}`}
+      </h2>
+      <p className="ceremony__lede">
+        Grants attach to the service account, never to a credential.
+      </p>
+
+      {grantable.length === 0 ? (
+        <p role="status">
+          This account already reads every environment in the project. There is nothing to widen.
+        </p>
+      ) : (
+        <GrantBody
+          project={project}
+          account={account}
+          scope={scope}
+          grantable={grantable}
+          liveCredentials={liveCredentials}
+          inFlight={inFlight}
+          onClose={onClose}
+          onGranted={onGranted}
+        />
+      )}
+    </dialog>
+  );
+}
+
+/**
+ * GrantBody exists so its queries and selection state are never mounted when
+ * there is nothing grantable. Hooks cannot be conditional, and a query fired
+ * for a dialog that only says "nothing to widen" would be a request the
+ * surface makes and then ignores.
+ */
+function GrantBody({
+  project,
+  account,
+  scope,
+  grantable,
+  liveCredentials,
+  inFlight,
+  onClose,
+  onGranted,
+}: {
+  project: ProjectRef;
+  account: ServiceAccount;
+  scope: readonly MachineEnvScope[];
+  grantable: readonly MachineEnvScope[];
+  liveCredentials: number;
+  /** GrantDialog's Escape gate — held while the mutation is in flight. */
+  inFlight: MutableRefObject<boolean>;
+  onClose: () => void;
+  onGranted: (environment: string) => void;
+}) {
+  const grant = useGrantEnvironment(project);
+  const refreshGrants = useRefreshGrants(project);
+  const first = grantable[0];
+  const [environment, setEnvironment] = useState(first === undefined ? '' : first.id);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // An in-flight grant is not dismissible by Back or unload either: a widening
+  // that commits behind a dismissed dialog is invisible at the moment it most
+  // needs review.
+  useNavigationGuard(busy, () => {});
+
+  /**
+   * What a `read` grant actually delivers, read off the delivery surface rather
+   * than guessed: the whole key CATALOGUE — every key's name and its
+   * classification — and no value of any classification, config included. So
+   * the newly reachable set is every key, not only the secrets. The catalogue
+   * endpoint is used rather than the value listing on purpose: a value listing
+   * is authorized for the HUMAN reading it and carries config plaintext this
+   * dialog never renders, and a fetch is a cached copy (see useKeyCatalogue).
+   */
+  const values = useKeyCatalogue(project);
+  const reachable = values.data?.items ?? [];
+  const chosen = grantable.find((s) => s.id === environment);
+  // The mint formula's conjunct for a WIDENING is the delta, not the whole
+  // post-state — which is what the server computes in checkMachineWidening.
+  const widening = grantWideningReach(scope, environment, 'read');
+
+  const submit = async () => {
+    setBusy(true);
+    inFlight.current = true;
+    setFailure(null);
+    // Issued-vs-nothing-happened, the mint's line: once the request leaves, a
+    // failure does not mean the widening did not land — and a widening that
+    // landed re-scoped every live credential the moment it did.
+    let issued = false;
+    try {
+      // Each newly reachable environment takes its own reauthentication, in the
+      // same purpose the server consumes. Empty today, and for the same reason
+      // the mint's is: nothing this account can hold reaches plaintext.
+      for (const widened of widening) {
+        await runPasskeyCeremony({
+          operation: 'mint',
+          environmentId: widened.id,
+          keyIds: [],
+        });
+      }
+      issued = true;
+      await grant.mutateAsync({
+        environment,
+        principal: account.principal_id,
+        capability: 'read',
+      });
+      onGranted(chosen?.name ?? environment);
+    } catch (error) {
+      if (issued) {
+        refreshGrants();
+        setFailure(grantFailureText(error));
+      } else {
+        setFailure(identityRefusalText(error));
+      }
+    } finally {
+      inFlight.current = false;
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="field">
+        <label htmlFor="grant-environment">Environment (read)</label>
+        <select
+          id="grant-environment"
+          value={environment}
+          onChange={(event) => setEnvironment(event.target.value)}
+        >
+          {grantable.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          {`This grant re-scopes every credential already in circulation. ${account.name} has ${String(liveCredentials)} live credential${liveCredentials === 1 ? '' : 's'}, and each one gains read — configuration and secret presence — on ${chosen?.name ?? 'that environment'} the moment this lands.`}
+        </span>
+      </p>
+
+      <p className="ceremony__stepup">
+        <span className="alert__glyph" aria-hidden="true">
+          ⚿
+        </span>
+        <span>
+          <strong>The formula.</strong> manage-identities on this project, manage-members over the
+          environment, and a disclosure capability over every environment this grant NEWLY lets the
+          account decrypt — the delta, not the whole post-state, because that is what the grant
+          adds.{' '}
+          {widening.length === 0
+            ? 'This grant newly decrypts nothing, so the disclosure conjunct is vacuous and no reauthentication is required.'
+            : `It newly decrypts ${widening.map((w) => w.name).join(', ')}, so each takes its own passkey reauthentication before the grant lands.`}
+        </span>
+      </p>
+
+      {/* FAIL CLOSED. A pending or failed catalogue read cannot be rendered as
+          "nothing becomes reachable": that is the one answer it does not have,
+          and it is the answer that makes the grant look harmless. */}
+      {values.isSuccess ? (
+        <>
+          <p className="ceremony__scope">
+            {reachable.length === 0
+              ? 'This project declares no keys, so the grant reaches an empty catalogue today — and every key declared later.'
+              : 'Newly reachable: every key below, by name and classification. No value of any classification is delivered to a machine by this build.'}
+          </p>
+          {reachable.length === 0 ? null : (
+            <ul className="ceremony__keys" aria-label="Keys this grant makes reachable">
+              {reachable.map((key) => (
+                <li className="mono" key={key.id}>
+                  {`${key.name} · ${key.classification}`}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      ) : (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            {values.isError
+              ? 'The key catalogue could not be read, so what this grant makes reachable cannot be named — and a grant whose blast radius is unknown is not one to make from here.'
+              : 'Reading what this grant would make reachable…'}
+          </span>
+        </p>
+      )}
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy || environment === '' || !values.isSuccess}
+          onClick={() => void submit()}
+        >
+          {busy ? 'Granting…' : 'Grant read'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+}
+
+/** blankClaims is a preset's pin fields, empty except the event a CI binding defaults to. */
+function blankClaims(preset: FederationPreset): Record<string, string> {
+  return Object.fromEntries(
+    preset.claims.map((field) => [field.claim, field.kind === 'event' ? 'push' : '']),
+  );
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -700,3 +700,286 @@ select {
   border-top: 1px solid var(--line);
   padding-top: 12px;
 }
+
+/* --- Machine access (#67, locked prototype #31 iteration 3) ---------------
+ *
+ * Nothing here carries state by colour: an expiry is a sentence, a journey
+ * step names its own state in words, and the policy strip is a paragraph. The
+ * palette only emphasises what the text already says — which is also what
+ * keeps the surface readable under forced-colors.
+ */
+
+.card--wide {
+  max-width: none;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 16px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.tab {
+  min-height: var(--touch);
+  padding: 0 14px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-control) var(--radius-control) 0 0;
+  background: none;
+  color: var(--tx-dim);
+  cursor: pointer;
+}
+
+.tab:hover {
+  color: var(--tx);
+}
+
+.tab[aria-selected='true'] {
+  color: var(--tx);
+  font-weight: 500;
+  border-bottom-color: var(--accent);
+}
+
+.machine__policy,
+.machine__lede,
+.machine__footnote {
+  margin: 12px 0;
+}
+
+.machine__lede,
+.machine__footnote {
+  color: var(--tx-dim);
+  max-width: 80ch;
+}
+
+.machine__none {
+  color: var(--tx-dim);
+  margin: 4px 0 12px;
+  max-width: 70ch;
+}
+
+/* The binding form's in-flight latch: a bare <fieldset> used only for its
+   native disabled propagation, stripped of every default it draws. The
+   min-inline-size reset matters — fieldset's UA min-content default breaks
+   narrow dialogs. */
+.machine__lock {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.machine__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.machine__table th,
+.machine__table td {
+  vertical-align: top;
+}
+
+.machine__sub > td {
+  background: var(--bg);
+  padding: 12px 8px 16px;
+}
+
+.machine__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px 32px;
+}
+
+.machine__subhead {
+  margin: 12px 0 6px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tx-dim);
+}
+
+.machine__creds,
+.machine__bindings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cred {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.cred__meta {
+  color: var(--tx-dim);
+}
+
+.machine__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 0;
+}
+
+.machine__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.btn[aria-pressed='true'] {
+  border-color: var(--accent);
+  color: var(--tx);
+  background: color-mix(in oklch, var(--bg-raise), var(--accent) 14%);
+}
+
+.bindrow {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+  padding: 12px;
+}
+
+.bindrow__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+
+.kv {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+
+.kv__pair {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr);
+  gap: 12px;
+}
+
+.kv dt {
+  color: var(--tx-dim);
+}
+
+.kv dd {
+  margin: 0;
+  color: var(--tx);
+  overflow-wrap: anywhere;
+}
+
+/* The setup journey. The state is a WORD in its own column, so the rail reads
+   the same with every colour removed. */
+.journey {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 90ch;
+}
+
+.journey__step {
+  display: grid;
+  grid-template-columns: 130px minmax(0, 1fr);
+  gap: 12px;
+  padding-left: 10px;
+  border-left: 2px solid var(--line);
+}
+
+.journey__step--done {
+  border-left-color: var(--accent);
+}
+
+.journey__step--unavailable {
+  border-left-style: dashed;
+}
+
+.journey__state {
+  color: var(--tx-dim);
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+}
+
+.journey__body {
+  display: flex;
+  flex-direction: column;
+}
+
+.journey__note {
+  color: var(--tx-dim);
+}
+
+.machine__token {
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-control);
+  background: var(--bg);
+  color: var(--tx);
+  overflow-wrap: anywhere;
+}
+
+/* A checkbox is a control the pinned set sweeps like any other, so it carries
+   the touch floor on a phone rather than the browser's 13px default. */
+.chk {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.chk input[type='checkbox'] {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  accent-color: var(--accent);
+}
+
+.chk label {
+  color: var(--tx);
+}
+
+.ceremony__stepup {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--changed);
+  border-radius: var(--radius-container);
+  background: color-mix(in oklch, var(--bg), var(--changed) 10%);
+  color: var(--tx);
+}
+
+@media (max-width: 800px) {
+  /* The two columns the expansion repeats in detail drop off the summary row
+     on a phone; the expansion still carries them. */
+  .col-secondary {
+    display: none;
+  }
+
+  .machine__grid,
+  .journey__step,
+  .kv__pair {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .chk input[type='checkbox'] {
+    width: var(--touch);
+    height: var(--touch);
+  }
+}


### PR DESCRIPTION
Closes #67. Parent #41 untouched.

## What

Machine-access UI per the locked prototype (#31, iteration 3, `prototype/machine-access/`):

- **Tabbed inventory** — Service accounts / Federation / Kubernetes targets, machine-reveal policy strip above the table (stated, not offered — the opt-in has no server surface yet).
- **Row expansion** — credentials + federated bindings (left), delivery targets + actions (right), five-step setup journey full-width below; steps this build cannot perform say `not in this build` instead of offering controls the server refuses.
- **Display-once mint** — step-up naming the post-state formula, value shown exactly once, stored-confirmation checkbox gating every dismissal path: buttons, Escape, browser Back (history sentinel), reload/close (`beforeunload`). Mint result kept out of the TanStack mutation cache; a mint that was issued and then failed says *a credential may still have been minted* and re-reads the rows.
- **Federation form** — K8s / Forgejo Actions / GitHub Actions presets with their mandatory pins, byte-exact members, mandatory audience (client-side too), lifetime control, and the pull-request refusal behind a deliberate acknowledgement (server enforces via the pinned `event_name` — `oidcfed.checkEventName`; the checkbox is the UI-level ceremony).
- **Grant-mutation warning** — names the live-credential count (server's `live_credentials`) and the full key catalogue a `read` grant reaches; fail-closed until the catalogue loads; formula + reauth leg over the widening delta (vacuous today, said in words).
- **Restore quarantine** — rendered from the real `reactivated_at`; the reconciliation ceremony itself is #76's.

## Backend change riding along (separable)

`listMachineCredentials` dropped the federated-binding members its own OpenAPI schema promises (issuer/subject/audience/required_claims/reactivated_at). Read-path-only fix in `internal/service/identities.go` + `internal/server/identities.go`; issuer resolved once per distinct configuration. Pinned by isolation tests on both engines plus a transport-level `wireCredential` test.

## Acceptance (mvp-boundary S3)

Registry gains the `machine-access` flow: 10 tests × 2 viewports, full pinned assertion set including with the display-once value on screen. Gaps where the prototype is ahead of the server are enumerated in `docs/handoff/67-machine-access.md` — each verified against the actual backend during review, none mocked.

## Verification

- Go: gofmt/build/vet clean; full suite 1883 passed dual-engine (sqlite + Postgres); post-rebase server/isolation/conformance 1623 passed dual-engine
- Web: typecheck clean, 48 unit tests, build clean, e2e 86 passed (desktop + mobile)
- Review: two-axis (standards/spec) — all 14 findings fixed; cross-model gpt-5.6-sol high, 3 rounds, **CLEAN** (R2 blocker — navigation could discard a display-once value — closed by the navigation guard, covered by two flow tests)

## Known pre-existing, deliberately untouched

- Shell breadcrumb resolves parameterised paths to "Not found" (`values` has it too)
- `e2e/global-teardown.ts` `--grep` escape hatch never triggers for CLI `--grep` in the pinned Playwright (#56's locked harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds the project-scoped machine-access interface and restores federated-binding metadata to credential-list responses.
- Adds tabbed service-account, federation, and Kubernetes-target inventory with expandable setup details.
- Adds guarded display-once credential minting, federation binding, and grant workflows.
- Returns issuer, subject, audience, claim pins, and reactivation metadata for federated credential rows.
- Tightens issuer URL validation for newly created federation configurations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the scope of this follow-up review.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/routes/MachineAccess.tsx | Implements the machine-access inventory and guarded mint, federation, and grant dialogs; the previously questioned history-sentinel behavior was correctly refuted. |
| web/src/api/identities.ts | Adds parsed API hooks and derivations supporting credential inventory, grant reach, claim pins, and dismissal decisions. |
| internal/service/identities.go | Populates federated-binding identity and restore metadata when listing machine credentials. |
| internal/server/identities.go | Serializes federated-binding metadata into machine-credential responses while leaving bearer-only fields absent. |
| internal/service/federation.go | Rejects newly created issuer URLs containing userinfo, queries, fragments, invalid schemes, or missing hosts. |
| web/e2e/flows/machine-access.spec.ts | Exercises the machine-access inventory, expansion, display-once mint, navigation guards, and federation workflow across configured viewports. |

</details>

<sub>Reviews (6): Last reviewed commit: ["feat(machine-access): tabbed inventory, ..."](https://github.com/dunky13/hikyo/commit/f7dd241d7dd1d52d8013a6392beb96002edc6961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52931044)</sub>

<!-- /greptile_comment -->