### PR TITLE
docs(readme): collapse implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 
 ## Implementation status
 
+<details>
+<summary>Show fully implemented, partially implemented, and not-started features</summary>
+
 “Implemented” means the feature and its acceptance coverage are present in the
 repository. It does not mean the API is frozen or that Hikyo 1.0 has shipped.
 The source and linked implementation tickets are authoritative; [#1] and [#41]
@@ -77,6 +80,8 @@ are planning/parent trackers rather than missing features.
 The remaining 1.0 implementation blockers are [#59], [#60], [#63]–[#66],
 [#70], [#74], [#75], [#77], and [#112]. Once they close, [#79] performs the
 full acceptance run and cuts the freeze/release tag.
+
+</details>
 
 [#1]: https://github.com/Hikyo-Org/Hikyo/issues/1
 [#41]: https://github.com/Hikyo-Org/Hikyo/issues/41


### PR DESCRIPTION
## Summary
- keep Implementation status visible
- collapse feature tables and blocker details by default
- preserve keyboard-accessible native disclosure

## Verification
- GitHub GFM renderer
- ./scripts/ci/verify-docs.sh
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789511275&installation_model_id=432348&pr_number=143&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F143&signature=6f20933ce3184c77b6df3bdcddc19bcdabef8220425de2968a51b61917c1e0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->