### PR TITLE
fix(federation): revalidate token age in transaction

### DIFF
--- a/docs/handoff/51-revisions-publish.md
+++ b/docs/handoff/51-revisions-publish.md
@@ -480,5 +480,7 @@ remaining inside its issuer expiry and complete one final delivery.
 in-transaction clock before its explicit expiry check. The cross-engine
 `FederationTokenAgeCannotExpireMidFlight` fixture advances the shared clock in
 `OnValidated`, proving a token that crosses only `MaxTokenAge` receives the
-uniform unauthenticated refusal. The other PR #109 threads remain fixed,
-contractually rebutted, or tracked by #113 as recorded above.
+uniform unauthenticated refusal. Its audit event retains the caller-invariant
+`token-age` cause rather than collapsing it into the decoy-backed `unbound`
+bucket. The other PR #109 threads remain fixed, contractually rebutted, or
+tracked by #113 as recorded above.

--- a/docs/handoff/51-revisions-publish.md
+++ b/docs/handoff/51-revisions-publish.md
@@ -468,3 +468,17 @@ Round 6 correction (sixth scan): the round-6 fix passed a fresh clock into
 re-checks `exp` against the caller's clock (same skew allowance as
 `checkTiming`), so the in-transaction predicate genuinely refuses a token
 that expired during the preflight.
+
+## Post-merge follow-up — PR #109
+
+Aikido posted one new thread after PR #109 merged: the authoritative
+`CheckBinding` pass rechecked issuer expiry, but not Hikyo's independent
+`MaxTokenAge`. A token could cross the one-hour age cap during preflight while
+remaining inside its issuer expiry and complete one final delivery.
+
+`CheckBinding` now reruns every predicate in `checkTiming` at the
+in-transaction clock before its explicit expiry check. The cross-engine
+`FederationTokenAgeCannotExpireMidFlight` fixture advances the shared clock in
+`OnValidated`, proving a token that crosses only `MaxTokenAge` receives the
+uniform unauthenticated refusal. The other PR #109 threads remain fixed,
+contractually rebutted, or tracked by #113 as recorded above.

--- a/docs/handoff/62-oidc-federation-cursor.md
+++ b/docs/handoff/62-oidc-federation-cursor.md
@@ -409,15 +409,19 @@ accepts, which is precisely the gap the predicate exists to close.
    disposition. The fetch path now exists but delivers **no plaintext**, so a
    disclosure event naming a key whose value was not disclosed would be a false
    record. Reasoning is recorded in `internal/audit/registry.go`.
-5. **The in-transaction refusal leg records ONE cause (`unbound`).** Which of
+5. **Binding-dependent failures on the in-transaction refusal leg record ONE
+   cause (`unbound`).** Which of
    "unbound identity", "revoked binding" and "failed binding predicate" happened
    is exactly what the uniform response withholds — and, more concretely, the
    resolution surface hands the predicate a *decoy* binding on a miss (so the
    unbound case is not the cheap case), which means the predicate's verdict on a
    miss is the decoy's. Reporting it as a cause would sometimes report the decoy.
+   Caller-invariant timing failures rechecked on this leg are the exception:
+   they depend only on the signed claims and authoritative clock, so token age
+   remains individually reported without revealing whether a binding exists.
    The pre-transaction causes (unknown issuer, unavailable keys, stale keys,
-   signature, token age, audience) *are* reported individually, because nothing
-   decoy-shaped produces them.
+   signature, token age, audience) are likewise reported individually, because
+   nothing decoy-shaped produces them.
 6. **Bindings share `max_live_credentials` and the lifetime clamp/enumeration
    with bearer tokens.** That is what the ADR asks for (same ceiling, same
    opt-in), and it is a consequence of the one-table decision: a service account

--- a/internal/isolation/federation_e2e_test.go
+++ b/internal/isolation/federation_e2e_test.go
@@ -1402,6 +1402,37 @@ func TestFederationTokenCapsSQLite(t *testing.T) {
 	}
 }
 
