### PR TITLE
ci: anchor pull request gate on main

### DIFF
--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -1,0 +1,32 @@
+# Pull-request orchestration must come from the base branch. This workflow
+# never executes PR-controlled workflow YAML, receives no secrets, and narrows
+# the automatic token to public-source read access.
+name: trusted-ci
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trusted-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validation:
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
+  # Permanent required context. This job and its success criteria are loaded
+  # from the base branch, so a PR cannot redefine its own merge gate.
+  ci-required:
+    if: always()
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require trusted validation
+        env:
+          VALIDATION_RESULT: ${{ needs.validation.result }}
+        run: test "$VALIDATION_RESULT" = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: ci
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_call:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
-# CI for the walking skeleton (#42): build, vet, generated-code freshness,
-# and the full test suite including the cross-engine conformance harness on
-# sqlite and postgres. Actions pinned by commit SHA and the Go toolchain
-# pinned exactly, per the system-architecture ADR's pinned-everything rule.
+# CI for the walking skeleton (#42): pull-request orchestration is loaded from
+# the trusted base branch while validation runs against the exact PR head.
+# Permissions stay read-only and PR jobs never save caches.
 name: ci
 
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -16,7 +16,7 @@ concurrency:
   # PR updates supersede the same PR; every main push stays independently
   # queued so a burst cannot discard the middle commit's CI/cache seed.
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   lint:
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -67,7 +68,7 @@ jobs:
           key: ${{ steps.lint-go-cache.outputs.cache-primary-key }}
 
   dco:
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -76,16 +77,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Require DCO sign-off on every PR commit
-        run: >-
-          ./scripts/ci/check-dco.sh
-          "${{ github.event.pull_request.base.sha }}"
-          "${{ github.event.pull_request.head.sha }}"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          trusted_dco="$RUNNER_TEMP/check-dco.sh"
+          git show "$BASE_SHA:scripts/ci/check-dco.sh" >"$trusted_dco"
+          chmod +x "$trusted_dco"
+          "$trusted_dco" "$BASE_SHA" "$HEAD_SHA"
 
   supply-chain-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
@@ -129,6 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -181,6 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -224,6 +232,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -252,6 +261,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -269,6 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -371,6 +382,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -454,6 +466,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/scripts/ci/check-required-jobs.sh
+++ b/scripts/ci/check-required-jobs.sh
@@ -11,7 +11,7 @@ results=$2
 expected='["client","dco","docs","generated","headline-guarantee","lint","release-snapshot","supply-chain-checks","test","web"]'
 
 case "$event" in
-	pull_request)
+	pull_request | pull_request_target)
 		allowed='all(to_entries[]; .value.result == "success")'
 		;;
 	push)

--- a/scripts/ci/check-required-jobs_test.sh
+++ b/scripts/ci/check-required-jobs_test.sh
@@ -39,6 +39,10 @@ all_success='{
 
 expect_accept 'successful pull request' pull_request "$all_success"
 expect_accept 'successful base-controlled pull request' pull_request_target "$all_success"
+for result in failure cancelled skipped; do
+	expect_reject "base-controlled pull request with $result client" pull_request_target \
+		"$(printf '%s' "$all_success" | jq --arg result "$result" '.client.result = $result')"
+done
 expect_accept 'main push with skipped DCO' push \
 	"$(printf '%s' "$all_success" | jq '.dco.result = "skipped"')"
 

--- a/scripts/ci/check-required-jobs_test.sh
+++ b/scripts/ci/check-required-jobs_test.sh
@@ -38,6 +38,7 @@ all_success='{
 }'
 
 expect_accept 'successful pull request' pull_request "$all_success"
+expect_accept 'successful base-controlled pull request' pull_request_target "$all_success"
 expect_accept 'main push with skipped DCO' push \
 	"$(printf '%s' "$all_success" | jq '.dco.result = "skipped"')"
 


### PR DESCRIPTION
## Summary

- Add a base-controlled `pull_request_target` controller with read-only permissions and no secrets.
- Call the full CI workflow from the trusted base revision while every validation job checks out the exact PR head.
- Keep DCO and aggregate gate logic on the base revision.
- Retain the existing `pull_request` trigger only for this bootstrap; PR #121 removes that untrusted entrypoint after this lands.

## Security boundaries

- GitHub-hosted runners only.
- `contents: read`; unspecified permissions are disabled.
- No secrets forwarded to the reusable workflow.
- Pull-request runs cannot save caches.
- Exact PR-head checkout uses `persist-credentials: false`.

## Validation

- `actionlint` passed.
- ShellCheck passed.
- Required-job positive/refusal fixtures passed for `pull_request`, `pull_request_target`, and `push`.
- `git diff --check` passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR anchors pull-request orchestration and its aggregate gate to the trusted base revision while running validation against the exact PR head.
- Adds a read-only `pull_request_target` controller that invokes the reusable CI workflow without forwarding secrets.
- Updates validation checkouts to select the PR head and disables credential persistence.
- Executes DCO policy from the trusted base revision.
- Extends required-job handling and fixtures to cover trusted pull-request events, including refusal cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-control.yml | Adds the trusted, read-only pull-request controller and permanent aggregate validation gate. |
| .github/workflows/ci.yml | Makes CI reusable, checks out the exact PR head for validation, and loads DCO enforcement from the base revision. |
| scripts/ci/check-required-jobs.sh | Applies the existing all-success pull-request policy to `pull_request_target` events. |
| scripts/ci/check-required-jobs_test.sh | Covers successful trusted events and rejection of failed, cancelled, or skipped validation results. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pull_request_target event] --> B[Base-controlled ci-control.yml]
    B --> C[Reusable ci.yml]
    C --> D[Checkout exact PR head]
    D --> E[Validation jobs]
    E --> F{All validation successful?}
    F -->|Yes| G[ci-required succeeds]
    F -->|No| H[ci-required fails]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: remove untrusted pull request entryp..."](https://github.com/dunky13/hikyo/commit/96772914cf0cf55e59ec9dd99f12c9272de9dd7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53144533)</sub>

<!-- /greptile_comment -->