### PR TITLE
fix(security): make contained reads race-resistant

### DIFF
--- a/internal/lint/appendonly.go
+++ b/internal/lint/appendonly.go
@@ -92,20 +92,15 @@ func checkNoSyncCommitDowngrade(repoRoot string) []string {
 			if !strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, ".sql") {
 				return nil
 			}
-			targetClean, ok := pathutil.ResolveWithin(root, path)
-			if !ok {
-				findings = append(findings, fmt.Sprintf("appendonly: invalid file path"))
-				return nil
-			}
-			b, rerr := os.ReadFile(targetClean)
+			b, rerr := pathutil.ReadFileWithin(root, path)
 			if rerr != nil {
-				findings = append(findings, fmt.Sprintf("appendonly: read %s: %v", targetClean, rerr))
+				findings = append(findings, fmt.Sprintf("appendonly: %v", rerr))
 				return nil
 			}
 			if syncCommitRe.Match(b) {
 				findings = append(findings, fmt.Sprintf(
 					"appendonly: %s issues SET synchronous_commit — durability is a boot-verified server setting, never a session downgrade (audit-model ADR CI invariant 7)",
-					targetClean))
+					path))
 			}
 			return nil
 		})

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -91,6 +91,63 @@ func TestQueryScanRejectsSymlinkEscape(t *testing.T) {
 	}
 	if _, err := ParseQueries(queryDir); err == nil {
 		t.Fatal("query scan followed a symlink outside its root")
+	} else if !strings.Contains(err.Error(), "read target") {
+		t.Fatalf("query scan hid target-read cause: %v", err)
+	}
+}
+
+func TestCheckSQLPredicatesReportsReadCauseWithoutDuplicatePrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows")
+	}
+	repo := t.TempDir()
+	migrationDir := filepath.Join(repo, "internal", "store", "migrations", "sqlite")
+	if err := os.MkdirAll(migrationDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.sql")
+	if err := os.WriteFile(outside, []byte("CREATE TABLE outside (id TEXT);\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(migrationDir, "escape.sql")); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := CheckSQLPredicates(repo)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %v, want one refused read", findings)
+	}
+	if count := strings.Count(findings[0], "sqlpredicate:"); count != 1 {
+		t.Fatalf("finding has %d subsystem prefixes, want one: %s", count, findings[0])
+	}
+	if !strings.Contains(findings[0], "read target") {
+		t.Fatalf("finding hid target-read cause: %s", findings[0])
+	}
+}
+
+func TestAppendOnlyScanRejectsSymlinkEscapeWithReadCause(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows")
+	}
+	repo := t.TempDir()
+	storeDir := filepath.Join(repo, "internal", "store")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.sql")
+	if err := os.WriteFile(outside, []byte("SELECT 1;\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(storeDir, "escape.sql")); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkNoSyncCommitDowngrade(repo)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %v, want one refused read", findings)
+	}
+	if !strings.Contains(findings[0], "read target") {
+		t.Fatalf("append-only scan hid target-read cause: %s", findings[0])
 	}
 }
 

--- a/internal/lint/sqlpredicate.go
+++ b/internal/lint/sqlpredicate.go
@@ -452,11 +452,8 @@ func eachSQLFile(dir string, fn func(path, src string) error) error {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
 			continue
 		}
-		path, ok := pathutil.ResolveWithin(dir, filepath.Join(dir, e.Name()))
-		if !ok {
-			return fmt.Errorf("invalid file path")
-		}
-		b, err := os.ReadFile(path)
+		path := filepath.Join(dir, e.Name())
+		b, err := pathutil.ReadFileWithin(dir, path)
 		if err != nil {
 			return err
 		}