+func TestFederationTokenAgeCannotExpireMidFlightSQLite(t *testing.T) {
+	runFederationTokenAgeCannotExpireMidFlight(t, seededDB(t, openSQLite))
+}
+
+func TestFederationTokenAgeCannotExpireMidFlightPostgres(t *testing.T) {
+	runFederationTokenAgeCannotExpireMidFlight(t, seededDB(t, openPostgres))
+}
+
+// runFederationTokenAgeCannotExpireMidFlight proves the authoritative,
+// in-transaction binding check revalidates Hikyo's own age cap. Signature-time
+// validation happens before OnValidated; advancing the clock there models a
+// slow delivery preflight without sleeping.
+func runFederationTokenAgeCannotExpireMidFlight(t *testing.T, db *store.DB) {
+	r := newFedRig(t, db)
+	shape := oidctest.KubernetesShape("prod", "age-racer", "uid-age-racer", "https://kubernetes.default.svc")
+	r.configureIssuer(t, domain.IssuerKubernetes, []string{shape.DefaultAudience})
+	r.bindShape(t, "wl-age-race", shape, hikyoAudience)
+
+	token, err := r.idp.MintShape(shape, hikyoAudience, r.clk.Now(), oidcfed.MaxTokenSpan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.fed.OnValidated = func() {
+		r.clk.advance(oidcfed.MaxTokenAge + time.Second)
+		r.fed.OnValidated = nil
+	}
+	if _, err := r.del.Fetch(t.Context(), token, scopeEnv(orgA, prjA1, envA1), ""); !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("token crossing the age cap during validation = %v, want the uniform refusal", err)
+	}
+}
+
 func TestFederationIssuerDeleteGuardSQLite(t *testing.T) {
 	runIssuerDeleteGuard(t, seededDB(t, openSQLite))
 }

