### PR TITLE
Refresh README and adopt Instrument Sans

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -16,10 +16,10 @@ hype.
 ### Aesthetic Direction
 
 Industrial and documentation-first. Use Hikyo's graphite/linen dual theme,
-restrained teal accent, Archivo body typography, and IBM Plex Mono for code.
-Prefer hairlines, compact geometry, and strong type hierarchy over cards,
-shadows, gradients, glow, or decorative motion. Dark is the default; light is
-fully supported.
+restrained teal accent, Instrument Sans for interface and body typography, and
+IBM Plex Mono for code, keys, and values. Prefer hairlines, compact geometry,
+and strong type hierarchy over cards, shadows, gradients, glow, or decorative
+motion. Dark is the default; light is fully supported.
 
 ### Design Principles
 

--- a/README.md
+++ b/README.md
@@ -1,130 +1,163 @@
-# Hikyo
+<div align="center">
+  <a href="https://hikyo.app/">
+    <img src="./docs/site/public/favicon.svg" alt="Hikyo" width="128" />
+  </a>
 
-Fully open-source secrets and configuration across environments, with
-validation, explicit per-environment values, and no enterprise tier.
+  <h1>Hikyo</h1>
 
-Hikyo is a self-hosted control plane for developers and platform engineers. It
-ships as one Go binary, embeds its own web UI, supports SQLite and PostgreSQL,
-and treats every value as explicitly `set` or `absent` in each environment.
+  <p><strong>Secrets and configuration you can reason about.</strong></p>
 
-> **Status:** active `0.x` development. Interfaces are not frozen until the
-> `1.0.0` release gate passes, and there are no published binaries, images, or
-> Helm charts yet — the supported install today is a source build.
+  <p>
+    A fully open-source, self-hosted control plane for explicit values across
+    development, staging, and production.
+  </p>
 
-## Why Hikyo
+  <p>
+    <a href="https://hikyo.app/docs/"><strong>Documentation</strong></a> ·
+    <a href="https://hikyo.app/docs/getting-started/">Getting started</a> ·
+    <a href="https://hikyo.app/docs/self-hosting/">Self-hosting</a> ·
+    <a href="./CONTRIBUTING.md">Contributing</a>
+  </p>
 
-- **Explicit state.** Each key's value in each environment is `set` or `absent`.
-  Values never inherit between environments, so development cannot silently
-  supply a default to production and an empty cell is never ambiguous.
-- **Declare before you write.** A key is declared (config vs. secret, validation
-  and presence rules) before any value exists. Writes are validated at write
-  time and rejected if the resulting environment state is invalid.
-- **Secrets are a separate disclosure path.** Ordinary reads return presence and
-  metadata, not plaintext. Revealing or copying a secret is a deliberate,
-  reauthenticated action with its own audit event.
-- **One authorization chokepoint.** Human sessions, machine identities, and
-  local break-glass all evaluate against the same capability-and-scope model.
-- **Fully open, no enterprise tier.** See below.
+  <p>
+    <a href="https://github.com/Hikyo-Org/Hikyo/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Hikyo-Org/Hikyo/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+    <a href="./LICENSE"><img alt="Mozilla Public License 2.0" src="https://img.shields.io/badge/license-MPL--2.0-3b82f6" /></a>
+    <img alt="Active 0.x development" src="https://img.shields.io/badge/status-active%200.x-f97316" />
+  </p>
+</div>
 
-## Quickstart (local evaluation)
+> [!IMPORTANT]
+> Hikyo is in active `0.x` development. Interfaces are not frozen, and there
+> are no published binaries, images, or Helm charts yet. Build from source to
+> evaluate it today.
 