--- a/internal/pathutil/contain.go
+++ b/internal/pathutil/contain.go
@@ -2,6 +2,8 @@
 package pathutil
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -17,21 +19,29 @@ func Within(root, target string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// ResolveWithin resolves symlinks and returns the resolved target only when it
-// remains inside the resolved root. Both paths must exist; use Within for a
-// destination that has not been created yet. Callers should read the returned
-// path so the checked symlink is not followed again.
-func ResolveWithin(root, target string) (string, bool) {
-	resolvedRoot, err := filepath.EvalSymlinks(root)
+// ReadFileWithin reads target through an open handle to root. The rooted read
+// follows symlinks only while they remain inside root, so validation and use
+// cannot be separated by a pathname race.
+func ReadFileWithin(root, target string) ([]byte, error) {
+	rootClean := filepath.Clean(root)
+	targetClean := filepath.Clean(target)
+	rel, err := filepath.Rel(rootClean, targetClean)
 	if err != nil {
-		return "", false
+		return nil, fmt.Errorf("make target %q relative to root %q: %w", targetClean, rootClean, err)
 	}
-	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("target %q escapes root %q: %w", targetClean, rootClean, os.ErrInvalid)
+	}
+
+	rootHandle, err := os.OpenRoot(rootClean)
 	if err != nil {
-		return "", false
+		return nil, fmt.Errorf("open root %q: %w", rootClean, err)
 	}
-	if !Within(resolvedRoot, resolvedTarget) {
-		return "", false
+	defer rootHandle.Close()
+
+	b, err := rootHandle.ReadFile(rel)
+	if err != nil {
+		return nil, fmt.Errorf("read target %q within root %q: %w", rel, rootClean, err)
 	}
-	return resolvedTarget, true
+	return b, nil
 }

--- a/internal/pathutil/contain_test.go
+++ b/internal/pathutil/contain_test.go
@@ -1,9 +1,11 @@
 package pathutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -20,7 +22,7 @@ func TestWithinUsesPathComponentBoundaries(t *testing.T) {
 	}
 }
 
-func TestResolveWithinRejectsSymlinkEscape(t *testing.T) {
+func TestReadFileWithinRejectsSymlinkEscape(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation is not reliably available on Windows")
 	}
@@ -33,7 +35,94 @@ func TestResolveWithinRejectsSymlinkEscape(t *testing.T) {
 	if err := os.Symlink(outside, link); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := ResolveWithin(root, link); ok {
-		t.Fatal("symlink target outside the root was accepted")
+	if _, err := ReadFileWithin(root, link); err == nil {
+		t.Fatal("symlink target outside the root was read")
+	}
+}
+
+func TestReadFileWithinAcceptsDoubleDotsInsideComponents(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root..prod")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "..safe.sql")
+	want := []byte("SELECT 1;\n")
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileWithin(root, target)
+	if err != nil {
+		t.Fatalf("valid dotted path rejected: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("read %q, want %q", got, want)
+	}
+}
+
+func TestReadFileWithinPreservesErrorCauseAndOperation(t *testing.T) {
+	root := t.TempDir()
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	tests := []struct {
+		name       string
+		root       string
+		target     string
+		wantCause  error
+		wantDetail string
+	}{
+		{
+			name:       "root open",
+			root:       missingRoot,
+			target:     filepath.Join(missingRoot, "query.sql"),
+			wantCause:  os.ErrNotExist,
+			wantDetail: "open root",
+		},
+		{
+			name:       "target read",
+			root:       root,
+			target:     filepath.Join(root, "missing.sql"),
+			wantCause:  os.ErrNotExist,
+			wantDetail: "read target",
+		},
+		{
+			name:       "lexical escape",
+			root:       root,
+			target:     filepath.Join(root, "..", "outside.sql"),
+			wantCause:  os.ErrInvalid,
+			wantDetail: "escapes root",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadFileWithin(tt.root, tt.target)
+			if !errors.Is(err, tt.wantCause) {
+				t.Fatalf("error = %v, want cause %v", err, tt.wantCause)
+			}
+			if !strings.Contains(err.Error(), tt.wantDetail) {
+				t.Fatalf("error = %q, want operation %q", err, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestReadFileWithinPreservesPermissionError(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforceable in this environment")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "private.sql")
+	if err := os.WriteFile(target, []byte("SELECT 1;\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(target, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(target, 0o600) })
+
+	_, err := ReadFileWithin(root, target)
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("error = %v, want permission cause", err)
+	}
+	if !strings.Contains(err.Error(), "read target") {
+		t.Fatalf("error = %q, want read operation", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #123 and its post-merge review findings.

## What changed

- replace the `EvalSymlinks` then pathname-read sequence with `os.OpenRoot(root).ReadFile(relative)`
- preserve component-aware lexical containment for uncreated PostgreSQL backup destinations
- wrap root-open, invalid-relative/escape, and target-read failures while preserving their concrete causes
- migrate both append-only and SQL-predicate root-bound reads; remove obsolete `ResolveWithin`

## Verification

- regression tests cover dotted path components, symlink escapes in both lint readers, missing root/target causes, and portable permission errors
- `go test ./internal/pathutil ./internal/lint`
- `go build ./...`
- `go vet ./...`
- `HIKYO_TEST_POSTGRES_DSN=postgres://hikyo:***@127.0.0.1:55432/hikyo_test go test -count=1 ./...` against PostgreSQL 18, including SQLite/PostgreSQL conformance
- `scripts/ci/check-dco.sh bbd736351886def546192077ec2ec13ec50ef0b6 HEAD .`

No old #123 threads were reopened or resolved; they were already resolved before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789551404&installation_model_id=432348&pr_number=149&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F149&signature=075d7d16d6a2b47526c6489a2d7718b60b6ef68c0bd97fe73d870299dec8139b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->