### PR TITLE
Derive chart registry owner from Go module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,14 @@ jobs:
           version: v4.2.3
       - name: Chart renders and carries release substitution anchors
         run: |
-          grep -Fx "  repository: ghcr.io/dunky13/hikyo" chart/hikyo/values.yaml
+          module_path="$(awk '$1 == "module" { print $2 }' go.mod)"
+          if [[ "$module_path" =~ ^github\.com/([^/]+)/hikyo$ ]]; then
+            module_owner="${BASH_REMATCH[1],,}"
+          else
+            echo "unexpected Go module path: $module_path" >&2
+            exit 1
+          fi
+          grep -Fx "  repository: ghcr.io/${module_owner}/hikyo" chart/hikyo/values.yaml
           grep -Fx "  digest: sha256:RELEASE_IMAGE_DIGEST" chart/hikyo/values.yaml
           helm lint chart/hikyo --set database.existingSecret=fixture \
             --set 'network.trustedProxyCIDRs={10.42.0.0/16}'


### PR DESCRIPTION
## Summary

- derive the expected GHCR owner from the exact `github.com/<owner>/hikyo` Go module path
- keep the Helm release-coordinate assertion strict across repository-owner transfers
- unblock trusted base-workflow validation for #127 without weakening the check

## Validation

- actionlint v1.7.12
- pre-transfer module/chart owner fixture passes
- nested, empty, and non-GitHub module owners fail closed
- standards/spec/security review clean after one strictness finding was fixed

Signed commit included for DCO.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789305940&installation_model_id=432348&pr_number=128&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F128&signature=7173f27518d01e6fa598cb7ffdb62a09f7450e416f8b7449a7e7789271181f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->