-Requires Go 1.26+, Node.js 24 (see `.nvmrc`), and Corepack/pnpm.
+## One matrix. No hidden inheritance.
+
+Hikyo makes every environment answer for itself. A value is explicitly `set`
+or `absent`; production never silently borrows a development default.
+
+| Key | development | staging | production |
+| --- | :---: | :---: | :---: |
+| `DATABASE_URL` | ● secret set | ● secret set | ● secret set |
+| `LOG_LEVEL` | `debug` | `info` | `info` |
+| `SENTRY_DSN` | ○ absent | ● secret set | ● secret set |
+
+The same model is available through the embedded web UI, CLI, and API. Hikyo
+ships as one Go binary and supports both SQLite and PostgreSQL.
+
+## What makes Hikyo different
+
+- **Explicit state.** Empty never means “inherited,” “unknown,” or “use a
+  default.” Each environment records `set` or `absent`.
+- **Declarations before values.** Define config vs. secret, validation, and
+  presence rules first. Invalid writes are refused before state changes.
+- **Deliberate secret disclosure.** Normal reads return metadata and presence.
+  Reveal and copy require reauthentication and create dedicated audit events.
+- **One authorization chokepoint.** Humans, machine identities, and local
+  break-glass use the same capability-and-scope decision model.
+- **Self-hosting is the product.** One binary, an embedded UI, your database,
+  your root key, and no enterprise-only implementation.
+
+## Quick start
+
+Requires Go 1.26+, Node.js 24 (see [`.nvmrc`](./.nvmrc)), and Corepack/pnpm.
 
 ```bash
-# 1. Build the binary with the embedded UI
-git clone https://github.com/Hikyo-Org/hikyo.git
-cd hikyo
+git clone https://github.com/Hikyo-Org/Hikyo.git
+cd Hikyo
+
 corepack enable
 pnpm --dir clients/ts install --frozen-lockfile
 pnpm --dir web install --frozen-lockfile
 pnpm --dir web build
 go build -tags ui -o ./bin/hikyo ./cmd/hikyo
 
-# 2. Run a zero-config, loopback-only dev instance
-#    Creates hikyo-dev.db + a 0600 root key in the current directory.
-./bin/hikyo server --dev              # serves API + UI on http://127.0.0.1:8080
+./bin/hikyo server --dev
 ```
 
-Open <http://127.0.0.1:8080> for the web UI, or check `curl --fail
-http://127.0.0.1:8080/healthz`. The `-tags ui` build embeds the browser app; a
-plain `go build` produces an API-only binary.
+Open <http://127.0.0.1:8080>. The command creates `hikyo-dev.db` and a
+permission-`0600` root key in the current directory.
 
