### PR TITLE
ci: right-size 4 trusted-ci runners (~$10/month saved)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
   labels:
     - blacksmith-2vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
   release-snapshot:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).release_snapshot }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -323,7 +323,7 @@ jobs:
   docs:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).docs }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -343,7 +343,7 @@ jobs:
   web:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -584,7 +584,7 @@ jobs:
       - supply-chain-checks
       - test
       - web
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Applies four runner-sizing changes selected from the Blacksmith right-sizing card, based on 30 days of observed CPU, memory, and runtime metrics. Net effect is about $10/month less spend and a materially faster `release-snapshot` job.

All four rows are `validation / *` jobs, which run in the reusable workflow `.github/workflows/ci.yml` called by `validation` in `.github/workflows/ci-control.yml`. The `runs-on:` lines therefore live in `ci.yml`, which is what this PR edits:

```yaml
  release-snapshot:
    needs: changes
    if: ${{ fromJSON(needs.changes.outputs.plan).release_snapshot }}
    runs-on: blacksmith-8vcpu-ubuntu-2404   # was blacksmith-4vcpu-ubuntu-2404
# ...
  docs:
    runs-on: blacksmith-2vcpu-ubuntu-2404   # was blacksmith-4vcpu-ubuntu-2404
  web:
    runs-on: blacksmith-2vcpu-ubuntu-2404   # was blacksmith-4vcpu-ubuntu-2404
  ci-required:
    runs-on: blacksmith-2vcpu-ubuntu-2404   # was blacksmith-4vcpu-ubuntu-2404
```

## Apply for speed

### `validation / release-snapshot`: 4 -> 8 vCPU

Medium confidence. Projected runtime change: about 32% faster (median 45.5s -> 30.8s, slow runs 116.9s -> 82.8s). Estimated monthly spend: $5.38 -> $7.33 (+$1.95). Roughly 528 runs/month.

This job is genuinely CPU-bound: average CPU is 75.6%, both the 95th and 99th percentile CPU sit at 100%, and it spends 68% of its runtime above 80% CPU with every core busy. That profile is the GoReleaser snapshot compiling six release targets plus the SPA build, which parallelizes well. There is no memory pressure (peak memory 27%), so the extra cores are the binding constraint. The small spend increase buys back wall time on every PR.

Sample runs: [median](https://app.blacksmith.sh/Hikyo-Org/runs/31857128765/jobs/94943963903?tab=metrics) - [slow run](https://app.blacksmith.sh/Hikyo-Org/runs/31959790991/jobs/95195932996?tab=metrics)

## Test before applying

These three are scale-downs with real headroom on average, but each shows short CPU spikes, so they are worth watching for a few runs before treating them as settled.

### `validation / web`: 4 -> 2 vCPU

Cautious confidence. Projected runtime change: about 5% slower (median 231.5s -> 243.3s, slow runs 246s -> 261.7s). Estimated monthly spend: $16.90 -> $8.90 (-$8.00). Roughly 528 runs/month.

The largest saving in the set. Average CPU is 21.3% with peak memory at 11%, and effective busy cores sit near 1.8, so two cores cover the steady state. The caveat is brief spikes to 98% CPU, likely the Playwright flow suite and the SPA build, which is why this one deserves a look at the next few runs rather than a blind merge.

Sample runs: [median](https://app.blacksmith.sh/Hikyo-Org/runs/31847307931/jobs/94916309904?tab=metrics) - [slow run](https://app.blacksmith.sh/Hikyo-Org/runs/31960661847/jobs/95198066994?tab=metrics)

### `validation / docs`: 4 -> 2 vCPU

Cautious confidence. Projected runtime change: about 1.4% slower (median 15s -> 15.2s, slow runs 38.8s -> 39.4s). Estimated monthly spend: $4.42 -> $2.24 (-$2.18). Roughly 552 runs/month.

Average CPU is 25.9% with 95th percentile CPU at 59.5% and peak memory under 10%, so the smaller runner fits comfortably and the projected slowdown is nearly noise. Flagged cautious because the job already uses most of its cores at peak, so there is little margin if the docs build grows.

Sample runs: [median](https://app.blacksmith.sh/Hikyo-Org/runs/31911814705/jobs/95077973455?tab=metrics) - [slow run](https://app.blacksmith.sh/Hikyo-Org/runs/31879920962/jobs/95000982732?tab=metrics)

### `validation / ci-required`: 4 -> 2 vCPU

Cautious confidence. Projected runtime change: about 7% slower (median 7s -> 7.5s, slow runs 7.9s -> 8.5s). Estimated monthly spend: $4.42 -> $2.37 (-$2.05). Roughly 552 runs/month.

This is the merge gate: a checkout plus a shell script that reconciles the needs context, so it is almost entirely idle. Average CPU is 23.8% and peak memory is only 2%. The 99th percentile CPU touches 95.7% in short bursts, but at a 7-second median the percentage slowdown translates to well under a second.

Sample runs: [median](https://app.blacksmith.sh/Hikyo-Org/runs/31865529488/jobs/94966330105?tab=metrics) - [slow run](https://app.blacksmith.sh/Hikyo-Org/runs/31944211900/jobs/95158157861?tab=metrics)

## Notes

The top-level `ci-required` job in `ci-control.yml` was already on 2 vCPU and is untouched; only the reusable-workflow job of the same name changed. No other `runs-on:` lines were modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->