### PR TITLE
Include security.txt in Pages artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,22 @@ jobs:
         run: ./scripts/ci/verify-docs.sh
       - name: Configure GitHub Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Archive Pages artifact, including security.txt
+        run: |
+          tar --dereference --hard-dereference \
+            --directory docs/site/dist \
+            --exclude=.git \
+            --exclude=.github \
+            -cvf "$RUNNER_TEMP/artifact.tar" .
+          tar -tf "$RUNNER_TEMP/artifact.tar" |
+            grep -Fx './.well-known/security.txt'
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          path: docs/site/dist
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

- replace the Pages artifact wrapper that unconditionally excludes top-level hidden paths
- preserve `.well-known/security.txt` in the deployed tar and assert its exact archive path
- keep the pinned GitHub-owned uploader, artifact name, retention, and fail-closed behavior

## Cause

The pinned `actions/upload-pages-artifact` implementation archives with `--exclude=".[^/]*"`, so every deployment omitted `.well-known/` and the live docs gate returned 404.

## Validation

- docs typecheck/build/policy/live fixture suite passed
- actionlint v1.7.12 passed
- local Pages-format tar contains `./.well-known/security.txt`
- standards/spec/security review clean

Signed commit included for DCO.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307454&installation_model_id=432348&pr_number=129&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F129&signature=f9299523d62c161bd16895b35c08506512205f99f0e664e789e92e9d37670a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->