--- a/internal/isolation/federation_e2e_test.go
+++ b/internal/isolation/federation_e2e_test.go
@@ -1431,6 +1431,14 @@ func runFederationTokenAgeCannotExpireMidFlight(t *testing.T, db *store.DB) {
 	if _, err := r.del.Fetch(t.Context(), token, scopeEnv(orgA, prjA1, envA1), ""); !errors.Is(err, domain.ErrUnauthenticated) {
 		t.Fatalf("token crossing the age cap during validation = %v, want the uniform refusal", err)
 	}
+	if n := queryInt(t, db,
+		"SELECT COUNT(*) FROM audit_instance_events WHERE type = 'identity.federation_refused' AND payload LIKE '%token-age%'"); n != 1 {
+		t.Fatalf("mid-flight age-cap refusal audit count = %d, want 1 token-age event", n)
+	}
+	if n := queryInt(t, db,
+		"SELECT COUNT(*) FROM audit_instance_events WHERE type = 'identity.federation_refused' AND payload LIKE '%unbound%'"); n != 0 {
+		t.Fatalf("mid-flight age-cap refusal was misclassified as unbound %d time(s)", n)
+	}
 }
 
 func TestFederationIssuerDeleteGuardSQLite(t *testing.T) {

--- a/internal/isolation/federation_e2e_test.go
+++ b/internal/isolation/federation_e2e_test.go
@@ -1424,12 +1424,17 @@ func runFederationTokenAgeCannotExpireMidFlight(t *testing.T, db *store.DB) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	validated := false
 	r.fed.OnValidated = func() {
+		validated = true
 		r.clk.advance(oidcfed.MaxTokenAge + time.Second)
 		r.fed.OnValidated = nil
 	}
 	if _, err := r.del.Fetch(t.Context(), token, scopeEnv(orgA, prjA1, envA1), ""); !errors.Is(err, domain.ErrUnauthenticated) {
 		t.Fatalf("token crossing the age cap during validation = %v, want the uniform refusal", err)
+	}
+	if !validated {
+		t.Fatal("OnValidated was not called; mid-flight timing was not tested")
 	}
 	if n := queryInt(t, db,
 		"SELECT COUNT(*) FROM audit_instance_events WHERE type = 'identity.federation_refused' AND payload LIKE '%token-age%'"); n != 1 {

--- a/internal/oidcfed/oidcfed.go
+++ b/internal/oidcfed/oidcfed.go
@@ -504,16 +504,14 @@ func checkTiming(c Claims, now time.Time) error {
 // to contain; the restore predicate last, because it is the only check that can
 // pass for a token that is in every other way correct.
 func CheckBinding(iss Issuer, b Binding, c Claims, now time.Time) error {
-	// EXPIRY IS RE-CHECKED HERE, against the caller's clock -- which the
-	// chokepoint reads inside the authorizing transaction. Signature-time
-	// validation (checkTiming, via go-oidc) proved the token was live when it
-	// was PRESENTED; the sealer preflight between presentation and this
-	// predicate can take real time, and a token whose `exp` passes during it
-	// must be refused by the authentication the delivery actually rides. The
-	// skew allowance is the same one checkTiming grants, so the two clocks
-	// disagree about nothing but the instant they were read.
-	if c.Expiry.IsZero() {
-		return fmt.Errorf("%w: token carries no exp", ErrTokenInvalid)
+	// ALL TIME-BASED PREDICATES ARE RE-CHECKED HERE, against the caller's clock
+	// -- which the chokepoint reads inside the authorizing transaction.
+	// Signature-time validation proved the token was live when it was PRESENTED;
+	// the sealer preflight between presentation and this predicate can take real
+	// time, and a token whose `exp`, `nbf`, or Hikyo-owned age cap passes during
+	// it must be refused by the authentication the delivery actually rides.
+	if err := checkTiming(c, now); err != nil {
+		return err
 	}
 	if now.After(c.Expiry.Add(MaxClockSkew)) {
 		return fmt.Errorf("%w: token expired during validation", ErrTokenInvalid)

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -303,7 +303,11 @@ func (s *Delivery) recordUnbound(ctx context.Context, actor Actor, cause error) 
 	if !errors.Is(cause, domain.ErrUnauthenticated) {
 		return cause
 	}
-	if auditErr := s.Federation.RecordBindingRefusal(ctx, actor.federated.IssuerID); auditErr != nil {
+	refusalCause := ""
+	if actor.federated.refusalCause != nil {
+		refusalCause = actor.federated.refusalCause.load()
+	}
+	if auditErr := s.Federation.RecordBindingRefusal(ctx, actor.federated.IssuerID, refusalCause); auditErr != nil {
 		return auditErr
 	}
 	return cause

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -808,8 +808,8 @@ func (s *Federation) Authenticate(ctx context.Context, presented string) (Federa
 				// The clock is read when the PREDICATE runs -- inside the
 				// authorizing transaction -- not captured at validation time. The
 				// sealer preflight between the two can take real time, and a token
-				// whose `exp` passes during it must be refused by the
-				// authentication this delivery actually rides.
+				// whose `exp`, `nbf`, or Hikyo-owned age cap passes during it must
+				// be refused by the authentication this delivery actually rides.
 			}, claims, s.now())
 		},
 	}, nil

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Dunky13/hikyo/internal/admission"
@@ -691,9 +692,24 @@ type FederatedCaller struct {
 	// Check is the binding half of validation, closed over the issuer
 	// configuration and the token's claims. The chokepoint refuses a nil one.
 	Check authz.BindingPredicate
-	// Cause is the closed refusal cause when validation failed, for the audit
-	// event. Empty on success.
-	Cause string
+	// refusalCause carries only caller-invariant failures discovered by the
+	// in-transaction predicate. Binding-dependent failures stay collapsed to
+	// `unbound`, because the predicate also runs against a decoy binding.
+	refusalCause *federationRefusalCause
+}
+
+type federationRefusalCause struct{ value atomic.Pointer[string] }
+
+func (c *federationRefusalCause) store(value string) {
+	v := value
+	c.value.Store(&v)
+}
+
+func (c *federationRefusalCause) load() string {
+	if value := c.value.Load(); value != nil {
+		return *value
+	}
+	return ""
 }
 
 // Authenticate is the PRE-TRANSACTION half of federated authentication: peek at
@@ -776,9 +792,11 @@ func (s *Federation) Authenticate(ctx context.Context, presented string) (Federa
 	if s.OnValidated != nil {
 		s.OnValidated()
 	}
+	postValidationCause := &federationRefusalCause{}
 	return FederatedCaller{
-		IssuerID: issuer.ID,
-		Subject:  claims.Subject,
+		IssuerID:     issuer.ID,
+		Subject:      claims.Subject,
+		refusalCause: postValidationCause,
 		Check: func(current authz.FederationIssuer, b authz.Binding) error {
 			// THE POLICY THIS REQUEST WAS VALIDATED UNDER MUST STILL BE THE
 			// CURRENT ONE. Everything above ran outside a transaction against
@@ -797,7 +815,7 @@ func (s *Federation) Authenticate(ctx context.Context, presented string) (Federa
 			// The IN-TRANSACTION row feeds the check, not the snapshot, so even a
 			// change this comparison somehow failed to notice cannot widen what is
 			// accepted.
-			return oidcfed.CheckBinding(oidcfed.Issuer{
+			err := oidcfed.CheckBinding(oidcfed.Issuer{
 				ID: current.ID, Issuer: current.Issuer, Type: current.Type,
 				Mode: current.Mode, StaticJWKS: current.StaticJWKS,
 				RefusedAudiences: current.RefusedAudiences,
@@ -811,6 +829,13 @@ func (s *Federation) Authenticate(ctx context.Context, presented string) (Federa
 				// whose `exp`, `nbf`, or Hikyo-owned age cap passes during it must
 				// be refused by the authentication this delivery actually rides.
 			}, claims, s.now())
+			// Timing failures depend only on the presented token and the
+			// authoritative clock, never on the real-or-decoy binding. Preserve
+			// their audit cause; every binding-dependent failure remains `unbound`.
+			if errors.Is(err, oidcfed.ErrTokenAge) || errors.Is(err, oidcfed.ErrTokenInvalid) {
+				postValidationCause.store(refusalCause(err))
+			}
+			return err
 		},
 	}, nil
 }
@@ -853,8 +878,11 @@ func issuerPolicyMoved(before, current authz.FederationIssuer) bool {
 // PRE-transaction causes (unknown issuer, unavailable or stale keys, signature,
 // token age, audience) are reported individually, because nothing decoy-shaped
 // is involved in producing them.
-func (s *Federation) RecordBindingRefusal(ctx context.Context, issuer string) error {
-	return s.recordRefusal(ctx, issuer, causeFedUnbound)
+func (s *Federation) RecordBindingRefusal(ctx context.Context, issuer, cause string) error {
+	if cause == "" {
+		cause = causeFedUnbound
+	}
+	return s.recordRefusal(ctx, issuer, cause)
 }
 
 // refusalCause maps a validation error onto the closed audit enum. By class,


### PR DESCRIPTION
Follow-up to #109.

## What changed

- rerun every federated token timing predicate at the authoritative in-transaction binding check
- refuse a token that crosses `MaxTokenAge` after presentation but before authorization
- add SQLite/PostgreSQL regression coverage using the existing deterministic `OnValidated` seam
- record the post-merge review disposition in the #51 handoff

The other #109 review threads remain fixed, contractually rebutted, or tracked by #113.

## Validation

- `go test -count=1 ./...` — 1,530 passed
- `go vet ./...` — clean
- focused regression — red before fix, green after fix
- native Codex high-effort security review — no actionable defects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Federated authentication now consistently rejects tokens that expire or exceed their maximum age while being processed.
  * Improved validation of token timing conditions, including issued-at, expiration, not-before, and maximum validity limits.
  * Ensured consistent unauthenticated responses across supported database engines.
  * Preserved specific token-age reasons in authentication refusal audit records.

* **Documentation**
  * Updated authentication behavior documentation to reflect comprehensive in-transaction token timing validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes the presentation-to-authorization timing gap by rerunning federated-token timing predicates inside the authoritative transaction.
- Revalidates expiration, not-before, issued-at, maximum age, and maximum span during binding authorization.
- Preserves caller-invariant timing causes for refusal auditing while retaining `unbound` for binding-dependent failures.
- Adds deterministic SQLite and PostgreSQL regression coverage for tokens crossing the age limit mid-flight.
- Updates federation handoff documentation with the revised timing and audit behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/oidcfed/oidcfed.go | Reuses the complete timing validator during the authoritative binding check while retaining the explicit expiration check. |
| internal/service/federation.go | Carries request-local post-validation timing causes from the transaction predicate into refusal auditing. |
| internal/service/delivery.go | Reads the request-local timing cause after authorization failure and forwards it to federation audit recording. |
| internal/isolation/federation_e2e_test.go | Adds cross-database regression coverage proving mid-flight maximum-age refusal and its audit classification. |
| docs/handoff/51-revisions-publish.md | Records the post-merge timing-gap resolution and regression coverage. |
| docs/handoff/62-oidc-federation-cursor.md | Clarifies that caller-invariant timing failures may retain specific audit causes without exposing binding existence. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Federation as Federation.Authenticate
    participant Preflight as Delivery preflight
    participant Tx as Authorization transaction
    participant Audit
    Client->>Federation: Present federated token
    Federation->>Federation: Verify signature and timing
    Federation-->>Preflight: FederatedCaller with binding predicate
    Preflight->>Tx: Begin authoritative delivery authorization
    Tx->>Tx: Reload issuer and binding
    Tx->>Tx: Recheck all token timing predicates
    alt Token remains valid
        Tx->>Tx: Check binding-dependent predicates
        Tx-->>Client: Continue delivery
    else Token crosses timing boundary
        Tx-->>Preflight: Unauthenticated refusal
        Preflight->>Audit: Record caller-invariant timing cause
        Preflight-->>Client: Uniform unauthenticated response
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(federation): prove validation timin..."](https://github.com/dunky13/hikyo/commit/85c69f55d6696ee21e46140d2408ba74a25ec7ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53100164)</sub>

<!-- /greptile_comment -->