-`--dev` is for evaluation only. From there,
-[Getting started](https://hikyo.app/docs/getting-started/) walks through
-creating the first administrator and
-[Your first project](https://hikyo.app/docs/first-project/) through your first
-key and value.
+`--dev` is loopback-only and intended for evaluation. A `-tags ui` build embeds
+the browser app; a plain `go build` produces an API-only binary.
+
+Next, follow [Getting started](https://hikyo.app/docs/getting-started/) to create
+the first administrator, then [Your first project](https://hikyo.app/docs/first-project/)
+to declare a key and set its first value.
 
 ## CLI at a glance
 
-One binary handles both server and client roles.
+One binary handles both operator and day-to-day client workflows.
 
 ```bash
-# Server / operator
+# Operate the instance
 hikyo server [--dev] [--listen ADDR] [--root-key-file PATH]
-hikyo migrate                         # apply DB migrations
-hikyo admin create --username admin   # host-only: bootstrap first authority
-hikyo backup export | restore run     # host-only backup/restore
+hikyo migrate
+hikyo admin create --username admin
+hikyo backup export
+hikyo restore run --from <archive> --identity-file <path>
 
-# Client (day to day)
+# Create a scoped environment
 hikyo login <instance-url> --local --as <user>
 hikyo org create --name <name>
 hikyo project create --name <name> --org <org-id>
 hikyo env create --name <name> --org <org-id> --project <project-id>
 hikyo context create <name> --instance <url> --org <id> --project <id> --env <id>
+
+# Declare and manage values
 hikyo key create --context <ctx> --name NAME --classification config|secret \
   --declaration '{"rule":{"type":"string"}}'
-hikyo values set NAME --context <ctx> --value-file PATH   # or --stdin / --clear
-hikyo values get NAME --context <ctx>                     # presence + metadata
-hikyo values get NAME --context <ctx> --reveal --output-file PATH   # plaintext
-hikyo values list | diff | copy --context <ctx>
+hikyo values set NAME --context <ctx> --value-file PATH
+hikyo values get NAME --context <ctx>
+hikyo values get NAME --context <ctx> --reveal --output-file PATH
+hikyo values list --context <ctx>
+hikyo values diff --context <ctx> --left development --right production
+hikyo values copy --context <ctx> --from staging --to production --keys NAME
 ```
 
-Secret values are never passed on the command line — use `--value-file` or
-`--stdin`. Full command list:
-[CLI reference](https://hikyo.app/docs/cli-reference/).
+Secret values never belong in command-line arguments. Use `--value-file` or
+`--stdin`. See the complete [CLI reference](https://hikyo.app/docs/cli-reference/).
 
-## Running in production
+## Run in production
 
-Outside `--dev` you must supply a datastore and a root key:
+Outside `--dev`, provide a datastore, external origin, trusted proxy boundary,
+and root key:
 
 ```bash
 HIKYO_DB=sqlite:/var/lib/hikyo/hikyo.db \
 HIKYO_EXTERNAL_ORIGIN=https://hikyo.example.com \
 HIKYO_TRUSTED_PROXY_CIDRS=127.0.0.1/32 \
-./hikyo server --listen 127.0.0.1:8080 --root-key-file /etc/hikyo/root.key
+./hikyo server --listen 127.0.0.1:8080 \
+  --root-key-file /etc/hikyo/root.key
 ```
 
 `HIKYO_DB` accepts `sqlite:PATH` or a PostgreSQL DSN. Terminate TLS at a reverse
-proxy and keep the listener private. See
-[Self-hosting](https://hikyo.app/docs/self-hosting/) and
+proxy and keep the Hikyo listener private.
+
+Read [Self-hosting](https://hikyo.app/docs/self-hosting/) before deployment and
 [Configuration](https://hikyo.app/docs/configuration/) for every flag and
 environment variable.
 
-## Fully open, no enterprise tier
+## Fully open. One product.
 
 Every capability required to run Hikyo in production is and will remain open
 source; there is no `/ee` directory and there will never be one.
 
-The full commitment, including how it may be amended, is in
+The enforceable commitment and amendment process live in
 [GOVERNANCE.md](./GOVERNANCE.md#fully-open-pledge).
 
-## Documentation
+## Explore the project
 
-Full docs live at **<https://hikyo.app/docs/>**.
+| Goal | Start here |
+| --- | --- |
+| Learn the model | [Core concepts](https://hikyo.app/docs/core-concepts/) |
+| Build from source | [Installation](https://hikyo.app/docs/installation/) |
+| Operate an instance | [Self-hosting](https://hikyo.app/docs/self-hosting/) |
+| Use the terminal | [CLI reference](https://hikyo.app/docs/cli-reference/) |
+| Contribute code | [Contributing guide](./CONTRIBUTING.md) |
 
-- [Getting started](https://hikyo.app/docs/getting-started/)
-- [Core concepts](https://hikyo.app/docs/core-concepts/)
-- [Self-hosting](https://hikyo.app/docs/self-hosting/)
-- [CLI reference](https://hikyo.app/docs/cli-reference/)
-
-Project policies:
-
-- [Security policy](./SECURITY.md)
-- [Support policy](./SUPPORT.md)
-- [Governance](./GOVERNANCE.md)
-- [Trademark policy](./TRADEMARK.md)
-- [Contributing](./CONTRIBUTING.md)
+[Security](./SECURITY.md) · [Support](./SUPPORT.md) ·
+[Governance](./GOVERNANCE.md) · [Trademark](./TRADEMARK.md)
 
 ## License
 

--- a/docs/handoff/137-readme-instrument-sans.md
+++ b/docs/handoff/137-readme-instrument-sans.md
@@ -1,0 +1,42 @@
+# Handoff: PR #137 README and Instrument Sans
+
+## Scope
+
+PR [#137](https://github.com/Hikyo-Org/Hikyo/pull/137) refreshes the repository
+README and adopts Instrument Sans as Hikyo's house sans-serif across the web
+app, landing page, and documentation.
+
+## Decisions
+
+- Instrument Sans owns interface and body typography.
+- IBM Plex Mono remains reserved for code, keys, and values.
+- The app uses the variable Fontsource package; the docs load static 400, 500,
+  and 700 weights. All packages remain pinned at `5.3.0`.
+- Fonts remain self-hosted with `font-display: swap`; no CSP or external-egress
+  change is required.
+- The README uses the existing Hikyo mark and a semantic environment matrix
+  rather than adding an unmaintained screenshot.
+
+## Changed surfaces
+
+- `README.md`: branded first screen, product proof, quick start, CLI examples,
+  production boundary, OSS commitment, and goal-based documentation map.
+- `.impeccable.md`: Instrument Sans is the canonical interface/body typeface.
+- `web/`: variable font dependency, import, design token, and computed-font
+  assertion description.
+- `docs/site/`: static font dependency and both landing/docs stylesheet stacks.
+
+## Verification
+
+- Web TypeScript check passed.
+- Vitest: 86 tests passed.
+- Playwright: 124 desktop/mobile tests passed across dark and light themes,
+  including computed typeface assertions.
+- Astro: 0 errors, warnings, or hints; 31 pages built.
+- OSS policy, live-doc, and fallback-channel gates passed.
+- Local desktop/mobile previews showed Instrument Sans loaded on landing and
+  docs pages with no horizontal overflow.
+
+For a fresh checkout, install `clients/ts` before validating `web`; the web
+package consumes generated client source whose `zod` dependency is owned by
+that standalone package.

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -15,7 +15,7 @@
     "@astrojs/markdown-remark": "7.2.2",
     "@astrojs/mdx": "7.0.5",
     "@astrojs/react": "6.0.2",
-    "@fontsource/archivo": "5.3.0",
+    "@fontsource/instrument-sans": "5.3.0",
     "@fontsource/ibm-plex-mono": "5.3.0",
     "@tailwindcss/vite": "4.3.3",
     "astro": "7.2.0",

--- a/docs/site/pnpm-lock.yaml
+++ b/docs/site/pnpm-lock.yaml
@@ -17,10 +17,10 @@ importers:
       '@astrojs/react':
         specifier: 6.0.2
         version: 6.0.2(@types/node@26.2.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(yaml@2.9.0)
-      '@fontsource/archivo':
+      '@fontsource/ibm-plex-mono':
         specifier: 5.3.0
         version: 5.3.0
-      '@fontsource/ibm-plex-mono':
+      '@fontsource/instrument-sans':
         specifier: 5.3.0
         version: 5.3.0
       '@tailwindcss/vite':
@@ -539,11 +539,11 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@fontsource/archivo@5.3.0':
-    resolution: {integrity: sha512-5DIMgPVJRi62OqdOVoogCFxP73EkNM/E0YVTSDIQlDEJfDbxqZduwM/YoNZwC9Sx1CDgpKinqf8ckRY1QNIecw==}
-
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
+
+  '@fontsource/instrument-sans@5.3.0':
+    resolution: {integrity: sha512-QwXc4hb/px3XvSPS2CPAOgey8nyrQFxgxrmXQQ+pN+P51hKdAcchxpg8rSbjANFfPu6VKXhDqkVDucXMZ9CM5g==}
 
   '@fuma-translate/react@1.0.2':
     resolution: {integrity: sha512-uOiOtBx3nRXR8Nu1GzBf1tApgF1FErDBTHxRIAQeyQdyOoZbrNRN6H4kDCWObY4qyGeGbHydG0DHzgeUgFDMIw==}
@@ -3683,9 +3683,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@fontsource/archivo@5.3.0': {}
-
   '@fontsource/ibm-plex-mono@5.3.0': {}
+
+  '@fontsource/instrument-sans@5.3.0': {}
 
   '@fuma-translate/react@1.0.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:

--- a/docs/site/src/styles/docs.css
+++ b/docs/site/src/styles/docs.css
@@ -1,13 +1,13 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
-@import '@fontsource/archivo/400.css';
-@import '@fontsource/archivo/500.css';
-@import '@fontsource/archivo/700.css';
+@import '@fontsource/instrument-sans/400.css';
+@import '@fontsource/instrument-sans/500.css';
+@import '@fontsource/instrument-sans/700.css';
 @import '@fontsource/ibm-plex-mono/400.css';
 
 @theme {
-  --font-sans: 'Archivo', sans-serif;
+  --font-sans: 'Instrument Sans', sans-serif;
   --font-mono: 'IBM Plex Mono', monospace;
   --color-fd-background: oklch(0.965 0.008 200);
   --color-fd-foreground: oklch(0.25 0.03 225);

--- a/docs/site/src/styles/landing.css
+++ b/docs/site/src/styles/landing.css
@@ -1,6 +1,6 @@
-@import '@fontsource/archivo/400.css';
-@import '@fontsource/archivo/500.css';
-@import '@fontsource/archivo/700.css';
+@import '@fontsource/instrument-sans/400.css';
+@import '@fontsource/instrument-sans/500.css';
+@import '@fontsource/instrument-sans/700.css';
 @import '@fontsource/ibm-plex-mono/400.css';
 @import '@fontsource/ibm-plex-mono/500.css';
 
@@ -20,7 +20,7 @@
   --danger-quiet: oklch(0.72 0.13 25 / 0.14);
   --warning: oklch(0.82 0.1 85);
   --mono: 'IBM Plex Mono', ui-monospace, monospace;
-  --sans: 'Archivo', sans-serif;
+  --sans: 'Instrument Sans', sans-serif;
   --max-width: 70rem;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   color-scheme: dark;

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -458,7 +458,7 @@ export async function expectRadiusRole(
   expect(got, `radius role "${role}" (DESIGN.md says ${want})`).toBe(want);
 }
 
-/** expectFontRole checks a component uses Archivo (UI) or IBM Plex Mono (keys/values). */
+/** Checks that UI uses Instrument Sans and keys/values use IBM Plex Mono. */
 export async function expectFontRole(page: Page, target: Locator, role: FontRole): Promise<void> {
   const want = await tokenValue(page, FONT_TOKEN[role]);
   const got = await target.evaluate((el) => getComputedStyle(el).fontFamily);

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
-    "@fontsource-variable/archivo": "5.3.0",
+    "@fontsource-variable/instrument-sans": "5.3.0",
     "@fontsource/ibm-plex-mono": "5.3.0",
     "@tanstack/react-query": "5.101.4",
     "@tanstack/react-virtual": "3.14.9",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     dependencies:
-      '@fontsource-variable/archivo':
+      '@fontsource-variable/instrument-sans':
         specifier: 5.3.0
         version: 5.3.0
       '@fontsource/ibm-plex-mono':
@@ -68,8 +68,8 @@ packages:
     peerDependencies:
       playwright-core: '>= 1.0.0'
 
-  '@fontsource-variable/archivo@5.3.0':
-    resolution: {integrity: sha512-HogK8FJelrD1o7TlZlkIVtHgc20bO5PZRWE7mUeUTdMN055alznQV6/00J00IBeu8FQAH4s3zW9UJNvKExXf+g==}
+  '@fontsource-variable/instrument-sans@5.3.0':
+    resolution: {integrity: sha512-u4gKbDBTNFGkg997tfQn3eHOhHuquWUFTRT/rwzuKtrxX5P2ekfs2x+LgBPP4P32+cC+vUwF1Cr+IdRoPQbrGw==}
 
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
@@ -586,7 +586,7 @@ snapshots:
       axe-core: 4.12.1
       playwright-core: 1.62.1
 
-  '@fontsource-variable/archivo@5.3.0': {}
+  '@fontsource-variable/instrument-sans@5.3.0': {}
 
   '@fontsource/ibm-plex-mono@5.3.0': {}
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,4 @@
-import '@fontsource-variable/archivo';
+import '@fontsource-variable/instrument-sans';
 import '@fontsource/ibm-plex-mono/400.css';
 import '@fontsource/ibm-plex-mono/500.css';
 import './styles/tokens.css';

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -35,7 +35,7 @@
   --radius-pill: 999px;
 
   /* Type */
-  --font-ui: 'Archivo Variable', 'Archivo', system-ui, sans-serif;
+  --font-ui: 'Instrument Sans Variable', 'Instrument Sans', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
 
   /* Density — matrix rows ~36px desktop, ~44px touch targets on mobile. */


### PR DESCRIPTION
## Summary

- rebuild the README around a branded first screen, product proof, quick start, and clearer project navigation
- adopt Instrument Sans across the app, landing page, and documentation while retaining IBM Plex Mono for code and values
- update the design context, Fontsource locks, and computed-font assertions

## Validation

- web TypeScript check
- 86 Vitest tests
- 124 Playwright desktop/mobile tests across dark and light themes
- Astro check and 31-page docs build
- OSS policy, live docs, and fallback-channel gates
- desktop and mobile preview inspection with Instrument Sans loaded and no horizontal overflow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789423841&installation_model_id=432348&pr_number=137&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F137&signature=5ae7a533193902db071d8e6121b4e895581c2d8c9f1f72c0e0238a5df9a40ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->