### PR TITLE
chore(security): record fallback channel receipt

### DIFF
--- a/release/repository/fallback-channel-test.json
+++ b/release/repository/fallback-channel-test.json
@@ -1,9 +1,9 @@
 {
   "schema": "hikyo.dev/fallback-channel-test/v1",
   "address": "security@developwent.io",
-  "status": "pending",
-  "sent_at": null,
-  "received_at": null,
-  "message_id_sha256": null,
-  "note": "Set passed only after a self-report sent from outside the fallback system is received and its Message-ID is hashed."
+  "status": "passed",
+  "sent_at": "2026-08-13T07:09:44Z",
+  "received_at": "2026-08-13T07:09:54Z",
+  "message_id_sha256": "b032cf8e5302aa852305cf9aadd8b24cfeb8b6e90811b918692a7c5c8b6a8093",
+  "note": "Externally sent self-report received through the fallback channel; exact Message-ID retained only as its SHA-256 hash."
 }


### PR DESCRIPTION
## Summary

- record externally delivered fallback-channel self-report
- store only UTC send/receipt timestamps and SHA-256 of exact Message-ID
- satisfy quarterly fail-closed security-channel evidence gate

## Validation

- ./scripts/ci/check-fallback-channel-test.sh release/repository/fallback-channel-test.json security@developwent.io
- ./scripts/ci/check-fallback-channel-test_test.sh
- jq -e . release/repository/fallback-channel-test.json
- git diff --check

Refs #93