### PR TITLE
Fix adapter audit lease clock regression

### DIFF
--- a/docs/handoff/65-adapter-outbox-forgejo.md
+++ b/docs/handoff/65-adapter-outbox-forgejo.md
@@ -690,13 +690,19 @@ that leg when `CI` is set and the DSN is absent.
   They do not replace the separately gated real-Forgejo lifecycle proof above;
   that remains an external prerequisite requiring the Forgejo URL, scoped PAT,
   owner/repository, and any operator-approved private endpoint policy.
-- The worktree is intentionally uncommitted for the parent lifecycle owner.
+- PR #160 landed as signed-off squash `1dc7f3813e31f9317bbbe57ea74a13bbd8484779`.
+  Its post-merge run exposed a time-dependent audit fixture: the adapter worker
+  claimed a two-minute provider lease from a fixed timestamp, while the journal
+  correctly checked expiry against the real clock. Anchoring the integration
+  fixture to the canonical current time makes that lease live regardless of
+  calendar date. The regression passed ten SQLite repetitions, three combined
+  SQLite/Postgres repetitions, and the full 3,005-test/44-package Go suite.
 - Generated sqlc/OpenAPI output is included alongside source changes.
 - The public grammar, atomic first-target bootstrap, adoption selection,
   origin-scoped egress policy, scrub-first move semantics, and purpose-aware
   reauthentication semantics are resolved and implemented to the extent noted
   above. Do not restore the superseded routing/ceremony design questions.
-- The parent-owned final broad suite and release snapshot have run successfully;
-  do not rerun them before commit without a new code change.
+- The parent-owned final broad suite and release snapshot ran successfully; the
+  post-merge fixture correction repeated the full Go/Postgres suite.
 - Postgres acceptance is covered by the final parent-owned suite. Do not claim
   real-Forgejo acceptance until the external command above runs successfully.

--- a/internal/isolation/adapter_audit_e2e_test.go
+++ b/internal/isolation/adapter_audit_e2e_test.go
@@ -78,7 +78,10 @@ func (auditAdapterLoader) Load(context.Context, adapter.Job, adapter.Journal) (a
 func runAdapterAuditLifecycle(t *testing.T, db *store.DB) {
 	t.Helper()
 	ctx := tctx(t)
-	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	// AdapterRuntime.Gate checks the provider lease against the real clock.
+	// Keep this integration fixture on that clock too: a fixed timestamp turns
+	// the claimed lease stale as soon as wall time passes the fixture date.
+	now := store.CanonTime(time.Now().UTC())
 	scope := domain.Scope{Org: orgA, Project: prjA1}
 
 	// Fixture authority only. Every adapter mutation and every corresponding


### PR DESCRIPTION
## Cause

PR #160 post-merge CI crossed the audit fixture timestamp. The worker claimed a two-minute provider lease from a fixed time while AdapterRuntime.Gate correctly checked expiry against the real clock, so the fixture became permanently superseded.

## Fix

Anchor the audit lifecycle fixture to the canonical current time and record the post-merge finding in the #65 handoff. Production runtime semantics are unchanged.

## Verification

- red loop: TestAuditCoreSQLite failed 10/10 before the fix
- fixed loop: TestAuditCoreSQLite passed 10/10, 150 subtests
- SQLite/PostgreSQL audit parity passed three repetitions, 90 subtests
- build and vet passed
- full SQLite/PostgreSQL Go suite passed: 3,005 tests across 44 packages
- git diff check passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789652896&installation_model_id=432348&pr_number=165&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F165&signature=35a64212165b8283fca6df92a5ba9faf5b304fb8b2cf5523b888679d3cfd0eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->