### PR TITLE
docs: publish prototype hub under /prototypes

### DIFF
--- a/docs/site/public/prototypes/app-chrome/1/index.html
+++ b/docs/site/public/prototypes/app-chrome/1/index.html
@@ -838,7 +838,11 @@ function submitGrant(){
   if(g.scope.startsWith('org:')){
     S.pendingGrant=g;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capability=document.createElement('b'), scope=document.createElement('b');
+    principal.textContent=g.p;
+    capability.className='cap'; capability.textContent=g.cap;
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capability,' on ',scope,' — current and future:');
     $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/1/index.html
+++ b/docs/site/public/prototypes/app-chrome/1/index.html
@@ -1,0 +1,891 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 1.
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Org-placement variants (floating bottom switcher / arrow keys):
+    ?variant=a  Rail owns orgs: org monograms stacked at rail top, projects
+                of the active org below a divider.
+    ?variant=b  Crumb owns org: rail is projects-only; the org name in the
+                header breadcrumb is the switcher (popover).
+    ?variant=c  Slack-style: one active-org tile at rail top opens a
+                full org-switcher overlay with role/project context.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  body[data-v=b] #app{grid-template-columns:56px 218px 1fr} /* same cols; rail content differs */
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  .orgbtn{font-weight:600;font-size:15px;display:inline-flex;align-items:center;gap:5px;
+    border:1px solid transparent;border-radius:6px;padding:3px 7px;margin:-3px -2px}
+  .orgbtn:hover{border-color:var(--line);background:var(--bg2)}
+  .orgbtn .car{font-size:9px;color:var(--tx-faint)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* matrix stub */
+  .stub{border:1px dashed var(--line);border-radius:12px;padding:34px;text-align:center;color:var(--tx-faint);
+    font-size:13px;line-height:1.6}
+  .stub a{color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  /* org switcher popover (variant b) */
+  #orgpop{position:fixed;z-index:30;min-width:240px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:10px;box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;display:none}
+  #orgpop.open{display:block}
+  #orgpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px 4px;font-weight:700}
+  #orgpop .orow{display:flex;align-items:center;gap:10px;width:100%;text-align:left;padding:9px 10px;
+    border-radius:7px;font-size:13px;min-height:44px}
+  #orgpop .orow:hover{background:var(--bg3)}
+  #orgpop .orow .r{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+  #orgpop .orow .chk{margin-left:auto;color:var(--accent)}
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* org overlay (variant c) */
+  #orgoverlay{position:fixed;inset:0;z-index:35;background:oklch(0 0 0/.55);display:none;
+    align-items:center;justify-content:center;padding:20px}
+  #orgoverlay.open{display:flex}
+  #orgoverlay .inner{width:min(560px,100%);background:var(--bg2);border:1px solid var(--line);
+    border-radius:16px;padding:22px;max-height:85dvh;overflow:auto}
+  #orgoverlay h4{font-size:16px;font-weight:700;margin-bottom:4px}
+  #orgoverlay .osub{font-size:12.5px;color:var(--tx-dim);margin-bottom:16px}
+  .orgcard{display:flex;align-items:center;gap:14px;width:100%;text-align:left;padding:14px;
+    border:1px solid var(--line);border-radius:12px;margin-bottom:10px;background:var(--bg)}
+  .orgcard:hover{border-color:var(--accent)}
+  .orgcard.act{border-color:var(--accent);background:var(--accent-soft)}
+  .orgcard .oav{width:40px;height:40px;font-size:13px;border-radius:12px}
+  .orgcard .main{display:grid;gap:3px}
+  .orgcard .t{font-weight:700;font-size:14.5px}
+  .orgcard .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* floating variant switcher */
+  #vswitch{position:fixed;z-index:60;left:50%;bottom:14px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:2px;background:oklch(0.14 0.01 220);color:oklch(0.95 0 0);
+    border-radius:999px;padding:4px 6px;box-shadow:0 6px 24px oklch(0 0 0/.5);font-size:12px}
+  [data-theme=light] #vswitch{background:oklch(0.3 0.02 225);}
+  #vswitch button{color:inherit;min-width:34px;min-height:34px;border-radius:50%;font-size:14px}
+  #vswitch button:hover{background:oklch(1 0 0/.12)}
+  #vswitch .vlabel{padding:0 10px;white-space:nowrap;font-weight:600}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="orgpop"></div>
+<div id="orgoverlay" onclick="if(event.target===this)closeOrgOverlay()"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">One capability, one scope, one revocable line. Roles are templates that expand into lines like this.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capability</label>
+      <select id="g-cap"><option>read</option><option>edit</option><option>publish</option><option>reveal</option><option>reveal-history</option><option>definitions-edit</option><option>project-settings</option><option>manage-members</option><option>audit-read</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<div id="vswitch">
+  <button onclick="cycleV(-1)" aria-label="previous variant">←</button>
+  <span class="vlabel" id="vlabel"></span>
+  <button onclick="cycleV(1)" aria-label="next variant">→</button>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+const VARIANTS=['a','b','c'];
+const VNAMES={a:'A — rail owns orgs',b:'B — crumb owns org',c:'C — org overlay'};
+let S={v:'a',persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(S.v==='a'&&multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  if(S.v==='c'){
+    const o=curOrg();
+    const b=document.createElement('button');
+    b.className='pav orgav act';b.title=multiOrg?'switch organization':`organization ${o.name}`;
+    b.textContent=mono(o.name);
+    if(multiOrg) b.onclick=()=>$('orgoverlay').classList.add('open');
+    r.appendChild(b);
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  if(S.v==='b'&&myOrgs().length>1){
+    /* variant b: org switching lives in the crumb; panel shows a subtle hint only */
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const items=[['matrix','Environment matrix'],['members','Members & access'],['settings','Project settings']];
+    for(const [v,l] of items){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();const multi=myOrgs().length>1;
+  const seg=[];
+  seg.push('<span>hikyo</span>');
+  seg.push('<span class="sep">/</span>');
+  if(S.v==='b'&&multi){
+    seg.push(`<button class="orgbtn" onclick="toggleOrgPop(event)" aria-haspopup="true">${o.name} <span class="car">▾</span></button>`);
+  }else{
+    seg.push(`<span class="dimseg">${o.name}</span>`);
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ---------------- org popover (variant b) ---------------- */
+function toggleOrgPop(ev){
+  const pop=$('orgpop');
+  if(pop.classList.contains('open')){pop.classList.remove('open');return;}
+  pop.innerHTML='<div class="et">organizations</div>'+myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orow" onclick="pickOrg('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span>${o.name}<div class="r">${role} · ${visProjects(o).length} project${visProjects(o).length>1?'s':''}</div></span>
+      ${o.id===S.org?'<span class="chk">✓</span>':''}</button>`;}).join('');
+  const r=ev.currentTarget.getBoundingClientRect();
+  pop.style.left=Math.min(r.left,innerWidth-260)+'px';pop.style.top=(r.bottom+6)+'px';
+  pop.classList.add('open');
+  setTimeout(()=>addEventListener('click',closeOrgPop,{once:true}),0);
+}
+function closeOrgPop(e){const pop=$('orgpop');if(!pop.contains(e?.target))pop.classList.remove('open');}
+function pickOrg(id){S.org=id;S.project=null;S.view='matrix';$('orgpop').classList.remove('open');update();}
+
+/* ---------------- org overlay (variant c) ---------------- */
+function renderOrgOverlay(){
+  const ov=$('orgoverlay');
+  ov.innerHTML=`<div class="inner"><h4>Your organizations</h4>
+  <div class="osub">Only organizations you belong to exist here — anything else is indistinguishable from nonexistent.</div>
+  ${myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orgcard${o.id===S.org?' act':''}" onclick="pickOrgC('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span class="main"><span class="t">${o.name}</span>
+      <span class="d">${role} · ${visProjects(o).length} projects</span></span></button>`;}).join('')}
+  </div>`;
+}
+function pickOrgC(id){S.org=id;S.project=null;S.view='matrix';closeOrgOverlay();update();}
+function closeOrgOverlay(){$('orgoverlay').classList.remove('open');}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  return `<div class="page">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="stub">The matrix itself is <a href="../../env-matrix/31/" target="_blank">/prototypes/env-matrix/31/</a> —
+      frozen reference design.<br>This prototype is about everything around it.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function grantRows(list,revocable){
+  return `<table class="grants"><thead><tr><th>principal</th><th>capability</th><th>scope</th><th>via</th><th></th></tr></thead>
+  <tbody>${list.map((g,i)=>{
+    const cls=g.scope.startsWith('org:')?'org':(g.scope==='env:production'?'prot':'');
+    return `<tr><td>${g.p}</td><td class="cap">${g.cap}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(g.scope)}</span></td>
+      <td class="mini">${g.via}</td>
+      <td style="text-align:right">${revocable?`<button class="xbtn" title="revoke this grant" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</td></tr>`;
+  }).join('')}</tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">Every line is one independently revocable grant: (principal, capability, scope). Roles are templates —
+      they expand at grant time, so revoking one line never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+      ${grantRows(q,false)}
+    </div>
+    <div class="card"><h3>All grant lines</h3>
+      ${grantRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px"><button class="btn primary" onclick="openGrant()">+ new grant</button></div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function pageAccount(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Everything here that changes how you authenticate asks for a possession factor first — the blue
+      "confirm it's you" step-up. It looks nothing like the teal reveal ceremony on purpose.</p>
+
+    <div class="card"><h3>Active sessions</h3>
+      ${SESSIONS.map((s,i)=>`<div class="rowline">
+        <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+        <span class="d">${s.detail} · last active ${s.last}</span></div>
+        <span class="grow"></span>
+        <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+        ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+      </div>`).join('')}
+      <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+        revoking one never touches the other kind.</div>
+    </div>
+
+    <div class="card"><h3>Sign-in factors</h3>
+      ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+        <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+        <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+        <span class="tag">enrolled</span></div>
+      <div class="rowline"><div class="main"><span class="t">Password</span>
+        <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+      <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+        <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+    </div>
+
+    <div class="card"><h3>Recovery</h3>
+      <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+        <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+      <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+        <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+        <span class="grow"></span>
+        <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+          onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+          ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+      ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+    </div>
+
+    <div class="card"><h3>Linked identities</h3>
+      ${IDENTITIES.map(id=>`<div class="rowline">
+        <div class="main"><span class="t">${id.issuer}</span>
+        <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+        <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+    </div>
+  </div>`;
+}
+
+function pageInstance(){
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Visible only to instance admins. Deliberately thin: the network surface stays small, heavy levers stay on the CLI at the box.</p>
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px"><button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button></div>
+    </div>
+    <div class="card"><h3>Instance settings</h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, not editable</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">instance-scoped policy (audit ADR)</span></div><span class="grow"></span><span class="tag mono">security: unlimited</span></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">instance ceiling clamps org values</span></div><span class="grow"></span><span class="tag mono">90d</span></div>
+    </div>
+    <div class="card qcard"><h3>Open question for this ticket</h3>
+      <div class="note" style="margin-top:0">How much of this exists in the v1 UI at all?<br><br>
+      <b>Option A</b> — this page as shown: org create + read-mostly instance settings in the UI; bootstrap, crypto rotation, backup/restore stay CLI-only.<br>
+      <b>Option B</b> — no instance surface in the v1 UI: everything via <span class="mini">hikyo admin …</span> / <span class="mini">instance-config</span> CLI; the UI starts at the organization.<br><br>
+      Everything below org creation (root-key ops, migrate, restore, break-glass) is locked CLI-side regardless (API/CLI ADR).</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal'])$(id).classList.remove('open');}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){document.body.classList.add('modal');$('grantmodal').classList.add('open');}
+function submitGrant(){
+  const g={p:$('g-principal').value,cap:$('g-cap').value,scope:$('g-scope').value,via:'direct'};
+  closeModals();
+  if(g.scope.startsWith('org:')){
+    S.pendingGrant=g;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(g);update();
+}
+function confirmGrant(){GRANTS.push(S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function cycleV(d){
+  const i=(VARIANTS.indexOf(S.v)+d+VARIANTS.length)%VARIANTS.length;
+  S.v=VARIANTS[i];
+  const u=new URL(location);u.searchParams.set('variant',S.v);history.replaceState(null,'',u);
+  update();
+}
+addEventListener('keydown',e=>{
+  if(/INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName))return;
+  if(e.key==='ArrowLeft')cycleV(-1);
+  if(e.key==='ArrowRight')cycleV(1);
+  if(e.key==='Escape'){closeModals();closeOrgOverlay();}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  document.body.dataset.v=S.v;
+  $('vlabel').textContent=VNAMES[S.v];
+  renderRail();renderSide();renderCrumb();renderOrgOverlay();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+S.v=new URL(location).searchParams.get('variant')||'a';
+if(!VARIANTS.includes(S.v))S.v='a';
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/10/index.html
+++ b/docs/site/public/prototypes/app-chrome/10/index.html
@@ -1062,7 +1062,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/10/index.html
+++ b/docs/site/public/prototypes/app-chrome/10/index.html
@@ -1,0 +1,1114 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 10.
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:4px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG — replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula — same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/11/index.html
+++ b/docs/site/public/prototypes/app-chrome/11/index.html
@@ -1073,7 +1073,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/11/index.html
+++ b/docs/site/public/prototypes/app-chrome/11/index.html
@@ -1,0 +1,1125 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 11.
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:flex-start;gap:8px;padding:8px;border-radius:4px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid input{margin-top:2px}
+  .capgrid .cw{display:grid;gap:2px}
+  .capgrid .cd{font-family:var(--sans);font-size:10.5px;color:var(--tx-faint);line-height:1.35;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG — replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula — same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap} — ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<label><input type="checkbox" value="${c}"> <span class="cw"><span class="cn">${c}</span><span class="cd">${d}</span></span></label>`).join('');
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/12/index.html
+++ b/docs/site/public/prototypes/app-chrome/12/index.html
@@ -1,0 +1,1139 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 12.
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG — replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula — same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap} — ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/12/index.html
+++ b/docs/site/public/prototypes/app-chrome/12/index.html
@@ -1087,7 +1087,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/13/index.html
+++ b/docs/site/public/prototypes/app-chrome/13/index.html
@@ -1,0 +1,1220 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 13.
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/13/index.html
+++ b/docs/site/public/prototypes/app-chrome/13/index.html
@@ -1144,7 +1144,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/14/index.html
+++ b/docs/site/public/prototypes/app-chrome/14/index.html
@@ -1289,7 +1289,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/14/index.html
+++ b/docs/site/public/prototypes/app-chrome/14/index.html
@@ -1,0 +1,1365 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 14.
+
+  Iteration 14: ORG SETTINGS surface (confirmed shape brief). Panel entry
+  "Org settings" beside "Org members & grants", org admins only (dana/sam
+  see nothing: unauthorized = nonexistent). Jump index, three sections:
+  Identity (name, preset hues, custom-hue slider, image upload; org avatar
+  stays a CIRCLE, propagates live to rail circles and panel head) ·
+  Members (entry-point card only) · Danger zone (rename slug with URL
+  warning; delete organization behind typed-name confirmation, inline, no
+  browser confirm — deleting really removes the org in the demo, landing
+  you in your remaining org). Authorization atom for org settings is NOT in
+  locked #15 — flagged for spec synthesis, prototype gates on org admin.
+
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* org settings */
+  .bigav-o{width:56px;height:56px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:17px;color:var(--on-accent);background-size:cover;background-position:center;flex:none}
+  .dangerc{border-color:color-mix(in oklch,var(--bad) 45%,var(--line))}
+  .dangerc h3{color:var(--bad)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,img:null,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,img:null,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  /* membership list can reference a deleted org — validate against ORGS */
+  const valid=me().orgs.filter(id=>ORGS.some(o=>o.id===id));
+  if(!valid.includes(S.org)) S.org=valid[0]??null;
+  if(!curOrg()){
+    /* zero orgs: the empty state (deleted last org, or revoked membership) */
+    if(!['account','instance'].includes(S.view)) S.view='noorg';
+    S.project=null;
+    return;
+  }
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&(S.view==='orgmembers'||S.view==='orgsettings')) S.view='matrix';
+  if(S.view==='noorg') S.view='matrix';
+}
+
+const orgFace=o=>o.img?{bg:`url(${o.img}) center/cover`,txt:''}:{bg:hueBg(o.hue),txt:mono(o.name)};
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  if(!curOrg()){
+    r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+    if(me().instanceAdmin){
+      const g=document.createElement('button');
+      g.className='railbtn'+(S.view==='instance'?' act':'');
+      g.title='instance administration';g.textContent='⚙';
+      g.onclick=()=>{S.view='instance';update();};
+      r.appendChild(g);
+    }
+    const a=document.createElement('button');
+    a.className='railbtn me'+(S.view==='account'?' act':'');
+    a.title='account & security';a.textContent=mono(me().label);
+    a.onclick=()=>{S.view='account';update();};
+    r.appendChild(a);
+    return;
+  }
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      const f=orgFace(o);
+      b.style.background=f.bg;b.style.color='var(--on-accent)';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=f.txt;
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  if(!o){
+    s.insertAdjacentHTML('beforeend',
+      '<div class="orghead"><div><div class="oname">no organization</div><div class="orole">ask for an invitation</div></div></div>');
+    return;
+  }
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" id="orghead-av" style="background:${orgFace(o).bg}">${orgFace(o).txt}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${orgFace(oo).bg};width:22px;height:22px;font-size:9px">${orgFace(oo).txt&&mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+    const os=document.createElement('button');
+    os.className='srow'+(S.view==='orgsettings'?' act':'');os.textContent='Org settings';
+    os.onclick=()=>{S.view='orgsettings';update();toggleSide(false);};
+    s.appendChild(os);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  if(!o){c.innerHTML='<span>hikyo</span>';return;}
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgsettings'){
+    seg.push('<span class="sep">/</span><span>org settings</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function orgHueLive(v){
+  curOrg().hue=+v;
+  document.getElementById('ohuedeg').textContent=v;
+  if(!curOrg().img)document.getElementById('bigav-org').style.background=hueBg(+v);
+}
+function setOrgImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{curOrg().img=r.result;update();};
+  r.readAsDataURL(f);
+}
+function orgDeleteCheck(inp){
+  document.getElementById('org-del-btn').disabled=inp.value!==curOrg().name;
+}
+function orgDelete(){
+  const o=curOrg();
+  const i=ORGS.indexOf(o);ORGS.splice(i,1);
+  showToast(`organization ${o.name} deleted`);
+  S.org=null;S.view='matrix';update();
+}
+
+function pageNoOrg(){
+  return `<div class="page">
+    <h2>No organizations</h2>
+    <div class="card"><h3>You are not a member of any organization</h3>
+      <div class="note" style="margin-top:0">Membership comes from an invitation. Ask an organization admin to invite you${me().instanceAdmin?', or create an organization from instance administration':''}.
+      </div>
+      ${me().instanceAdmin?`<div style="margin-top:12px"><button class="btn primary" onclick="S.view='instance';update()">open instance administration</button></div>`:''}
+    </div>
+  </div>`;
+}
+
+function pageOrgSettings(){
+  const o=curOrg();
+  const hues=[195,280,60,140,20,320];
+  const f=orgFace(o);
+  const orgGrants=GRANTS.filter(g=>g.scope.startsWith('org:')).length;
+  return `<div class="page">
+    <h2>Org settings · ${o.name}</h2>
+    <p class="sub">Organization identity and lifecycle. Access lives on its own surface; the danger zone is deliberately last.</p>
+    ${jump([['sec-oident','Identity'],['sec-omembers','Members'],['sec-odanger','Danger zone']])}
+    <div class="card" id="sec-oident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav-o" id="bigav-org" style="background:${f.bg}">${f.txt}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===o.hue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="curOrg().hue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="ohuedeg">${o.hue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${o.hue}" aria-label="custom org hue"
+              oninput="orgHueLive(this.value)" onchange="update()"></div>
+        </div>
+      </div>
+      <div class="fgrid" style="margin-top:14px">
+        <div class="field"><label>name</label>
+          <input type="text" value="${o.name}" onchange="curOrg().name=this.value;update()"></div>
+      </div>
+      <div class="rowline" style="margin-top:6px"><div class="main"><span class="t">Image</span>
+        <span class="d">${o.img?'custom image, shown on every org circle':'PNG / SVG / JPG, replaces the monogram'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="oimg" accept="image/*" hidden onchange="setOrgImg(this)">
+        <button class="btn" onclick="document.getElementById('oimg').click()">${o.img?'replace…':'upload…'}</button>
+        ${o.img?'<button class="xbtn" title="remove image" onclick="curOrg().img=null;update()">✕</button>':''}
+      </div>
+      <div class="note">The org avatar stays a circle: identity circles are one of the three reserved pill shapes.</div>
+    </div>
+    <div class="card" id="sec-omembers"><h3>Members</h3>
+      <div class="rowline"><div class="main"><span class="t">Org members & grants</span>
+        <span class="d">${orgGrants} org-scoped grant lines</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='orgmembers';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    <div class="card dangerc" id="sec-odanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${o.id}" aria-label="organization slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete organization</span>
+        <span class="d">Deletes every project, environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${o.name} to confirm" aria-label="type the organization name to confirm deletion"
+          oninput="orgDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="org-del-btn" disabled onclick="orgDelete()">delete</button></div>
+    </div>
+  </div>`;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),orgsettings:pageOrgSettings,noorg:pageNoOrg,account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/15/index.html
+++ b/docs/site/public/prototypes/app-chrome/15/index.html
@@ -1,0 +1,1437 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 15.
+
+  Iteration 15: project settings gains the sections that make it symmetric
+  with org settings, all ADR-backed:
+  - POLICY (the project-settings capability's real contents, locked #15/#13/
+    #16): per-environment protected flag (live: toggling production updates
+    the matrix header), reveal reauth window (protected always 0: passkey
+    per disclosure), definitions_source db|git (git = definitions read-only
+    in the UI, values unaffected).
+  - DANGER ZONE: rename slug (URL warning) + delete project behind
+    typed-name confirmation; deleting really deletes, and an org with no
+    projects left gets a zero-project empty state on the matrix view.
+  Jump index: Identity · Metadata · Policy · Access · Danger zone.
+
+
+  Iteration 14: ORG SETTINGS surface (confirmed shape brief). Panel entry
+  "Org settings" beside "Org members & grants", org admins only (dana/sam
+  see nothing: unauthorized = nonexistent). Jump index, three sections:
+  Identity (name, preset hues, custom-hue slider, image upload; org avatar
+  stays a CIRCLE, propagates live to rail circles and panel head) ·
+  Members (entry-point card only) · Danger zone (rename slug with URL
+  warning; delete organization behind typed-name confirmation, inline, no
+  browser confirm — deleting really removes the org in the demo, landing
+  you in your remaining org). Authorization atom for org settings is NOT in
+  locked #15 — flagged for spec synthesis, prototype gates on org admin.
+
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* org settings */
+  .bigav-o{width:56px;height:56px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:17px;color:var(--on-accent);background-size:cover;background-position:center;flex:none}
+  .dangerc{border-color:color-mix(in oklch,var(--bad) 45%,var(--line))}
+  .dangerc h3{color:var(--bad)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,img:null,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,img:null,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,revealWin:'15m',defSrc:'db',
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  /* membership list can reference a deleted org — validate against ORGS */
+  const valid=me().orgs.filter(id=>ORGS.some(o=>o.id===id));
+  if(!valid.includes(S.org)) S.org=valid[0]??null;
+  if(!curOrg()){
+    /* zero orgs: the empty state (deleted last org, or revoked membership) */
+    if(!['account','instance'].includes(S.view)) S.view='noorg';
+    S.project=null;
+    return;
+  }
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&(S.view==='orgmembers'||S.view==='orgsettings')) S.view='matrix';
+  if(S.view==='noorg') S.view='matrix';
+}
+
+const orgFace=o=>o.img?{bg:`url(${o.img}) center/cover`,txt:''}:{bg:hueBg(o.hue),txt:mono(o.name)};
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  if(!curOrg()){
+    r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+    if(me().instanceAdmin){
+      const g=document.createElement('button');
+      g.className='railbtn'+(S.view==='instance'?' act':'');
+      g.title='instance administration';g.textContent='⚙';
+      g.onclick=()=>{S.view='instance';update();};
+      r.appendChild(g);
+    }
+    const a=document.createElement('button');
+    a.className='railbtn me'+(S.view==='account'?' act':'');
+    a.title='account & security';a.textContent=mono(me().label);
+    a.onclick=()=>{S.view='account';update();};
+    r.appendChild(a);
+    return;
+  }
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      const f=orgFace(o);
+      b.style.background=f.bg;b.style.color='var(--on-accent)';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=f.txt;
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  if(!o){
+    s.insertAdjacentHTML('beforeend',
+      '<div class="orghead"><div><div class="oname">no organization</div><div class="orole">ask for an invitation</div></div></div>');
+    return;
+  }
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" id="orghead-av" style="background:${orgFace(o).bg}">${orgFace(o).txt}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${orgFace(oo).bg};width:22px;height:22px;font-size:9px">${orgFace(oo).txt&&mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+    const os=document.createElement('button');
+    os.className='srow'+(S.view==='orgsettings'?' act':'');os.textContent='Org settings';
+    os.onclick=()=>{S.view='orgsettings';update();toggleSide(false);};
+    s.appendChild(os);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  if(!o){c.innerHTML='<span>hikyo</span>';return;}
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgsettings'){
+    seg.push('<span class="sep">/</span><span>org settings</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  if(!proj){
+    return `<div class="page">
+      <h2>No projects</h2>
+      <div class="card"><h3>This organization has no projects yet</h3>
+        <div class="note" style="margin-top:0">Create one to get an environment matrix${isOrgAdmin()?'':' (an org admin can)'}.
+        </div>
+        ${isOrgAdmin()?`<div style="margin-top:12px"><button class="btn primary" onclick="showToast('project created (demo)')">+ create project</button></div>`:''}
+      </div>
+    </div>`;
+  }
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const canPolicy=isOrgAdmin(); /* stands in for the project-settings capability */
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],...(canPolicy?[['sec-ppolicy','Policy']]:[]),['sec-paccess','Access'],...(canPolicy?[['sec-pdanger','Danger zone']]:[])])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    ${canPolicy?`<div class="card" id="sec-ppolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Protected environments</span>
+        <span class="d">a protected environment caps the reveal window at 0: passkey per disclosure, no TOTP</span></div>
+        <span class="grow"></span>
+        ${MXENVS.map(e=>`<button class="tag${e.prot?' bad':''}" style="min-height:32px;cursor:pointer"
+          title="${e.prot?'protected: click to unprotect':'click to protect'}"
+          onclick="MXENVS.find(x=>x.id==='${e.id}').prot=${e.prot?'undefined':'true'};update()">${e.prot?'🔒 ':''}${e.n}</button>`).join('')}
+      </div>
+      <div class="rowline"><div class="main"><span class="t">Reveal reauth window</span>
+        <span class="d">how long a successful reveal reauth stands for further disclosures</span></div>
+        <span class="grow"></span>
+        <select onchange="S.revealWin=this.value;update()" aria-label="reveal reauth window" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          ${['0 (every disclosure)','5m','15m','60m'].map(w=>`<option${w===S.revealWin||w.startsWith(S.revealWin)?' selected':''}>${w}</option>`).join('')}
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Definitions source</span>
+        <span class="d">${S.defSrc==='git'?'definitions are read-only in the UI; change them via the reviewed Git bundle. Values unaffected.':'definitions edited in the UI; switch to git for a review gate'}</span></div>
+        <span class="grow"></span>
+        <select onchange="S.defSrc=this.value;update()" aria-label="definitions source" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px;font-family:var(--mono)">
+          <option value="db"${S.defSrc==='db'?' selected':''}>db</option>
+          <option value="git"${S.defSrc==='git'?' selected':''}>git</option>
+        </select></div>
+      <div class="note">These are the project-settings capability's contents (#15): the guards on the definitions editor live apart from the editor they restrain.</div>
+    </div>`:''}
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    ${canPolicy?`<div class="card dangerc" id="sec-pdanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${proj.id}" aria-label="project slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete project</span>
+        <span class="d">Deletes every environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${proj.name} to confirm" aria-label="type the project name to confirm deletion"
+          oninput="projDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="proj-del-btn" disabled onclick="projDelete()">delete</button></div>
+    </div>`:''}
+  </div>`;
+}
+
+function projDeleteCheck(inp){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  document.getElementById('proj-del-btn').disabled=inp.value!==proj.name;
+}
+function projDelete(){
+  const o=curOrg();
+  const proj=o.projects.find(p=>p.id===S.project);
+  o.projects.splice(o.projects.indexOf(proj),1);
+  showToast(`project ${proj.name} deleted`);
+  S.project=null;S.view='matrix';update();
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function orgHueLive(v){
+  curOrg().hue=+v;
+  document.getElementById('ohuedeg').textContent=v;
+  if(!curOrg().img)document.getElementById('bigav-org').style.background=hueBg(+v);
+}
+function setOrgImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{curOrg().img=r.result;update();};
+  r.readAsDataURL(f);
+}
+function orgDeleteCheck(inp){
+  document.getElementById('org-del-btn').disabled=inp.value!==curOrg().name;
+}
+function orgDelete(){
+  const o=curOrg();
+  const i=ORGS.indexOf(o);ORGS.splice(i,1);
+  showToast(`organization ${o.name} deleted`);
+  S.org=null;S.view='matrix';update();
+}
+
+function pageNoOrg(){
+  return `<div class="page">
+    <h2>No organizations</h2>
+    <div class="card"><h3>You are not a member of any organization</h3>
+      <div class="note" style="margin-top:0">Membership comes from an invitation. Ask an organization admin to invite you${me().instanceAdmin?', or create an organization from instance administration':''}.
+      </div>
+      ${me().instanceAdmin?`<div style="margin-top:12px"><button class="btn primary" onclick="S.view='instance';update()">open instance administration</button></div>`:''}
+    </div>
+  </div>`;
+}
+
+function pageOrgSettings(){
+  const o=curOrg();
+  const hues=[195,280,60,140,20,320];
+  const f=orgFace(o);
+  const orgGrants=GRANTS.filter(g=>g.scope.startsWith('org:')).length;
+  return `<div class="page">
+    <h2>Org settings · ${o.name}</h2>
+    <p class="sub">Organization identity and lifecycle. Access lives on its own surface; the danger zone is deliberately last.</p>
+    ${jump([['sec-oident','Identity'],['sec-omembers','Members'],['sec-odanger','Danger zone']])}
+    <div class="card" id="sec-oident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav-o" id="bigav-org" style="background:${f.bg}">${f.txt}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===o.hue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="curOrg().hue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="ohuedeg">${o.hue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${o.hue}" aria-label="custom org hue"
+              oninput="orgHueLive(this.value)" onchange="update()"></div>
+        </div>
+      </div>
+      <div class="fgrid" style="margin-top:14px">
+        <div class="field"><label>name</label>
+          <input type="text" value="${o.name}" onchange="curOrg().name=this.value;update()"></div>
+      </div>
+      <div class="rowline" style="margin-top:6px"><div class="main"><span class="t">Image</span>
+        <span class="d">${o.img?'custom image, shown on every org circle':'PNG / SVG / JPG, replaces the monogram'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="oimg" accept="image/*" hidden onchange="setOrgImg(this)">
+        <button class="btn" onclick="document.getElementById('oimg').click()">${o.img?'replace…':'upload…'}</button>
+        ${o.img?'<button class="xbtn" title="remove image" onclick="curOrg().img=null;update()">✕</button>':''}
+      </div>
+      <div class="note">The org avatar stays a circle: identity circles are one of the three reserved pill shapes.</div>
+    </div>
+    <div class="card" id="sec-omembers"><h3>Members</h3>
+      <div class="rowline"><div class="main"><span class="t">Org members & grants</span>
+        <span class="d">${orgGrants} org-scoped grant lines</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='orgmembers';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    <div class="card dangerc" id="sec-odanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${o.id}" aria-label="organization slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete organization</span>
+        <span class="d">Deletes every project, environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${o.name} to confirm" aria-label="type the organization name to confirm deletion"
+          oninput="orgDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="org-del-btn" disabled onclick="orgDelete()">delete</button></div>
+    </div>
+  </div>`;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),orgsettings:pageOrgSettings,noorg:pageNoOrg,account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/15/index.html
+++ b/docs/site/public/prototypes/app-chrome/15/index.html
@@ -1361,7 +1361,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/16/index.html
+++ b/docs/site/public/prototypes/app-chrome/16/index.html
@@ -1,0 +1,1499 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 15.
+
+  Iteration 15: project settings gains the sections that make it symmetric
+  with org settings, all ADR-backed:
+  - POLICY (the project-settings capability's real contents, locked #15/#13/
+    #16): per-environment protected flag (live: toggling production updates
+    the matrix header), reveal reauth window (protected always 0: passkey
+    per disclosure), definitions_source db|git (git = definitions read-only
+    in the UI, values unaffected).
+  - DANGER ZONE: rename slug (URL warning) + delete project behind
+    typed-name confirmation; deleting really deletes, and an org with no
+    projects left gets a zero-project empty state on the matrix view.
+  Jump index: Identity · Metadata · Policy · Access · Danger zone.
+ITERATION 16 (wayfinder #30 spillover): revision retention moves into the
+settings surfaces where it belongs (Alex: not in the history drawer).
+- Project settings › Policy gains "Revision retention": inherit org default
+  (follows org changes) or custom ≤ org (detaches; set-time refusal above
+  the org value; shown "capped by org" when the org later lowers).
+- Org settings gains a Policy card: org default retention (new projects
+  start here; inheriting projects follow) + per-project state list.
+Semantics decided in revision-history iteration 5; changes audited
+(#24: retention-policy change). Concrete defaults → ops spec #32.
+
+
+  Iteration 14: ORG SETTINGS surface (confirmed shape brief). Panel entry
+  "Org settings" beside "Org members & grants", org admins only (dana/sam
+  see nothing: unauthorized = nonexistent). Jump index, three sections:
+  Identity (name, preset hues, custom-hue slider, image upload; org avatar
+  stays a CIRCLE, propagates live to rail circles and panel head) ·
+  Members (entry-point card only) · Danger zone (rename slug with URL
+  warning; delete organization behind typed-name confirmation, inline, no
+  browser confirm — deleting really removes the org in the demo, landing
+  you in your remaining org). Authorization atom for org settings is NOT in
+  locked #15 — flagged for spec synthesis, prototype gates on org admin.
+
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* org settings */
+  .bigav-o{width:56px;height:56px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:17px;color:var(--on-accent);background-size:cover;background-position:center;flex:none}
+  .dangerc{border-color:color-mix(in oklch,var(--bad) 45%,var(--line))}
+  .dangerc h3{color:var(--bad)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,img:null,ret:6,projects:[
+    {id:'demo',name:'demo',hue:195},                              /* inherits */
+    {id:'website',name:'website',hue:280,ret:{mode:'custom',n:4}},
+    {id:'mobile',name:'mobile-app',hue:60,ret:{mode:'custom',n:10}}, /* set while org was 12 ⇒ capped */
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,img:null,ret:8,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+/* retention semantics (revision-history it-5): inherit-until-modified, org cap */
+const orgRet=o=>o.ret??6;
+function projRet(o,p){
+  if(!p.ret||p.ret.mode==='inherit')return{mode:'inherit',eff:orgRet(o)};
+  return{mode:'custom',n:p.ret.n,eff:Math.min(p.ret.n,orgRet(o)),capped:p.ret.n>orgRet(o)};
+}
+function setProjRetMode(mode){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  if(mode==='inherit'){delete p.ret;showToast('retention: inherits org default ('+orgRet(o)+') — follows org changes · audited');}
+  else{p.ret={mode:'custom',n:Math.min(projRet(o,p).eff,orgRet(o))};showToast('retention: custom '+p.ret.n+' — detached from org changes · audited');}
+  update();
+}
+function setProjRetN(inp){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  const n=Math.max(1,+inp.value||1);
+  if(n>orgRet(o)){showToast('refused: cannot exceed the org retention ('+orgRet(o)+') — a project may never keep more history than the org allows');inp.value=p.ret.n;return;}
+  p.ret={mode:'custom',n};showToast('retention: custom '+n+' · audited');update();
+}
+function setOrgRet(inp){
+  const o=curOrg();
+  const n=Math.max(1,+inp.value||1);
+  o.ret=n;
+  showToast('org default retention → keep last '+n+' — inheriting projects follow; overrides keep their value, capped at '+n+' · audited');
+  update();
+}
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,revealWin:'15m',defSrc:'db',
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  /* membership list can reference a deleted org — validate against ORGS */
+  const valid=me().orgs.filter(id=>ORGS.some(o=>o.id===id));
+  if(!valid.includes(S.org)) S.org=valid[0]??null;
+  if(!curOrg()){
+    /* zero orgs: the empty state (deleted last org, or revoked membership) */
+    if(!['account','instance'].includes(S.view)) S.view='noorg';
+    S.project=null;
+    return;
+  }
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&(S.view==='orgmembers'||S.view==='orgsettings')) S.view='matrix';
+  if(S.view==='noorg') S.view='matrix';
+}
+
+const orgFace=o=>o.img?{bg:`url(${o.img}) center/cover`,txt:''}:{bg:hueBg(o.hue),txt:mono(o.name)};
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  if(!curOrg()){
+    r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+    if(me().instanceAdmin){
+      const g=document.createElement('button');
+      g.className='railbtn'+(S.view==='instance'?' act':'');
+      g.title='instance administration';g.textContent='⚙';
+      g.onclick=()=>{S.view='instance';update();};
+      r.appendChild(g);
+    }
+    const a=document.createElement('button');
+    a.className='railbtn me'+(S.view==='account'?' act':'');
+    a.title='account & security';a.textContent=mono(me().label);
+    a.onclick=()=>{S.view='account';update();};
+    r.appendChild(a);
+    return;
+  }
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      const f=orgFace(o);
+      b.style.background=f.bg;b.style.color='var(--on-accent)';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=f.txt;
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  if(!o){
+    s.insertAdjacentHTML('beforeend',
+      '<div class="orghead"><div><div class="oname">no organization</div><div class="orole">ask for an invitation</div></div></div>');
+    return;
+  }
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" id="orghead-av" style="background:${orgFace(o).bg}">${orgFace(o).txt}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${orgFace(oo).bg};width:22px;height:22px;font-size:9px">${orgFace(oo).txt&&mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+    const os=document.createElement('button');
+    os.className='srow'+(S.view==='orgsettings'?' act':'');os.textContent='Org settings';
+    os.onclick=()=>{S.view='orgsettings';update();toggleSide(false);};
+    s.appendChild(os);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  if(!o){c.innerHTML='<span>hikyo</span>';return;}
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgsettings'){
+    seg.push('<span class="sep">/</span><span>org settings</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  if(!proj){
+    return `<div class="page">
+      <h2>No projects</h2>
+      <div class="card"><h3>This organization has no projects yet</h3>
+        <div class="note" style="margin-top:0">Create one to get an environment matrix${isOrgAdmin()?'':' (an org admin can)'}.
+        </div>
+        ${isOrgAdmin()?`<div style="margin-top:12px"><button class="btn primary" onclick="showToast('project created (demo)')">+ create project</button></div>`:''}
+      </div>
+    </div>`;
+  }
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const canPolicy=isOrgAdmin(); /* stands in for the project-settings capability */
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],...(canPolicy?[['sec-ppolicy','Policy']]:[]),['sec-paccess','Access'],...(canPolicy?[['sec-pdanger','Danger zone']]:[])])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    ${canPolicy?`<div class="card" id="sec-ppolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Protected environments</span>
+        <span class="d">a protected environment caps the reveal window at 0: passkey per disclosure, no TOTP</span></div>
+        <span class="grow"></span>
+        ${MXENVS.map(e=>`<button class="tag${e.prot?' bad':''}" style="min-height:32px;cursor:pointer"
+          title="${e.prot?'protected: click to unprotect':'click to protect'}"
+          onclick="MXENVS.find(x=>x.id==='${e.id}').prot=${e.prot?'undefined':'true'};update()">${e.prot?'🔒 ':''}${e.n}</button>`).join('')}
+      </div>
+      <div class="rowline"><div class="main"><span class="t">Reveal reauth window</span>
+        <span class="d">how long a successful reveal reauth stands for further disclosures</span></div>
+        <span class="grow"></span>
+        <select onchange="S.revealWin=this.value;update()" aria-label="reveal reauth window" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          ${['0 (every disclosure)','5m','15m','60m'].map(w=>`<option${w===S.revealWin||w.startsWith(S.revealWin)?' selected':''}>${w}</option>`).join('')}
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Definitions source</span>
+        <span class="d">${S.defSrc==='git'?'definitions are read-only in the UI; change them via the reviewed Git bundle. Values unaffected.':'definitions edited in the UI; switch to git for a review gate'}</span></div>
+        <span class="grow"></span>
+        <select onchange="S.defSrc=this.value;update()" aria-label="definitions source" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px;font-family:var(--mono)">
+          <option value="db"${S.defSrc==='db'?' selected':''}>db</option>
+          <option value="git"${S.defSrc==='git'?' selected':''}>git</option>
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Revision retention</span>
+        <span class="d">${(()=>{const r=projRet(curOrg(),proj);
+          if(r.mode==='inherit')return`inherits the org default — values kept for the last ${r.eff} revisions per environment; follows org changes`;
+          if(r.capped)return`custom ${r.n}, capped to ${r.eff} by the org — a project may never keep more than the org allows`;
+          return`custom ${r.n} — detached from later org changes`})()}</span></div>
+        <span class="grow"></span>
+        <select onchange="setProjRetMode(this.value)" aria-label="retention mode" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          <option value="inherit"${projRet(curOrg(),proj).mode==='inherit'?' selected':''}>inherit org (${orgRet(curOrg())})</option>
+          <option value="custom"${projRet(curOrg(),proj).mode==='custom'?' selected':''}>custom</option>
+        </select>
+        ${projRet(curOrg(),proj).mode==='custom'?`<input type="number" min="1" max="99" value="${projRet(curOrg(),proj).n}" aria-label="revisions kept"
+          onchange="setProjRetN(this)" style="background:var(--bg);border:1px solid ${projRet(curOrg(),proj).capped?'var(--bad)':'var(--line)'};color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">`:''}
+      </div>
+      <div class="note">Older revisions lose their values as collection runs (pinned ones always stay); who-changed-what history is permanent. A custom value may not exceed the org default — refused at set time; if the org later lowers its default, this value is capped, not rewritten. Changes are audited.</div>
+      <div class="note">These are the project-settings capability's contents (#15): the guards on the definitions editor live apart from the editor they restrain.</div>
+    </div>`:''}
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    ${canPolicy?`<div class="card dangerc" id="sec-pdanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${proj.id}" aria-label="project slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete project</span>
+        <span class="d">Deletes every environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${proj.name} to confirm" aria-label="type the project name to confirm deletion"
+          oninput="projDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="proj-del-btn" disabled onclick="projDelete()">delete</button></div>
+    </div>`:''}
+  </div>`;
+}
+
+function projDeleteCheck(inp){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  document.getElementById('proj-del-btn').disabled=inp.value!==proj.name;
+}
+function projDelete(){
+  const o=curOrg();
+  const proj=o.projects.find(p=>p.id===S.project);
+  o.projects.splice(o.projects.indexOf(proj),1);
+  showToast(`project ${proj.name} deleted`);
+  S.project=null;S.view='matrix';update();
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function orgHueLive(v){
+  curOrg().hue=+v;
+  document.getElementById('ohuedeg').textContent=v;
+  if(!curOrg().img)document.getElementById('bigav-org').style.background=hueBg(+v);
+}
+function setOrgImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{curOrg().img=r.result;update();};
+  r.readAsDataURL(f);
+}
+function orgDeleteCheck(inp){
+  document.getElementById('org-del-btn').disabled=inp.value!==curOrg().name;
+}
+function orgDelete(){
+  const o=curOrg();
+  const i=ORGS.indexOf(o);ORGS.splice(i,1);
+  showToast(`organization ${o.name} deleted`);
+  S.org=null;S.view='matrix';update();
+}
+
+function pageNoOrg(){
+  return `<div class="page">
+    <h2>No organizations</h2>
+    <div class="card"><h3>You are not a member of any organization</h3>
+      <div class="note" style="margin-top:0">Membership comes from an invitation. Ask an organization admin to invite you${me().instanceAdmin?', or create an organization from instance administration':''}.
+      </div>
+      ${me().instanceAdmin?`<div style="margin-top:12px"><button class="btn primary" onclick="S.view='instance';update()">open instance administration</button></div>`:''}
+    </div>
+  </div>`;
+}
+
+function pageOrgSettings(){
+  const o=curOrg();
+  const hues=[195,280,60,140,20,320];
+  const f=orgFace(o);
+  const orgGrants=GRANTS.filter(g=>g.scope.startsWith('org:')).length;
+  return `<div class="page">
+    <h2>Org settings · ${o.name}</h2>
+    <p class="sub">Organization identity and lifecycle. Access lives on its own surface; the danger zone is deliberately last.</p>
+    ${jump([['sec-oident','Identity'],['sec-opolicy','Policy'],['sec-omembers','Members'],['sec-odanger','Danger zone']])}
+    <div class="card" id="sec-oident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav-o" id="bigav-org" style="background:${f.bg}">${f.txt}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===o.hue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="curOrg().hue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="ohuedeg">${o.hue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${o.hue}" aria-label="custom org hue"
+              oninput="orgHueLive(this.value)" onchange="update()"></div>
+        </div>
+      </div>
+      <div class="fgrid" style="margin-top:14px">
+        <div class="field"><label>name</label>
+          <input type="text" value="${o.name}" onchange="curOrg().name=this.value;update()"></div>
+      </div>
+      <div class="rowline" style="margin-top:6px"><div class="main"><span class="t">Image</span>
+        <span class="d">${o.img?'custom image, shown on every org circle':'PNG / SVG / JPG, replaces the monogram'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="oimg" accept="image/*" hidden onchange="setOrgImg(this)">
+        <button class="btn" onclick="document.getElementById('oimg').click()">${o.img?'replace…':'upload…'}</button>
+        ${o.img?'<button class="xbtn" title="remove image" onclick="curOrg().img=null;update()">✕</button>':''}
+      </div>
+      <div class="note">The org avatar stays a circle: identity circles are one of the three reserved pill shapes.</div>
+    </div>
+    <div class="card" id="sec-opolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Default revision retention</span>
+        <span class="d">new projects start here; projects still inheriting follow this value when it changes</span></div>
+        <span class="grow"></span>
+        <span style="font-size:13px;color:var(--tx-dim)">keep last</span>
+        <input type="number" min="1" max="99" value="${orgRet(o)}" aria-label="org default revisions kept"
+          onchange="setOrgRet(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">
+        <span style="font-size:13px;color:var(--tx-dim)">revisions</span></div>
+      ${o.projects.map(p=>{const r=projRet(o,p);
+        return`<div class="rowline"><div class="main"><span class="t" style="font-family:var(--mono);font-size:12.5px">${p.name}</span></div>
+        <span class="grow"></span>
+        <span style="font-size:12px;color:${r.mode==='inherit'?'var(--tx-faint)':r.capped?'var(--bad)':'var(--chg)'};font-family:var(--mono)">${r.mode==='inherit'?`inherits → ${r.eff}`:r.capped?`custom ${r.n} — capped to ${r.eff} by org ⚠`:`custom ${r.n}`}</span></div>`}).join('')}
+      <div class="note">Lowering the default never rewrites a project's own value — it caps it: a project may never keep more revisions than the org allows. Older values past a window are collected (pinned revisions stay); history itself is permanent. Changes are audited.</div>
+    </div>
+    <div class="card" id="sec-omembers"><h3>Members</h3>
+      <div class="rowline"><div class="main"><span class="t">Org members & grants</span>
+        <span class="d">${orgGrants} org-scoped grant lines</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='orgmembers';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    <div class="card dangerc" id="sec-odanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${o.id}" aria-label="organization slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete organization</span>
+        <span class="d">Deletes every project, environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${o.name} to confirm" aria-label="type the organization name to confirm deletion"
+          oninput="orgDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="org-del-btn" disabled onclick="orgDelete()">delete</button></div>
+    </div>
+  </div>`;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),orgsettings:pageOrgSettings,noorg:pageNoOrg,account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/16/index.html
+++ b/docs/site/public/prototypes/app-chrome/16/index.html
@@ -1423,7 +1423,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/17/index.html
+++ b/docs/site/public/prototypes/app-chrome/17/index.html
@@ -1467,7 +1467,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');
@@ -1555,7 +1559,9 @@ function setSideVar(id){
   document.body.dataset.sidevar=id;
   const u=new URL(location);u.searchParams.set('side',id);history.replaceState(null,'',u);
   const i=SIDEVARS.findIndex(v=>v.id===id);
-  document.getElementById('sidevarlabel').innerHTML=`<b>${id}</b> — ${SIDEVARS[i].label}`;
+  const sideVariantLabel=document.getElementById('sidevarlabel'), sideVariantId=document.createElement('b');
+  sideVariantId.textContent=id;
+  sideVariantLabel.replaceChildren(sideVariantId,` — ${SIDEVARS[i].label}`);
 }
 function cycleSideVar(dir){
   const i=SIDEVARS.findIndex(v=>v.id===document.body.dataset.sidevar);

--- a/docs/site/public/prototypes/app-chrome/17/index.html
+++ b/docs/site/public/prototypes/app-chrome/17/index.html
@@ -1,0 +1,1572 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 15.
+
+  Iteration 15: project settings gains the sections that make it symmetric
+  with org settings, all ADR-backed:
+  - POLICY (the project-settings capability's real contents, locked #15/#13/
+    #16): per-environment protected flag (live: toggling production updates
+    the matrix header), reveal reauth window (protected always 0: passkey
+    per disclosure), definitions_source db|git (git = definitions read-only
+    in the UI, values unaffected).
+  - DANGER ZONE: rename slug (URL warning) + delete project behind
+    typed-name confirmation; deleting really deletes, and an org with no
+    projects left gets a zero-project empty state on the matrix view.
+  Jump index: Identity · Metadata · Policy · Access · Danger zone.
+ITERATION 17 — SIDEBAR HIERARCHY (Alex's nitpick): with the small
+indentation, top-level section labels and sub-items blur together at
+first glance. Four treatments, switchable via ?side= + floating bar:
+  a — baseline (iteration 16 as-is)
+  b — breathing room: more space between sections, nothing else
+  c — mild separator: dull 1px bar, half the column wide, centered,
+      above each section label (Alex's own sketch)
+  d — structural indent: sub-items indented onto a hairline left rule,
+      section labels stay flush — hierarchy by geometry, not spacing
+Pick one or mix; CSS-only, everything else identical to iteration 16.
+ITERATION 16 (wayfinder #30 spillover): revision retention moves into the
+settings surfaces where it belongs (Alex: not in the history drawer).
+- Project settings › Policy gains "Revision retention": inherit org default
+  (follows org changes) or custom ≤ org (detaches; set-time refusal above
+  the org value; shown "capped by org" when the org later lowers).
+- Org settings gains a Policy card: org default retention (new projects
+  start here; inheriting projects follow) + per-project state list.
+Semantics decided in revision-history iteration 5; changes audited
+(#24: retention-policy change). Concrete defaults → ops spec #32.
+
+
+  Iteration 14: ORG SETTINGS surface (confirmed shape brief). Panel entry
+  "Org settings" beside "Org members & grants", org admins only (dana/sam
+  see nothing: unauthorized = nonexistent). Jump index, three sections:
+  Identity (name, preset hues, custom-hue slider, image upload; org avatar
+  stays a CIRCLE, propagates live to rail circles and panel head) ·
+  Members (entry-point card only) · Danger zone (rename slug with URL
+  warning; delete organization behind typed-name confirmation, inline, no
+  browser confirm — deleting really removes the org in the demo, landing
+  you in your remaining org). Authorization atom for org settings is NOT in
+  locked #15 — flagged for spec synthesis, prototype gates on org admin.
+
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  /* ---- iteration 17 sidebar-hierarchy variants (body[data-sidevar]) ---- */
+  /* b — breathing room: sections separated by space alone */
+  body[data-sidevar=b] #side .stitle{padding-top:30px}
+  body[data-sidevar=b] #side .stitle:first-child,
+  body[data-sidevar=b] #side .orghead+.stitle{padding-top:16px}
+  /* c — mild separator: dull 1px bar, half-width, centered, above the label */
+  body[data-sidevar=c] #side .stitle{padding-top:22px;position:relative}
+  body[data-sidevar=c] #side .stitle::before{
+    content:'';position:absolute;top:10px;left:25%;width:50%;height:1px;
+    background:oklch(from var(--line) l c h/.7)}
+  body[data-sidevar=c] #side .stitle:first-child::before,
+  body[data-sidevar=c] #side .orghead+.stitle::before{content:none}
+  body[data-sidevar=c] #side .stitle:first-child,
+  body[data-sidevar=c] #side .orghead+.stitle{padding-top:16px}
+  /* d — structural indent: items on a hairline left rule, labels flush */
+  body[data-sidevar=d] #side .srow{
+    margin-left:19px;width:calc(100% - 19px);padding-left:13px;
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  body[data-sidevar=d] #side .srow.act{border-left-color:var(--accent)}
+  body[data-sidevar=d] #side .stitle{padding-top:20px}
+  /* floating variant switcher — prototype chrome, off-system on purpose */
+  #sidebar17{
+    position:fixed;bottom:calc(12px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:60;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.02 300);border:1px solid oklch(0.45 0.06 300);
+    border-radius:999px;padding:4px;box-shadow:0 8px 30px oklch(0 0 0/.55);
+    font-family:var(--mono);font-size:11px;color:oklch(0.92 0.02 300);
+  }
+  #sidebar17 button{min-width:32px;min-height:32px;border-radius:999px;color:inherit;
+    display:flex;align-items:center;justify-content:center;font-size:13px;border:none;background:none;cursor:pointer}
+  #sidebar17 button:hover{background:oklch(0.26 0.03 300)}
+  #sidebar17 .sl{padding:0 10px;white-space:nowrap;min-width:210px;text-align:center}
+  #sidebar17 .sl b{color:oklch(0.85 0.1 300);font-weight:500}
+
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* org settings */
+  .bigav-o{width:56px;height:56px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:17px;color:var(--on-accent);background-size:cover;background-position:center;flex:none}
+  .dangerc{border-color:color-mix(in oklch,var(--bad) 45%,var(--line))}
+  .dangerc h3{color:var(--bad)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,img:null,ret:6,projects:[
+    {id:'demo',name:'demo',hue:195},                              /* inherits */
+    {id:'website',name:'website',hue:280,ret:{mode:'custom',n:4}},
+    {id:'mobile',name:'mobile-app',hue:60,ret:{mode:'custom',n:10}}, /* set while org was 12 ⇒ capped */
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,img:null,ret:8,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+/* retention semantics (revision-history it-5): inherit-until-modified, org cap */
+const orgRet=o=>o.ret??6;
+function projRet(o,p){
+  if(!p.ret||p.ret.mode==='inherit')return{mode:'inherit',eff:orgRet(o)};
+  return{mode:'custom',n:p.ret.n,eff:Math.min(p.ret.n,orgRet(o)),capped:p.ret.n>orgRet(o)};
+}
+function setProjRetMode(mode){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  if(mode==='inherit'){delete p.ret;showToast('retention: inherits org default ('+orgRet(o)+') — follows org changes · audited');}
+  else{p.ret={mode:'custom',n:Math.min(projRet(o,p).eff,orgRet(o))};showToast('retention: custom '+p.ret.n+' — detached from org changes · audited');}
+  update();
+}
+function setProjRetN(inp){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  const n=Math.max(1,+inp.value||1);
+  if(n>orgRet(o)){showToast('refused: cannot exceed the org retention ('+orgRet(o)+') — a project may never keep more history than the org allows');inp.value=p.ret.n;return;}
+  p.ret={mode:'custom',n};showToast('retention: custom '+n+' · audited');update();
+}
+function setOrgRet(inp){
+  const o=curOrg();
+  const n=Math.max(1,+inp.value||1);
+  o.ret=n;
+  showToast('org default retention → keep last '+n+' — inheriting projects follow; overrides keep their value, capped at '+n+' · audited');
+  update();
+}
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,revealWin:'15m',defSrc:'db',
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  /* membership list can reference a deleted org — validate against ORGS */
+  const valid=me().orgs.filter(id=>ORGS.some(o=>o.id===id));
+  if(!valid.includes(S.org)) S.org=valid[0]??null;
+  if(!curOrg()){
+    /* zero orgs: the empty state (deleted last org, or revoked membership) */
+    if(!['account','instance'].includes(S.view)) S.view='noorg';
+    S.project=null;
+    return;
+  }
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&(S.view==='orgmembers'||S.view==='orgsettings')) S.view='matrix';
+  if(S.view==='noorg') S.view='matrix';
+}
+
+const orgFace=o=>o.img?{bg:`url(${o.img}) center/cover`,txt:''}:{bg:hueBg(o.hue),txt:mono(o.name)};
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  if(!curOrg()){
+    r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+    if(me().instanceAdmin){
+      const g=document.createElement('button');
+      g.className='railbtn'+(S.view==='instance'?' act':'');
+      g.title='instance administration';g.textContent='⚙';
+      g.onclick=()=>{S.view='instance';update();};
+      r.appendChild(g);
+    }
+    const a=document.createElement('button');
+    a.className='railbtn me'+(S.view==='account'?' act':'');
+    a.title='account & security';a.textContent=mono(me().label);
+    a.onclick=()=>{S.view='account';update();};
+    r.appendChild(a);
+    return;
+  }
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      const f=orgFace(o);
+      b.style.background=f.bg;b.style.color='var(--on-accent)';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=f.txt;
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  if(!o){
+    s.insertAdjacentHTML('beforeend',
+      '<div class="orghead"><div><div class="oname">no organization</div><div class="orole">ask for an invitation</div></div></div>');
+    return;
+  }
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" id="orghead-av" style="background:${orgFace(o).bg}">${orgFace(o).txt}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${orgFace(oo).bg};width:22px;height:22px;font-size:9px">${orgFace(oo).txt&&mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+    const os=document.createElement('button');
+    os.className='srow'+(S.view==='orgsettings'?' act':'');os.textContent='Org settings';
+    os.onclick=()=>{S.view='orgsettings';update();toggleSide(false);};
+    s.appendChild(os);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  if(!o){c.innerHTML='<span>hikyo</span>';return;}
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgsettings'){
+    seg.push('<span class="sep">/</span><span>org settings</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  if(!proj){
+    return `<div class="page">
+      <h2>No projects</h2>
+      <div class="card"><h3>This organization has no projects yet</h3>
+        <div class="note" style="margin-top:0">Create one to get an environment matrix${isOrgAdmin()?'':' (an org admin can)'}.
+        </div>
+        ${isOrgAdmin()?`<div style="margin-top:12px"><button class="btn primary" onclick="showToast('project created (demo)')">+ create project</button></div>`:''}
+      </div>
+    </div>`;
+  }
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const canPolicy=isOrgAdmin(); /* stands in for the project-settings capability */
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],...(canPolicy?[['sec-ppolicy','Policy']]:[]),['sec-paccess','Access'],...(canPolicy?[['sec-pdanger','Danger zone']]:[])])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    ${canPolicy?`<div class="card" id="sec-ppolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Protected environments</span>
+        <span class="d">a protected environment caps the reveal window at 0: passkey per disclosure, no TOTP</span></div>
+        <span class="grow"></span>
+        ${MXENVS.map(e=>`<button class="tag${e.prot?' bad':''}" style="min-height:32px;cursor:pointer"
+          title="${e.prot?'protected: click to unprotect':'click to protect'}"
+          onclick="MXENVS.find(x=>x.id==='${e.id}').prot=${e.prot?'undefined':'true'};update()">${e.prot?'🔒 ':''}${e.n}</button>`).join('')}
+      </div>
+      <div class="rowline"><div class="main"><span class="t">Reveal reauth window</span>
+        <span class="d">how long a successful reveal reauth stands for further disclosures</span></div>
+        <span class="grow"></span>
+        <select onchange="S.revealWin=this.value;update()" aria-label="reveal reauth window" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          ${['0 (every disclosure)','5m','15m','60m'].map(w=>`<option${w===S.revealWin||w.startsWith(S.revealWin)?' selected':''}>${w}</option>`).join('')}
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Definitions source</span>
+        <span class="d">${S.defSrc==='git'?'definitions are read-only in the UI; change them via the reviewed Git bundle. Values unaffected.':'definitions edited in the UI; switch to git for a review gate'}</span></div>
+        <span class="grow"></span>
+        <select onchange="S.defSrc=this.value;update()" aria-label="definitions source" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px;font-family:var(--mono)">
+          <option value="db"${S.defSrc==='db'?' selected':''}>db</option>
+          <option value="git"${S.defSrc==='git'?' selected':''}>git</option>
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Revision retention</span>
+        <span class="d">${(()=>{const r=projRet(curOrg(),proj);
+          if(r.mode==='inherit')return`inherits the org default — values kept for the last ${r.eff} revisions per environment; follows org changes`;
+          if(r.capped)return`custom ${r.n}, capped to ${r.eff} by the org — a project may never keep more than the org allows`;
+          return`custom ${r.n} — detached from later org changes`})()}</span></div>
+        <span class="grow"></span>
+        <select onchange="setProjRetMode(this.value)" aria-label="retention mode" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          <option value="inherit"${projRet(curOrg(),proj).mode==='inherit'?' selected':''}>inherit org (${orgRet(curOrg())})</option>
+          <option value="custom"${projRet(curOrg(),proj).mode==='custom'?' selected':''}>custom</option>
+        </select>
+        ${projRet(curOrg(),proj).mode==='custom'?`<input type="number" min="1" max="99" value="${projRet(curOrg(),proj).n}" aria-label="revisions kept"
+          onchange="setProjRetN(this)" style="background:var(--bg);border:1px solid ${projRet(curOrg(),proj).capped?'var(--bad)':'var(--line)'};color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">`:''}
+      </div>
+      <div class="note">Older revisions lose their values as collection runs (pinned ones always stay); who-changed-what history is permanent. A custom value may not exceed the org default — refused at set time; if the org later lowers its default, this value is capped, not rewritten. Changes are audited.</div>
+      <div class="note">These are the project-settings capability's contents (#15): the guards on the definitions editor live apart from the editor they restrain.</div>
+    </div>`:''}
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    ${canPolicy?`<div class="card dangerc" id="sec-pdanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${proj.id}" aria-label="project slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete project</span>
+        <span class="d">Deletes every environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${proj.name} to confirm" aria-label="type the project name to confirm deletion"
+          oninput="projDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="proj-del-btn" disabled onclick="projDelete()">delete</button></div>
+    </div>`:''}
+  </div>`;
+}
+
+function projDeleteCheck(inp){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  document.getElementById('proj-del-btn').disabled=inp.value!==proj.name;
+}
+function projDelete(){
+  const o=curOrg();
+  const proj=o.projects.find(p=>p.id===S.project);
+  o.projects.splice(o.projects.indexOf(proj),1);
+  showToast(`project ${proj.name} deleted`);
+  S.project=null;S.view='matrix';update();
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function orgHueLive(v){
+  curOrg().hue=+v;
+  document.getElementById('ohuedeg').textContent=v;
+  if(!curOrg().img)document.getElementById('bigav-org').style.background=hueBg(+v);
+}
+function setOrgImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{curOrg().img=r.result;update();};
+  r.readAsDataURL(f);
+}
+function orgDeleteCheck(inp){
+  document.getElementById('org-del-btn').disabled=inp.value!==curOrg().name;
+}
+function orgDelete(){
+  const o=curOrg();
+  const i=ORGS.indexOf(o);ORGS.splice(i,1);
+  showToast(`organization ${o.name} deleted`);
+  S.org=null;S.view='matrix';update();
+}
+
+function pageNoOrg(){
+  return `<div class="page">
+    <h2>No organizations</h2>
+    <div class="card"><h3>You are not a member of any organization</h3>
+      <div class="note" style="margin-top:0">Membership comes from an invitation. Ask an organization admin to invite you${me().instanceAdmin?', or create an organization from instance administration':''}.
+      </div>
+      ${me().instanceAdmin?`<div style="margin-top:12px"><button class="btn primary" onclick="S.view='instance';update()">open instance administration</button></div>`:''}
+    </div>
+  </div>`;
+}
+
+function pageOrgSettings(){
+  const o=curOrg();
+  const hues=[195,280,60,140,20,320];
+  const f=orgFace(o);
+  const orgGrants=GRANTS.filter(g=>g.scope.startsWith('org:')).length;
+  return `<div class="page">
+    <h2>Org settings · ${o.name}</h2>
+    <p class="sub">Organization identity and lifecycle. Access lives on its own surface; the danger zone is deliberately last.</p>
+    ${jump([['sec-oident','Identity'],['sec-opolicy','Policy'],['sec-omembers','Members'],['sec-odanger','Danger zone']])}
+    <div class="card" id="sec-oident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav-o" id="bigav-org" style="background:${f.bg}">${f.txt}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===o.hue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="curOrg().hue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="ohuedeg">${o.hue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${o.hue}" aria-label="custom org hue"
+              oninput="orgHueLive(this.value)" onchange="update()"></div>
+        </div>
+      </div>
+      <div class="fgrid" style="margin-top:14px">
+        <div class="field"><label>name</label>
+          <input type="text" value="${o.name}" onchange="curOrg().name=this.value;update()"></div>
+      </div>
+      <div class="rowline" style="margin-top:6px"><div class="main"><span class="t">Image</span>
+        <span class="d">${o.img?'custom image, shown on every org circle':'PNG / SVG / JPG, replaces the monogram'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="oimg" accept="image/*" hidden onchange="setOrgImg(this)">
+        <button class="btn" onclick="document.getElementById('oimg').click()">${o.img?'replace…':'upload…'}</button>
+        ${o.img?'<button class="xbtn" title="remove image" onclick="curOrg().img=null;update()">✕</button>':''}
+      </div>
+      <div class="note">The org avatar stays a circle: identity circles are one of the three reserved pill shapes.</div>
+    </div>
+    <div class="card" id="sec-opolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Default revision retention</span>
+        <span class="d">new projects start here; projects still inheriting follow this value when it changes</span></div>
+        <span class="grow"></span>
+        <span style="font-size:13px;color:var(--tx-dim)">keep last</span>
+        <input type="number" min="1" max="99" value="${orgRet(o)}" aria-label="org default revisions kept"
+          onchange="setOrgRet(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">
+        <span style="font-size:13px;color:var(--tx-dim)">revisions</span></div>
+      ${o.projects.map(p=>{const r=projRet(o,p);
+        return`<div class="rowline"><div class="main"><span class="t" style="font-family:var(--mono);font-size:12.5px">${p.name}</span></div>
+        <span class="grow"></span>
+        <span style="font-size:12px;color:${r.mode==='inherit'?'var(--tx-faint)':r.capped?'var(--bad)':'var(--chg)'};font-family:var(--mono)">${r.mode==='inherit'?`inherits → ${r.eff}`:r.capped?`custom ${r.n} — capped to ${r.eff} by org ⚠`:`custom ${r.n}`}</span></div>`}).join('')}
+      <div class="note">Lowering the default never rewrites a project's own value — it caps it: a project may never keep more revisions than the org allows. Older values past a window are collected (pinned revisions stay); history itself is permanent. Changes are audited.</div>
+    </div>
+    <div class="card" id="sec-omembers"><h3>Members</h3>
+      <div class="rowline"><div class="main"><span class="t">Org members & grants</span>
+        <span class="d">${orgGrants} org-scoped grant lines</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='orgmembers';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    <div class="card dangerc" id="sec-odanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${o.id}" aria-label="organization slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete organization</span>
+        <span class="d">Deletes every project, environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${o.name} to confirm" aria-label="type the organization name to confirm deletion"
+          oninput="orgDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="org-del-btn" disabled onclick="orgDelete()">delete</button></div>
+    </div>
+  </div>`;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),orgsettings:pageOrgSettings,noorg:pageNoOrg,account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+<div id="sidebar17" role="group" aria-label="sidebar hierarchy variant switcher">
+  <button onclick="cycleSideVar(-1)" aria-label="previous variant">‹</button>
+  <span class="sl" id="sidevarlabel"></span>
+  <button onclick="cycleSideVar(1)" aria-label="next variant">›</button>
+</div>
+<script>
+const SIDEVARS=[
+  {id:'a',label:'baseline (it-16)'},
+  {id:'b',label:'breathing room'},
+  {id:'c',label:'mild separator'},
+  {id:'d',label:'structural indent'},
+];
+function setSideVar(id){
+  document.body.dataset.sidevar=id;
+  const u=new URL(location);u.searchParams.set('side',id);history.replaceState(null,'',u);
+  const i=SIDEVARS.findIndex(v=>v.id===id);
+  document.getElementById('sidevarlabel').innerHTML=`<b>${id}</b> — ${SIDEVARS[i].label}`;
+}
+function cycleSideVar(dir){
+  const i=SIDEVARS.findIndex(v=>v.id===document.body.dataset.sidevar);
+  setSideVar(SIDEVARS[(i+dir+SIDEVARS.length)%SIDEVARS.length].id);
+}
+document.addEventListener('keydown',e=>{
+  if(e.target.closest('input,textarea,select,[contenteditable]'))return;
+  if(e.key==='ArrowLeft')cycleSideVar(-1);
+  if(e.key==='ArrowRight')cycleSideVar(1);
+});
+setSideVar((v=>SIDEVARS.some(x=>x.id===v)?v:'a')(new URLSearchParams(location.search).get('side')||'a'));
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/18/index.html
+++ b/docs/site/public/prototypes/app-chrome/18/index.html
@@ -1478,7 +1478,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,`: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');
@@ -1567,7 +1571,9 @@ function setSideVar(id){
   document.body.dataset.sidevar=id;
   const u=new URL(location);u.searchParams.set('side',id);history.replaceState(null,'',u);
   const i=SIDEVARS.findIndex(v=>v.id===id);
-  document.getElementById('sidevarlabel').innerHTML=`<b>${id}</b> — ${SIDEVARS[i].label}`;
+  const sideVariantLabel=document.getElementById('sidevarlabel'), sideVariantId=document.createElement('b');
+  sideVariantId.textContent=id;
+  sideVariantLabel.replaceChildren(sideVariantId,` — ${SIDEVARS[i].label}`);
 }
 function cycleSideVar(dir){
   const i=SIDEVARS.findIndex(v=>v.id===document.body.dataset.sidevar);

--- a/docs/site/public/prototypes/app-chrome/18/index.html
+++ b/docs/site/public/prototypes/app-chrome/18/index.html
@@ -1,0 +1,1584 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 15.
+
+  Iteration 15: project settings gains the sections that make it symmetric
+  with org settings, all ADR-backed:
+  - POLICY (the project-settings capability's real contents, locked #15/#13/
+    #16): per-environment protected flag (live: toggling production updates
+    the matrix header), reveal reauth window (protected always 0: passkey
+    per disclosure), definitions_source db|git (git = definitions read-only
+    in the UI, values unaffected).
+  - DANGER ZONE: rename slug (URL warning) + delete project behind
+    typed-name confirmation; deleting really deletes, and an org with no
+    projects left gets a zero-project empty state on the matrix view.
+  Jump index: Identity · Metadata · Policy · Access · Danger zone.
+ITERATION 18 — variant e added: Alex likes b AND d, e combines them
+(30px inter-section breathing room + sub-items on a hairline left rule).
+Default view = e; a-d kept for side-by-side comparison.
+ITERATION 17 — SIDEBAR HIERARCHY (Alex's nitpick): with the small
+indentation, top-level section labels and sub-items blur together at
+first glance. Four treatments, switchable via ?side= + floating bar:
+  a — baseline (iteration 16 as-is)
+  b — breathing room: more space between sections, nothing else
+  c — mild separator: dull 1px bar, half the column wide, centered,
+      above each section label (Alex's own sketch)
+  d — structural indent: sub-items indented onto a hairline left rule,
+      section labels stay flush — hierarchy by geometry, not spacing
+Pick one or mix; CSS-only, everything else identical to iteration 16.
+ITERATION 16 (wayfinder #30 spillover): revision retention moves into the
+settings surfaces where it belongs (Alex: not in the history drawer).
+- Project settings › Policy gains "Revision retention": inherit org default
+  (follows org changes) or custom ≤ org (detaches; set-time refusal above
+  the org value; shown "capped by org" when the org later lowers).
+- Org settings gains a Policy card: org default retention (new projects
+  start here; inheriting projects follow) + per-project state list.
+Semantics decided in revision-history iteration 5; changes audited
+(#24: retention-policy change). Concrete defaults → ops spec #32.
+
+
+  Iteration 14: ORG SETTINGS surface (confirmed shape brief). Panel entry
+  "Org settings" beside "Org members & grants", org admins only (dana/sam
+  see nothing: unauthorized = nonexistent). Jump index, three sections:
+  Identity (name, preset hues, custom-hue slider, image upload; org avatar
+  stays a CIRCLE, propagates live to rail circles and panel head) ·
+  Members (entry-point card only) · Danger zone (rename slug with URL
+  warning; delete organization behind typed-name confirmation, inline, no
+  browser confirm — deleting really removes the org in the demo, landing
+  you in your remaining org). Authorization atom for org settings is NOT in
+  locked #15 — flagged for spec synthesis, prototype gates on org admin.
+
+
+  Iteration 13: fixes from the /impeccable critique (two isolated
+  assessments: design-director review + deterministic detector, 25/40):
+  - tx-faint lifted to AA+ contrast on both themes (was 4.35:1 at 10-11px)
+  - validation errors carry text + aria-live, never color-only
+  - new-grant scope ordered narrow-to-wide, SAFEST default (staging), the
+    protected env last and never preselected
+  - blast warning gains "back, change scope" preserving the composition
+  - revoke and grant get an undo toast (revoke stays one-click: absence is
+    the only denial, but the toast covers the self-revoke foot-gun) and the
+    toast doubles as post-grant feedback
+  - modal headings h3 (no h2-to-h4 skip), sticky modal footer on phones,
+    org-members crumb disambiguated, matrix first/last column breathing
+    room, em dashes removed from UI copy
+  ADR refs in copy stay: prototype scaffolding for spec synthesis (NOTES).
+
+
+  Iteration 12 (Alex): the capability explanations collapse behind a (?)
+  per row — tap toggles the sub-line (touch), title supplies desktop
+  hover. The checklist is compact single-line rows again.
+
+
+  Iteration 11 (Alex): every capability in the new-grant checklist carries
+  its explanation (permission-ADR wording) as an always-visible sub-line —
+  a hover tooltip would be dead weight on touch, and this is a mobile-first
+  product. Member-table capability chips get the same text as their title.
+
+
+  Iteration 10 (Alex): project Identity gains a CUSTOM HUE slider (any
+  hue, pinned to the brand oklch formula so every choice stays on-palette)
+  and an IMAGE UPLOAD (FileReader dataURL, shown in the header avatar and
+  the rail tile; removable) — alongside the existing monogram, preset
+  hues and glyphs. Priority: image > glyph > monogram.
+
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  /* ---- iteration 17 sidebar-hierarchy variants (body[data-sidevar]) ---- */
+  /* b — breathing room: sections separated by space alone */
+  body[data-sidevar=b] #side .stitle{padding-top:30px}
+  body[data-sidevar=b] #side .stitle:first-child,
+  body[data-sidevar=b] #side .orghead+.stitle{padding-top:16px}
+  /* c — mild separator: dull 1px bar, half-width, centered, above the label */
+  body[data-sidevar=c] #side .stitle{padding-top:22px;position:relative}
+  body[data-sidevar=c] #side .stitle::before{
+    content:'';position:absolute;top:10px;left:25%;width:50%;height:1px;
+    background:oklch(from var(--line) l c h/.7)}
+  body[data-sidevar=c] #side .stitle:first-child::before,
+  body[data-sidevar=c] #side .orghead+.stitle::before{content:none}
+  body[data-sidevar=c] #side .stitle:first-child,
+  body[data-sidevar=c] #side .orghead+.stitle{padding-top:16px}
+  /* d — structural indent: items on a hairline left rule, labels flush */
+  body[data-sidevar=d] #side .srow{
+    margin-left:19px;width:calc(100% - 19px);padding-left:13px;
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  body[data-sidevar=d] #side .srow.act{border-left-color:var(--accent)}
+  body[data-sidevar=d] #side .stitle{padding-top:20px}
+  /* e — b + d combined: breathing room AND structural indent */
+  body[data-sidevar=e] #side .stitle{padding-top:30px}
+  body[data-sidevar=e] #side .stitle:first-child,
+  body[data-sidevar=e] #side .orghead+.stitle{padding-top:16px}
+  body[data-sidevar=e] #side .srow{
+    margin-left:19px;width:calc(100% - 19px);padding-left:13px;
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  body[data-sidevar=e] #side .srow.act{border-left-color:var(--accent)}
+  /* floating variant switcher — prototype chrome, off-system on purpose */
+  #sidebar17{
+    position:fixed;bottom:calc(12px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:60;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.02 300);border:1px solid oklch(0.45 0.06 300);
+    border-radius:999px;padding:4px;box-shadow:0 8px 30px oklch(0 0 0/.55);
+    font-family:var(--mono);font-size:11px;color:oklch(0.92 0.02 300);
+  }
+  #sidebar17 button{min-width:32px;min-height:32px;border-radius:999px;color:inherit;
+    display:flex;align-items:center;justify-content:center;font-size:13px;border:none;background:none;cursor:pointer}
+  #sidebar17 button:hover{background:oklch(0.26 0.03 300)}
+  #sidebar17 .sl{padding:0 10px;white-space:nowrap;min-width:210px;text-align:center}
+  #sidebar17 .sl b{color:oklch(0.85 0.1 300);font-weight:500}
+
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capitem{display:flex;align-items:center;flex-wrap:wrap;border-radius:4px}
+  .capitem:hover{background:var(--bg3)}
+  .capitem label{display:flex;align-items:center;gap:8px;padding:7px 4px 7px 8px;flex:1;min-height:36px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .qh{width:24px;height:24px;border-radius:3px;border:1px solid var(--line);color:var(--tx-faint);
+    font-size:11px;margin-right:6px;flex:none;display:inline-flex;align-items:center;justify-content:center}
+  .qh:hover,.qh[aria-expanded=true]{border-color:var(--accent);color:var(--accent)}
+  .capitem .cd{flex-basis:100%;padding:0 8px 8px 30px;font-family:var(--sans);font-size:11px;
+    color:var(--tx-faint);line-height:1.4;white-space:normal;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* org settings */
+  .bigav-o{width:56px;height:56px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:17px;color:var(--on-accent);background-size:cover;background-position:center;flex:none}
+  .dangerc{border-color:color-mix(in oklch,var(--bad) 45%,var(--line))}
+  .dangerc h3{color:var(--bad)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+  .bigav.img{background-size:cover;background-position:center}
+  .huerange{appearance:none;width:100%;max-width:260px;height:10px;border-radius:3px;outline-offset:4px;
+    background:linear-gradient(to right,oklch(0.62 0.11 0),oklch(0.62 0.11 60),oklch(0.62 0.11 120),
+    oklch(0.62 0.11 180),oklch(0.62 0.11 240),oklch(0.62 0.11 300),oklch(0.62 0.11 359))}
+  .huerange::-webkit-slider-thumb{appearance:none;width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+  .huerange::-moz-range-thumb{width:22px;height:22px;border-radius:50%;
+    background:var(--tx);border:3px solid var(--bg);box-shadow:0 0 0 1px var(--line)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  .formerr{color:var(--bad);font-size:12.5px;font-weight:600}
+  #toast{position:fixed;z-index:70;left:50%;bottom:16px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;padding:10px 10px 10px 16px;box-shadow:0 8px 30px oklch(0 0 0/.4);
+    font-size:13px;max-width:min(520px,calc(100vw - 24px))}
+  #toast[hidden]{display:none}
+  #toast .btn{min-height:32px;padding:5px 12px}
+  .mx th:first-child,.mx td:first-child{padding-left:16px}
+  .mx th:last-child,.mx td:last-child{padding-right:16px}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box .mh{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px;
+    letter-spacing:0;text-transform:none;color:var(--tx);margin:0}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup .mh{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast .mh{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    .modal-box .mrow{position:sticky;bottom:-20px;background:var(--bg2);padding-top:12px;margin-top:12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="toast" role="status" aria-live="polite" hidden>
+  <span id="toast-msg"></span>
+  <button class="btn" id="toast-undo">undo</button>
+</div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h3 class="mh">🛡 Confirm it's you</h3>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure: revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here; a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h3 class="mh">Recovery codes</h3>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes; after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h3 class="mh">⚠ Org-scoped grant: check the blast radius</h3>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial: there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn" onclick="blastBack()">back, change scope</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h3 class="mh">Invite member</h3>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b>;
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org" aria-describedby="iv-err"></div>
+    <div class="formerr" id="iv-err" role="alert" hidden></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h3 class="mh">New grant</h3>
+  <div class="msub">Pick any number of capabilities: each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps"></div></div>
+    <div class="formerr" id="g-err" role="alert" hidden></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:staging" selected>env · staging</option>
+        <option value="env:production">env · production (protected)</option>
+        <option value="project:demo">project · demo (all environments)</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,img:null,ret:6,projects:[
+    {id:'demo',name:'demo',hue:195},                              /* inherits */
+    {id:'website',name:'website',hue:280,ret:{mode:'custom',n:4}},
+    {id:'mobile',name:'mobile-app',hue:60,ret:{mode:'custom',n:10}}, /* set while org was 12 ⇒ capped */
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,img:null,ret:8,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+/* retention semantics (revision-history it-5): inherit-until-modified, org cap */
+const orgRet=o=>o.ret??6;
+function projRet(o,p){
+  if(!p.ret||p.ret.mode==='inherit')return{mode:'inherit',eff:orgRet(o)};
+  return{mode:'custom',n:p.ret.n,eff:Math.min(p.ret.n,orgRet(o)),capped:p.ret.n>orgRet(o)};
+}
+function setProjRetMode(mode){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  if(mode==='inherit'){delete p.ret;showToast('retention: inherits org default ('+orgRet(o)+') — follows org changes · audited');}
+  else{p.ret={mode:'custom',n:Math.min(projRet(o,p).eff,orgRet(o))};showToast('retention: custom '+p.ret.n+' — detached from org changes · audited');}
+  update();
+}
+function setProjRetN(inp){
+  const o=curOrg(),p=visProjects(o).find(x=>x.id===S.project);
+  const n=Math.max(1,+inp.value||1);
+  if(n>orgRet(o)){showToast('refused: cannot exceed the org retention ('+orgRet(o)+') — a project may never keep more history than the org allows');inp.value=p.ret.n;return;}
+  p.ret={mode:'custom',n};showToast('retention: custom '+n+' · audited');update();
+}
+function setOrgRet(inp){
+  const o=curOrg();
+  const n=Math.max(1,+inp.value||1);
+  o.ret=n;
+  showToast('org default retention → keep last '+n+' — inheriting projects follow; overrides keep their value, capped at '+n+' · audited');
+  update();
+}
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+const CAPDESC={
+  'read':'see keys and non-secret values; secrets stay masked',
+  'edit':'create and change draft values (a draft is never a disclosure)',
+  'publish':'make drafts live for an environment',
+  'reveal':'see secret plaintext: a disclosure, runs the reauth ceremony',
+  'reveal-history':'see superseded secret values, separate from reveal',
+  'definitions-edit':'keys, schema rules, environment topology',
+  'project-settings':'protected flag, reveal window, definitions source: the guards on the definitions editor',
+  'manage-members':'grant and revoke capabilities',
+  'audit-read':'read the audit trail: its own power, MFA required',
+};
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,projImg:null,revealWin:'15m',defSrc:'db',
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  /* membership list can reference a deleted org — validate against ORGS */
+  const valid=me().orgs.filter(id=>ORGS.some(o=>o.id===id));
+  if(!valid.includes(S.org)) S.org=valid[0]??null;
+  if(!curOrg()){
+    /* zero orgs: the empty state (deleted last org, or revoked membership) */
+    if(!['account','instance'].includes(S.view)) S.view='noorg';
+    S.project=null;
+    return;
+  }
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&(S.view==='orgmembers'||S.view==='orgsettings')) S.view='matrix';
+  if(S.view==='noorg') S.view='matrix';
+}
+
+const orgFace=o=>o.img?{bg:`url(${o.img}) center/cover`,txt:''}:{bg:hueBg(o.hue),txt:mono(o.name)};
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  if(!curOrg()){
+    r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+    if(me().instanceAdmin){
+      const g=document.createElement('button');
+      g.className='railbtn'+(S.view==='instance'?' act':'');
+      g.title='instance administration';g.textContent='⚙';
+      g.onclick=()=>{S.view='instance';update();};
+      r.appendChild(g);
+    }
+    const a=document.createElement('button');
+    a.className='railbtn me'+(S.view==='account'?' act':'');
+    a.title='account & security';a.textContent=mono(me().label);
+    a.onclick=()=>{S.view='account';update();};
+    r.appendChild(a);
+    return;
+  }
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      const f=orgFace(o);
+      b.style.background=f.bg;b.style.color='var(--on-accent)';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=f.txt;
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(p.id===S.project&&S.projImg){b.textContent='';b.style.background=`url(${S.projImg}) center/cover`;}
+    else if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  if(!o){
+    s.insertAdjacentHTML('beforeend',
+      '<div class="orghead"><div><div class="oname">no organization</div><div class="orole">ask for an invitation</div></div></div>');
+    return;
+  }
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" id="orghead-av" style="background:${orgFace(o).bg}">${orgFace(o).txt}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${orgFace(oo).bg};width:22px;height:22px;font-size:9px">${orgFace(oo).txt&&mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+    const os=document.createElement('button');
+    os.className='srow'+(S.view==='orgsettings'?' act':'');os.textContent='Org settings';
+    os.onclick=()=>{S.view='orgsettings';update();toggleSide(false);};
+    s.appendChild(os);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  if(!o){c.innerHTML='<span>hikyo</span>';return;}
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgsettings'){
+    seg.push('<span class="sep">/</span><span>org settings</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>org members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  if(!proj){
+    return `<div class="page">
+      <h2>No projects</h2>
+      <div class="card"><h3>This organization has no projects yet</h3>
+        <div class="note" style="margin-top:0">Create one to get an environment matrix${isOrgAdmin()?'':' (an org admin can)'}.
+        </div>
+        ${isOrgAdmin()?`<div style="margin-top:12px"><button class="btn primary" onclick="showToast('project created (demo)')">+ create project</button></div>`:''}
+      </div>
+    </div>`;
+  }
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} · environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed: full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projImg?'':(S.projGlyph??mono(proj.name));
+  const canPolicy=isOrgAdmin(); /* stands in for the project-settings capability */
+  const avStyle=S.projImg?`background-image:url(${S.projImg})`:`background:${hueBg(S.projHue)}`;
+  return `<div class="page">
+    <h2>Project settings · ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface: one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],...(canPolicy?[['sec-ppolicy','Policy']]:[]),['sec-paccess','Access'],...(canPolicy?[['sec-pdanger','Danger zone']]:[])])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav${S.projImg?' img':''}" id="bigav-prev" style="${avStyle}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="huedeg">${S.projHue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${S.projHue}" aria-label="custom hue"
+              oninput="projHueLive(this.value)" onchange="update()"></div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="rowline" style="margin-top:14px"><div class="main"><span class="t">Image</span>
+        <span class="d">${S.projImg?'custom image · shown in the rail and header':'PNG / SVG / JPG, replaces monogram and glyph'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="pimg" accept="image/*" hidden onchange="setProjImg(this)">
+        <button class="btn" onclick="document.getElementById('pimg').click()">${S.projImg?'replace…':'upload…'}</button>
+        ${S.projImg?'<button class="xbtn" title="remove image" onclick="S.projImg=null;update()">✕</button>':''}
+      </div>
+      <div class="note">Monogram + hue is the default; glyph and image are opt-in (image wins). The custom-hue slider keeps every choice on the brand formula: same lightness and chroma, hue free. Iteration 9 of the matrix prototype showed monograms alone collapse at scale.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    ${canPolicy?`<div class="card" id="sec-ppolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Protected environments</span>
+        <span class="d">a protected environment caps the reveal window at 0: passkey per disclosure, no TOTP</span></div>
+        <span class="grow"></span>
+        ${MXENVS.map(e=>`<button class="tag${e.prot?' bad':''}" style="min-height:32px;cursor:pointer"
+          title="${e.prot?'protected: click to unprotect':'click to protect'}"
+          onclick="MXENVS.find(x=>x.id==='${e.id}').prot=${e.prot?'undefined':'true'};update()">${e.prot?'🔒 ':''}${e.n}</button>`).join('')}
+      </div>
+      <div class="rowline"><div class="main"><span class="t">Reveal reauth window</span>
+        <span class="d">how long a successful reveal reauth stands for further disclosures</span></div>
+        <span class="grow"></span>
+        <select onchange="S.revealWin=this.value;update()" aria-label="reveal reauth window" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          ${['0 (every disclosure)','5m','15m','60m'].map(w=>`<option${w===S.revealWin||w.startsWith(S.revealWin)?' selected':''}>${w}</option>`).join('')}
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Definitions source</span>
+        <span class="d">${S.defSrc==='git'?'definitions are read-only in the UI; change them via the reviewed Git bundle. Values unaffected.':'definitions edited in the UI; switch to git for a review gate'}</span></div>
+        <span class="grow"></span>
+        <select onchange="S.defSrc=this.value;update()" aria-label="definitions source" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px;font-family:var(--mono)">
+          <option value="db"${S.defSrc==='db'?' selected':''}>db</option>
+          <option value="git"${S.defSrc==='git'?' selected':''}>git</option>
+        </select></div>
+      <div class="rowline"><div class="main"><span class="t">Revision retention</span>
+        <span class="d">${(()=>{const r=projRet(curOrg(),proj);
+          if(r.mode==='inherit')return`inherits the org default — values kept for the last ${r.eff} revisions per environment; follows org changes`;
+          if(r.capped)return`custom ${r.n}, capped to ${r.eff} by the org — a project may never keep more than the org allows`;
+          return`custom ${r.n} — detached from later org changes`})()}</span></div>
+        <span class="grow"></span>
+        <select onchange="setProjRetMode(this.value)" aria-label="retention mode" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-size:13px">
+          <option value="inherit"${projRet(curOrg(),proj).mode==='inherit'?' selected':''}>inherit org (${orgRet(curOrg())})</option>
+          <option value="custom"${projRet(curOrg(),proj).mode==='custom'?' selected':''}>custom</option>
+        </select>
+        ${projRet(curOrg(),proj).mode==='custom'?`<input type="number" min="1" max="99" value="${projRet(curOrg(),proj).n}" aria-label="revisions kept"
+          onchange="setProjRetN(this)" style="background:var(--bg);border:1px solid ${projRet(curOrg(),proj).capped?'var(--bad)':'var(--line)'};color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">`:''}
+      </div>
+      <div class="note">Older revisions lose their values as collection runs (pinned ones always stay); who-changed-what history is permanent. A custom value may not exceed the org default — refused at set time; if the org later lowers its default, this value is capped, not rewritten. Changes are audited.</div>
+      <div class="note">These are the project-settings capability's contents (#15): the guards on the definitions editor live apart from the editor they restrain.</div>
+    </div>`:''}
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    ${canPolicy?`<div class="card dangerc" id="sec-pdanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${proj.id}" aria-label="project slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete project</span>
+        <span class="d">Deletes every environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${proj.name} to confirm" aria-label="type the project name to confirm deletion"
+          oninput="projDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="proj-del-btn" disabled onclick="projDelete()">delete</button></div>
+    </div>`:''}
+  </div>`;
+}
+
+function projDeleteCheck(inp){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  document.getElementById('proj-del-btn').disabled=inp.value!==proj.name;
+}
+function projDelete(){
+  const o=curOrg();
+  const proj=o.projects.find(p=>p.id===S.project);
+  o.projects.splice(o.projects.indexOf(proj),1);
+  showToast(`project ${proj.name} deleted`);
+  S.project=null;S.view='matrix';update();
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="${g.cap}: ${CAPDESC[g.cap]||''} · via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending: binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants · '+curOrg().name:'Members & access · demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant;
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? Answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here: this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function orgHueLive(v){
+  curOrg().hue=+v;
+  document.getElementById('ohuedeg').textContent=v;
+  if(!curOrg().img)document.getElementById('bigav-org').style.background=hueBg(+v);
+}
+function setOrgImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{curOrg().img=r.result;update();};
+  r.readAsDataURL(f);
+}
+function orgDeleteCheck(inp){
+  document.getElementById('org-del-btn').disabled=inp.value!==curOrg().name;
+}
+function orgDelete(){
+  const o=curOrg();
+  const i=ORGS.indexOf(o);ORGS.splice(i,1);
+  showToast(`organization ${o.name} deleted`);
+  S.org=null;S.view='matrix';update();
+}
+
+function pageNoOrg(){
+  return `<div class="page">
+    <h2>No organizations</h2>
+    <div class="card"><h3>You are not a member of any organization</h3>
+      <div class="note" style="margin-top:0">Membership comes from an invitation. Ask an organization admin to invite you${me().instanceAdmin?', or create an organization from instance administration':''}.
+      </div>
+      ${me().instanceAdmin?`<div style="margin-top:12px"><button class="btn primary" onclick="S.view='instance';update()">open instance administration</button></div>`:''}
+    </div>
+  </div>`;
+}
+
+function pageOrgSettings(){
+  const o=curOrg();
+  const hues=[195,280,60,140,20,320];
+  const f=orgFace(o);
+  const orgGrants=GRANTS.filter(g=>g.scope.startsWith('org:')).length;
+  return `<div class="page">
+    <h2>Org settings · ${o.name}</h2>
+    <p class="sub">Organization identity and lifecycle. Access lives on its own surface; the danger zone is deliberately last.</p>
+    ${jump([['sec-oident','Identity'],['sec-opolicy','Policy'],['sec-omembers','Members'],['sec-odanger','Danger zone']])}
+    <div class="card" id="sec-oident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav-o" id="bigav-org" style="background:${f.bg}">${f.txt}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===o.hue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="curOrg().hue=${h};update()"></button>`).join('')}</div>
+          <div class="field" style="max-width:280px"><label>custom hue · <span id="ohuedeg">${o.hue}</span>°</label>
+            <input type="range" class="huerange" min="0" max="359" value="${o.hue}" aria-label="custom org hue"
+              oninput="orgHueLive(this.value)" onchange="update()"></div>
+        </div>
+      </div>
+      <div class="fgrid" style="margin-top:14px">
+        <div class="field"><label>name</label>
+          <input type="text" value="${o.name}" onchange="curOrg().name=this.value;update()"></div>
+      </div>
+      <div class="rowline" style="margin-top:6px"><div class="main"><span class="t">Image</span>
+        <span class="d">${o.img?'custom image, shown on every org circle':'PNG / SVG / JPG, replaces the monogram'}</span></div>
+        <span class="grow"></span>
+        <input type="file" id="oimg" accept="image/*" hidden onchange="setOrgImg(this)">
+        <button class="btn" onclick="document.getElementById('oimg').click()">${o.img?'replace…':'upload…'}</button>
+        ${o.img?'<button class="xbtn" title="remove image" onclick="curOrg().img=null;update()">✕</button>':''}
+      </div>
+      <div class="note">The org avatar stays a circle: identity circles are one of the three reserved pill shapes.</div>
+    </div>
+    <div class="card" id="sec-opolicy"><h3>Policy</h3>
+      <div class="rowline"><div class="main"><span class="t">Default revision retention</span>
+        <span class="d">new projects start here; projects still inheriting follow this value when it changes</span></div>
+        <span class="grow"></span>
+        <span style="font-size:13px;color:var(--tx-dim)">keep last</span>
+        <input type="number" min="1" max="99" value="${orgRet(o)}" aria-label="org default revisions kept"
+          onchange="setOrgRet(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 6px;border-radius:4px;font-family:var(--mono);font-size:13px;width:60px;text-align:center">
+        <span style="font-size:13px;color:var(--tx-dim)">revisions</span></div>
+      ${o.projects.map(p=>{const r=projRet(o,p);
+        return`<div class="rowline"><div class="main"><span class="t" style="font-family:var(--mono);font-size:12.5px">${p.name}</span></div>
+        <span class="grow"></span>
+        <span style="font-size:12px;color:${r.mode==='inherit'?'var(--tx-faint)':r.capped?'var(--bad)':'var(--chg)'};font-family:var(--mono)">${r.mode==='inherit'?`inherits → ${r.eff}`:r.capped?`custom ${r.n} — capped to ${r.eff} by org ⚠`:`custom ${r.n}`}</span></div>`}).join('')}
+      <div class="note">Lowering the default never rewrites a project's own value — it caps it: a project may never keep more revisions than the org allows. Older values past a window are collected (pinned revisions stay); history itself is permanent. Changes are audited.</div>
+    </div>
+    <div class="card" id="sec-omembers"><h3>Members</h3>
+      <div class="rowline"><div class="main"><span class="t">Org members & grants</span>
+        <span class="d">${orgGrants} org-scoped grant lines</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='orgmembers';update()">open members →</button></div>
+      <div class="note">Entry point only: granting, revoking and inspection live on the members surface.</div>
+    </div>
+    <div class="card dangerc" id="sec-odanger"><h3>Danger zone</h3>
+      <div class="rowline"><div class="main"><span class="t">Rename slug</span>
+        <span class="d">Changing the slug changes every URL under it.</span></div>
+        <span class="grow"></span>
+        <input type="text" value="${o.id}" aria-label="organization slug" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:130px">
+        <button class="btn" onclick="showToast('slug renamed (demo)')">rename</button></div>
+      <div class="rowline"><div class="main"><span class="t">Delete organization</span>
+        <span class="d">Deletes every project, environment and value in it. Grants and audit history follow the retention policy.</span></div>
+        <span class="grow"></span>
+        <input type="text" placeholder="type ${o.name} to confirm" aria-label="type the organization name to confirm deletion"
+          oninput="orgDeleteCheck(this)" style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:8px 10px;border-radius:4px;font-family:var(--mono);font-size:12.5px;width:180px">
+        <button class="btn danger" id="org-del-btn" disabled onclick="orgDelete()">delete</button></div>
+    </div>
+  </div>`;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email (delivery only)</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land; it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in, never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes;
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding: an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17); email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link: always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first: the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere; the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install: shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'}: one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances · exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h, last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only, see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b>: Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){
+  $('iv-err').hidden=true;$('iv-email').style.borderColor='';
+  document.body.classList.add('modal');$('invitemodal').classList.add('open');
+}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){
+    $('iv-email').style.borderColor='var(--bad)';
+    $('iv-err').textContent='✕ an email address is needed to deliver the invitation';$('iv-err').hidden=false;
+    return;
+  }
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+  showToast(`invitation created for ${email}`);
+}
+function revokeInvite(i){
+  const iv=INVITES[i];INVITES.splice(i,1);update();
+  showToast(`revoked invitation for ${iv.email}`,()=>{INVITES.push(iv);update();});
+}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(restore){
+  $('g-caps').innerHTML=Object.entries(CAPDESC).map(([c,d])=>
+    `<div class="capitem">
+      <label><input type="checkbox" value="${c}"> <span class="cn">${c}</span></label>
+      <button type="button" class="qh" title="${d}" aria-label="explain ${c}" aria-expanded="false"
+        onclick="const x=this.parentElement.querySelector('.cd');x.hidden=!x.hidden;this.setAttribute('aria-expanded',String(!x.hidden))">?</button>
+      <div class="cd" hidden>${d}</div>
+    </div>`).join('');
+  $('g-caps').style.borderColor='';
+  $('g-err').hidden=true;
+  if(restore){
+    $('g-principal').value=restore.p;
+    $('g-scope').value=restore.scope;
+    [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=restore.caps.includes(i.value));
+  }
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){
+    $('g-caps').style.borderColor='var(--bad)';
+    $('g-err').textContent='✕ pick at least one capability';$('g-err').hidden=false;
+    return;
+  }
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  S.pendingSel={p,caps,scope};
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b>: ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+  grantToast(gs);
+}
+function confirmGrant(){
+  const gs=S.pendingGrant;GRANTS.push(...gs);S.pendingGrant=null;closeModals();update();
+  grantToast(gs);
+}
+function blastBack(){closeModals();openGrant(S.pendingSel);}
+function grantToast(gs){
+  showToast(`granted ${gs.length} capabilit${gs.length>1?'ies':'y'} to ${gs[0].p} on ${scopeLabel(gs[0].scope)}`,
+    ()=>{for(const g of gs){const i=GRANTS.indexOf(g);if(i>=0)GRANTS.splice(i,1);}update();});
+}
+function revoke(i){
+  const g=GRANTS[i];GRANTS.splice(i,1);update();
+  showToast(`revoked ${g.cap} on ${scopeLabel(g.scope)} for ${g.p}`,()=>{GRANTS.push(g);update();});
+}
+
+let toastTimer=null;
+function showToast(msg,undoFn){
+  const t=$('toast');
+  $('toast-msg').textContent=msg;
+  const u=$('toast-undo');
+  u.hidden=!undoFn;
+  u.onclick=()=>{t.hidden=true;clearTimeout(toastTimer);undoFn&&undoFn();};
+  t.hidden=false;
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>{t.hidden=true;},8000);
+}
+
+/* ============================ plumbing ============================ */
+function projHueLive(v){
+  S.projHue=+v;
+  document.getElementById('huedeg').textContent=v;
+  if(!S.projImg)document.getElementById('bigav-prev').style.background=hueBg(+v);
+}
+function setProjImg(inp){
+  const f=inp.files&&inp.files[0];if(!f)return;
+  const r=new FileReader();
+  r.onload=()=>{S.projImg=r.result;update();};
+  r.readAsDataURL(f);
+}
+
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),orgsettings:pageOrgSettings,noorg:pageNoOrg,account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+<div id="sidebar17" role="group" aria-label="sidebar hierarchy variant switcher">
+  <button onclick="cycleSideVar(-1)" aria-label="previous variant">‹</button>
+  <span class="sl" id="sidevarlabel"></span>
+  <button onclick="cycleSideVar(1)" aria-label="next variant">›</button>
+</div>
+<script>
+const SIDEVARS=[
+  {id:'a',label:'baseline (it-16)'},
+  {id:'b',label:'breathing room'},
+  {id:'c',label:'mild separator'},
+  {id:'d',label:'structural indent'},
+  {id:'e',label:'b + d combined'},
+];
+function setSideVar(id){
+  document.body.dataset.sidevar=id;
+  const u=new URL(location);u.searchParams.set('side',id);history.replaceState(null,'',u);
+  const i=SIDEVARS.findIndex(v=>v.id===id);
+  document.getElementById('sidevarlabel').innerHTML=`<b>${id}</b> — ${SIDEVARS[i].label}`;
+}
+function cycleSideVar(dir){
+  const i=SIDEVARS.findIndex(v=>v.id===document.body.dataset.sidevar);
+  setSideVar(SIDEVARS[(i+dir+SIDEVARS.length)%SIDEVARS.length].id);
+}
+document.addEventListener('keydown',e=>{
+  if(e.target.closest('input,textarea,select,[contenteditable]'))return;
+  if(e.key==='ArrowLeft')cycleSideVar(-1);
+  if(e.key==='ArrowRight')cycleSideVar(1);
+});
+setSideVar((v=>SIDEVARS.some(x=>x.id===v)?v:'e')(new URLSearchParams(location.search).get('side')||'e'));
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/2/index.html
+++ b/docs/site/public/prototypes/app-chrome/2/index.html
@@ -1,0 +1,1036 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 2.
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 2 (Alex's round-1 feedback):
+  - Matrix view is now a real (condensed) matrix and the side panel is the
+    env-matrix-31 panel (groups with problem badges, views) — ONE sidebar,
+    chrome entries merged into it, no double-sidebar risk.
+  - Mobile org switching: the drawer now carries an organization section in
+    every variant (rail is hidden on mobile, so a/b/c converge there);
+    variant b's crumb popover renders as a full-width sheet under the header
+    on small screens instead of an offset popover.
+  - Members: one row per (member, scope) — capabilities grouped as chips,
+    each chip still individually revocable (the grant stays the atom).
+  - Invite: org-level "invite member" flow — invitation binds to the
+    capability set, never to an email comparison (ADR #16); pending
+    invitations listed with revoke.
+
+  Org-placement variants (floating bottom switcher / arrow keys):
+    ?variant=a  Rail owns orgs: org monograms stacked at rail top, projects
+                of the active org below a divider.
+    ?variant=b  Crumb owns org: rail is projects-only; the org name in the
+                header breadcrumb is the switcher (popover).
+    ?variant=c  Slack-style: one active-org tile at rail top opens a
+                full org-switcher overlay with role/project context.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  body[data-v=b] #app{grid-template-columns:56px 218px 1fr} /* same cols; rail content differs */
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  .orgbtn{font-weight:600;font-size:15px;display:inline-flex;align-items:center;gap:5px;
+    border:1px solid transparent;border-radius:6px;padding:3px 7px;margin:-3px -2px}
+  .orgbtn:hover{border-color:var(--line);background:var(--bg2)}
+  .orgbtn .car{font-size:9px;color:var(--tx-faint)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  /* org switcher popover (variant b) */
+  #orgpop{position:fixed;z-index:30;min-width:240px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:10px;box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;display:none}
+  #orgpop.open{display:block}
+  #orgpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px 4px;font-weight:700}
+  #orgpop .orow{display:flex;align-items:center;gap:10px;width:100%;text-align:left;padding:9px 10px;
+    border-radius:7px;font-size:13px;min-height:44px}
+  #orgpop .orow:hover{background:var(--bg3)}
+  #orgpop .orow .r{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+  #orgpop .orow .chk{margin-left:auto;color:var(--accent)}
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* org overlay (variant c) */
+  #orgoverlay{position:fixed;inset:0;z-index:35;background:oklch(0 0 0/.55);display:none;
+    align-items:center;justify-content:center;padding:20px}
+  #orgoverlay.open{display:flex}
+  #orgoverlay .inner{width:min(560px,100%);background:var(--bg2);border:1px solid var(--line);
+    border-radius:16px;padding:22px;max-height:85dvh;overflow:auto}
+  #orgoverlay h4{font-size:16px;font-weight:700;margin-bottom:4px}
+  #orgoverlay .osub{font-size:12.5px;color:var(--tx-dim);margin-bottom:16px}
+  .orgcard{display:flex;align-items:center;gap:14px;width:100%;text-align:left;padding:14px;
+    border:1px solid var(--line);border-radius:12px;margin-bottom:10px;background:var(--bg)}
+  .orgcard:hover{border-color:var(--accent)}
+  .orgcard.act{border-color:var(--accent);background:var(--accent-soft)}
+  .orgcard .oav{width:40px;height:40px;font-size:13px;border-radius:12px}
+  .orgcard .main{display:grid;gap:3px}
+  .orgcard .t{font-weight:700;font-size:14.5px}
+  .orgcard .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* floating variant switcher */
+  #vswitch{position:fixed;z-index:60;left:50%;bottom:14px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:2px;background:oklch(0.14 0.01 220);color:oklch(0.95 0 0);
+    border-radius:999px;padding:4px 6px;box-shadow:0 6px 24px oklch(0 0 0/.5);font-size:12px}
+  [data-theme=light] #vswitch{background:oklch(0.3 0.02 225);}
+  #vswitch button{color:inherit;min-width:34px;min-height:34px;border-radius:50%;font-size:14px}
+  #vswitch button:hover{background:oklch(1 0 0/.12)}
+  #vswitch .vlabel{padding:0 10px;white-space:nowrap;font-weight:600}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="orgpop"></div>
+<div id="orgoverlay" onclick="if(event.target===this)closeOrgOverlay()"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">One capability, one scope, one revocable line. Roles are templates that expand into lines like this.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capability</label>
+      <select id="g-cap"><option>read</option><option>edit</option><option>publish</option><option>reveal</option><option>reveal-history</option><option>definitions-edit</option><option>project-settings</option><option>manage-members</option><option>audit-read</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<div id="vswitch">
+  <button onclick="cycleV(-1)" aria-label="previous variant">←</button>
+  <span class="vlabel" id="vlabel"></span>
+  <button onclick="cycleV(1)" aria-label="next variant">→</button>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+const VARIANTS=['a','b','c'];
+const VNAMES={a:'A — rail owns orgs',b:'B — crumb owns org',c:'C — org overlay'};
+let S={v:'a',persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(S.v==='a'&&multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  if(S.v==='c'){
+    const o=curOrg();
+    const b=document.createElement('button');
+    b.className='pav orgav act';b.title=multiOrg?'switch organization':`organization ${o.name}`;
+    b.textContent=mono(o.name);
+    if(multiOrg) b.onclick=()=>$('orgoverlay').classList.add('open');
+    r.appendChild(b);
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so every variant's org switching converges here */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();const multi=myOrgs().length>1;
+  const seg=[];
+  seg.push('<span>hikyo</span>');
+  seg.push('<span class="sep">/</span>');
+  if(S.v==='b'&&multi){
+    seg.push(`<button class="orgbtn" onclick="toggleOrgPop(event)" aria-haspopup="true">${o.name} <span class="car">▾</span></button>`);
+  }else{
+    seg.push(`<span class="dimseg">${o.name}</span>`);
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ---------------- org popover (variant b) ---------------- */
+function toggleOrgPop(ev){
+  const pop=$('orgpop');
+  if(pop.classList.contains('open')){pop.classList.remove('open');return;}
+  pop.innerHTML='<div class="et">organizations</div>'+myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orow" onclick="pickOrg('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span>${o.name}<div class="r">${role} · ${visProjects(o).length} project${visProjects(o).length>1?'s':''}</div></span>
+      ${o.id===S.org?'<span class="chk">✓</span>':''}</button>`;}).join('');
+  const r=ev.currentTarget.getBoundingClientRect();
+  if(innerWidth<=700){
+    /* small screens: full-width sheet under the header, never an offset popover */
+    pop.style.left='12px';pop.style.right='12px';pop.style.top=(r.bottom+8)+'px';
+  }else{
+    pop.style.right='auto';
+    pop.style.left=Math.min(r.left,innerWidth-260)+'px';pop.style.top=(r.bottom+6)+'px';
+  }
+  pop.classList.add('open');
+  setTimeout(()=>addEventListener('click',closeOrgPop,{once:true}),0);
+}
+function closeOrgPop(e){const pop=$('orgpop');if(!pop.contains(e?.target))pop.classList.remove('open');}
+function pickOrg(id){S.org=id;S.project=null;S.view='matrix';$('orgpop').classList.remove('open');update();}
+
+/* ---------------- org overlay (variant c) ---------------- */
+function renderOrgOverlay(){
+  const ov=$('orgoverlay');
+  ov.innerHTML=`<div class="inner"><h4>Your organizations</h4>
+  <div class="osub">Only organizations you belong to exist here — anything else is indistinguishable from nonexistent.</div>
+  ${myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orgcard${o.id===S.org?' act':''}" onclick="pickOrgC('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span class="main"><span class="t">${o.name}</span>
+      <span class="d">${role} · ${visProjects(o).length} projects</span></span></button>`;}).join('')}
+  </div>`;
+}
+function pickOrgC(id){S.org=id;S.project=null;S.view='matrix';closeOrgOverlay();update();}
+function closeOrgOverlay(){$('orgoverlay').classList.remove('open');}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function pageAccount(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Everything here that changes how you authenticate asks for a possession factor first — the blue
+      "confirm it's you" step-up. It looks nothing like the teal reveal ceremony on purpose.</p>
+
+    <div class="card"><h3>Active sessions</h3>
+      ${SESSIONS.map((s,i)=>`<div class="rowline">
+        <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+        <span class="d">${s.detail} · last active ${s.last}</span></div>
+        <span class="grow"></span>
+        <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+        ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+      </div>`).join('')}
+      <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+        revoking one never touches the other kind.</div>
+    </div>
+
+    <div class="card"><h3>Sign-in factors</h3>
+      ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+        <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+        <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+        <span class="tag">enrolled</span></div>
+      <div class="rowline"><div class="main"><span class="t">Password</span>
+        <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+      <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+        <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+    </div>
+
+    <div class="card"><h3>Recovery</h3>
+      <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+        <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+      <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+        <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+        <span class="grow"></span>
+        <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+          onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+          ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+      ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+    </div>
+
+    <div class="card"><h3>Linked identities</h3>
+      ${IDENTITIES.map(id=>`<div class="rowline">
+        <div class="main"><span class="t">${id.issuer}</span>
+        <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+        <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+    </div>
+  </div>`;
+}
+
+function pageInstance(){
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Visible only to instance admins. Deliberately thin: the network surface stays small, heavy levers stay on the CLI at the box.</p>
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px"><button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button></div>
+    </div>
+    <div class="card"><h3>Instance settings</h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, not editable</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">instance-scoped policy (audit ADR)</span></div><span class="grow"></span><span class="tag mono">security: unlimited</span></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">instance ceiling clamps org values</span></div><span class="grow"></span><span class="tag mono">90d</span></div>
+    </div>
+    <div class="card qcard"><h3>Open question for this ticket</h3>
+      <div class="note" style="margin-top:0">How much of this exists in the v1 UI at all?<br><br>
+      <b>Option A</b> — this page as shown: org create + read-mostly instance settings in the UI; bootstrap, crypto rotation, backup/restore stay CLI-only.<br>
+      <b>Option B</b> — no instance surface in the v1 UI: everything via <span class="mini">hikyo admin …</span> / <span class="mini">instance-config</span> CLI; the UI starts at the organization.<br><br>
+      Everything below org creation (root-key ops, migrate, restore, break-glass) is locked CLI-side regardless (API/CLI ADR).</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){document.body.classList.add('modal');$('grantmodal').classList.add('open');}
+function submitGrant(){
+  const g={p:$('g-principal').value,cap:$('g-cap').value,scope:$('g-scope').value,via:'direct'};
+  closeModals();
+  if(g.scope.startsWith('org:')){
+    S.pendingGrant=g;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(g);update();
+}
+function confirmGrant(){GRANTS.push(S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function cycleV(d){
+  const i=(VARIANTS.indexOf(S.v)+d+VARIANTS.length)%VARIANTS.length;
+  S.v=VARIANTS[i];
+  const u=new URL(location);u.searchParams.set('variant',S.v);history.replaceState(null,'',u);
+  update();
+}
+addEventListener('keydown',e=>{
+  if(/INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName))return;
+  if(e.key==='ArrowLeft')cycleV(-1);
+  if(e.key==='ArrowRight')cycleV(1);
+  if(e.key==='Escape'){closeModals();closeOrgOverlay();}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  document.body.dataset.v=S.v;
+  $('vlabel').textContent=VNAMES[S.v];
+  renderRail();renderSide();renderCrumb();renderOrgOverlay();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+S.v=new URL(location).searchParams.get('variant')||'a';
+if(!VARIANTS.includes(S.v))S.v='a';
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/2/index.html
+++ b/docs/site/public/prototypes/app-chrome/2/index.html
@@ -983,7 +983,11 @@ function submitGrant(){
   if(g.scope.startsWith('org:')){
     S.pendingGrant=g;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capability=document.createElement('b'), scope=document.createElement('b');
+    principal.textContent=g.p;
+    capability.className='cap'; capability.textContent=g.cap;
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capability,' on ',scope,' — current and future:');
     $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/3/index.html
+++ b/docs/site/public/prototypes/app-chrome/3/index.html
@@ -1,0 +1,1071 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 3.
+
+  Iteration 3 (Alex's round-2 feedback): a and c were indistinguishable on
+  mobile and b rendered badly there — but this product is mobile-first, so
+  the org-placement variants must differ ON THE PHONE, not just desktop:
+    a  mobile: drawer opens with an organizations section (drawer owns orgs).
+    b  mobile: compact crumb (hikyo/ prefix hidden ≤700px), org segment
+       opens a full-width sheet under the header, with scrim; the drawer has
+       NO org section — the crumb is the one org affordance.
+    c  mobile: org monogram button in the header (left of the crumb) opens
+       the switcher as a FULL-SCREEN overlay; drawer has no org section.
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 2 (Alex's round-1 feedback):
+  - Matrix view is now a real (condensed) matrix and the side panel is the
+    env-matrix-31 panel (groups with problem badges, views) — ONE sidebar,
+    chrome entries merged into it, no double-sidebar risk.
+  - Mobile org switching: the drawer now carries an organization section in
+    every variant (rail is hidden on mobile, so a/b/c converge there);
+    variant b's crumb popover renders as a full-width sheet under the header
+    on small screens instead of an offset popover.
+  - Members: one row per (member, scope) — capabilities grouped as chips,
+    each chip still individually revocable (the grant stays the atom).
+  - Invite: org-level "invite member" flow — invitation binds to the
+    capability set, never to an email comparison (ADR #16); pending
+    invitations listed with revoke.
+
+  Org-placement variants (floating bottom switcher / arrow keys):
+    ?variant=a  Rail owns orgs: org monograms stacked at rail top, projects
+                of the active org below a divider.
+    ?variant=b  Crumb owns org: rail is projects-only; the org name in the
+                header breadcrumb is the switcher (popover).
+    ?variant=c  Slack-style: one active-org tile at rail top opens a
+                full org-switcher overlay with role/project context.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  body[data-v=b] #app{grid-template-columns:56px 218px 1fr} /* same cols; rail content differs */
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  .orgbtn{font-weight:600;font-size:15px;display:inline-flex;align-items:center;gap:5px;
+    border:1px solid transparent;border-radius:6px;padding:3px 7px;margin:-3px -2px}
+  .orgbtn:hover{border-color:var(--line);background:var(--bg2)}
+  .orgbtn .car{font-size:9px;color:var(--tx-faint)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  /* org switcher popover (variant b) */
+  #orgpop{position:fixed;z-index:30;min-width:240px;background:var(--bg2);border:1px solid var(--line);
+    border-radius:10px;box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;display:none}
+  #orgpop.open{display:block}
+  #orgpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px 4px;font-weight:700}
+  #orgpop .orow{display:flex;align-items:center;gap:10px;width:100%;text-align:left;padding:9px 10px;
+    border-radius:7px;font-size:13px;min-height:44px}
+  #orgpop .orow:hover{background:var(--bg3)}
+  #orgpop .orow .r{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+  #orgpop .orow .chk{margin-left:auto;color:var(--accent)}
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* org overlay (variant c) */
+  #orgoverlay{position:fixed;inset:0;z-index:35;background:oklch(0 0 0/.55);display:none;
+    align-items:center;justify-content:center;padding:20px}
+  #orgoverlay.open{display:flex}
+  #orgoverlay .inner{width:min(560px,100%);background:var(--bg2);border:1px solid var(--line);
+    border-radius:16px;padding:22px;max-height:85dvh;overflow:auto}
+  #orgoverlay h4{font-size:16px;font-weight:700;margin-bottom:4px}
+  #orgoverlay .osub{font-size:12.5px;color:var(--tx-dim);margin-bottom:16px}
+  .orgcard{display:flex;align-items:center;gap:14px;width:100%;text-align:left;padding:14px;
+    border:1px solid var(--line);border-radius:12px;margin-bottom:10px;background:var(--bg)}
+  .orgcard:hover{border-color:var(--accent)}
+  .orgcard.act{border-color:var(--accent);background:var(--accent-soft)}
+  .orgcard .oav{width:40px;height:40px;font-size:13px;border-radius:12px}
+  .orgcard .main{display:grid;gap:3px}
+  .orgcard .t{font-weight:700;font-size:14.5px}
+  .orgcard .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* floating variant switcher */
+  #vswitch{position:fixed;z-index:60;left:50%;bottom:14px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:2px;background:oklch(0.14 0.01 220);color:oklch(0.95 0 0);
+    border-radius:999px;padding:4px 6px;box-shadow:0 6px 24px oklch(0 0 0/.5);font-size:12px}
+  [data-theme=light] #vswitch{background:oklch(0.3 0.02 225);}
+  #vswitch button{color:inherit;min-width:34px;min-height:34px;border-radius:50%;font-size:14px}
+  #vswitch button:hover{background:oklch(1 0 0/.12)}
+  #vswitch .vlabel{padding:0 10px;white-space:nowrap;font-weight:600}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+    /* variant c: full-screen org overlay on phones */
+    #orgoverlay{padding:0}
+    #orgoverlay .inner{width:100%;height:100dvh;max-height:none;border-radius:0;border:none}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="orgpop"></div>
+<div id="orgoverlay" onclick="if(event.target===this)closeOrgOverlay()"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">One capability, one scope, one revocable line. Roles are templates that expand into lines like this.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capability</label>
+      <select id="g-cap"><option>read</option><option>edit</option><option>publish</option><option>reveal</option><option>reveal-history</option><option>definitions-edit</option><option>project-settings</option><option>manage-members</option><option>audit-read</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<div id="vswitch">
+  <button onclick="cycleV(-1)" aria-label="previous variant">←</button>
+  <span class="vlabel" id="vlabel"></span>
+  <button onclick="cycleV(1)" aria-label="next variant">→</button>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+const VARIANTS=['a','b','c'];
+const VNAMES={a:'A — rail owns orgs',b:'B — crumb owns org',c:'C — org overlay'};
+let S={v:'a',persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(S.v==='a'&&multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  if(S.v==='c'){
+    const o=curOrg();
+    const b=document.createElement('button');
+    b.className='pav orgav act';b.title=multiOrg?'switch organization':`organization ${o.name}`;
+    b.textContent=mono(o.name);
+    if(multiOrg) b.onclick=()=>$('orgoverlay').classList.add('open');
+    r.appendChild(b);
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: only variant a puts orgs in the drawer — b keeps them in the
+     crumb sheet, c in the header-avatar full-screen overlay */
+  if(S.v==='a'&&myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();const multi=myOrgs().length>1;
+  const seg=[];
+  if(S.v==='c'&&multi){
+    /* mobile-only trigger: the rail (and its org tile) is hidden on phones */
+    seg.push(`<button class="pav orgav m-only" style="width:30px;height:30px;font-size:9px;border-color:var(--line)"
+      title="switch organization" onclick="$('orgoverlay').classList.add('open')">${mono(o.name)}</button>`);
+  }
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  if(S.v==='b'&&multi){
+    seg.push(`<button class="orgbtn" onclick="toggleOrgPop(event)" aria-haspopup="true">${o.name} <span class="car">▾</span></button>`);
+  }else{
+    seg.push(`<span class="dimseg">${o.name}</span>`);
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ---------------- org popover (variant b) ---------------- */
+function toggleOrgPop(ev){
+  const pop=$('orgpop');
+  if(pop.classList.contains('open')){pop.classList.remove('open');return;}
+  pop.innerHTML='<div class="et">organizations</div>'+myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orow" onclick="pickOrg('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span>${o.name}<div class="r">${role} · ${visProjects(o).length} project${visProjects(o).length>1?'s':''}</div></span>
+      ${o.id===S.org?'<span class="chk">✓</span>':''}</button>`;}).join('');
+  if(innerWidth<=700){
+    /* small screens: full-width sheet pinned under the header, with scrim */
+    const hdr=document.querySelector('header').getBoundingClientRect();
+    pop.style.left='10px';pop.style.right='10px';pop.style.top=(hdr.bottom+8)+'px';
+    $('sidescrim').style.display='block';
+  }else{
+    const r=ev.currentTarget.getBoundingClientRect();
+    pop.style.right='auto';
+    pop.style.left=Math.min(r.left,innerWidth-260)+'px';pop.style.top=(r.bottom+6)+'px';
+  }
+  pop.classList.add('open');
+  setTimeout(()=>addEventListener('click',closeOrgPop,{once:true}),0);
+}
+function closeOrgPop(e){const pop=$('orgpop');
+  if(!pop.contains(e?.target)){pop.classList.remove('open');$('sidescrim').style.display='';}}
+function pickOrg(id){S.org=id;S.project=null;S.view='matrix';
+  $('orgpop').classList.remove('open');$('sidescrim').style.display='';update();}
+
+/* ---------------- org overlay (variant c) ---------------- */
+function renderOrgOverlay(){
+  const ov=$('orgoverlay');
+  ov.innerHTML=`<div class="inner">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h4>Your organizations</h4>
+    <button class="xbtn" style="font-size:18px" aria-label="close" onclick="closeOrgOverlay()">✕</button>
+  </div>
+  <div class="osub">Only organizations you belong to exist here — anything else is indistinguishable from nonexistent.</div>
+  ${myOrgs().map(o=>{
+    const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+    return `<button class="orgcard${o.id===S.org?' act':''}" onclick="pickOrgC('${o.id}')">
+      <span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+      <span class="main"><span class="t">${o.name}</span>
+      <span class="d">${role} · ${visProjects(o).length} projects</span></span></button>`;}).join('')}
+  </div>`;
+}
+function pickOrgC(id){S.org=id;S.project=null;S.view='matrix';closeOrgOverlay();update();}
+function closeOrgOverlay(){$('orgoverlay').classList.remove('open');}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function pageAccount(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Everything here that changes how you authenticate asks for a possession factor first — the blue
+      "confirm it's you" step-up. It looks nothing like the teal reveal ceremony on purpose.</p>
+
+    <div class="card"><h3>Active sessions</h3>
+      ${SESSIONS.map((s,i)=>`<div class="rowline">
+        <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+        <span class="d">${s.detail} · last active ${s.last}</span></div>
+        <span class="grow"></span>
+        <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+        ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+      </div>`).join('')}
+      <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+        revoking one never touches the other kind.</div>
+    </div>
+
+    <div class="card"><h3>Sign-in factors</h3>
+      ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+        <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+        <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+        <span class="tag">enrolled</span></div>
+      <div class="rowline"><div class="main"><span class="t">Password</span>
+        <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+      <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+        <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+    </div>
+
+    <div class="card"><h3>Recovery</h3>
+      <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+        <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+      <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+        <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+        <span class="grow"></span>
+        <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+          onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+          ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+      ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+    </div>
+
+    <div class="card"><h3>Linked identities</h3>
+      ${IDENTITIES.map(id=>`<div class="rowline">
+        <div class="main"><span class="t">${id.issuer}</span>
+        <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+        <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+    </div>
+  </div>`;
+}
+
+function pageInstance(){
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Visible only to instance admins. Deliberately thin: the network surface stays small, heavy levers stay on the CLI at the box.</p>
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px"><button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button></div>
+    </div>
+    <div class="card"><h3>Instance settings</h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, not editable</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">instance-scoped policy (audit ADR)</span></div><span class="grow"></span><span class="tag mono">security: unlimited</span></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">instance ceiling clamps org values</span></div><span class="grow"></span><span class="tag mono">90d</span></div>
+    </div>
+    <div class="card qcard"><h3>Open question for this ticket</h3>
+      <div class="note" style="margin-top:0">How much of this exists in the v1 UI at all?<br><br>
+      <b>Option A</b> — this page as shown: org create + read-mostly instance settings in the UI; bootstrap, crypto rotation, backup/restore stay CLI-only.<br>
+      <b>Option B</b> — no instance surface in the v1 UI: everything via <span class="mini">hikyo admin …</span> / <span class="mini">instance-config</span> CLI; the UI starts at the organization.<br><br>
+      Everything below org creation (root-key ops, migrate, restore, break-glass) is locked CLI-side regardless (API/CLI ADR).</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){document.body.classList.add('modal');$('grantmodal').classList.add('open');}
+function submitGrant(){
+  const g={p:$('g-principal').value,cap:$('g-cap').value,scope:$('g-scope').value,via:'direct'};
+  closeModals();
+  if(g.scope.startsWith('org:')){
+    S.pendingGrant=g;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(g);update();
+}
+function confirmGrant(){GRANTS.push(S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function cycleV(d){
+  const i=(VARIANTS.indexOf(S.v)+d+VARIANTS.length)%VARIANTS.length;
+  S.v=VARIANTS[i];
+  const u=new URL(location);u.searchParams.set('variant',S.v);history.replaceState(null,'',u);
+  update();
+}
+addEventListener('keydown',e=>{
+  if(/INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName))return;
+  if(e.key==='ArrowLeft')cycleV(-1);
+  if(e.key==='ArrowRight')cycleV(1);
+  if(e.key==='Escape'){closeModals();closeOrgOverlay();}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  document.body.dataset.v=S.v;
+  $('vlabel').textContent=VNAMES[S.v];
+  renderRail();renderSide();renderCrumb();renderOrgOverlay();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+S.v=new URL(location).searchParams.get('variant')||'a';
+if(!VARIANTS.includes(S.v))S.v='a';
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/3/index.html
+++ b/docs/site/public/prototypes/app-chrome/3/index.html
@@ -1018,7 +1018,11 @@ function submitGrant(){
   if(g.scope.startsWith('org:')){
     S.pendingGrant=g;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capability=document.createElement('b'), scope=document.createElement('b');
+    principal.textContent=g.p;
+    capability.className='cap'; capability.textContent=g.cap;
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capability,' on ',scope,' — current and future:');
     $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/4/index.html
+++ b/docs/site/public/prototypes/app-chrome/4/index.html
@@ -1,0 +1,954 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 4.
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">One capability, one scope, one revocable line. Roles are templates that expand into lines like this.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capability</label>
+      <select id="g-cap"><option>read</option><option>edit</option><option>publish</option><option>reveal</option><option>reveal-history</option><option>definitions-edit</option><option>project-settings</option><option>manage-members</option><option>audit-read</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function pageAccount(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Everything here that changes how you authenticate asks for a possession factor first — the blue
+      "confirm it's you" step-up. It looks nothing like the teal reveal ceremony on purpose.</p>
+
+    <div class="card"><h3>Active sessions</h3>
+      ${SESSIONS.map((s,i)=>`<div class="rowline">
+        <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+        <span class="d">${s.detail} · last active ${s.last}</span></div>
+        <span class="grow"></span>
+        <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+        ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+      </div>`).join('')}
+      <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+        revoking one never touches the other kind.</div>
+    </div>
+
+    <div class="card"><h3>Sign-in factors</h3>
+      ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+        <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+        <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+        <span class="tag">enrolled</span></div>
+      <div class="rowline"><div class="main"><span class="t">Password</span>
+        <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+      <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+        <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+    </div>
+
+    <div class="card"><h3>Recovery</h3>
+      <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+        <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+      <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+        <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+        <span class="grow"></span>
+        <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+          onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+          ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+      ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+    </div>
+
+    <div class="card"><h3>Linked identities</h3>
+      ${IDENTITIES.map(id=>`<div class="rowline">
+        <div class="main"><span class="t">${id.issuer}</span>
+        <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+        <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+    </div>
+  </div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<span class="tag mono" title="same operation on the CLI">$ ${v}</span>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <span class="tag mono">security: unlimited</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <span class="tag mono">90d</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){document.body.classList.add('modal');$('grantmodal').classList.add('open');}
+function submitGrant(){
+  const g={p:$('g-principal').value,cap:$('g-cap').value,scope:$('g-scope').value,via:'direct'};
+  closeModals();
+  if(g.scope.startsWith('org:')){
+    S.pendingGrant=g;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(g);update();
+}
+function confirmGrant(){GRANTS.push(S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape')closeModals();
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/4/index.html
+++ b/docs/site/public/prototypes/app-chrome/4/index.html
@@ -914,7 +914,11 @@ function submitGrant(){
   if(g.scope.startsWith('org:')){
     S.pendingGrant=g;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${g.p}</b> gets <b class="cap">${g.cap}</b> on <b>every project and environment in ${curOrg().name}</b> — current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capability=document.createElement('b'), scope=document.createElement('b');
+    principal.textContent=g.p;
+    capability.className='cap'; capability.textContent=g.cap;
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capability,' on ',scope,' — current and future:');
     $('blastlist').innerHTML=projs.map(p=>`<div class="bl"><span class="p">${p.name}</span><span>development · staging · production${p.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/5/index.html
+++ b/docs/site/public/prototypes/app-chrome/5/index.html
@@ -1,0 +1,989 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 5.
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:8px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:6px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+function pageAccount(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Everything here that changes how you authenticate asks for a possession factor first — the blue
+      "confirm it's you" step-up. It looks nothing like the teal reveal ceremony on purpose.</p>
+
+    <div class="card"><h3>Active sessions</h3>
+      ${SESSIONS.map((s,i)=>`<div class="rowline">
+        <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+        <span class="d">${s.detail} · last active ${s.last}</span></div>
+        <span class="grow"></span>
+        <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+        ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+      </div>`).join('')}
+      <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+        revoking one never touches the other kind.</div>
+    </div>
+
+    <div class="card"><h3>Sign-in factors</h3>
+      ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+        <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+        <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+        <span class="tag">enrolled</span></div>
+      <div class="rowline"><div class="main"><span class="t">Password</span>
+        <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+      <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+        <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+        <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+    </div>
+
+    <div class="card"><h3>Recovery</h3>
+      <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+        <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+      <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+        <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+        <span class="grow"></span>
+        <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+          onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+          ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+      ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+    </div>
+
+    <div class="card"><h3>Linked identities</h3>
+      ${IDENTITIES.map(id=>`<div class="rowline">
+        <div class="main"><span class="t">${id.issuer}</span>
+        <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+        <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+      <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+        <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+    </div>
+  </div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<span class="tag mono" title="same operation on the CLI">$ ${v}</span>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <span class="tag mono">security: unlimited</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <span class="tag mono">90d</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape')closeModals();
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/5/index.html
+++ b/docs/site/public/prototypes/app-chrome/5/index.html
@@ -949,7 +949,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/6/index.html
+++ b/docs/site/public/prototypes/app-chrome/6/index.html
@@ -1,0 +1,1150 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 6.
+
+  Iteration 6 (Alex): Account & security was missing account-level settings
+  and scrolled too long. Added Profile (display name, email as delivery-only
+  per #16) and Preferences (theme, expiry-warning transports per #17,
+  always-on security alerts). FIVE structurally different layouts for the
+  account surface, switchable via bottom bar / arrows / ?account= — only
+  while the account view is open:
+    a  tabs         one section visible, chip-tab row on top
+    b  panel nav    the side panel owns the account sections (like a project)
+    c  jump index   one scroll, sticky chip index, smooth anchor jumps
+    d  accordion    collapsed cards with live summary lines, one open
+    e  tiles        overview grid of summary tiles, tap to drill in, back out
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* account layout variants */
+  .acct-tabs,.acct-jump{display:flex;gap:6px;flex-wrap:wrap}
+  .acct-jump{position:sticky;top:-17px;z-index:5;background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:999px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+  .atab.act{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .card.collapsed{padding:0}
+  .acc-wrap .card{border-top-left-radius:0;border-top-right-radius:0;border-top:none;margin-top:-6px}
+  .acc-wrap .card h3{display:none}
+  .acc-head{display:flex;align-items:center;gap:12px;width:100%;text-align:left;padding:14px 18px;
+    font-size:13.5px;font-weight:700;min-height:48px}
+  .acc-wrap .acc-head{background:var(--bg2);border:1px solid var(--line);border-radius:12px 12px 0 0}
+  .acc-head .sum{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  .acc-head .chev{color:var(--tx-faint);font-size:11px}
+  .acc-head:hover .chev{color:var(--accent)}
+  .tilegrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:12px}
+  .tile{display:grid;gap:6px;text-align:left;background:var(--bg2);border:1px solid var(--line);
+    border-radius:12px;padding:16px 18px;min-height:86px;position:relative}
+  .tile:hover{border-color:var(--accent)}
+  .tile .tt{font-weight:700;font-size:14px}
+  .tile .ts{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .tile .go{position:absolute;right:14px;top:14px;color:var(--tx-faint)}
+  .tile:hover .go{color:var(--accent)}
+
+  /* account layout switcher */
+  #aswitch{position:fixed;z-index:60;left:50%;bottom:14px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:2px;background:oklch(0.14 0.01 220);color:oklch(0.95 0 0);
+    border-radius:999px;padding:4px 6px;box-shadow:0 6px 24px oklch(0 0 0/.5);font-size:12px}
+  [data-theme=light] #aswitch{background:oklch(0.3 0.02 225)}
+  #aswitch button{color:inherit;min-width:34px;min-height:34px;border-radius:50%;font-size:14px}
+  #aswitch button:hover{background:oklch(1 0 0/.12)}
+  #aswitch .vlabel{padding:0 10px;white-space:nowrap;font-weight:600}
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:8px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:6px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<div id="aswitch" hidden>
+  <button onclick="cycleAcct(-1)" aria-label="previous account layout">←</button>
+  <span class="vlabel" id="alabel"></span>
+  <button onclick="cycleAcct(1)" aria-label="next account layout">→</button>
+</div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,
+       acct:'a',acctSec:'profile',acctOpen:'factors',acctFocus:null};
+const ACCT_VARIANTS=['a','b','c','d','e'];
+const ACCT_NAMES={a:'A — tabs',b:'B — panel nav',c:'C — jump index',d:'D — accordion',e:'E — tiles + drill-in'};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  /* account layout b: the panel owns the account sections */
+  if(S.view==='account'&&S.acct==='b'){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">account</div>');
+    for(const x of ACCT_SECTIONS){
+      const b=document.createElement('button');
+      b.className='srow'+(S.acctSec===x.id?' act':'');b.textContent=x.t;
+      b.onclick=()=>{S.acctSec=x.id;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+const acctSec=()=>ACCT_SECTIONS.find(x=>x.id===S.acctSec)||ACCT_SECTIONS[0];
+
+/* five structurally different account layouts, ?account=a..e */
+function pageAccount(){
+  const head=`<h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>`;
+  const v=S.acct;
+  if(v==='a'){ /* tabs */
+    return `<div class="page">${head}
+      <div class="acct-tabs">${ACCT_SECTIONS.map(x=>`<button class="atab${x.id===S.acctSec?' act':''}"
+        onclick="S.acctSec='${x.id}';update()">${x.t}</button>`).join('')}</div>
+      ${acctSec().render()}</div>`;
+  }
+  if(v==='b'){ /* side-panel nav owns the sections (rendered in renderSide) */
+    return `<div class="page">${head}${acctSec().render()}
+      <div class="note">Sections are in the side panel — the account surface navigates like a project.</div></div>`;
+  }
+  if(v==='c'){ /* one scroll + sticky jump index */
+    return `<div class="page">${head}
+      <div class="acct-jump">${ACCT_SECTIONS.map(x=>`<button class="atab"
+        onclick="document.getElementById('sec-${x.id}').scrollIntoView({behavior:'smooth',block:'start'})">${x.t}</button>`).join('')}</div>
+      ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+  }
+  if(v==='d'){ /* accordion with summary lines */
+    return `<div class="page">${head}
+      ${ACCT_SECTIONS.map(x=>{
+        const open=S.acctOpen===x.id;
+        const headBtn=`<button class="acc-head${open?' open':''}" onclick="S.acctOpen=${open?'null':`'${x.id}'`};update()">
+          <span>${x.t}</span><span class="sum">${x.sum()}</span><span class="chev">${open?'▾':'▸'}</span></button>`;
+        return open?`<div class="acc-wrap">${headBtn}${x.render()}</div>`
+          :`<div class="card collapsed">${headBtn}</div>`;
+      }).join('')}</div>`;
+  }
+  /* e: overview tiles + drill-in */
+  if(S.acctFocus){
+    const x=ACCT_SECTIONS.find(s=>s.id===S.acctFocus);
+    return `<div class="page">
+      <button class="btn" style="justify-self:start" onclick="S.acctFocus=null;update()">← account overview</button>
+      ${x.render()}</div>`;
+  }
+  return `<div class="page">${head}
+    <div class="tilegrid">${ACCT_SECTIONS.map(x=>`<button class="tile" onclick="S.acctFocus='${x.id}';update()">
+      <span class="tt">${x.t}</span><span class="ts">${x.sum()}</span><span class="go">→</span></button>`).join('')}</div></div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<span class="tag mono" title="same operation on the CLI">$ ${v}</span>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <span class="tag mono">security: unlimited</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <span class="tag mono">90d</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape')closeModals();
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function cycleAcct(d){
+  const i=(ACCT_VARIANTS.indexOf(S.acct)+d+ACCT_VARIANTS.length)%ACCT_VARIANTS.length;
+  S.acct=ACCT_VARIANTS[i];S.acctFocus=null;
+  const u=new URL(location);u.searchParams.set('account',S.acct);history.replaceState(null,'',u);
+  update();
+}
+addEventListener('keydown',e=>{
+  if(S.view!=='account')return;
+  if(/INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName))return;
+  if(e.key==='ArrowLeft')cycleAcct(-1);
+  if(e.key==='ArrowRight')cycleAcct(1);
+});
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+  const sw=$('aswitch');
+  sw.hidden=S.view!=='account';
+  if(!sw.hidden)$('alabel').textContent=ACCT_NAMES[S.acct];
+}
+
+/* init */
+S.acct=new URL(location).searchParams.get('account')||'a';
+if(!ACCT_VARIANTS.includes(S.acct))S.acct='a';
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/6/index.html
+++ b/docs/site/public/prototypes/app-chrome/6/index.html
@@ -1092,7 +1092,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/7/index.html
+++ b/docs/site/public/prototypes/app-chrome/7/index.html
@@ -1076,7 +1076,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/7/index.html
+++ b/docs/site/public/prototypes/app-chrome/7/index.html
@@ -1,0 +1,1132 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 7.
+
+  Iteration 7 (Alex): account layout DECIDED — c, the jump index (one
+  scroll, sticky chip index). Other four layouts and their switcher removed.
+
+  New question this iteration: too many / too much rounded corners & pills.
+  Four SHAPE TREATMENTS, app-wide, switchable via bottom bar / ← → /
+  ?shape= (impeccable pass; DESIGN.md's "6px controls, 999px pills" line is
+  what's being reopened — amendment lands only after a verdict):
+    a  baseline    current skin: 8-14px radii, 999px pills everywhere
+    b  squared     one geometry: every radius collapses to 2px, pills
+                   become small rectangles; terminal/hairline feel
+    c  role scale  radius carries a role: containers 6px, controls 4px,
+                   badges 3px; the 999px pill is RESERVED for the matrix
+                   cell-state vocabulary and count badges, nothing else
+    d  flat        de-carded: sections separated by hairline rules instead
+                   of card boxes; tags become colored mono text with no
+                   border at all; radius 0 except overlays
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:7px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px;position:sticky;left:0}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx tr:hover td.val .pen{opacity:1;color:var(--accent)}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:6px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;padding:0 1px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+
+  /* account: jump index (decided layout) */
+  .acct-jump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:999px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+  /* ============ shape treatments (?shape=a..d) ============
+     a = baseline above. b/c/d override radius + pill grammar app-wide. */
+
+  /* b — squared: one geometry, everything 2px; pills become small rectangles */
+  [data-shape=b] :is(.card,.modal-box,.btn,.xbtn,.tile,.mxwrap,.stub,.capgrid,.qcard,
+    header select,header .iconbtn,.field input[type=text],.field select,select.projsel,
+    .answerbox,.oncewarn,.blastlist,#side .srow.act,.pav,.orgcard){border-radius:2px}
+  [data-shape=b] :is(.tag,.scopechip,.capchip,.atab,.drafts,#side .srow .pb,.st){border-radius:2px}
+  [data-shape=b] .pav.orgav{border-radius:2px}
+  [data-shape=b] .oav,[data-shape=b] .bigav,[data-shape=b] .glyph,[data-shape=b] .hue{border-radius:2px}
+  [data-shape=b] #rail .railbtn,[data-shape=b] #rail .me{border-radius:2px}
+  [data-shape=b] .codes code{border-radius:2px}
+
+  /* c — role scale: containers 6px, controls 4px, badges 3px;
+     999px reserved for count badges + matrix cell states only */
+  [data-shape=c] :is(.card,.modal-box,.mxwrap,.stub,.qcard,.capgrid,.answerbox,.oncewarn,.tile,.orgcard){border-radius:6px}
+  [data-shape=c] :is(.btn,.xbtn,header select,header .iconbtn,.field input[type=text],.field select,
+    select.projsel,.codes code){border-radius:4px}
+  [data-shape=c] :is(.tag,.scopechip,.capchip,.atab,.drafts){border-radius:3px}
+  [data-shape=c] .pav{border-radius:6px}
+  [data-shape=c] #rail .railbtn{border-radius:6px}
+  [data-shape=c] .bigav{border-radius:8px}
+  [data-shape=c] .glyph{border-radius:4px}
+  /* org identity + count badges keep their circle/pill — the reserved cases */
+
+  /* d — flat, de-carded: sections as hairline-ruled runs, tags as colored text */
+  [data-shape=d] *{border-radius:0!important}
+  [data-shape=d] .modal-box{border-radius:8px!important} /* overlays keep a soft edge */
+  [data-shape=d] .page .card{background:none;border:none;padding:18px 0 20px;border-top:1px solid var(--line)}
+  [data-shape=d] .page .card:first-of-type,[data-shape=d] .page h2+.sub+.card{border-top:none}
+  [data-shape=d] .page .card h3{color:var(--tx);font-size:12px}
+  [data-shape=d] :is(.tag,.scopechip){border:none;background:none;padding:0;font-weight:700}
+  [data-shape=d] .tag.mono,[data-shape=d] .scopechip{color:var(--tx-dim)}
+  [data-shape=d] .capchip{border:none;background:var(--bg3)}
+  [data-shape=d] .capchip.pend{border:1px dashed var(--chg)}
+  [data-shape=d] .atab{border:none;background:var(--bg3);color:var(--tx-dim)}
+  [data-shape=d] .atab:hover{color:var(--accent);background:var(--bg3)}
+  [data-shape=d] .answerbox{border:none;border-top:2px solid var(--accent);background:var(--accent-soft)}
+  [data-shape=d] .qcard{border:1px dashed var(--line);padding:16px 18px}
+  [data-shape=d] .mxwrap{border-left:none;border-right:none}
+  [data-shape=d] .rowline{border-top-color:color-mix(in oklch,var(--line) 55%,transparent)}
+
+  /* account layout switcher */
+  #aswitch{position:fixed;z-index:60;left:50%;bottom:14px;transform:translateX(-50%);
+    display:flex;align-items:center;gap:2px;background:oklch(0.14 0.01 220);color:oklch(0.95 0 0);
+    border-radius:999px;padding:4px 6px;box-shadow:0 6px 24px oklch(0 0 0/.5);font-size:12px}
+  [data-theme=light] #aswitch{background:oklch(0.3 0.02 225)}
+  #aswitch button{color:inherit;min-width:34px;min-height:34px;border-radius:50%;font-size:14px}
+  #aswitch button:hover{background:oklch(1 0 0/.12)}
+  #aswitch .vlabel{padding:0 10px;white-space:nowrap;font-weight:600}
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:8px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:6px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:14px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:50%;border:2px solid transparent}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:9px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .grants tr:hover td{background:var(--rowalt)}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:10px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:8px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:7px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:8px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)"></div>
+<div id="scrim" onclick="closeModals()"></div>
+
+<div id="aswitch">
+  <button onclick="cycleShape(-1)" aria-label="previous shape treatment">←</button>
+  <span class="vlabel" id="alabel"></span>
+  <button onclick="cycleShape(1)" aria-label="next shape treatment">→</button>
+</div>
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,
+       shape:'a'};
+const SHAPES=['a','b','c','d'];
+const SHAPE_NAMES={a:'A — baseline (soft)',b:'B — squared 2px',c:'C — role scale',d:'D — flat, de-carded'};
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp"><td colspan="${MXENVS.length+1}">${K.g}</td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    <div class="acct-jump">${ACCT_SECTIONS.map(x=>`<button class="atab"
+      onclick="document.getElementById('sec-${x.id}').scrollIntoView({behavior:'smooth',block:'start'})">${x.t}</button>`).join('')}</div>
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<span class="tag mono" title="same operation on the CLI">$ ${v}</span>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><span class="tag mono">hikyo.example.com</span></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <span class="tag mono">security: unlimited</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <span class="tag mono">90d</span><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape')closeModals();
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function cycleShape(d){
+  const i=(SHAPES.indexOf(S.shape)+d+SHAPES.length)%SHAPES.length;
+  S.shape=SHAPES[i];
+  const u=new URL(location);u.searchParams.set('shape',S.shape);history.replaceState(null,'',u);
+  update();
+}
+addEventListener('keydown',e=>{
+  if(/INPUT|TEXTAREA|SELECT/.test(document.activeElement?.tagName))return;
+  if(e.key==='ArrowLeft')cycleShape(-1);
+  if(e.key==='ArrowRight')cycleShape(1);
+});
+
+function update(){
+  ensureValidContext();
+  document.body.dataset.shape=S.shape;
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+  $('alabel').textContent=SHAPE_NAMES[S.shape];
+}
+
+/* init */
+S.shape=new URL(location).searchParams.get('shape')||'a';
+if(!SHAPES.includes(S.shape))S.shape='a';
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/8/index.html
+++ b/docs/site/public/prototypes/app-chrome/8/index.html
@@ -1,0 +1,1064 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 8.
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* account: jump index (decided layout) */
+  .acct-jump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:4px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    <div class="card"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    <div class="card"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    <div class="acct-jump">${ACCT_SECTIONS.map(x=>`<button class="atab"
+      onclick="document.getElementById('sec-${x.id}').scrollIntoView({behavior:'smooth',block:'start'})">${x.t}</button>`).join('')}</div>
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+
+    <div class="card"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/8/index.html
+++ b/docs/site/public/prototypes/app-chrome/8/index.html
@@ -1024,7 +1024,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/9/index.html
+++ b/docs/site/public/prototypes/app-chrome/9/index.html
@@ -1,0 +1,1075 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo app chrome (ticket #29)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #29, iteration 9.
+
+  Iteration 9 (Alex): the sticky jump index (decided for Account &
+  security in it7) is now the pattern for EVERY sectioned settings
+  surface — project settings, instance administration, members — via a
+  shared jump() helper. Same chips, same smooth anchor scroll.
+
+
+  Iteration 8 (Alex): shape DECIDED — c, the role scale, now baked in as
+  the only skin (switcher and treatments a/b/d removed; DESIGN.md Shape
+  section amended to match):
+    containers 6px · controls 4px · badges/tags/chips 3px
+    999px pill RESERVED for org identity circles, count badges, and the
+    matrix cell-state vocabulary — nothing else.
+  Plus a Codex-driven placement audit of pills, buttons and interactions;
+  its accepted findings are implemented in this iteration (see NOTES.md).
+
+
+  Iteration 5 (Alex): new-grant modal takes a capability CHECKLIST instead of
+  a single select — any number at once. Consistent with the permission ADR:
+  each checked capability lands as its OWN revocable grant line at the chosen
+  scope (that is exactly what role templates do with a preset checklist);
+  the org-scope blast warning enumerates the checked capabilities and states
+  they are separate lines.
+
+
+  Question: how do the surfaces AROUND the matrix hang together — org
+  switching in the chrome, account/profile, project settings, membership &
+  roles, instance administration — in the env-matrix-31 design language.
+
+  Iteration 4 (Alex's round-3 verdicts):
+  - ORG PLACEMENT DECIDED: variant A — the rail owns orgs (monograms above
+    the project squares; mobile drawer opens with an organizations section).
+    Variants b/c and the switcher are removed.
+  - INSTANCE SURFACE DECIDED IN: full CLI<->UI feature parity for instance
+    management (#25's parity principle extended to the instance scope) —
+    hikyo may run local/VPS/k8s/docker while managing orgs and projects
+    hosted elsewhere, so the CLI is not always the convenient surface. The
+    one exception stays: the SystemProof local set (init, migrate, restore
+    reconciliation, break-glass) is local host authority by locked ADR #23/
+    #25 and deliberately has no UI.
+  - NEW EXPLORATION (open question, own wayfinder ticket): Portainer-style
+    multi-instance management — one MAIN instance connects to and manages
+    other hikyo instances. Sketched as a "Connected instances" card on
+    the instance surface to react to; the decision itself is out of this
+    ticket's scope.
+
+  Persona simulator (header): alex = 2 orgs + org admin + instance admin;
+  dana = single org, developer; sam = external, sees ONE project.
+  "Unauthorized ≡ nonexistent" (permission ADR #15): single-org personas get
+  NO org-switching chrome at all; sam's rail shows only the project he holds
+  a grant on.
+
+  Step-up (account security, blue, "confirm it's you") is deliberately a
+  different ceremony from reveal reauth (teal, "disclosure", enumerated keys,
+  ticket #21) — ADR #16 requires them distinguishable.
+
+  Design context: PRODUCT.md / DESIGN.md at repo root; reference design
+  prototype/env-matrix/31.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+
+  /* rail */
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0 12px;border-right:1px solid var(--line);background:var(--bg2)}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent;position:relative;flex:none}
+  .pav:hover{border-color:var(--line);color:var(--tx)}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  .pav.orgav{border-radius:50%;font-size:11px}
+  .pav.orgav.act{outline:2px solid var(--accent);outline-offset:2px;background:var(--bg3);color:var(--tx)}
+  #rail .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0;flex:none}
+  #rail .spacer{flex:1}
+  #rail .railbtn{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-faint);font-size:15px;flex:none;border:1px solid transparent}
+  #rail .railbtn:hover{color:var(--tx);border-color:var(--line)}
+  #rail .railbtn.act{color:var(--accent);border-color:var(--accent)}
+  #rail .me{border-radius:50%;background:var(--bg3);color:var(--tx);font-weight:700;font-size:11px}
+
+  /* side panel */
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .orghead{display:flex;align-items:center;gap:10px;padding:12px 16px 4px}
+  #side .orghead .oname{font-weight:700;font-size:14px}
+  #side .orghead .orole{font-size:10.5px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* header */
+  header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);background:var(--bg);flex:none}
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  header .crumb .sep{color:var(--accent)}
+  header .crumb .dimseg{color:var(--tx-dim);font-weight:500}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px}
+  header .iconbtn{border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center}
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #menubtn{display:none}
+
+  /* content */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain;padding:clamp(16px,3vw,32px)}
+  .page{max-width:860px;margin:0 auto;display:grid;gap:18px}
+  .page h2{font-size:19px;font-weight:700;letter-spacing:-.01em}
+  .page .sub{font-size:13px;color:var(--tx-dim);margin-top:-12px;line-height:1.55;max-width:64ch}
+  .card{background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:16px 18px}
+  .card h3{font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+  .card .note{font-size:12.5px;color:var(--tx-faint);line-height:1.55;margin-top:10px}
+  .qcard{border-style:dashed;background:transparent}
+  .qcard b{color:var(--chg)}
+  .rowline{display:flex;align-items:center;gap:10px;padding:10px 0;border-top:1px solid var(--line);flex-wrap:wrap}
+  .rowline:first-of-type{border-top:none}
+  .rowline .main{display:grid;gap:2px;min-width:0}
+  .rowline .t{font-size:13.5px;font-weight:600}
+  .rowline .d{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+  .rowline .grow{flex:1}
+  .tag{font-size:10px;letter-spacing:.07em;font-weight:700;text-transform:uppercase;
+    border-radius:3px;padding:3px 9px;border:1px solid var(--line);color:var(--tx-dim);white-space:nowrap}
+  .tag.acc{color:var(--accent);border-color:var(--accent)}
+  .tag.blue{color:var(--chg);border-color:var(--chg)}
+  .tag.bad{color:var(--bad);border-color:var(--bad)}
+  .tag.mono{font-family:var(--mono);text-transform:none;letter-spacing:0}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:8px 14px;font-size:13px;color:var(--tx);
+    min-height:36px;display:inline-flex;align-items:center;gap:7px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+  .btn.blue{color:var(--chg)}
+  .btn.blue:hover{border-color:var(--chg)}
+  .xbtn{color:var(--tx-faint);font-size:15px;min-width:34px;min-height:34px;display:inline-flex;
+    align-items:center;justify-content:center;border-radius:4px;border:1px solid transparent}
+  .xbtn:hover{color:var(--bad);border-color:var(--bad)}
+  .field{display:grid;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input[type=text],.field select{background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:4px;font-size:13.5px;min-height:42px;width:100%}
+  .fgrid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .mini{font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+
+  /* condensed matrix (shell-integration fidelity, not full env-matrix/31) */
+  .mxwrap{overflow:auto;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  table.mx{border-collapse:collapse;width:100%;font-size:12.5px;min-width:640px}
+  .mx thead th{position:sticky;top:0;z-index:2;background:var(--bg2);text-align:left;font-size:10px;
+    letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);padding:10px 12px;
+    border-bottom:1px solid var(--line);font-weight:700;white-space:nowrap}
+  .mx thead th:first-child{left:0;z-index:3}
+  .mx thead th .prot{color:var(--bad);margin-left:6px;letter-spacing:.06em}
+  .mx td{padding:7px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  .mx tr:last-child td{border-bottom:none}
+  /* z-index: the ✎ pen's opacity creates a stacking context that would
+     otherwise paint above the sticky key column on horizontal scroll */
+  .mx td.key{font-family:var(--mono);font-size:11.5px;color:var(--tx);position:sticky;left:0;z-index:1;background:var(--bg2)}
+  .mx td.key .sec{color:var(--tx-faint);margin-left:6px}
+  .mx tr.grp td{background:var(--bg3);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:6px 12px}
+  /* colspan cell cannot shift within itself — the label is what sticks */
+  .mx tr.grp td .gl{position:sticky;left:12px;display:inline-block}
+  .mx td.val{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);max-width:180px;
+    overflow:hidden;text-overflow:ellipsis}
+  .mx td.val .pen{color:var(--tx-faint);opacity:.45;margin-left:5px}
+  .mx td.val.bad{color:var(--bad);border-bottom:1px solid var(--bad)}
+  .mx td.val .dots{letter-spacing:.18em}
+  .mxnote{font-size:11.5px;color:var(--tx-faint);font-family:var(--mono);margin-top:10px}
+  .mxnote a{color:var(--accent)}
+
+  /* grouped capability chips */
+  .capchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;color:var(--tx);margin:2px 4px 2px 0;
+    white-space:nowrap}
+  .capchip .rm{color:var(--tx-faint);font-size:12px;line-height:1;min-width:26px;min-height:26px;
+    display:inline-flex;align-items:center;justify-content:center;margin:-6px -8px -6px -2px;border-radius:3px}
+  .capchip .rm:hover{color:var(--bad)}
+  .capchip.pend{border-style:dashed;color:var(--chg);border-color:var(--chg)}
+  /* values & CLI refs are text, never tags (tags = categorical status only) */
+  code.val,code.cliv{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);white-space:nowrap}
+  code.cliv{color:var(--tx-faint)}
+
+  /* sticky jump index — the pattern for every sectioned settings surface */
+  .page .card{scroll-margin-top:72px} /* jump targets stop below the sticky bar */
+  .secjump{display:flex;gap:6px;flex-wrap:wrap;position:sticky;top:-17px;z-index:5;
+    background:var(--bg);padding:10px 0;margin:-10px 0}
+  .atab{border:1px solid var(--line);border-radius:4px;padding:7px 14px;font-size:12.5px;color:var(--tx-dim);min-height:36px}
+  .atab:hover{border-color:var(--accent);color:var(--accent)}
+
+
+  /* grant-modal capability checklist */
+  .capgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:2px;
+    border:1px solid var(--line);border-radius:6px;padding:8px;background:var(--bg)}
+  .capgrid label{display:flex;align-items:center;gap:8px;padding:7px 8px;border-radius:4px;
+    font-family:var(--mono);font-size:12px;color:var(--tx);cursor:pointer;min-height:36px;
+    text-transform:none;letter-spacing:0;font-weight:400}
+  .capgrid label:hover{background:var(--bg3)}
+  .capgrid input{accent-color:var(--accent)}
+
+  /* icon picker */
+  .iconrow{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .bigav{width:56px;height:56px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:19px;color:var(--on-accent)}
+  .hues{display:flex;gap:8px;flex-wrap:wrap}
+  .hue{width:30px;height:30px;border-radius:4px;border:2px solid transparent}
+  .hue:hover{border-color:var(--tx-faint)}
+  .hue.act{border-color:var(--tx)}
+  .glyphs{display:flex;gap:6px;flex-wrap:wrap}
+  .glyph{width:38px;height:38px;border-radius:4px;border:1px solid var(--line);display:flex;
+    align-items:center;justify-content:center;font-size:16px}
+  .glyph:hover{border-color:var(--accent)}
+  .glyph.act{border-color:var(--accent);background:var(--accent-soft)}
+
+  /* grants table */
+  .grants{width:100%;border-collapse:collapse;font-size:13px}
+  .grants th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--tx-faint);
+    padding:8px 10px;border-bottom:1px solid var(--line);font-weight:700}
+  .grants td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .grants tr:last-child td{border-bottom:none}
+  .cap{font-family:var(--mono);font-size:12px;color:var(--tx)}
+  .scopechip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:3px;padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .scopechip.org{color:var(--chg);border-color:var(--chg)}
+  .scopechip.prot{color:var(--bad);border-color:var(--bad)}
+  .inspect{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:14px}
+  .answerbox{background:var(--accent-soft);border:1px solid var(--accent);border-radius:6px;padding:12px 14px;
+    font-size:13px;margin-bottom:14px}
+  .answerbox b{font-family:var(--mono)}
+
+  /* modals */
+  #scrim{position:fixed;inset:0;z-index:40;background:oklch(0 0 0/.45);display:none}
+  body.modal #scrim{display:block}
+  .modal-box{position:fixed;z-index:41;left:50%;top:50%;transform:translate(-50%,-50%);
+    width:min(480px,calc(100vw - 32px));max-height:85dvh;overflow:auto;
+    background:var(--bg2);border:1px solid var(--line);border-radius:6px;padding:20px;display:none;
+    box-shadow:0 18px 60px oklch(0 0 0/.5)}
+  .modal-box.open{display:block}
+  .modal-box h4{font-size:15px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .modal-box .msub{font-size:12.5px;color:var(--tx-dim);line-height:1.55;margin:8px 0 14px}
+  .modal-box .mrow{display:flex;gap:10px;justify-content:flex-end;margin-top:16px;flex-wrap:wrap}
+  .modal-box.stepup{border-color:var(--chg)}
+  .modal-box.stepup h4{color:var(--chg)}
+  .modal-box.stepup .banner{background:var(--chg-soft);border:1px solid var(--chg);border-radius:6px;
+    padding:9px 12px;font-size:12px;color:var(--tx);line-height:1.5;margin-bottom:12px}
+  .modal-box.blast{border-color:var(--bad)}
+  .modal-box.blast h4{color:var(--bad)}
+  .codes{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin:12px 0}
+  .codes code{font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;padding:8px 10px;text-align:center;letter-spacing:.06em}
+  .oncewarn{background:var(--bad-soft);border:1px solid var(--bad);border-radius:6px;padding:9px 12px;
+    font-size:12.5px;line-height:1.5;margin-bottom:6px}
+  .blastlist{margin:10px 0;display:grid;gap:5px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+  .blastlist .bl{display:flex;gap:8px;align-items:baseline}
+  .blastlist .bl .p{color:var(--tx)}
+
+  .oav{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:10px;color:var(--on-accent);flex:none}
+
+  /* mobile */
+  @media (max-width:700px){
+    #app{grid-template-columns:1fr}
+    #rail{display:none}
+    header{flex-wrap:nowrap;gap:8px;padding:10px 12px}
+    /* AAA touch targets on phones */
+    :is(.btn,.xbtn,.atab,header select,header .iconbtn,.capgrid label,.glyph){min-height:44px}
+    :is(.glyph,.hue){min-width:44px;min-height:44px}
+    .capchip .rm{min-width:34px;min-height:34px}
+    header .crumb{font-size:13.5px;min-width:0;overflow:hidden;white-space:nowrap;flex-wrap:nowrap}
+    header .crumb .dimseg,header .crumb span:not(.sep){overflow:hidden;text-overflow:ellipsis}
+    header .ctl select{max-width:104px;text-overflow:ellipsis}
+    #side{position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4)}
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    header .ctl .lbl{display:none}
+    .codes{grid-template-columns:1fr 1fr}
+  }
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  /* rail carries projects/account/instance on desktop; panel repeats them only on mobile */
+  #side .mobileonly{display:none}
+  .m-only{display:none!important}
+  @media (max-width:700px){
+    #side div.mobileonly{display:block}
+    #side button.mobileonly{display:flex}
+    .m-only{display:inline-flex!important}
+    header .crumb .hidemobile{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="toggleSide()" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb" id="crumb"></span>
+  <span class="grow"></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="persona" aria-label="simulated persona" title="simulated persona — decides which orgs and projects exist for you">
+      <option value="alex">alex · 2 orgs · org+instance admin</option>
+      <option value="dana">dana · 1 org · developer</option>
+      <option value="sam">sam · external · 1 project</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+<div class="wrap" id="content"></div>
+</div>
+</div>
+
+<div id="sidescrim" onclick="toggleSide(false)" aria-hidden="true"></div>
+<div id="scrim" onclick="closeModals()" aria-hidden="true"></div>
+
+
+<!-- account-security step-up: deliberately NOT the reveal ceremony -->
+<div class="modal-box stepup" id="stepup" role="dialog" aria-modal="true" aria-label="account security step-up">
+  <h4>🛡 Confirm it's you</h4>
+  <div class="banner">Account-security change: <b id="stepup-what"></b>. This asks for your possession factor.
+    It is <b>not</b> a secret disclosure — revealing values is a separate, teal ceremony that names the keys it covers.</div>
+  <div class="msub">Passwords don't count here — a stolen session implies the password. Recovery codes restore access, never authorize changes.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn blue" onclick="stepupOk('totp')">enter TOTP</button>
+    <button class="btn blue" onclick="stepupOk('passkey')">use passkey</button>
+  </div>
+</div>
+
+<div class="modal-box" id="codesmodal" role="dialog" aria-modal="true" aria-label="recovery codes">
+  <h4>Recovery codes</h4>
+  <div class="oncewarn"><b>Shown once.</b> Hikyo stores only hashes — after this dialog closes these codes
+    cannot be displayed again, only replaced.</div>
+  <div class="codes" id="codesgrid"></div>
+  <label style="display:flex;gap:9px;align-items:center;font-size:13px;margin-top:6px;cursor:pointer;min-height:44px">
+    <input type="checkbox" id="codesack"> I saved these somewhere safe
+  </label>
+  <div class="mrow">
+    <button class="btn" onclick="copyCodes(this)">copy all</button>
+    <button class="btn primary" onclick="closeCodes()">done</button>
+  </div>
+</div>
+
+<div class="modal-box blast" id="blastmodal" role="dialog" aria-modal="true" aria-label="org-scope grant warning">
+  <h4>⚠ Org-scoped grant — check the blast radius</h4>
+  <div class="msub" id="blastsub"></div>
+  <div class="blastlist" id="blastlist"></div>
+  <div class="msub">Absence is the only denial — there is no per-project exception under an org grant.
+    Narrower option: grant per project or per environment instead.</div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn danger" onclick="confirmGrant()">grant at org scope</button>
+  </div>
+</div>
+
+<div class="modal-box" id="invitemodal" role="dialog" aria-modal="true" aria-label="invite member">
+  <h4>Invite member</h4>
+  <div class="msub">The invitation carries the capability set below and binds to <b>whoever redeems it</b> —
+    the email is delivery, never a linking key (an email match is not an identity).</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>email (delivery only)</label>
+      <input type="text" id="iv-email" placeholder="person@example.org"></div>
+    <div class="field"><label>role template</label>
+      <select id="iv-tpl"><option>viewer</option><option selected>developer</option><option>admin</option></select></div>
+    <div class="field"><label>scope</label>
+      <select id="iv-scope">
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitInvite()">create invitation</button>
+  </div>
+</div>
+
+<div class="modal-box" id="grantmodal" role="dialog" aria-modal="true" aria-label="new grant">
+  <h4>New grant</h4>
+  <div class="msub">Pick any number of capabilities — each becomes its <b>own revocable line</b> at this scope,
+    never a bundle. Roles are templates doing exactly this with a preset checklist.</div>
+  <div style="display:grid;gap:12px">
+    <div class="field"><label>principal</label>
+      <select id="g-principal"><option>dana</option><option>sam</option><option>priya</option></select></div>
+    <div class="field"><label>capabilities</label>
+      <div class="capgrid" id="g-caps">
+        <label><input type="checkbox" value="read"> <span>read</span></label>
+        <label><input type="checkbox" value="edit"> <span>edit</span></label>
+        <label><input type="checkbox" value="publish"> <span>publish</span></label>
+        <label><input type="checkbox" value="reveal"> <span>reveal</span></label>
+        <label><input type="checkbox" value="reveal-history"> <span>reveal-history</span></label>
+        <label><input type="checkbox" value="definitions-edit"> <span>definitions-edit</span></label>
+        <label><input type="checkbox" value="project-settings"> <span>project-settings</span></label>
+        <label><input type="checkbox" value="manage-members"> <span>manage-members</span></label>
+        <label><input type="checkbox" value="audit-read"> <span>audit-read</span></label>
+      </div></div>
+    <div class="field"><label>scope</label>
+      <select id="g-scope">
+        <option value="env:production">env · production (protected)</option>
+        <option value="env:staging">env · staging</option>
+        <option value="project:demo">project · demo</option>
+        <option value="org:acme">org · acme (all projects)</option>
+      </select></div>
+  </div>
+  <div class="mrow">
+    <button class="btn" onclick="closeModals()">cancel</button>
+    <button class="btn primary" onclick="submitGrant()">grant</button>
+  </div>
+</div>
+
+<script>
+/* ============================ demo data ============================ */
+const ORGS=[
+  {id:'acme',name:'acme',hue:195,projects:[
+    {id:'demo',name:'demo',hue:195},
+    {id:'website',name:'website',hue:280},
+    {id:'mobile',name:'mobile-app',hue:60},
+  ]},
+  {id:'sample-org',name:'sample-org',hue:280,projects:[
+    {id:'sandbox',name:'sandbox',hue:140},
+    {id:'poke',name:'sample-catalog',hue:20},
+  ]},
+];
+const PERSONAS={
+  alex:{label:'alex',orgs:['acme','sample-org'],orgAdmin:['acme','sample-org'],instanceAdmin:true,
+        projectFilter:null,roleIn:o=>'org admin'},
+  dana:{label:'dana',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:null,roleIn:o=>'developer'},
+  sam:{label:'sam',orgs:['acme'],orgAdmin:[],instanceAdmin:false,
+        projectFilter:{acme:['demo']},roleIn:o=>'external'},
+};
+/* grants: each line independently revocable (permission ADR #15) */
+let GRANTS=[
+  {p:'alex', cap:'manage-members', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal',         scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'reveal-history', scope:'org:acme', via:'admin template'},
+  {p:'alex', cap:'audit-read',     scope:'org:acme', via:'admin template'},
+  {p:'dana', cap:'read',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'edit',           scope:'project:demo', via:'developer template'},
+  {p:'dana', cap:'publish',        scope:'env:staging',  via:'developer template'},
+  {p:'dana', cap:'reveal',         scope:'env:staging',  via:'direct'},
+  {p:'sam',  cap:'read',           scope:'project:demo', via:'direct'},
+  {p:'priya',cap:'read',           scope:'project:demo', via:'viewer template'},
+  {p:'priya',cap:'reveal',         scope:'env:production',via:'direct'},
+];
+/* condensed matrix demo data (subset of env-matrix/31's) */
+const MXENVS=[{id:'dev',n:'development'},{id:'stg',n:'staging'},{id:'prd',n:'production',prot:true},{id:'pre',n:'preview'}];
+const MXKEYS=[
+  {g:'app',k:'APP_NAME',v:{dev:'Hikyo Demo',stg:'Hikyo Demo',prd:'Hikyo',pre:'Hikyo Demo'}},
+  {g:'app',k:'APP_URL',v:{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.dev'}},
+  {g:'app',k:'PORT',v:{dev:'8080',stg:'8080',prd:'8080',pre:'8080'}},
+  {g:'db',k:'DATABASE_URL',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'db',k:'DB_POOL_SIZE',v:{dev:'5',stg:'10',prd:'25',pre:'5'}},
+  {g:'auth',k:'SESSION_SECRET',sec:true,v:{dev:'•',stg:'•',prd:'•',pre:'•'}},
+  {g:'auth',k:'OIDC_ISSUER',v:{dev:'https://git.example.com',stg:'https://git.example.com',prd:'',pre:'https://git.example.com'},bad:{prd:'required, unset'}},
+];
+let INVITES=[];
+const SESSIONS=[
+  {type:'browser',label:'Safari · macOS',detail:'193.28.x.x · Amsterdam',last:'now',current:true},
+  {type:'browser',label:'Firefox · Fedora',detail:'193.28.x.x · Amsterdam',last:'2 days ago'},
+  {type:'cli',label:'hikyo CLI',detail:'laptop.example · device authorization',last:'25 min ago'},
+  {type:'cli',label:'hikyo CLI',detail:'example-cluster-0 · device authorization',last:'6 days ago'},
+];
+let FACTORS={passkeys:[{n:'MacBook Touch ID',added:'2026-05-12'},{n:'YubiKey 5C',added:'2026-05-12'}],
+  totp:true,password:true,codesGenerated:false,passkeyOnly:false};
+const IDENTITIES=[{issuer:'git.example.com',subject:'alex',linked:'2026-06-02'}];
+
+/* ============================ state ============================ */
+/* org placement decided: A — the rail owns orgs (iteration 4) */
+let S={persona:'alex',org:'acme',project:'demo',view:'matrix',theme:'dark',
+       inspectCap:'reveal',inspectScope:'env:production',pendingGrant:null,
+       projHue:195,projGlyph:null,
+       };
+
+const $=id=>document.getElementById(id);
+const me=()=>PERSONAS[S.persona];
+const myOrgs=()=>ORGS.filter(o=>me().orgs.includes(o.id));
+const curOrg=()=>ORGS.find(o=>o.id===S.org)||myOrgs()[0];
+const visProjects=o=>{const f=me().projectFilter;
+  return o.projects.filter(p=>!f||!f[o.id]||f[o.id].includes(p.id));};
+const mono=n=>n.slice(0,2).toUpperCase();
+const hueBg=h=>`oklch(0.62 0.11 ${h})`;
+const scopeLabel=s=>s.replace(':',' · ');
+const isOrgAdmin=()=>me().orgAdmin.includes(S.org);
+
+/* ============================ shell render ============================ */
+function ensureValidContext(){
+  if(!me().orgs.includes(S.org)) S.org=me().orgs[0];
+  const vp=visProjects(curOrg());
+  if(!vp.some(p=>p.id===S.project)) S.project=vp[0]?.id;
+  if(!me().instanceAdmin&&S.view==='instance') S.view='matrix';
+  if(!isOrgAdmin()&&S.view==='orgmembers') S.view='matrix';
+}
+
+function renderRail(){
+  const r=$('rail');r.innerHTML='';
+  const multiOrg=myOrgs().length>1;
+  if(multiOrg){
+    for(const o of myOrgs()){
+      const b=document.createElement('button');
+      b.className='pav orgav'+(o.id===S.org?' act':'');
+      b.style.background=o.id===S.org?'':'transparent';
+      b.style.borderColor='var(--line)';
+      b.title=`organization ${o.name}`;b.textContent=mono(o.name);
+      b.onclick=()=>{S.org=o.id;S.project=null;S.view='matrix';update();};
+      r.appendChild(b);
+    }
+    r.insertAdjacentHTML('beforeend','<div class="raildiv"></div>');
+  }
+  for(const p of visProjects(curOrg())){
+    const b=document.createElement('button');
+    b.className='pav'+(p.id===S.project&&!['account','instance'].includes(S.view)?' act':'');
+    b.title=`project ${p.name}`;b.textContent=mono(p.name);
+    if(!(p.id===S.project)) b.style.background=hueBg(p.hue).replace(')','/.18)');
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();};
+    r.appendChild(b);
+  }
+  r.insertAdjacentHTML('beforeend','<div class="spacer"></div>');
+  if(me().instanceAdmin){
+    const g=document.createElement('button');
+    g.className='railbtn'+(S.view==='instance'?' act':'');
+    g.title='instance administration';g.textContent='⚙';
+    g.onclick=()=>{S.view='instance';update();};
+    r.appendChild(g);
+  }
+  const a=document.createElement('button');
+  a.className='railbtn me'+(S.view==='account'?' act':'');
+  a.title='account & security';a.textContent=mono(me().label);
+  a.onclick=()=>{S.view='account';update();};
+  r.appendChild(a);
+}
+
+function renderSide(){
+  const s=$('side');s.innerHTML='';
+  const o=curOrg();
+  const role=me().orgAdmin.includes(o.id)?'org admin':me().roleIn(o);
+  s.insertAdjacentHTML('beforeend',
+    `<div class="orghead"><span class="oav" style="background:${hueBg(o.hue)}">${mono(o.name)}</span>
+     <div><div class="oname">${o.name}</div><div class="orole">${role}</div></div></div>`);
+  /* mobile: the rail is hidden, so the drawer opens with the org section */
+  if(myOrgs().length>1){
+    s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">organizations</div>');
+    for(const oo of myOrgs()){
+      const b=document.createElement('button');
+      b.className='srow mobileonly'+(oo.id===S.org?' act':'');
+      b.innerHTML=`<span class="oav" style="background:${hueBg(oo.hue)};width:22px;height:22px;font-size:9px">${mono(oo.name)}</span> ${oo.name}`
+        +(oo.id===S.org?'<span class="cnt">✓</span>':'');
+      b.onclick=()=>{S.org=oo.id;S.project=null;S.view='matrix';update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(proj){
+    /* env-matrix-31 panel: the matrix's own nav lives HERE — one sidebar, merged */
+    s.insertAdjacentHTML('beforeend','<div class="stitle">project · '+proj.name+'</div>');
+    const mb=document.createElement('button');
+    mb.className='srow'+(S.view==='matrix'?' act':'');
+    mb.innerHTML='Environment matrix';
+    mb.onclick=()=>{S.view='matrix';update();toggleSide(false);};
+    s.appendChild(mb);
+    if(S.view==='matrix'){
+      const groups={};MXKEYS.forEach(K=>{groups[K.g]=groups[K.g]||{n:0,bad:0};groups[K.g].n++;
+        if(K.bad)groups[K.g].bad+=Object.keys(K.bad).length;});
+      for(const [g,info] of Object.entries(groups)){
+        const b=document.createElement('button');
+        b.className='srow';b.style.paddingLeft='28px';
+        b.innerHTML=`${g}${info.bad?`<span class="pb">${info.bad}</span>`:`<span class="cnt">${info.n}</span>`}`;
+        b.onclick=()=>{toggleSide(false);document.getElementById('mxg-'+g)?.scrollIntoView({behavior:'smooth',block:'start'});};
+        s.appendChild(b);
+      }
+      const pv=document.createElement('button');
+      pv.className='srow';pv.style.paddingLeft='28px';
+      pv.innerHTML='problems<span class="pb">1</span>';
+      pv.onclick=()=>{toggleSide(false);document.querySelector('.mx td.val.bad')?.scrollIntoView({behavior:'smooth',block:'center'});};
+      s.appendChild(pv);
+    }
+    for(const [v,l] of [['members','Members & access'],['settings','Project settings']]){
+      const b=document.createElement('button');
+      b.className='srow'+(S.view===v?' act':'');b.textContent=l;
+      b.onclick=()=>{S.view=v;update();toggleSide(false);};
+      s.appendChild(b);
+    }
+  }
+  if(isOrgAdmin()){
+    s.insertAdjacentHTML('beforeend','<div class="stitle">organization</div>');
+    const b=document.createElement('button');
+    b.className='srow'+(S.view==='orgmembers'?' act':'');b.textContent='Org members & grants';
+    b.onclick=()=>{S.view='orgmembers';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  /* mobile-only: projects list + account/instance (rail is hidden) */
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly" style="margin-top:8px">projects</div>');
+  for(const p of visProjects(o)){
+    const b=document.createElement('button');
+    b.className='srow mobileonly'+(p.id===S.project?' act':'');
+    b.textContent=p.name;
+    b.onclick=()=>{S.project=p.id;S.view='matrix';update();toggleSide(false);};
+    s.appendChild(b);
+  }
+  s.insertAdjacentHTML('beforeend','<div class="stitle mobileonly">you</div>');
+  const acc=document.createElement('button');
+  acc.className='srow mobileonly'+(S.view==='account'?' act':'');acc.textContent='Account & security';
+  acc.onclick=()=>{S.view='account';update();toggleSide(false);};
+  s.appendChild(acc);
+  if(me().instanceAdmin){
+    const ins=document.createElement('button');
+    ins.className='srow mobileonly'+(S.view==='instance'?' act':'');ins.textContent='Instance administration';
+    ins.onclick=()=>{S.view='instance';update();toggleSide(false);};
+    s.appendChild(ins);
+  }
+}
+
+function renderCrumb(){
+  const c=$('crumb');c.innerHTML='';
+  const o=curOrg();
+  const seg=[];
+  seg.push('<span class="hidemobile">hikyo</span>');
+  seg.push('<span class="sep hidemobile">/</span>');
+  seg.push(`<span class="dimseg">${o.name}</span>`);
+  const proj=visProjects(o).find(p=>p.id===S.project);
+  if(['matrix','members','settings'].includes(S.view)&&proj){
+    seg.push('<span class="sep">/</span>');
+    seg.push(`<span>${proj.name}</span>`);
+  }else if(S.view==='account'){
+    seg.push('<span class="sep">/</span><span>account</span>');
+  }else if(S.view==='instance'){
+    seg.push('<span class="sep">/</span><span>instance</span>');
+  }else if(S.view==='orgmembers'){
+    seg.push('<span class="sep">/</span><span>members</span>');
+  }
+  c.innerHTML=seg.join(' ');
+}
+
+/* ============================ pages ============================ */
+function pageMatrix(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  let rows='',lastG='';
+  for(const K of MXKEYS){
+    if(K.g!==lastG){lastG=K.g;
+      rows+=`<tr class="grp" id="mxg-${K.g}"><td colspan="${MXENVS.length+1}"><span class="gl">${K.g}</span></td></tr>`;}
+    rows+=`<tr><td class="key">${K.k}${K.sec?'<span class="sec" title="secret">🔒</span>':''}</td>`
+      +MXENVS.map(e=>{
+        const bad=K.bad&&K.bad[e.id];
+        const val=K.sec?'<span class="dots">••••••</span>':(K.v[e.id]||(bad?'—':''));
+        return `<td class="val${bad?' bad':''}" title="${bad||''}">${val}<span class="pen">✎</span></td>`;
+      }).join('')+'</tr>';
+  }
+  return `<div class="page" style="max-width:1080px">
+    <h2>${proj?proj.name:'no project'} — environment matrix</h2>
+    <div class="mxwrap"><table class="mx">
+      <thead><tr><th>key</th>${MXENVS.map(e=>`<th>${e.n}${e.prot?'<span class="prot">PROTECTED</span>':''}</th>`).join('')}</tr></thead>
+      <tbody>${rows}</tbody></table></div>
+    <div class="mxnote">condensed — full behaviour is <a href="../../env-matrix/31/" target="_blank">env-matrix/31</a> (frozen reference);
+      shown here so the chrome and the matrix share ONE panel, one shell.</div>
+  </div>`;
+}
+
+function pageSettings(){
+  const proj=visProjects(curOrg()).find(p=>p.id===S.project);
+  const glyphs=['🚀','🔐','🌿','📦','🛰','🧪'];
+  const hues=[195,280,60,140,20,320];
+  const face=S.projGlyph??mono(proj.name);
+  return `<div class="page">
+    <h2>Project settings — ${proj.name}</h2>
+    <p class="sub">Project identity and metadata. Access management is its own surface — one entry point, no second permission editor here.</p>
+    ${jump([['sec-pident','Identity'],['sec-pmeta','Metadata'],['sec-paccess','Access']])}
+    <div class="card" id="sec-pident"><h3>Identity</h3>
+      <div class="iconrow">
+        <span class="bigav" style="background:${hueBg(S.projHue)}">${face}</span>
+        <div style="display:grid;gap:10px">
+          <div class="hues">${hues.map(h=>`<button class="hue${h===S.projHue?' act':''}" style="background:${hueBg(h)}" title="hue ${h}" onclick="S.projHue=${h};update()"></button>`).join('')}</div>
+          <div class="glyphs">
+            <button class="glyph${S.projGlyph===null?' act':''}" title="monogram" onclick="S.projGlyph=null;update()">${mono(proj.name)}</button>
+            ${glyphs.map(g=>`<button class="glyph${S.projGlyph===g?' act':''}" onclick="S.projGlyph='${g}';update()">${g}</button>`).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="note">Monogram + hue is the default; a glyph is opt-in. Iteration 9 of the matrix prototype showed monograms alone collapse at scale — hue carries most of the distinction in the rail.</div>
+    </div>
+    <div class="card" id="sec-pmeta"><h3>Metadata</h3>
+      <div class="fgrid">
+        <div class="field"><label>name</label><input type="text" value="${proj.name}"></div>
+        <div class="field"><label>description</label><input type="text" value="Demo project for the spec prototypes" placeholder="what is this project?"></div>
+      </div>
+    </div>
+    <div class="card" id="sec-paccess"><h3>Access</h3>
+      <div class="rowline"><div class="main"><span class="t">Members & grants</span>
+        <span class="d">${GRANTS.filter(g=>g.scope.includes('demo')||g.scope.startsWith('env:')).length} grant lines on this project</span></div>
+        <span class="grow"></span>
+        <button class="btn" onclick="S.view='members';update()">open members →</button></div>
+      <div class="note">Entry point only — granting, revoking and inspection live on the members surface.</div>
+    </div>
+  </div>`;
+}
+
+function groupedRows(list,canManage){
+  const m=new Map();
+  for(const g of list){
+    const k=g.p+'|'+g.scope;
+    if(!m.has(k))m.set(k,{p:g.p,scope:g.scope,items:[]});
+    m.get(k).items.push(g);
+  }
+  return `<table class="grants"><thead><tr><th>member</th><th>scope</th><th>capabilities</th></tr></thead>
+  <tbody>${[...m.values()].map(row=>{
+    const cls=row.scope.startsWith('org:')?'org':(row.scope==='env:production'?'prot':'');
+    return `<tr><td style="font-weight:600">${row.p}</td>
+      <td><span class="scopechip ${cls}">${scopeLabel(row.scope)}</span></td>
+      <td>${row.items.map(g=>`<span class="capchip" title="via ${g.via}">${g.cap}${canManage?`<button class="rm" title="revoke ${g.cap} on ${scopeLabel(g.scope)}" onclick="revoke(${GRANTS.indexOf(g)})">✕</button>`:''}</span>`).join('')}</td>
+    </tr>`;}).join('')}
+  ${INVITES.map((iv,i)=>`<tr><td style="font-weight:600">${iv.email} <span class="tag blue">invited</span></td>
+    <td><span class="scopechip ${iv.scope.startsWith('org:')?'org':''}">${scopeLabel(iv.scope)}</span></td>
+    <td><span class="capchip pend" title="pending — binds when redeemed">${iv.tpl} template${canManage?`<button class="rm" title="revoke invitation" onclick="revokeInvite(${i})">✕</button>`:''}</span></td>
+  </tr>`).join('')}
+  </tbody></table>`;
+}
+
+function pageMembers(orgLevel){
+  const canManage=isOrgAdmin();
+  const scopeMatch=g=>orgLevel?true:(g.scope.includes(':demo')||g.scope.startsWith('env:'));
+  const list=GRANTS.filter(scopeMatch);
+  /* inspection query */
+  const q=GRANTS.filter(g=>g.cap===S.inspectCap&&coveredBy(S.inspectScope,g.scope));
+  return `<div class="page">
+    <h2>${orgLevel?'Org members & grants — '+curOrg().name:'Members & access — demo'}</h2>
+    <p class="sub">One row per member per scope; each capability chip is still its own revocable grant —
+      roles are templates that expand at grant time, so revoking a chip never drags a bundle with it.</p>
+    ${jump([['sec-minspect','Who can…?'],['sec-mlist','Members']])}
+    <div class="card" id="sec-minspect"><h3>Who can…? — answer by inspection</h3>
+      <div class="inspect">
+        <div class="field"><label>capability</label>
+          <select onchange="S.inspectCap=this.value;update()">${['reveal','read','publish','edit','manage-members','audit-read'].map(c=>`<option${c===S.inspectCap?' selected':''}>${c}</option>`).join('')}</select></div>
+        <div class="field"><label>on scope</label>
+          <select onchange="S.inspectScope=this.value;update()">
+            <option value="env:production"${S.inspectScope==='env:production'?' selected':''}>env · production</option>
+            <option value="env:staging"${S.inspectScope==='env:staging'?' selected':''}>env · staging</option>
+            <option value="project:demo"${S.inspectScope==='project:demo'?' selected':''}>project · demo</option>
+          </select></div>
+      </div>
+      <div class="answerbox"><b>${S.inspectCap}</b> on <b>${scopeLabel(S.inspectScope)}</b> →
+        ${q.length?q.map(g=>`<b>${g.p}</b> <span class="mini">(via ${scopeLabel(g.scope)})</span>`).join(', '):'nobody'}</div>
+    </div>
+    <div class="card" id="sec-mlist"><h3>Members</h3>
+      ${groupedRows(list,canManage)}
+      ${canManage?`<div style="margin-top:14px;display:flex;gap:10px;flex-wrap:wrap">
+        <button class="btn primary" onclick="openGrant()">+ new grant</button>
+        ${orgLevel?`<button class="btn" onclick="openInvite()">✉ invite member</button>`:''}
+      </div>`:
+      `<div class="note">You hold no manage-members here — this list shows only what you're allowed to see.</div>`}
+    </div>
+  </div>`;
+}
+
+function coveredBy(target,grantScope){
+  if(grantScope===target)return true;
+  if(grantScope.startsWith('org:'))return true;                     /* org covers everything below (demo simplification) */
+  if(grantScope==='project:demo'&&target.startsWith('env:'))return true;
+  return false;
+}
+
+/* ---------------- account sections (shared across layout variants) ---------------- */
+function secProfile(){
+  return `<div class="card" id="sec-profile"><h3>Profile</h3>
+    <div class="fgrid">
+      <div class="field"><label>display name</label><input type="text" value="Alex"></div>
+      <div class="field"><label>email — delivery only</label><input type="text" value="alex@example.com"></div>
+    </div>
+    <div class="note">Email is where invitations and expiry warnings land — it is never an identity and never links
+      accounts (#16). Changing it is a plain edit, not a security change.</div>
+  </div>`;
+}
+function secFactors(){
+  return `<div class="card" id="sec-factors"><h3>Sign-in factors</h3>
+    ${FACTORS.passkeys.map(pk=>`<div class="rowline">
+      <div class="main"><span class="t">🔑 ${pk.n}</span><span class="d">passkey · added ${pk.added}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('remove passkey ${pk.n}',()=>alert('removed (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Authenticator app</span>
+      <span class="d">TOTP · single-use per step</span></div><span class="grow"></span>
+      <span class="tag">enrolled</span></div>
+    <div class="rowline"><div class="main"><span class="t">Password</span>
+      <span class="d">signs you in — never authorizes security changes</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('change password',()=>alert('changed (demo)'))">change</button></div>
+    <div class="rowline"><div class="main"><span class="t">Add passkey</span>
+      <span class="d">a new credential never authorizes its own enrolment</span></div><span class="grow"></span>
+      <button class="btn" onclick="stepupThen('add a passkey',()=>{FACTORS.passkeys.push({n:'New device',added:'today'});update()})">+ add</button></div>
+  </div>`;
+}
+function secRecovery(){
+  const canPasskeyOnly=FACTORS.passkeys.length>=2&&FACTORS.codesGenerated;
+  return `<div class="card" id="sec-recovery"><h3>Recovery</h3>
+    <div class="rowline"><div class="main"><span class="t">Recovery codes</span>
+      <span class="d">${FACTORS.codesGenerated?'generated · shown once at creation':'not generated yet'}</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('generate recovery codes',showCodes)">${FACTORS.codesGenerated?'replace':'generate'}</button></div>
+    <div class="rowline"><div class="main"><span class="t">Passkey-only sign-in</span>
+      <span class="d">requires recovery codes + at least 2 passkeys</span></div>
+      <span class="grow"></span>
+      <button class="btn" ${canPasskeyOnly?'':'disabled title="needs recovery codes and ≥2 passkeys"'}
+        onclick="stepupThen('enable passkey-only sign-in',()=>{FACTORS.passkeyOnly=true;update()})">
+        ${FACTORS.passkeyOnly?'enabled':'enable'}</button></div>
+    ${canPasskeyOnly?'':`<div class="note">Locked until preconditions are met: ${FACTORS.passkeys.length}/2 passkeys · recovery codes ${FACTORS.codesGenerated?'✓':'✗'}. Codes restore <i>access</i>; they never satisfy a disclosure reauth.</div>`}
+  </div>`;
+}
+function secSessions(){
+  return `<div class="card" id="sec-sessions"><h3>Active sessions</h3>
+    ${SESSIONS.map(s=>`<div class="rowline">
+      <div class="main"><span class="t">${s.label} ${s.current?'<span class="tag acc">this session</span>':''}</span>
+      <span class="d">${s.detail} · last active ${s.last}</span></div>
+      <span class="grow"></span>
+      <span class="tag ${s.type==='cli'?'blue mono':'mono'}">${s.type==='cli'?'CLI artifact':'browser'}</span>
+      ${s.current?'':`<button class="xbtn" title="revoke session" onclick="alert('revoked (demo)')">✕</button>`}
+    </div>`).join('')}
+    <div class="note">Browser sessions and CLI sessions are distinct artifact types with their own lifetimes —
+      revoking one never touches the other kind.</div>
+  </div>`;
+}
+function secIdentities(){
+  return `<div class="card" id="sec-identities"><h3>Linked identities</h3>
+    ${IDENTITIES.map(id=>`<div class="rowline">
+      <div class="main"><span class="t">${id.issuer}</span>
+      <span class="d">(issuer, subject) = (${id.issuer}, ${id.subject}) · linked ${id.linked}</span></div>
+      <span class="grow"></span><button class="xbtn" onclick="stepupThen('unlink ${id.issuer}',()=>alert('unlinked (demo)'))">✕</button></div>`).join('')}
+    <div class="rowline"><div class="main"><span class="t">Link another identity</span>
+      <span class="d">explicit binding — an unknown identity at sign-in is never a login, email never links</span></div>
+      <span class="grow"></span>
+      <button class="btn" onclick="stepupThen('link a new identity',()=>alert('provider round-trip with binding purpose = link (demo)'))">link…</button></div>
+  </div>`;
+}
+function secPrefs(){
+  return `<div class="card" id="sec-prefs"><h3>Preferences</h3>
+    <div class="fgrid">
+      <div class="field"><label>theme</label>
+        <select onchange="S.theme=this.value==='auto'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):this.value;document.body.dataset.theme=S.theme">
+          <option>auto</option><option${S.theme==='dark'?' selected':''}>dark</option><option${S.theme==='light'?' selected':''}>light</option></select></div>
+    </div>
+    <div class="rowline" style="margin-top:10px"><div class="main"><span class="t">Credential-expiry warnings</span>
+      <span class="d">in-product, always on (#17) — email is an added transport, not the mechanism</span></div>
+      <span class="grow"></span><span class="tag">in-app</span>
+      <label style="display:flex;align-items:center;gap:7px;font-size:12.5px;cursor:pointer;min-height:36px"><input type="checkbox" checked> also email</label></div>
+    <div class="rowline"><div class="main"><span class="t">Security alerts</span>
+      <span class="d">new session, factor change, identity link — always notified, not disableable</span></div>
+      <span class="grow"></span><span class="tag">always</span></div>
+  </div>`;
+}
+
+const ACCT_SECTIONS=[
+  {id:'profile',t:'Profile',render:secProfile,sum:()=>'Alex · alex@example.com'},
+  {id:'factors',t:'Sign-in factors',render:secFactors,sum:()=>`${FACTORS.passkeys.length} passkeys · TOTP · password`},
+  {id:'recovery',t:'Recovery',render:secRecovery,sum:()=>`codes ${FACTORS.codesGenerated?'✓':'✗'} · passkey-only ${FACTORS.passkeyOnly?'on':'off'}`},
+  {id:'sessions',t:'Sessions',render:secSessions,sum:()=>`${SESSIONS.length} active (${SESSIONS.filter(s=>s.type==='cli').length} CLI)`},
+  {id:'identities',t:'Identities',render:secIdentities,sum:()=>`${IDENTITIES.length} linked`},
+  {id:'prefs',t:'Preferences',render:secPrefs,sum:()=>`${S.theme} · expiry warnings in-app`},
+];
+/* account layout decided: c — one scroll + sticky jump index (iteration 7) */
+const jump=list=>`<div class="secjump">${list.map(([id,t])=>`<button class="atab"
+  onclick="document.getElementById('${id}')?.scrollIntoView({behavior:'smooth',block:'start'})">${t}</button>`).join('')}</div>`;
+
+function pageAccount(){
+  return `<div class="page">
+    <h2>Account & security</h2>
+    <p class="sub">Security changes ask for a possession factor first — the blue "confirm it's you" step-up,
+      deliberately unlike the teal reveal ceremony.</p>
+    ${jump(ACCT_SECTIONS.map(x=>['sec-'+x.id,x.t]))}
+    ${ACCT_SECTIONS.map(x=>x.render()).join('')}</div>`;
+}
+
+function pageInstance(){
+  const cli=v=>`<code class="cliv" title="same operation on the CLI">$ ${v}</code>`;
+  return `<div class="page">
+    <h2>Instance administration</h2>
+    <p class="sub">Full CLI ↔ UI parity (decided round 3): hikyo may run locally, on a VPS, in k8s or docker while
+      managing orgs and projects hosted elsewhere — the CLI is not always the convenient surface. Every operation here
+      is the same grant-evaluated network operation the CLI verb calls; nothing is UI-special (#25).</p>
+    ${jump([['sec-iorgs','Organizations'],['sec-iconf','Settings'],['sec-icrypto','Keys & crypto'],['sec-iconn','Instances']])}
+    <div class="card" id="sec-iorgs"><h3>Organizations</h3>
+      ${ORGS.map(o=>`<div class="rowline">
+        <div class="main"><span class="t">${o.name}</span><span class="d">${o.projects.length} projects</span></div>
+        <span class="grow"></span><span class="tag mono">active</span></div>`).join('')}
+      <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn primary" onclick="alert('org created (demo)')">+ create organization</button>
+        ${cli('hikyo org create')}</div>
+    </div>
+
+    <div class="card" id="sec-iconf"><h3>Instance settings <span class="mini" style="text-transform:none;letter-spacing:0">· instance-config</span></h3>
+      <div class="rowline"><div class="main"><span class="t">Server URL / RP ID</span><span class="d">immutable after install — shown, never editable (any surface)</span></div><span class="grow"></span><code class="val">hikyo.example.com</code></div>
+      <div class="rowline"><div class="main"><span class="t">Audit retention</span><span class="d">security / access classes (audit ADR)</span></div><span class="grow"></span>
+        <code class="val">security: unlimited</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="rowline"><div class="main"><span class="t">Machine-credential ceiling</span><span class="d">clamps every org value</span></div><span class="grow"></span>
+        <code class="val">90d</code><button class="btn" onclick="alert('edit (demo)')">edit</button></div>
+      <div class="note">Same operations as ${'`'}hikyo instance-config${'`'} — one permission language, one audit trail.</div>
+    </div>
+
+    <div class="card" id="sec-icrypto"><h3>Keys & crypto</h3>
+      <div class="rowline"><div class="main"><span class="t">Master key</span><span class="d">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-master-key')}<button class="btn" onclick="alert('rotation started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Change-token key</span><span class="d">warned operation: every client cursor invalidates, next fetch is full — no restart wave</span></div>
+        <span class="grow"></span>${cli('hikyo rotate-token-key')}<button class="btn" onclick="alert('warned + started (demo)')">rotate</button></div>
+      <div class="rowline"><div class="main"><span class="t">Re-encryption</span><span class="d">background, resumable, per-row</span></div>
+        <span class="grow"></span><span class="tag">idle</span></div>
+      <div class="note">Root-key rotation, ${'`'}init${'`'}, ${'`'}migrate${'`'}, restore reconciliation and break-glass are
+        <b>local host authority</b> (SystemProof, #23/#25) — deliberately absent from every network surface, UI and API alike.
+        That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</div>
+    </div>
+
+    <div class="card qcard" id="sec-iconn"><h3>Connected instances — exploration</h3>
+      <div class="rowline"><div class="main"><span class="t">this instance</span>
+        <span class="d">hikyo.example.com · v1.0</span></div><span class="grow"></span><span class="tag acc">main</span></div>
+      <div class="rowline"><div class="main"><span class="t">example-cluster</span>
+        <span class="d">hikyo.k3s.internal · v1.0 · reachable · 1 org, 4 projects</span></div>
+        <span class="grow"></span><span class="tag mono">connected</span></div>
+      <div class="rowline"><div class="main"><span class="t">hetzner-vps</span>
+        <span class="d">ew.example.dev · v0.9 · unreachable 2h — last known state shown</span></div>
+        <span class="grow"></span><span class="tag bad">unreachable</span></div>
+      <div style="margin-top:12px"><button class="btn" onclick="alert('exploration only — see the multi-instance wayfinder ticket')">+ connect instance</button></div>
+      <div class="note" style="margin-top:10px"><b>Open question, own wayfinder ticket</b> — Portainer-style: one MAIN instance
+        connects to and manages others. Undecided: what "manage" means (proxy the API? sync orgs? just deep-link?),
+        the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model
+        consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</div>
+    </div>
+  </div>`;
+}
+
+/* ============================ modals ============================ */
+let afterStepup=null;
+function stepupThen(what,fn){afterStepup=fn;$('stepup-what').textContent=what;
+  document.body.classList.add('modal');$('stepup').classList.add('open');}
+function stepupOk(how){closeModals();const fn=afterStepup;afterStepup=null;fn&&fn();}
+function closeModals(){document.body.classList.remove('modal');
+  for(const id of['stepup','codesmodal','blastmodal','grantmodal','invitemodal'])$(id).classList.remove('open');}
+
+function openInvite(){document.body.classList.add('modal');$('invitemodal').classList.add('open');}
+function submitInvite(){
+  const email=$('iv-email').value.trim();
+  if(!email){$('iv-email').style.borderColor='var(--bad)';return;}
+  INVITES.push({email,tpl:$('iv-tpl').value,scope:$('iv-scope').value});
+  closeModals();update();
+}
+function revokeInvite(i){INVITES.splice(i,1);update();}
+
+function showCodes(){
+  const grid=$('codesgrid');grid.innerHTML='';
+  for(let i=0;i<10;i++){const c=document.createElement('code');
+    c.textContent=Math.random().toString(36).slice(2,7)+'-'+Math.random().toString(36).slice(2,7);
+    grid.appendChild(c);}
+  $('codesack').checked=false;
+  document.body.classList.add('modal');$('codesmodal').classList.add('open');
+}
+function closeCodes(){
+  if(!$('codesack').checked){$('codesack').closest('label').style.color='var(--bad)';return;}
+  FACTORS.codesGenerated=true;closeModals();update();
+}
+function copyCodes(btn){navigator.clipboard?.writeText([...$('codesgrid').children].map(c=>c.textContent).join('\n'));
+  btn.textContent='copied ✓';setTimeout(()=>btn.textContent='copy all',1200);}
+
+function openGrant(){
+  [...$('g-caps').querySelectorAll('input')].forEach(i=>i.checked=false);
+  $('g-caps').style.borderColor='';
+  document.body.classList.add('modal');$('grantmodal').classList.add('open');
+}
+function submitGrant(){
+  const caps=[...$('g-caps').querySelectorAll('input:checked')].map(i=>i.value);
+  if(!caps.length){$('g-caps').style.borderColor='var(--bad)';return;}
+  const p=$('g-principal').value,scope=$('g-scope').value;
+  const gs=caps.map(cap=>({p,cap,scope,via:'direct'}));
+  closeModals();
+  if(scope.startsWith('org:')){
+    S.pendingGrant=gs;
+    const projs=visProjects(curOrg());
+    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
+      +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
+    document.body.classList.add('modal');$('blastmodal').classList.add('open');
+    return;
+  }
+  GRANTS.push(...gs);update();
+}
+function confirmGrant(){GRANTS.push(...S.pendingGrant);S.pendingGrant=null;closeModals();update();}
+function revoke(i){GRANTS.splice(i,1);update();}
+
+/* ============================ plumbing ============================ */
+function toggleSide(force){
+  const open=force!==undefined?force:!$('side').classList.contains('open');
+  $('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+addEventListener('keydown',e=>{
+  if(e.key==='Escape'){closeModals();toggleSide(false);}
+});
+$('persona').onchange=e=>{S.persona=e.target.value;update();};
+$('themebtn').onclick=()=>{S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;};
+
+function update(){
+  ensureValidContext();
+  renderRail();renderSide();renderCrumb();
+  const views={matrix:pageMatrix,settings:pageSettings,members:()=>pageMembers(false),
+    orgmembers:()=>pageMembers(true),account:pageAccount,instance:pageInstance};
+  $('content').innerHTML=(views[S.view]||pageMatrix)();
+}
+
+/* init */
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light';}
+update();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/app-chrome/9/index.html
+++ b/docs/site/public/prototypes/app-chrome/9/index.html
@@ -1035,7 +1035,11 @@ function submitGrant(){
   if(scope.startsWith('org:')){
     S.pendingGrant=gs;
     const projs=visProjects(curOrg());
-    $('blastsub').innerHTML=`<b>${p}</b> gets <b class="cap">${caps.join('</b>, <b class="cap">')}</b> — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on <b>every project and environment in ${curOrg().name}</b>, current and future:`;
+    const summary=$('blastsub'), principal=document.createElement('b'), capabilityList=document.createDocumentFragment(), scope=document.createElement('b');
+    principal.textContent=p;
+    caps.forEach((cap,index)=>{if(index) capabilityList.append(', ');const capability=document.createElement('b');capability.className='cap';capability.textContent=cap;capabilityList.append(capability)});
+    scope.textContent=`every project and environment in ${curOrg().name}`;
+    summary.replaceChildren(principal,' gets ',capabilityList,` — ${caps.length>1?caps.length+' separate grant lines, each':'one grant line,'} on `,scope,', current and future:');
     $('blastlist').innerHTML=projs.map(pr=>`<div class="bl"><span class="p">${pr.name}</span><span>development · staging · production${pr.id==='demo'?' (protected)':''} · preview</span></div>`).join('')
       +'<div class="bl"><span class="p">+ any project created later</span><span>inherits automatically</span></div>';
     document.body.classList.add('modal');$('blastmodal').classList.add('open');

--- a/docs/site/public/prototypes/app-chrome/index.html
+++ b/docs/site/public/prototypes/app-chrome/index.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>App chrome — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,64px) clamp(18px,6vw,64px)}
+  .back{font-size:12.5px;color:var(--tx-faint);text-decoration:none}
+  .back:hover{color:var(--accent)}
+  h1{font-size:clamp(22px,4vw,30px);font-weight:700;letter-spacing:-0.01em;margin:10px 0 4px}
+  h1 span{color:var(--accent)}
+  .q{font-size:13.5px;color:var(--tx-dim);max-width:60ch;line-height:1.6;margin-bottom:32px}
+  ul{list-style:none;display:grid;gap:10px;max-width:760px}
+  li a{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:10px;background:var(--bg2);transition:border-color .15s}
+  li a:hover{border-color:var(--accent)}
+  li a:hover .name{color:var(--accent)}
+  .num{font-family:var(--mono);font-size:13px;color:var(--tx-faint);min-width:22px}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+  footer a{color:var(--tx-dim)}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>app chrome <span>/</span> iterations</h1>
+  <p class="q">How do the surfaces around the matrix hang together — org switching, account &amp; security, project settings, membership &amp; grants, instance administration? Wayfinder ticket #29.</p>
+  <ul>
+    <li><a href="18/">
+      <span class="num">18</span><span class="name">Sidebar hierarchy — e combined</span><span class="latest">LOCKED</span>
+      <span class="desc">Alex likes b and d both: variant e combines them — 30px breathing room between sections plus sub-items on a hairline left rule (accent on active). Default view; a–d kept for side-by-side comparison. LOCKED as the reference sidebar treatment (amends it-15); retention UI (it-16) locked with it.</span>
+    </a></li>
+    <li><a href="17/">
+      <span class="num">17</span><span class="name">Sidebar hierarchy variants</span>
+      <span class="desc">Alex's nitpick: section labels and sub-items blur at the small indent. Four CSS-only treatments switchable via ?side= + floating bar (arrows cycle): a baseline · b breathing room (space between sections) · c mild separator (dull 1px half-width centered bar, Alex's sketch) · d structural indent (items on a hairline left rule, accent on the active row).</span>
+    </a></li>
+    <li><a href="16/">
+      <span class="num">16</span><span class="name">Revision retention in settings</span>
+      <span class="desc">Wayfinder #30 spillover: retention belongs in settings, not the history drawer. Project settings › Policy gains "Revision retention" (inherit org default / custom ≤ org, set-time refusal, capped-by-org state); Org settings gains a Policy card with the org default + per-project state list. Semantics from revision-history it-5; changes audited.</span>
+    </a></li>
+    <li><a href="15/">
+      <span class="num">15</span><span class="name">Project policy + danger zone</span>
+      <span class="desc">The project-settings capability's real contents (#15) land: per-env protected toggles (live matrix header update), reveal reauth window, definitions_source db|git — plus a danger zone (slug rename, typed-name project deletion) and a zero-project empty state. Policy and danger gated off for non-holders.</span>
+    </a></li>
+    <li><a href="14/">
+      <span class="num">14</span><span class="name">Org settings — identity, members entry, danger zone</span>
+      <span class="desc">Confirmed shape brief: panel entry for org admins only; jump index over Identity (hue/image propagating to the rail circles), Members entry point, and a danger zone (slug rename warning, typed-name org deletion). Deleting your last org lands on a new zero-org empty state instead of crashing. Toast hidden-attribute bug fixed in 13+14.</span>
+    </a></li>
+    <li><a href="13/">
+      <span class="num">13</span><span class="name">Critique fixes — contrast, safe defaults, undo</span>
+      <span class="desc">/impeccable critique (25/40, not-slop verdict) implemented: tx-faint to AA+ contrast, text+aria validation errors, grant scope narrow→wide with staging default, blast warning "back, change scope" preserving composition, undo toasts on revoke/grant/invite, modal h3s, sticky mobile modal footer, em-dash sweep.</span>
+    </a></li>
+    <li><a href="12/">
+      <span class="num">12</span><span class="name">Grant explanations behind (?)</span>
+      <span class="desc">Single-line capability rows with a (?) per row: tap toggles the permission-ADR explanation inline (touch-friendly), title gives desktop hover. Member-table chips carry the same text.</span>
+    </a></li>
+    <li><a href="11/">
+      <span class="num">11</span><span class="name">Grant modal — capability explanations</span>
+      <span class="desc">Always-visible explanation sub-lines under every capability (superseded by 12's (?) toggle).</span>
+    </a></li>
+    <li><a href="10/">
+      <span class="num">10</span><span class="name">Project identity — custom hue + image upload</span>
+      <span class="desc">Custom-hue slider (live preview, pinned to the brand oklch formula so any hue stays on-palette) and image upload (shown in header avatar and rail tile, removable) alongside monogram, preset hues and glyphs. Priority: image &gt; glyph &gt; monogram.</span>
+    </a></li>
+    <li><a href="9/">
+      <span class="num">9</span><span class="name">Jump index on every settings surface</span>
+      <span class="desc">The sticky jump index (decided for Account &amp; security) generalized via one shared helper: project settings (Identity · Metadata · Access), members (Who can…? · Members), instance administration (Organizations · Settings · Keys &amp; crypto · Instances).</span>
+    </a></li>
+    <li><a href="8/">
+      <span class="num">8</span><span class="name">Shape role-scale baked in · Codex placement audit</span>
+      <span class="desc">Shape decided: c, the role scale — containers 6px / controls 4px / badges 3px, the 999px pill reserved for org circles, count badges and matrix cell states (DESIGN.md amended). Codex audit findings on pill/button/interaction placement implemented.</span>
+    </a></li>
+    <li><a href="7/">
+      <span class="num">7</span><span class="name">Account layout c locked · four shape treatments</span>
+      <span class="desc">Account layout decided: c, the sticky jump index. New exploration app-wide via <code>?shape=</code>: <b>a</b> baseline (soft radii + pills) · <b>b</b> squared — everything 2px, pills become rectangles · <b>c</b> role scale — containers 6px / controls 4px / badges 3px, 999px reserved for org circles + count badges + matrix cell states · <b>d</b> flat — de-carded hairline-ruled sections, tags as colored mono text, radius only on overlays.</span>
+    </a></li>
+    <li><a href="6/">
+      <span class="num">6</span><span class="name">Account & security — five layout approaches</span>
+      <span class="desc">Added Profile (email = delivery only) and Preferences (theme, expiry-warning transports, always-on security alerts). Five structural layouts for the account surface via bottom bar / ← → / <code>?account=</code>: <b>a</b> tabs · <b>b</b> side-panel nav · <b>c</b> sticky jump index · <b>d</b> accordion with live summary lines · <b>e</b> overview tiles with drill-in.</span>
+    </a></li>
+    <li><a href="5/">
+      <span class="num">5</span><span class="name">Grant modal — capability checklist</span>
+      <span class="desc">New-grant modal takes a capability checklist instead of a single select: any number at once, each checked capability landing as its own revocable grant line (what role templates do with a preset checklist); empty selection refused; the org-scope blast warning enumerates the checked capabilities as separate lines.</span>
+    </a></li>
+    <li><a href="4/">
+      <span class="num">4</span><span class="name">Verdicts applied — rail owns orgs; instance surface with CLI↔UI parity</span>
+      <span class="desc">Org placement decided: variant A (rail monograms above projects, drawer org section on mobile) — switcher and variants b/c removed. Instance administration decided into the v1 UI with full CLI↔UI parity (every row shows its CLI-verb twin; the SystemProof local set stays UI-less by locked ADR). Plus a "Connected instances" exploration card (Portainer-style main instance) feeding its own wayfinder ticket.</span>
+    </a></li>
+    <li><a href="3/">
+      <span class="num">3</span><span class="name">Org variants differentiated on mobile</span>
+      <span class="desc">a = drawer owns orgs · b = compact crumb + full-width sheet with scrim · c = header monogram opens full-screen overlay; single-row mobile header.</span>
+    </a></li>
+    <li><a href="2/">
+      <span class="num">2</span><span class="name">Merged sidebar, mobile org switching, grouped members, invites</span>
+      <span class="desc">Round-1 feedback: the side panel is now the env-matrix-31 panel (condensed real matrix + group/problem rows) so chrome and matrix share ONE sidebar; the mobile drawer carries an organizations section in every variant (a/b/c converge on phones) and variant b's popover becomes a full-width sheet; members grouped one row per (member, scope) with individually revocable capability chips; org-level invite flow (binds to capability set, email is delivery only, pending invites revocable).</span>
+    </a></li>
+    <li><a href="1/">
+      <span class="num">1</span><span class="name">Baseline — three org-placement shapes + all five surfaces</span>
+      <span class="desc">Org placement via bottom bar / ← → / <code>?variant=</code>: <b>a</b> rail owns orgs (monograms above projects) · <b>b</b> crumb owns org (breadcrumb popover) · <b>c</b> Slack-style org overlay. Persona simulator shows "unauthorized ≡ nonexistent": single-org users get zero org chrome, sam (external) sees one project. Surfaces: account (sessions browser vs CLI, factors, display-once recovery codes, passkey-only preconditions, identity linking), members &amp; grants (per-line revoke, who-can-do-what inspection, org-scope blast-radius warning), project settings (hue + optional glyph over monogram), instance admin (option A/B question posed in-UI). Blue "confirm it's you" step-up deliberately distinct from the teal reveal ceremony.</span>
+    </a></li>
+  </ul>
+  <footer>every change is a new numbered iteration — published ones never mutate · <a href="../env-matrix/31/">env-matrix reference (frozen)</a></footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/1/index.html
+++ b/docs/site/public/prototypes/env-matrix/1/index.html
@@ -1,0 +1,741 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20.
+  Question: does a side-by-side environment matrix communicate inheritance,
+  overrides, gaps, validation, and drift legibly?
+  Three variants on one page, switchable via ?variant=a|b|c or the floating bar (← / →).
+
+  Design context (derived from positioning ADR #3, not inferred from code):
+  audience = self-hosting developers first, platform engineers second;
+  job = see the whole config surface across environments at a glance, spot
+  gaps/violations/drift, edit safely; tone = open-source craft, deliberately
+  NOT a generic cloud console.
+
+  Domain rules honoured (inheritance ADR #10, schema ADR #12, revision ADR #11):
+  layers project-defaults → base chain → environment, nearest-ancestor-wins;
+  value states set | absent | masked; secret/config classification on the key;
+  secrets masked by default; production carries the protected-environment flag.
+  Deep reveal/reauth UX is ticket #21 — only a placeholder gesture here.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{height:100%}
+  body{-webkit-font-smoothing:antialiased}
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer}
+  input,select{font:inherit}
+  #root{min-height:100%}
+
+  /* ============ floating switcher (not part of the design) ============ */
+  #switcher{
+    position:fixed;bottom:18px;left:50%;transform:translateX(-50%);z-index:99;
+    display:flex;align-items:center;gap:2px;
+    background:oklch(0.2 0.02 280);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:6px 10px;
+    box-shadow:0 6px 24px oklch(0 0 0/.35);
+    font:13px/1 system-ui,sans-serif;letter-spacing:.02em;
+  }
+  #switcher button{padding:4px 10px;border-radius:999px;font-size:15px}
+  #switcher button:hover{background:oklch(0.32 0.03 280)}
+  #switcher .lbl{padding:0 10px;min-width:150px;text-align:center}
+  #switcher .lbl b{font-weight:600}
+
+  /* =====================================================================
+     VARIANT A — "Ledger". Editorial print. Paper, ink, ruled hairlines,
+     serif headings, footnote provenance. Dense spreadsheet.
+  ===================================================================== */
+  .vA{
+    --paper:oklch(0.962 0.014 85);
+    --ink:oklch(0.26 0.022 60);
+    --ink-soft:oklch(0.26 0.022 60/.55);
+    --ink-faint:oklch(0.26 0.022 60/.34);
+    --rule:oklch(0.26 0.022 60/.16);
+    --oxblood:oklch(0.44 0.13 25);
+    --pencil:oklch(0.5 0.1 250);
+    --amber-ink:oklch(0.55 0.12 70);
+    background:var(--paper);color:var(--ink);
+    font-family:Georgia,serif;
+    padding:0 0 120px;
+  }
+  .vA .masthead{
+    padding:clamp(20px,4vw,44px) clamp(16px,4vw,56px) 10px;
+    display:flex;align-items:baseline;justify-content:space-between;gap:24px;flex-wrap:wrap;
+    border-bottom:2px solid var(--ink);
+  }
+  .vA .masthead h1{
+    font-size:clamp(26px,3.4vw,40px);font-weight:560;letter-spacing:-0.015em;
+    font-variation-settings:"opsz" 100;
+  }
+  .vA .masthead h1 em{font-style:italic;font-weight:400;color:var(--ink-soft)}
+  .vA .masthead .tally{
+    font-size:14px;font-style:italic;color:var(--ink-soft);text-align:right;
+  }
+  .vA .masthead .tally b{font-style:normal;font-weight:600;color:var(--ink)}
+  .vA .masthead .tally .bad{color:var(--oxblood)}
+  .vA .footnotebar{
+    position:sticky;top:0;z-index:5;
+    background:var(--paper);
+    border-bottom:1px solid var(--rule);
+    padding:8px clamp(16px,4vw,56px);
+    font-size:13px;font-style:italic;color:var(--ink-soft);
+    min-height:34px;display:flex;align-items:center;gap:8px;
+  }
+  .vA .footnotebar .fchain{font-style:normal;font-family:var(--mono);font-size:11.5px}
+  .vA .footnotebar .win{color:var(--oxblood);font-weight:500}
+  .vA table{border-collapse:collapse;width:100%;font-size:13px}
+  .vA thead th{
+    position:sticky;top:34px;z-index:4;background:var(--paper);
+    text-align:left;font-weight:600;font-size:12px;letter-spacing:.14em;text-transform:uppercase;
+    padding:12px 14px 8px;border-bottom:1.5px solid var(--ink);
+  }
+  .vA thead th .base{display:block;font-weight:400;text-transform:none;letter-spacing:0;
+    font-style:italic;font-size:11.5px;color:var(--ink-faint)}
+  .vA thead th.prot .flag{color:var(--oxblood);font-style:normal}
+  .vA .keycol{width:270px;padding-left:clamp(16px,4vw,56px)!important}
+  .vA tbody tr{border-bottom:1px solid var(--rule)}
+  .vA tr.folder td{
+    padding:26px 14px 6px;padding-left:clamp(16px,4vw,56px);
+    font-size:17px;font-weight:560;font-style:italic;letter-spacing:.01em;
+    border-bottom:1px solid var(--ink);
+  }
+  .vA tr.folder td .cnt{font-size:12px;font-style:normal;color:var(--ink-faint);margin-left:8px}
+  .vA td{padding:7px 14px;vertical-align:baseline}
+  .vA td.key{padding-left:clamp(16px,4vw,56px);font-family:var(--mono);font-size:12px;white-space:nowrap}
+  .vA td.key .sec{color:var(--oxblood);margin-right:6px;font-family:Georgia,serif;font-weight:700}
+  .vA td.key .typ{color:var(--ink-faint);font-size:10.5px;margin-left:8px;font-style:italic;font-family:Georgia,serif}
+  .vA td.key .diffmark{color:var(--pencil);margin-left:6px;font-weight:600}
+  .vA td.cell{font-family:var(--mono);font-size:12px;cursor:default;position:relative}
+  .vA .cell .v{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px;display:inline-block;vertical-align:bottom}
+  .vA .cell.own .v{font-weight:600}
+  .vA .cell.inh .v{color:var(--ink-soft)}
+  .vA .cell .orig{
+    font-family:Georgia,serif;font-style:italic;font-size:10.5px;color:var(--ink-faint);
+    margin-left:6px;vertical-align:super}
+  .vA .cell.absent .v{color:var(--ink-faint)}
+  .vA .cell.masked .v{color:var(--ink-soft);font-style:italic;font-family:Georgia,serif}
+  .vA .cell.missing .v{color:var(--oxblood);font-style:italic;font-family:Georgia,serif;font-weight:500}
+  .vA .cell.invalid .v{
+    text-decoration:underline wavy var(--oxblood) 1px;text-underline-offset:3px}
+  .vA .cell .delta{color:var(--pencil);font-weight:700;margin-left:5px;font-size:11px}
+  .vA .cell .note{color:var(--oxblood);font-weight:700;margin-left:4px;font-family:Georgia,serif}
+  .vA .cell .sdot{letter-spacing:2px}
+  .vA tr.adder td{padding:8px 14px 14px;padding-left:clamp(16px,4vw,56px)}
+  .vA tr.adder button.ghost{
+    font-style:italic;color:var(--ink-faint);font-size:13px}
+  .vA tr.adder button.ghost:hover{color:var(--oxblood)}
+  .vA .addform{display:flex;gap:8px;align-items:center;font-family:var(--mono);font-size:12px}
+  .vA .addform input,.vA .addform select{
+    border:none;border-bottom:1px solid var(--ink-soft);background:none;padding:3px 2px;
+    font-family:var(--mono);font-size:12px;color:var(--ink)}
+  .vA .addform button.go{border:1px solid var(--ink);padding:3px 12px;font-family:Georgia,serif;font-style:italic}
+  .vA .addform button.go:hover{background:var(--ink);color:var(--paper)}
+  .vA .legend{
+    margin:34px clamp(16px,4vw,56px) 0;padding-top:12px;border-top:2px solid var(--ink);
+    font-size:12.5px;font-style:italic;color:var(--ink-soft);
+    display:flex;flex-wrap:wrap;gap:6px 26px}
+  .vA .legend .m{font-family:var(--mono);font-style:normal;font-size:11.5px;color:var(--ink)}
+
+  /* =====================================================================
+     VARIANT B — "Panel". Industrial dark master–detail. Key list with a
+     per-environment state strip; provenance chain in the detail panel.
+  ===================================================================== */
+  .vB{
+    --bg:oklch(0.21 0.012 260);
+    --bg2:oklch(0.245 0.014 260);
+    --bg3:oklch(0.29 0.016 260);
+    --line:oklch(0.36 0.02 260);
+    --tx:oklch(0.91 0.012 85);
+    --tx-dim:oklch(0.91 0.012 85/.55);
+    --tx-faint:oklch(0.91 0.012 85/.32);
+    --amber:oklch(0.8 0.13 75);
+    --red:oklch(0.62 0.17 25);
+    --ok:oklch(0.72 0.09 150);
+    --inh:oklch(0.6 0.02 260);
+    background:var(--bg);color:var(--tx);
+    font-family:system-ui,sans-serif;
+    display:grid;grid-template-rows:auto 1fr;height:100vh;overflow:hidden;
+  }
+  .vB header{
+    display:flex;align-items:center;gap:18px;padding:14px 22px;
+    border-bottom:1px solid var(--line);flex-wrap:wrap;
+  }
+  .vB header h1{font-size:17px;font-weight:600;letter-spacing:.01em}
+  .vB header h1 span{color:var(--amber)}
+  .vB header .env-tags{display:flex;gap:6px;font-size:11.5px;color:var(--tx-dim)}
+  .vB header .env-tags i{font-style:normal;border:1px solid var(--line);padding:2px 8px;border-radius:3px}
+  .vB header .env-tags i.prot{border-color:var(--amber);color:var(--amber)}
+  .vB header .grow{flex:1}
+  .vB header input.search{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:6px 12px;border-radius:3px;font-size:13px;width:220px}
+  .vB header label.prob{font-size:12.5px;color:var(--tx-dim);display:flex;align-items:center;gap:6px;cursor:pointer}
+  .vB header button.addkey{
+    border:1px solid var(--amber);color:var(--amber);padding:6px 14px;border-radius:3px;
+    font-size:12.5px;font-weight:600;letter-spacing:.04em}
+  .vB header button.addkey:hover{background:var(--amber);color:var(--bg)}
+  .vB .cols{display:grid;grid-template-columns:minmax(380px,46%) 1fr;overflow:hidden}
+  .vB .list{overflow-y:auto;border-right:1px solid var(--line)}
+  .vB .list .flabel{
+    position:sticky;top:0;background:var(--bg);z-index:2;
+    padding:16px 22px 6px;font-size:11px;letter-spacing:.22em;text-transform:uppercase;
+    color:var(--tx-faint);border-bottom:1px solid var(--line)}
+  .vB .krow{
+    display:flex;align-items:center;gap:12px;width:100%;text-align:left;
+    padding:8px 22px;border-bottom:1px solid oklch(0.36 0.02 260/.4)}
+  .vB .krow:hover{background:var(--bg2)}
+  .vB .krow.sel{background:var(--bg3)}
+  .vB .krow .name{font-family:var(--mono);font-size:12px;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .vB .krow .name .sec{color:var(--amber);margin-right:6px}
+  .vB .krow .name .draft{color:var(--tx-faint);font-size:10px;margin-left:6px;letter-spacing:.1em}
+  .vB .krow .strip{display:flex;gap:3px}
+  .vB .strip i{width:22px;height:14px;border-radius:2px;display:block}
+  .vB .strip i.own{background:var(--ok)}
+  .vB .strip i.inh{background:var(--inh)}
+  .vB .strip i.absent{background:var(--bg3)}
+  .vB .strip i.masked{background:repeating-linear-gradient(45deg,var(--bg3) 0 3px,var(--inh) 3px 5px)}
+  .vB .strip i.missing{background:var(--red)}
+  .vB .strip i.invalid{background:var(--red);outline:2px solid var(--red);outline-offset:1px}
+  .vB .strip i.chg{box-shadow:inset 0 -3px 0 var(--amber)}
+  .vB .krow .diffm{font-size:11px;color:var(--amber);width:14px}
+  .vB .detail{overflow-y:auto;padding:22px 26px 140px}
+  .vB .detail .dhead{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;margin-bottom:4px}
+  .vB .detail .dhead h2{font-family:var(--mono);font-size:16px;font-weight:500}
+  .vB .detail .dhead .meta{font-size:12px;color:var(--tx-dim)}
+  .vB .detail .dhead .meta b{color:var(--amber);font-weight:600}
+  .vB .detail .desc{font-size:12.5px;color:var(--tx-faint);margin-bottom:18px}
+  .vB .envsec{border-top:1px solid var(--line);padding:14px 0}
+  .vB .envsec .erow{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+  .vB .envsec .ename{font-size:13px;font-weight:600;width:110px}
+  .vB .envsec .ename .p{color:var(--amber);font-size:10px;display:block;font-weight:500;letter-spacing:.08em}
+  .vB .envsec .val{font-family:var(--mono);font-size:13px;flex:1;min-width:200px}
+  .vB .envsec .val.dim{color:var(--tx-dim)}
+  .vB .envsec .val.bad{color:var(--red)}
+  .vB .envsec .val.maskedtxt{color:var(--tx-dim);font-style:italic;font-family:system-ui,sans-serif}
+  .vB .envsec .stx{font-size:11px;letter-spacing:.06em;color:var(--tx-faint);width:150px;text-align:right}
+  .vB .envsec .stx.chg{color:var(--amber)}
+  .vB .chain{
+    display:flex;align-items:center;gap:0;margin-top:9px;font-size:11px;color:var(--tx-faint);
+    font-family:var(--mono)}
+  .vB .chain .hop{padding:3px 9px;border:1px solid var(--line);border-radius:2px}
+  .vB .chain .hop.win{border-color:var(--ok);color:var(--ok)}
+  .vB .chain .hop.stop{border-color:var(--tx-dim);color:var(--tx-dim);text-decoration:line-through}
+  .vB .chain .arr{padding:0 7px;color:var(--tx-faint)}
+  .vB .chain .verdict{margin-left:12px;font-family:system-ui,sans-serif}
+  .vB .envsec .err{margin-top:8px;font-size:12px;color:var(--red);font-family:var(--mono)}
+  .vB .legend{padding:16px 22px;border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:18px;flex-wrap:wrap;align-items:center}
+  .vB .legend i{width:16px;height:11px;border-radius:2px;display:inline-block;vertical-align:-1px;margin-right:5px}
+  .vB .addbar{padding:12px 22px;border-bottom:1px solid var(--line);background:var(--bg2);
+    display:flex;gap:10px;align-items:center;font-size:13px}
+  .vB .addbar input,.vB .addbar select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:5px 10px;border-radius:3px;font-family:var(--mono);font-size:12px}
+  .vB .addbar button.go{border:1px solid var(--ok);color:var(--ok);padding:5px 14px;border-radius:3px}
+  .vB .empty{color:var(--tx-faint);font-size:14px;padding:60px 0;text-align:center}
+
+  /* =====================================================================
+     VARIANT C — "Cascade". Inheritance-first lanes on cool linen; columns
+     ordered by base chain; inherited cells point back at their origin.
+  ===================================================================== */
+  .vC{
+    --linen:oklch(0.965 0.008 200);
+    --ink:oklch(0.27 0.03 230);
+    --ink-dim:oklch(0.27 0.03 230/.6);
+    --ink-faint:oklch(0.27 0.03 230/.35);
+    --teal:oklch(0.46 0.085 210);
+    --teal-soft:oklch(0.46 0.085 210/.12);
+    --rust:oklch(0.5 0.14 35);
+    --rust-soft:oklch(0.5 0.14 35/.1);
+    --chg:oklch(0.55 0.11 260);
+    --lane:oklch(0.94 0.012 200);
+    background:var(--linen);color:var(--ink);
+    font-family:system-ui,sans-serif;
+    padding:0 0 130px;
+  }
+  .vC .top{
+    padding:clamp(18px,3.5vw,40px) clamp(16px,3.5vw,48px) 18px;
+    display:flex;align-items:flex-end;gap:30px;flex-wrap:wrap;
+  }
+  .vC .top h1{font-size:clamp(24px,3vw,34px);font-weight:750;letter-spacing:-0.02em}
+  .vC .top h1 .w{color:var(--teal)}
+  .vC .top .sub{font-size:13px;color:var(--ink-dim);max-width:420px}
+  .vC .legend{margin-left:auto;display:flex;gap:14px;flex-wrap:wrap;font-size:11.5px;color:var(--ink-dim)}
+  .vC .legend .pill{display:inline-block;padding:2px 9px;border-radius:999px;margin-right:4px;font-family:var(--mono);font-size:10.5px}
+  .vC .matrix{overflow-x:auto}
+  .vC table{border-collapse:separate;border-spacing:0;width:100%;min-width:1080px}
+  .vC thead th{
+    position:sticky;top:0;z-index:4;background:var(--linen);
+    text-align:left;padding:10px 10px 12px;vertical-align:bottom;
+  }
+  .vC thead th.keyh{padding-left:clamp(16px,3.5vw,48px);font-size:11px;letter-spacing:.2em;
+    text-transform:uppercase;color:var(--ink-faint);font-weight:700}
+  .vC thead .lanehead{min-width:215px}
+  .vC thead .lanehead .lname{font-size:15px;font-weight:750}
+  .vC thead .lanehead .lname .p{color:var(--rust);font-size:10px;vertical-align:super;margin-left:4px;letter-spacing:.08em}
+  .vC thead .lanehead .basefrom{font-size:11px;color:var(--ink-faint);font-weight:500}
+  .vC thead .lanehead .basefrom b{color:var(--teal);font-weight:700}
+  .vC tbody td{padding:4px 10px;vertical-align:middle}
+  .vC td.lane{background:var(--lane)}
+  .vC td.lane.first{border-left:1px solid oklch(0.27 0.03 230/.09)}
+  .vC tr.folder td{
+    padding:28px 10px 8px;padding-left:clamp(16px,3.5vw,48px);
+    font-size:13px;font-weight:750;letter-spacing:.14em;text-transform:uppercase;color:var(--teal);
+    background:var(--linen)!important}
+  .vC tr.folder td button.addk{margin-left:14px;font-size:11px;letter-spacing:.05em;
+    color:var(--ink-faint);border:1px dashed var(--ink-faint);border-radius:999px;padding:2px 10px}
+  .vC tr.folder td button.addk:hover{color:var(--teal);border-color:var(--teal)}
+  .vC td.key{padding-left:clamp(16px,3.5vw,48px);font-family:var(--mono);font-size:12px;white-space:nowrap}
+  .vC td.key .sec{color:var(--rust);margin-right:5px}
+  .vC td.key .req{color:var(--ink-faint);font-size:10px;margin-left:7px}
+  .vC tr.diffrow td.lane{background:oklch(0.93 0.025 75/.55)}
+  .vC .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:230px;
+    font-family:var(--mono);font-size:11.5px;
+    padding:3px 10px;border-radius:999px;white-space:nowrap;overflow:hidden}
+  .vC .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .vC .pill.own{background:var(--teal);color:oklch(0.97 0.008 200)}
+  .vC .pill.inh{background:none;border:1px solid oklch(0.27 0.03 230/.22);color:var(--ink-dim)}
+  .vC .pill.inh .from{color:var(--teal);font-weight:600;font-size:10px}
+  .vC .pill.def{background:var(--teal-soft);color:var(--ink-dim);border:none}
+  .vC .pill.absent{border:1px dashed oklch(0.27 0.03 230/.25);color:var(--ink-faint)}
+  .vC .pill.masked{background:repeating-linear-gradient(45deg,transparent 0 4px,oklch(0.27 0.03 230/.08) 4px 7px);
+    border:1px solid oklch(0.27 0.03 230/.2);color:var(--ink-dim);font-style:italic}
+  .vC .pill.missing{background:var(--rust-soft);border:1px solid var(--rust);color:var(--rust);font-weight:500}
+  .vC .pill.invalid{border:2px solid var(--rust);color:var(--rust)}
+  .vC .pill .d{color:var(--chg);font-weight:700}
+  .vC .pill.own .d{color:oklch(0.97 0.008 200)}
+  .vC td .viol{display:block;font-size:10.5px;color:var(--rust);margin-top:2px;font-family:var(--mono)}
+  .vC .addform{display:flex;gap:8px;align-items:center;font-size:12px;padding:6px 0}
+  .vC .addform input,.vC .addform select{
+    border:1px solid oklch(0.27 0.03 230/.25);background:oklch(1 0 0/.6);border-radius:6px;
+    padding:4px 9px;font-family:var(--mono);font-size:12px}
+  .vC .addform button.go{background:var(--teal);color:oklch(0.97 0.008 200);border-radius:999px;padding:4px 14px;font-weight:600}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<div id="switcher">
+  <button id="sw-prev" title="previous variant (←)">‹</button>
+  <span class="lbl" id="sw-lbl"></span>
+  <button id="sw-next" title="next variant (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+const ENVS=[
+  {id:'dev',name:'development',base:null},
+  {id:'stg',name:'staging',base:'dev'},
+  {id:'prd',name:'production',base:'stg',protected:true},
+  {id:'pre',name:'preview',base:'stg'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         defaults?:string, layers:{env:{v}|{masked:true}},
+         invalid:{env:msg}, changed:[envIds], draft?:bool} */
+const K=(folder,name,type,secret,required,defaults,layers,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,defaults,layers:layers||{},invalid:invalid||{},changed:changed||[],desc});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all','Hikyo Demo',{},{},[],'Display name, shared everywhere.'),
+  K('app','APP_URL','url',false,'all','http://localhost:8080',
+    {stg:{v:'https://stg.hikyo.dev'},prd:{v:'https://hikyo.dev'},pre:{v:'https://pr-{n}.preview.hikyo.dev'}},{},['prd'],
+    'Public base URL. Overridden per deployed environment.'),
+  K('app','PORT','int',false,'all','8080',{},{},[]),
+  K('app','LOG_LEVEL','string',false,'all','info',{dev:{v:'debug'}},{},[]),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none','false',{pre:{v:'true'}},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',undefined,
+    {dev:{v:'postgres://hikyo:hikyo@localhost:5432/hikyo'},stg:{v:'postgres://hikyo@db.stg:5432/hikyo'},prd:{v:'postgres://hikyo@db.prd:5432/hikyo'}},{},[],
+    'Preview inherits staging’s database on purpose.'),
+  K('database','DB_POOL_SIZE','int',false,'all','10',
+    {stg:{v:'ten'},prd:{v:'40'}},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],undefined,{prd:{v:'verify-full'}},{},[]),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all','true',{prd:{v:'false'}},{},[]),
+  K('auth','SESSION_SECRET','string',true,'all',undefined,
+    {dev:{v:'dev-only-not-secret'},stg:{v:'s3cr3t-stg-9f2e'},prd:{v:'s3cr3t-prd-77aa'}},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],'https://id.example.dev',
+    {pre:{v:'localhost:8080'}},{pre:'url must be absolute'},[]),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],undefined,
+    {stg:{v:'ew-stg'},prd:{v:'ew-prd'}},{},[]),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],undefined,
+    {stg:{v:'oidc-stg-secret'}},{},[],'Required in production but never set — the gap to spot.'),
+  K('mail','SMTP_HOST','string',false,'none','mail.internal',{prd:{v:'smtp.eu.mailer.dev'}},{},[]),
+  K('mail','SMTP_PORT','int',false,'none','587',{},{},[]),
+  K('mail','SMTP_PASSWORD','string',true,'none',undefined,
+    {dev:{masked:true},stg:{v:'stg-smtp-pass'},prd:{v:'prd-smtp-pass'}},{},[],
+    'Deliberately masked in development: no mail from dev boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',undefined,{prd:{v:'hik_1_at_x9k2m4'}},{},[]),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all','AKIADEFAULT0000',
+    {prd:{v:'AKIAPRODONLY9999'}},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all','wJalrXUtnFEMI/DEMO',
+    {prd:{masked:true}},{},[],'Masked in production while required: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',undefined,
+    {stg:{v:'https://s1@sentry.io/11'},prd:{v:'https://s2@sentry.io/12'}},{},[]),
+  K('observability','OTEL_ENDPOINT','url',false,'none','http://otel.internal:4317',{},{},[]),
+];
+
+/* deterministic filler to reach 50+ keys (density test) */
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',val,{},{},[]);
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.layers[e]={v:type==='int'?String(Math.floor(rnd()*90)+10):val};}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ resolution ============================ */
+function chainOf(envId){const c=[];let e=envById(envId);while(e){c.push(e.id);e=e.base?envById(e.base):null}return c}
+function resolve(key,envId){
+  for(const id of chainOf(envId)){
+    const l=key.layers[id];
+    if(l){ if(l.masked)return{state:'masked',origin:id};
+      return{state:id===envId?'own':'inh',origin:id,value:l.v}; }
+  }
+  if(key.defaults!==undefined)return{state:'def',origin:'defaults',value:key.defaults};
+  return{state:'absent'};
+}
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+function cellInfo(k,envId){
+  const r=resolve(k,envId);
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&(r.state==='absent'||r.state==='masked');
+  const changed=k.changed.includes(envId);
+  return{...r,required,invalid,missing,changed};
+}
+function rowDiff(k){
+  const vals=ENVS.map(e=>resolve(k,e.id)).filter(r=>r.value!==undefined).map(r=>r.value);
+  return new Set(vals).size>1;
+}
+function problems(){
+  let inv=0,miss=0;
+  for(const k of KEYS)for(const e of ENVS){const c=cellInfo(k,e.id);if(c.invalid)inv++;else if(c.missing)miss++}
+  return{inv,miss};
+}
+function provChain(k,envId){ /* [{layer,has,masked,win}] project-defaults → …base… → env */
+  const ids=chainOf(envId).reverse(); // defaults first
+  const hops=[{layer:'defaults',has:k.defaults!==undefined}];
+  for(const id of ids)hops.push({layer:id,has:!!k.layers[id],masked:!!(k.layers[id]&&k.layers[id].masked)});
+  const r=resolve(k,envId);
+  for(const h of hops)h.win=(h.layer===(r.origin||''));
+  return{hops,r};
+}
+
+/* ============================ shared ui state ============================ */
+const S={
+  revealed:new Set(),      // `${key.name}:${envId}`
+  selected:KEYS[12].name,  // variant B selection (OIDC_CLIENT_SECRET)
+  adding:null,             // folder currently showing the add form (A, C) or '_top' (B)
+  search:'', probOnly:false,
+  footnote:null,           // variant A hovered-cell provenance
+};
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function displayValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+function toggleReveal(name,envId){
+  const k=KEYS.find(x=>x.name===name);const env=envById(envId);
+  const id=name+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(env.protected&&!confirm('production is a protected environment — reveal requires re-authentication.\n\n(prototype stand-in; the real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},6000); // auto-remask
+}
+function addKey(folder,name,type,secret){
+  if(!name||KEYS.some(k=>k.name===name))return;
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),type,secret,'none',undefined,{},{},[]);
+  k.draft=true;
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;S.selected=k.name;render();
+}
+function addFormHTML(folder,cls){
+  return `<span class="addform ${cls||''}">
+    <input id="nk-name" placeholder="KEY_NAME" size="18" autofocus>
+    <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+    <label style="display:flex;align-items:center;gap:4px;font-size:11px"><input type="checkbox" id="nk-sec">secret</label>
+    <button class="go" onclick="addKey('${folder}',document.getElementById('nk-name').value,document.getElementById('nk-type').value,document.getElementById('nk-sec').checked)">declare</button>
+    <button onclick="S.adding=null;render()" style="opacity:.5">cancel</button>
+  </span>`;
+}
+
+/* ============================ variant A — Ledger ============================ */
+function renderA(){
+  const p=problems();
+  const head=ENVS.map(e=>`<th class="${e.protected?'prot':''}">${e.name}${e.protected?' <span class="flag">✳ protected</span>':''}
+      <span class="base">${e.base?'after '+envById(e.base).name:'after project defaults'}</span></th>`).join('');
+  let rows='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    rows+=`<tr class="folder"><td colspan="5">${f} /<span class="cnt">${ks.length} keys</span></td></tr>`;
+    for(const k of ks){
+      const diff=rowDiff(k);
+      rows+=`<tr><td class="key">${k.secret?'<span class="sec" title="secret">§</span>':''}${esc(k.name)}<span class="typ">${k.type}${k.draft?' · draft':''}</span>${diff?'<span class="diffmark" title="values differ across environments">≠</span>':''}</td>`;
+      for(const e of ENVS){
+        const c=cellInfo(k,e.id);
+        let cls='cell',body='';
+        if(c.invalid){cls+=' invalid own';body=`<span class="v">${esc(displayValue(k,e.id,c))}</span><span class="note" title="${esc(c.invalid)}">†</span>`}
+        else if(c.missing){cls+=' missing';body=`<span class="v">required — ${c.state==='masked'?'masked':'unset'}</span>`}
+        else if(c.state==='masked'){cls+=' masked';body=`<span class="v">∅ masked</span>`}
+        else if(c.state==='absent'){cls+=' absent';body=`<span class="v">—</span>`}
+        else{
+          cls+=c.state==='own'?' own':' inh';
+          const orig=c.state==='own'?'':`<span class="orig">${c.origin==='defaults'?'≡ defaults':'↑ '+c.origin}</span>`;
+          const v=displayValue(k,e.id,c);
+          body=`<span class="v ${k.secret&&!S.revealed.has(k.name+':'+e.id)?'sdot':''}">${esc(v)}</span>${orig}`;
+        }
+        if(c.changed)body+=`<span class="delta" title="changed since last published revision">Δ</span>`;
+        const rv=k.secret&&c.value!==undefined?`onclick="toggleReveal('${k.name}','${e.id}')" style="cursor:pointer" title="click to reveal (auto-remasks)"`:'';
+        rows+=`<td class="${cls}" data-fn="${k.name}|${e.id}" ${rv}>${body}</td>`;
+      }
+      rows+='</tr>';
+    }
+    rows+=`<tr class="adder"><td colspan="5">${S.adding===f?addFormHTML(f):`<button class="ghost" onclick="S.adding='${f}';render()">+ declare a key in ${f}/ …</button>`}</td></tr>`;
+  }
+  const fn=S.footnote?footnoteA(S.footnote):`<span>hover a cell for its provenance — where the value resolves from, layer by layer.</span>`;
+  return `
+  <div class="masthead">
+    <h1>acme / <em>hikyo-demo</em> — configuration ledger</h1>
+    <div class="tally"><b>${KEYS.length}</b> keys · <b>4</b> environments ·
+      <b class="bad">${p.inv}</b> violations · <b class="bad">${p.miss}</b> required unset</div>
+  </div>
+  <div class="footnotebar" id="fnbar">${fn}</div>
+  <table>
+    <thead><tr><th class="keycol">key</th>${head}</tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+  <div class="legend">
+    <span><span class="m">bold</span> set here</span>
+    <span><span class="m">faded ↑env / ≡ defaults</span> inherited, with origin</span>
+    <span><span class="m">∅ masked</span> deliberately unset</span>
+    <span><span class="m">—</span> absent (optional)</span>
+    <span><span class="m">†</span> schema violation (see footnote)</span>
+    <span><span class="m">Δ</span> changed since last publish</span>
+    <span><span class="m">≠</span> differs across environments</span>
+    <span><span class="m">§</span> secret — click to reveal</span>
+  </div>`;
+}
+function footnoteA(fnKey){
+  const[name,envId]=fnKey.split('|');
+  const k=KEYS.find(x=>x.name===name);if(!k)return'';
+  const{hops,r}=provChain(k,envId);
+  const chain=hops.map(h=>{
+    const t=h.layer==='defaults'?'project-defaults':h.layer;
+    if(h.win)return`<span class="win">${t} ◀ resolves here</span>`;
+    if(h.masked)return`<s>${t} (mask)</s>`;
+    return h.has?`${t} (set)`:`<span style="opacity:.45">${t} (—)</span>`;
+  }).join(' → ');
+  const extra=k.invalid[envId]?` &nbsp;† ${esc(k.invalid[envId])}`:(r.state==='absent'?' — no layer sets this key':'');
+  return`<span class="fchain"><b>${esc(name)}</b> in ${envById(envId).name}: ${chain}${extra}</span>`;
+}
+
+/* ============================ variant B — Panel ============================ */
+function renderB(){
+  const q=S.search.toLowerCase();
+  const visible=KEYS.filter(k=>{
+    if(q&&!k.name.toLowerCase().includes(q))return false;
+    if(S.probOnly&&!ENVS.some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing}))return false;
+    return true;
+  });
+  let list='';
+  for(const f of FOLDERS){
+    const ks=visible.filter(k=>k.folder===f);
+    if(!ks.length)continue;
+    list+=`<div class="flabel">${f} /</div>`;
+    for(const k of ks){
+      const strip=ENVS.map(e=>{
+        const c=cellInfo(k,e.id);
+        let s=c.invalid?'invalid':c.missing?'missing':c.state==='own'?'own':c.state==='masked'?'masked':c.state==='absent'?'absent':'inh';
+        return`<i class="${s} ${c.changed?'chg':''}" title="${e.name}: ${s}${c.changed?' · changed':''}"></i>`;
+      }).join('');
+      list+=`<button class="krow ${S.selected===k.name?'sel':''}" onclick="S.selected='${k.name}';render()">
+        <span class="name">${k.secret?'<span class="sec">§</span>':''}${esc(k.name)}${k.draft?'<span class="draft">DRAFT</span>':''}</span>
+        <span class="diffm">${rowDiff(k)?'≠':''}</span>
+        <span class="strip">${strip}</span></button>`;
+    }
+  }
+  const k=KEYS.find(x=>x.name===S.selected);
+  let detail='<div class="empty">select a key</div>';
+  if(k){
+    let secs='';
+    for(const e of ENVS){
+      const c=cellInfo(k,e.id);
+      const{hops}=provChain(k,e.id);
+      const chain=hops.map((h,i)=>{
+        const t=h.layer==='defaults'?'defaults':h.layer;
+        const cls=h.win?'win':h.masked?'stop':'';
+        const inner=h.masked?`${t} ∅`:h.has?t:`<span style="opacity:.4">${t}</span>`;
+        return`${i?'<span class="arr">→</span>':''}<span class="hop ${cls}">${inner}</span>`;
+      }).join('');
+      let vhtml,stx='';
+      if(c.invalid){vhtml=`<span class="val bad">${esc(displayValue(k,e.id,c))}</span>`;stx='SCHEMA VIOLATION'}
+      else if(c.missing){vhtml=`<span class="val bad">required — ${c.state==='masked'?'masked':'unset'}</span>`;stx='BLOCKS PUBLISH'}
+      else if(c.state==='masked'){vhtml=`<span class="val maskedtxt">deliberately masked</span>`;stx='MASKED'}
+      else if(c.state==='absent'){vhtml=`<span class="val dim">—</span>`;stx='ABSENT'}
+      else{
+        const v=displayValue(k,e.id,c);
+        const rv=k.secret?` style="cursor:pointer" onclick="toggleReveal('${k.name}','${e.id}')" title="click to reveal"`:'';
+        vhtml=`<span class="val ${c.state!=='own'?'dim':''}"${rv}>${esc(v)}</span>`;
+        stx=c.state==='own'?'SET HERE':'INHERITED · '+(c.origin==='defaults'?'DEFAULTS':c.origin.toUpperCase());
+      }
+      secs+=`<div class="envsec">
+        <div class="erow">
+          <span class="ename">${e.name}${e.protected?'<span class="p">PROTECTED</span>':''}</span>
+          ${vhtml}
+          <span class="stx ${c.changed?'chg':''}">${c.changed?'Δ CHANGED · ':''}${stx}</span>
+        </div>
+        <div class="chain">${chain}</div>
+        ${c.invalid?`<div class="err">✕ ${esc(c.invalid)}</div>`:''}
+      </div>`;
+    }
+    detail=`<div class="dhead"><h2>${k.secret?'§ ':''}${esc(k.name)}</h2>
+      <span class="meta">${k.folder}/ · ${k.type} · <b>${k.secret?'secret':'config'}</b> · required: ${k.required==='all'?'everywhere':k.required==='none'?'nowhere':k.required.join(', ')}</span></div>
+      ${k.desc?`<div class="desc">${esc(k.desc)}</div>`:''}
+      ${secs}`;
+  }
+  return `
+  <header>
+    <h1>hikyo<span>/</span>acme<span>/</span>hikyo-demo</h1>
+    <span class="env-tags">${ENVS.map(e=>`<i class="${e.protected?'prot':''}">${e.id}${e.base?'←'+e.base:''}</i>`).join('')}</span>
+    <span class="grow"></span>
+    <input class="search" placeholder="filter keys…" value="${esc(S.search)}" oninput="S.search=this.value;render();this.focus();this.setSelectionRange(this.value.length,this.value.length)">
+    <label class="prob"><input type="checkbox" ${S.probOnly?'checked':''} onchange="S.probOnly=this.checked;render()"> problems only</label>
+    <button class="addkey" onclick="S.adding=S.adding?null:'_top';render()">+ key</button>
+  </header>
+  <div style="display:flex;flex-direction:column;overflow:hidden">
+    ${S.adding?`<div class="addbar">declare in <select id="nk-folder">${FOLDERS.map(f=>`<option>${f}</option>`).join('')}</select> ${addFormHTML('','').replace(`addKey('',`,`addKey(document.getElementById('nk-folder').value,`)}</div>`:''}
+    <div class="cols">
+      <div class="list">${list||'<div class="empty">no keys match</div>'}</div>
+      <div class="detail">${detail}</div>
+    </div>
+    <div class="legend">
+      <span><i style="background:var(--ok)"></i>set here</span>
+      <span><i style="background:var(--inh)"></i>inherited</span>
+      <span><i style="background:var(--bg3)"></i>absent</span>
+      <span><i style="background:repeating-linear-gradient(45deg,var(--bg3) 0 3px,var(--inh) 3px 5px)"></i>masked</span>
+      <span><i style="background:var(--red)"></i>missing / violation</span>
+      <span><i style="background:var(--bg3);box-shadow:inset 0 -3px 0 var(--amber)"></i>changed</span>
+      <span>≠ differs across envs · § secret</span>
+    </div>
+  </div>`;
+}
+
+/* ============================ variant C — Cascade ============================ */
+function renderC(){
+  const order=['dev','stg','prd','pre']; // base-chain order, prd/pre both fed by stg
+  const head=order.map((id,i)=>{const e=envById(id);
+    return`<th class="lanehead"><div class="lname">${e.name}${e.protected?'<span class="p">PROTECTED</span>':''}</div>
+      <div class="basefrom">${e.base?`inherits <b>◂ ${envById(e.base).name}</b>`:'inherits <b>◂ project defaults</b>'}</div></th>`}).join('');
+  let rows='';
+  for(const f of FOLDERS){
+    rows+=`<tr class="folder"><td colspan="5">${f}
+      ${S.adding===f?'':`<button class="addk" onclick="S.adding='${f}';render()">+ key</button>`}</td></tr>`;
+    if(S.adding===f)rows+=`<tr><td colspan="5" style="padding-left:clamp(16px,3.5vw,48px)">${addFormHTML(f)}</td></tr>`;
+    for(const k of KEYS.filter(k=>k.folder===f)){
+      const diff=rowDiff(k);
+      rows+=`<tr class="${diff?'diffrow':''}"><td class="key">${k.secret?'<span class="sec">§</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req·all':Array.isArray(k.required)?'req·'+k.required.join(','):''}${k.draft?' draft':''}</span></td>`;
+      order.forEach((id,i)=>{
+        const c=cellInfo(k,id);
+        let pill;
+        const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+        if(c.invalid)pill=`<span class="pill invalid"><span class="tx">${esc(displayValue(k,id,c))}</span>${d}</span><span class="viol">✕ ${esc(c.invalid)}</span>`;
+        else if(c.missing)pill=`<span class="pill missing"><span class="tx">required · ${c.state==='masked'?'masked':'unset'}</span>${d}</span>`;
+        else if(c.state==='masked')pill=`<span class="pill masked"><span class="tx">∅ masked</span>${d}</span>`;
+        else if(c.state==='absent')pill=`<span class="pill absent"><span class="tx">·</span></span>`;
+        else{
+          const v=esc(displayValue(k,id,c));
+          const rv=k.secret&&c.value!==undefined?` style="cursor:pointer" onclick="toggleReveal('${k.name}','${id}')" title="click to reveal"`:'';
+          if(c.state==='own')pill=`<span class="pill own"${rv}><span class="tx">${v}</span>${d}</span>`;
+          else if(c.state==='def')pill=`<span class="pill def"${rv}><span class="from">◂ def</span><span class="tx">${v}</span>${d}</span>`;
+          else pill=`<span class="pill inh"${rv}><span class="from">◂ ${c.origin}</span><span class="tx">${v}</span>${d}</span>`;
+        }
+        rows+=`<td class="lane ${i===0?'first':''}">${pill}</td>`;
+      });
+      rows+='</tr>';
+    }
+  }
+  return `
+  <div class="top">
+    <div><h1>hikyo-demo <span class="w">— the weave</span></h1>
+    <div class="sub">Values flow left to right along each environment's base chain. A filled pill is set in that lane; a ghost pill points back at where it comes from.</div></div>
+    <div class="legend">
+      <span><span class="pill own">value</span>set here</span>
+      <span><span class="pill inh"><span class="from">◂ stg</span>value</span>inherited</span>
+      <span><span class="pill def"><span class="from">◂ def</span>value</span>from defaults</span>
+      <span><span class="pill masked">∅ masked</span></span>
+      <span><span class="pill missing">required · unset</span></span>
+      <span>amber row = drift · Δ changed · § secret</span>
+    </div>
+  </div>
+  <div class="matrix"><table>
+    <thead><tr><th class="keyh">key</th>${head}</tr></thead>
+    <tbody>${rows}</tbody>
+  </table></div>`;
+}
+
+/* ============================ switcher & boot ============================ */
+const VARIANTS=[
+  {key:'a',name:'Ledger',fn:renderA,cls:'vA'},
+  {key:'b',name:'Panel',fn:renderB,cls:'vB'},
+  {key:'c',name:'Cascade',fn:renderC,cls:'vC'},
+];
+let current=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!VARIANTS.some(v=>v.key===current))current='a';
+
+function render(){
+  const v=VARIANTS.find(x=>x.key===current);
+  const root=document.getElementById('root');
+  root.className=v.cls;
+  root.innerHTML=v.fn();
+  document.getElementById('sw-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+  if(current==='a'){
+    root.querySelectorAll('[data-fn]').forEach(td=>{
+      td.addEventListener('mouseenter',()=>{S.footnote=td.dataset.fn;
+        document.getElementById('fnbar').innerHTML=footnoteA(S.footnote)});
+    });
+  }
+}
+function cycle(d){
+  const i=VARIANTS.findIndex(v=>v.key===current);
+  current=VARIANTS[(i+d+VARIANTS.length)%VARIANTS.length].key;
+  try{history.replaceState(null,'','?variant='+current)}catch(_){/* file:// or sandboxed */}
+  S.adding=null;render();
+}
+document.getElementById('sw-prev').onclick=()=>cycle(-1);
+document.getElementById('sw-next').onclick=()=>cycle(1);
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable))return;
+  if(e.key==='ArrowLeft')cycle(-1);
+  if(e.key==='ArrowRight')cycle(1);
+});
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/10/index.html
+++ b/docs/site/public/prototypes/env-matrix/10/index.html
@@ -1,0 +1,963 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 10.
+  The environment chips bar is gone — it duplicated the column header row.
+  Environment show/hide moves into the matrix header itself: an "envs"
+  checkbox popover in the sticky corner cell. Otherwise identical to 9,
+  which refined:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="document.getElementById('side').classList.toggle('open')" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="envpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop'))
+    {S.envpop=false;renderEnvPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> set in that environment — everything explicit, nothing inherits
+    <span class="pill absent">·</span> not set
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values differ</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderLegend();renderDrafts();renderShell();renderEnvPop();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  document.getElementById('side').classList.remove('open');
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  document.getElementById('side').classList.remove('open')}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="stitle" style="padding-top:18px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  document.getElementById('side').classList.remove('open');
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/11/index.html
+++ b/docs/site/public/prototypes/env-matrix/11/index.html
@@ -1,0 +1,983 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 11.
+  The footer legend is gone — its content lives in a "?" icon popover in
+  the header (explicit tooltip). Otherwise identical to 10 (env picker in
+  the matrix header), which sat on 9:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="document.getElementById('side').classList.toggle('open')" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="pill val">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="pill absent">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">🔒 secret — tap to reveal, if permitted<br>Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>amber row = values differ across environments<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  document.getElementById('side').classList.remove('open');
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  document.getElementById('side').classList.remove('open')}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="stitle" style="padding-top:18px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  document.getElementById('side').classList.remove('open');
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/12/index.html
+++ b/docs/site/public/prototypes/env-matrix/12/index.html
@@ -1,0 +1,989 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 12.
+  Zebra striping: every other data row gets a slightly raised hue, and the
+  amber drift tint on rows with differing values is removed (with its
+  machinery). Otherwise identical to 11, which sat on:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.05);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="document.getElementById('side').classList.toggle('open')" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="pill val">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="pill absent">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">🔒 secret — tap to reveal, if permitted<br>Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  document.getElementById('side').classList.remove('open');
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  document.getElementById('side').classList.remove('open')}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="stitle" style="padding-top:18px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  document.getElementById('side').classList.remove('open');
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/13/index.html
+++ b/docs/site/public/prototypes/env-matrix/13/index.html
@@ -1,0 +1,1015 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 13.
+  Mobile drawer fixes: a backdrop behind the open drawer swallows outside
+  taps (tap closes the drawer instead of falling through to a cell), and
+  small screens get a project switcher — a customizable <select>
+  (appearance:base-select, styled picker where supported, graceful plain
+  select elsewhere) at the top of the panel. Otherwise identical to 12:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.05);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="pill val">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="pill absent">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">🔒 secret — tap to reveal, if permitted<br>Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  setSide(false)}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/14/index.html
+++ b/docs/site/public/prototypes/env-matrix/14/index.html
@@ -1,0 +1,1026 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 14.
+  Distilled cells (critique issue 1): ordinary set values are plain mono
+  text — border chrome is reserved for exceptional states (missing,
+  invalid). The per-cell lock glyph drops (the key column already carries
+  it); secret values are dim masked dots. Hover tint + focus ring keep the
+  tap affordance. Otherwise identical to 13:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.05);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  setSide(false)}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/15/index.html
+++ b/docs/site/public/prototypes/env-matrix/15/index.html
@@ -1,0 +1,1025 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 15.
+  Distilled sheet (critique issue 4): the permanent teaching paragraph is
+  gone (the header "?" legend owns vocabulary), required-in collapses to a
+  one-line schema disclosure, the redundant close button drops (backdrop,
+  Escape and the grab all close), and hint copy is halved. Create and
+  publish sheets trimmed the same way. Otherwise identical to 14:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.05);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  setSide(false)}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/16/index.html
+++ b/docs/site/public/prototypes/env-matrix/16/index.html
@@ -1,0 +1,1029 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 16.
+  Clarify pass (critique issue 3 + copy sweep): reveal is a real button;
+  confirm dialogs name the action and its consequence; validation messages
+  are human with examples ("must be a whole number, e.g. 8080"); icon
+  buttons carry aria-labels and clearer titles. Otherwise identical to 15:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.05);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:4px 8px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .revealbtn{
+    border:1px solid var(--line);border-radius:8px;padding:9px 16px;
+    font-size:13px;color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .revealbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  setSide(false)}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="revealbtn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/17/index.html
+++ b/docs/site/public/prototypes/env-matrix/17/index.html
@@ -1,0 +1,1032 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 17.
+  Polish pass: unified focus rings on every control; key names truncate
+  without eating the req badge; monogram hues spread by golden angle (no
+  more near-identical browns); light-theme zebra strengthened; icon
+  buttons optically equal; inline SVG favicon (kills the only console
+  error); dead pill CSS removed. Otherwise identical to 16:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .revealbtn{
+    border:1px solid var(--line);border-radius:8px;padding:9px 16px;
+    font-size:13px;color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .revealbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  setSide(false)}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="revealbtn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/18/index.html
+++ b/docs/site/public/prototypes/env-matrix/18/index.html
@@ -1,0 +1,1077 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 18.
+  Onboarding (critique issue 2): projects hold their own keys now, so
+  switching to an un-seeded project shows a real empty state — what the
+  matrix is, declare-first-key (create sheet gains a group field when no
+  groups exist yet), and the .env import path (locked scaffold flow,
+  stubbed). Drafts and reveals clear on project switch. Otherwise
+  identical to 17:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+  #empty .ecta button{border:1px solid var(--line);border-radius:8px;padding:11px 18px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  #empty .ecta button:hover{border-color:var(--accent);color:var(--accent)}
+  #empty .ecta button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #empty .ecta button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .revealbtn{
+    border:1px solid var(--line);border-radius:8px;padding:9px 16px;
+    font-size:13px;color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .revealbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden>
+  <svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>
+  <h3 class="eh">no keys yet</h3>
+  <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+  <div class="ecta">
+    <button class="primary" onclick="openCreate(null)">declare first key</button>
+    <button onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+  </div>
+</div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  if(KEYS.length===0){
+    document.getElementById('matrix').innerHTML='';
+    document.getElementById('empty').hidden=false;
+    document.getElementById('empty').querySelector('.eh').textContent=`no keys in ${PROJ} yet`;
+    return;
+  }
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="revealbtn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/19/index.html
+++ b/docs/site/public/prototypes/env-matrix/19/index.html
@@ -1,0 +1,1073 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 19.
+  Normalize (critique issue 5): one .btn vocabulary across sheet, reveal
+  and empty state (three duplicate rule-sets deleted); one badge rule —
+  pending/error counts vanish at zero; the problems view is a real filter
+  now (badge with total, toggles the matrix to problem keys only, calm
+  all-valid state) instead of an alert stub. Otherwise identical to 18:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/2/index.html
+++ b/docs/site/public/prototypes/env-matrix/2/index.html
@@ -1,0 +1,676 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 2.
+  Variant C (Cascade) won round 1; editorial style dropped project-wide.
+  This iteration: dark default + light theme, mobile-first, in-place editing
+  via a bottom sheet, permission-gated reveal (role simulator), mask-vs-secret
+  clarity, env show/hide chips, collapsible groups with comma key list.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:0;background:var(--bg);z-index:10;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--line);border-radius:999px;padding:6px 12px;
+  }
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:61px;background:var(--bg);z-index:9;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .b{color:var(--tx-faint);font-size:11px}
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{overflow-x:auto;overscroll-behavior-x:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:3;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);margin-top:2px}
+  thead th .base b{color:var(--accent);font-weight:500}
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;left:0;background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.own{background:var(--accent);color:var(--on-accent);font-weight:500}
+  .pill.inh{border-color:var(--line);color:var(--tx-dim)}
+  .pill.inh .from,.pill.def .from{color:var(--accent);font-weight:600;font-size:10px}
+  .pill.own .from{color:var(--on-accent);font-weight:600;font-size:10px;opacity:.75}
+  .pill.def{background:var(--accent-soft);color:var(--tx-dim)}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.masked{
+    background:repeating-linear-gradient(45deg,transparent 0 4px,oklch(from var(--tx) l c h/.09) 4px 7px);
+    border-color:var(--line);color:var(--tx-dim);font-style:italic}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill.own .d{color:var(--on-accent)}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    display:flex;gap:10px 20px;flex-wrap:wrap;align-items:center;
+    padding:18px 16px 120px;font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .chain{
+    display:flex;align-items:center;flex-wrap:wrap;gap:6px;margin:14px 0 0;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);
+  }
+  #sheet .chain .hop{padding:5px 10px;border:1px solid var(--line);border-radius:6px}
+  #sheet .chain .hop.win{border-color:var(--accent);color:var(--accent);font-weight:600}
+  #sheet .chain .hop.stop{text-decoration:line-through;color:var(--tx-dim)}
+  #sheet .chain .arr{color:var(--tx-faint)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .acts button:disabled{opacity:.4;cursor:not-allowed}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+
+  /* ---------------- add key form ---------------- */
+  tr.addrow td{padding:10px 16px}
+  .addform{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:12.5px}
+  .addform input[type=text],.addform select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:9px 12px;border-radius:6px;font-family:var(--mono);font-size:12px;min-height:40px}
+  .addform label{display:flex;align-items:center;gap:5px;color:var(--tx-dim);font-size:12px}
+  .addform button.go{background:var(--accent);color:var(--on-accent);border-radius:6px;padding:9px 16px;font-weight:600;min-height:40px}
+  .addform button.x{color:var(--tx-faint);padding:9px 6px}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{top:57px;padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <span class="drafts" id="drafts" hidden></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+const ENVS=[
+  {id:'dev',name:'development',base:null},
+  {id:'stg',name:'staging',base:'dev'},
+  {id:'prd',name:'production',base:'stg',protected:true},
+  {id:'pre',name:'preview',base:'stg'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,required,defaults,layers,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,defaults,layers:layers||{},invalid:invalid||{},changed:changed||[],desc});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all','Hikyo Demo',{},{},[]),
+  K('app','APP_URL','url',false,'all','http://localhost:8080',
+    {stg:{v:'https://stg.hikyo.dev'},prd:{v:'https://hikyo.dev'},pre:{v:'https://pr-{n}.preview.hikyo.dev'}},{},['prd']),
+  K('app','PORT','int',false,'all','8080',{},{},[]),
+  K('app','LOG_LEVEL','string',false,'all','info',{dev:{v:'debug'}},{},[]),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none','false',{pre:{v:'true'}},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',undefined,
+    {dev:{v:'postgres://hikyo:hikyo@localhost:5432/hikyo'},stg:{v:'postgres://hikyo@db.stg:5432/hikyo'},prd:{v:'postgres://hikyo@db.prd:5432/hikyo'}},{},[],
+    'Preview inherits staging’s database on purpose.'),
+  K('database','DB_POOL_SIZE','int',false,'all','10',
+    {stg:{v:'ten'},prd:{v:'40'}},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],undefined,{prd:{v:'verify-full'}},{},[]),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all','true',{prd:{v:'false'}},{},[]),
+  K('auth','SESSION_SECRET','string',true,'all',undefined,
+    {dev:{v:'dev-only-not-secret'},stg:{v:'s3cr3t-stg-9f2e'},prd:{v:'s3cr3t-prd-77aa'}},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],'https://id.example.dev',
+    {pre:{v:'localhost:8080'}},{pre:'url must be absolute'},[]),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],undefined,
+    {stg:{v:'ew-stg'},prd:{v:'ew-prd'}},{},[]),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],undefined,
+    {stg:{v:'oidc-stg-secret'}},{},[],
+    'Required in production; currently satisfied only by inheriting staging’s value.'),
+  K('mail','SMTP_HOST','string',false,'none','mail.internal',{prd:{v:'smtp.eu.mailer.dev'}},{},[]),
+  K('mail','SMTP_PORT','int',false,'none','587',{},{},[]),
+  K('mail','SMTP_PASSWORD','string',true,'none',undefined,
+    {dev:{masked:true},stg:{v:'stg-smtp-pass'},prd:{v:'prd-smtp-pass'}},{},[],
+    'Deliberately masked in development: no mail from dev boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',undefined,{prd:{v:'hik_1_at_x9k2m4'}},{},[]),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all','AKIADEFAULT0000',
+    {prd:{v:'AKIAPRODONLY9999'}},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all','wJalrXUtnFEMI/DEMO',
+    {prd:{masked:true}},{},[],'Masked in production while required: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',undefined,
+    {stg:{v:'https://s1@sentry.io/11'},prd:{v:'https://s2@sentry.io/12'}},{},[]),
+  K('observability','OTEL_ENDPOINT','url',false,'none','http://otel.internal:4317',{},{},[]),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',val,{},{},[]);
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.layers[e]={v:type==='int'?String(Math.floor(rnd()*90)+10):val};}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ resolution ============================ */
+function chainOf(envId){const c=[];let e=envById(envId);while(e){c.push(e.id);e=e.base?envById(e.base):null}return c}
+function resolve(key,envId){
+  for(const id of chainOf(envId)){
+    const l=key.layers[id];
+    if(l){ if(l.masked)return{state:'masked',origin:id};
+      return{state:id===envId?'own':'inh',origin:id,value:l.v}; }
+  }
+  if(key.defaults!==undefined)return{state:'def',origin:'defaults',value:key.defaults};
+  return{state:'absent'};
+}
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+function cellInfo(k,envId){
+  const r=resolve(k,envId);
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&(r.state==='absent'||r.state==='masked');
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{...r,required,invalid,missing,changed};
+}
+function rowDiff(k){
+  const vals=ENVS.map(e=>resolve(k,e.id)).filter(r=>r.value!==undefined).map(r=>r.value);
+  return new Set(vals).size>1;
+}
+function provChain(k,envId){
+  const ids=chainOf(envId).reverse();
+  const hops=[{layer:'defaults',has:k.defaults!==undefined}];
+  for(const id of ids)hops.push({layer:id,has:!!k.layers[id],masked:!!(k.layers[id]&&k.layers[id].masked)});
+  const r=resolve(k,envId);
+  for(const h of hops)h.win=(h.layer===(r.origin||''));
+  return{hops,r};
+}
+/* light client-side validation for in-place edits (prototype only) */
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+
+/* ============================ ui state ============================ */
+const S={
+  theme:'dark',
+  role:'dev',                     // admin | dev | viewer
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),             // `${key}:${env}`
+  drafts:new Set(),               // local unpublished edits `${key}:${env}`
+  sheet:null,                     // {key,envId,mode:'view'|'edit'}
+  adding:null,
+};
+/* who may reveal where (simulated permission model; real one = ADR #15) */
+function canReveal(envId){
+  if(S.role==='admin')return true;
+  if(S.role==='dev')return !envById(envId).protected;
+  return false;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const visibleEnvs=()=>ENVS.filter(e=>!S.hiddenEnvs.has(e.id));
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    ENVS.map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.base?`<span class="b">◂ ${e.base}</span>`:'<span class="b">◂ defaults</span>'}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of ENVS){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  let inner;
+  if(c.invalid)inner=`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  else if(c.missing)inner=`<span class="pill missing" ${open}><span class="tx">! required · ${c.state==='masked'?'masked':'unset'}</span></span>`;
+  else if(c.state==='masked')inner=`<span class="pill masked" ${open}><span class="tx">∅ masked</span></span>`;
+  else if(c.state==='absent')inner=`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  else{
+    const v=esc(shownValue(k,e.id,c));
+    if(c.state==='own')inner=`<span class="pill own" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+    else if(c.state==='def')inner=`<span class="pill def" ${open}><span class="from">◂ def</span><span class="tx">${v}</span>${d}${draft}</span>`;
+    else inner=`<span class="pill inh" ${open}><span class="from">◂ ${c.origin}</span><span class="tx">${v}</span>${d}${draft}</span>`;
+  }
+  return inner;
+}
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+     <span class="base">inherits <b>◂ ${e.base?envById(e.base).name:'project defaults'}</b></span></th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();S.adding='${f}';render()" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    if(S.adding===f)body+=`<tr class="addrow"><td colspan="${envs.length+1}">
+      <span class="addform">
+        <input type="text" id="nk-name" placeholder="KEY_NAME" size="16">
+        <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+        <label><input type="checkbox" id="nk-sec"> secret</label>
+        <button class="go" onclick="addKey('${f}')">declare</button>
+        <button class="x" onclick="S.adding=null;render()">cancel</button>
+      </span></td></tr>`;
+    for(const k of ks){
+      body+=`<tr class="${rowDiff(k)?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill own">value</span> set in this environment
+    <span class="pill inh"><span class="from">◂ stg</span>value</span> inherited
+    <span class="pill def"><span class="from">◂ def</span>value</span> from project defaults
+    <span class="pill masked">∅ masked</span> no value here, on purpose
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values drift · tap any cell to inspect or edit</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''}`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const{hops}=provChain(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  const chain=hops.map((h,i)=>{
+    const t=h.layer==='defaults'?'defaults':h.layer;
+    const cls=h.win?'win':h.masked?'stop':'';
+    const inner=h.masked?`${t} ∅`:h.has?t:`<span style="opacity:.45">${t}</span>`;
+    return`${i?'<span class="arr">→</span>':''}<span class="hop ${cls}">${inner}</span>`;
+  }).join('');
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and ${c.state==='masked'?'masked':'unset'}</b> — publish is blocked`;
+  else if(c.state==='masked')stateLine=`<b>masked</b> in ${env.name}`;
+  else if(c.state==='absent')stateLine=`unset — no layer provides a value`;
+  else if(c.state==='own')stateLine=`set in <b>${env.name}</b>`;
+  else stateLine=`inherited from <b>${c.origin==='defaults'?'project defaults':c.origin}</b>`;
+
+  /* value row */
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">${c.state==='masked'?'∅ masked':'—'}</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can still replace the value write-only.</div>`:''}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='own'?'edit value':'override here'}</button>
+      ${c.state==='own'&&!k.draft?`<button onclick="clearOverride()">clear override</button>`:''}
+      ${c.state!=='masked'?`<button class="danger" onclick="maskHere()">mask here</button>`:`<button onclick="clearOverride()">unmask</button>`}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    <div class="chain">${chain}</div>
+    ${vrow}
+    <div class="explain">
+      <b>secret vs mask</b> — <b>secret</b> is what a key <i>is</i> (classification): its values exist but are hidden; seeing one takes reveal permission. <b>mask</b> is a per-environment value state: “no value here, on purpose” — it also stops inheritance from filling this cell.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.layers[envId]={v:val};
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearOverride(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.layers[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function maskHere(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  k.layers[envId]={masked:true};delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function addKey(folder){
+  const name=document.getElementById('nk-name').value;
+  if(!name||KEYS.some(k=>k.name===name.toUpperCase()))return;
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),
+    document.getElementById('nk-type').value,document.getElementById('nk-sec').checked,'none',undefined,{},{},[]);
+  k.draft=true;
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{S.role=e.target.value;S.revealed.clear();render()};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/20/index.html
+++ b/docs/site/public/prototypes/env-matrix/20/index.html
@@ -1,0 +1,1078 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 20.
+  Editability affordance (Alex): iteration 14's plain-text cells stopped
+  reading as input fields. Values now carry the inline-edit convention — a
+  quiet dotted underline (accent on hover), visible on mobile where hover
+  does not exist. Absent cells get the same treatment on a wider slot.
+  No border chrome returns. Otherwise identical to 19:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+    border-bottom:1px dotted oklch(from var(--tx) l c h/.32);padding-bottom:2px;
+  }
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv:hover .tx{border-bottom-color:var(--accent)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  setSide(false);
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/21/index.html
+++ b/docs/site/public/prototypes/env-matrix/21/index.html
@@ -1,0 +1,1079 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 21.
+  Cell-affordance options (Alex: dotted underline too subtle). Four
+  selectable strengths via the bottom-right pill or ?cell=:
+    underline — iteration 20's dotted underline
+    well      — filled input-slot background
+    baseline  — solid bottom edge, spreadsheet feel
+    pencil    — trailing edit glyph
+  Alex picks; the winner becomes the next iteration. Shell selection
+  removed — rail + panel (C) is the shell. Otherwise 20:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* affordance option: underline (iteration 20) */
+  body[data-cell=underline] .cellv .tx{border-bottom:1px dotted oklch(from var(--tx) l c h/.32)}
+  body[data-cell=underline] .cellv:hover .tx{border-bottom-color:var(--accent)}
+  /* affordance option: well — filled input slot */
+  body[data-cell=well] .cellv{background:oklch(from var(--tx) l c h/.06)}
+  body[data-cell=well] .cellv:hover{background:oklch(from var(--tx) l c h/.11)}
+  /* affordance option: baseline — solid bottom edge, spreadsheet feel */
+  body[data-cell=baseline] .cellv{border-bottom:1px solid var(--line);border-radius:8px 8px 0 0}
+  body[data-cell=baseline] .cellv:hover{border-bottom-color:var(--accent)}
+  /* affordance option: pencil — trailing edit glyph */
+  body[data-cell=pencil] .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  body[data-cell=pencil] .cellv:hover::after{color:var(--accent)}
+  #cellswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));right:16px;
+    z-index:15;display:flex;align-items:center;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #cellswitch button{padding:4px 12px;border-radius:999px}
+  #cellswitch button:hover{background:oklch(0.28 0.02 250)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="cellswitch">
+  <button onclick="cycleCell()" title="cycle cell affordance option" aria-label="cycle cell affordance option">cell: <b id="cs-lbl"></b> ›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+const CELLSTYLES=['underline','well','baseline','pencil'];
+let CVAR=(()=>{try{return new URLSearchParams(location.search).get('cell')||'underline'}catch(_){return'underline'}})();
+if(!CELLSTYLES.includes(CVAR))CVAR='underline';
+function syncQS(){try{history.replaceState(null,'','?cell='+CVAR)}catch(_){/* file:// */}}
+function applyCell(){
+  document.body.dataset.cell=CVAR;
+  document.getElementById('cs-lbl').textContent=CVAR;
+}
+function cycleCell(){
+  CVAR=CELLSTYLES[(CELLSTYLES.indexOf(CVAR)+1)%CELLSTYLES.length];
+  syncQS();applyCell();
+}
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+applyCell();
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/22/index.html
+++ b/docs/site/public/prototypes/env-matrix/22/index.html
@@ -1,0 +1,1040 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>schema · required in ${esc(reqTxt)}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/23/index.html
+++ b/docs/site/public/prototypes/env-matrix/23/index.html
@@ -1,0 +1,1119 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .schemapre{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);background:var(--bg);
+    border:1px solid var(--line);border-radius:8px;padding:10px 12px;margin-top:10px;
+    overflow:auto;max-height:160px;width:100%;
+  }
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const schemaLbl=`schema · ${k.schema?'json schema · ':''}required in ${esc(reqTxt)}`;
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${k.schema?`<pre class="schemapre">${esc(JSON.stringify(k.schema,null,2))}</pre>`:''}`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const v=document.getElementById('nk-val');v.rows=this.value==='json'?5:1;v.placeholder=this.value==='json'?'first value (json — multiline)':'first value (optional)'"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/24/index.html
+++ b/docs/site/public/prototypes/env-matrix/24/index.html
@@ -1,0 +1,1214 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  if(k.type==='json')cnFields=`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+    placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>`;
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    const t=document.getElementById('cn-jschema').value.trim();
+    if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+    else delete k.schema;
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="vrow" id="nk-schemarow" hidden>
+      <textarea class="editor" id="nk-schema" rows="3" spellcheck="false"
+        placeholder='optional JSON Schema for values, e.g. {"type":"object"}'
+        onkeydown="if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  let schema;
+  if(type==='json'){
+    const t=document.getElementById('nk-schema').value.trim();
+    if(t){try{schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+  }
+  if(val){
+    const v=validateEdit({type,schema},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  if(schema)k.schema=schema;
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/25/index.html
+++ b/docs/site/public/prototypes/env-matrix/25/index.html
@@ -1,0 +1,1302 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/26/index.html
+++ b/docs/site/public/prototypes/env-matrix/26/index.html
@@ -1,0 +1,1329 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:100%;padding:10px 0 14px;margin:-8px 0 0;cursor:grab;touch-action:none}
+  #sheet .grab::after{content:'';display:block;width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto}
+  #sheet .grab:active{cursor:grabbing}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+/* drag-to-dismiss on the sheet grab handle (delegated — the sheet re-renders) */
+(function(){
+  const sheet=document.getElementById('sheet');
+  let sy=null,dy=0;
+  sheet.addEventListener('pointerdown',e=>{
+    if(!e.target.closest('.grab'))return;
+    sy=e.clientY;dy=0;
+    sheet.style.transition='none';
+    sheet.setPointerCapture(e.pointerId);
+  });
+  sheet.addEventListener('pointermove',e=>{
+    if(sy===null)return;
+    dy=Math.max(0,e.clientY-sy);
+    sheet.style.transform=`translate(-50%,${dy}px)`;
+  });
+  const end=()=>{
+    if(sy===null)return;
+    sheet.style.transition='';
+    sheet.style.transform='';
+    if(dy>110)closeSheet();
+    sy=null;
+  };
+  sheet.addEventListener('pointerup',end);
+  sheet.addEventListener('pointercancel',end);
+})();
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/27/index.html
+++ b/docs/site/public/prototypes/env-matrix/27/index.html
@@ -1,0 +1,1366 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:100%;padding:10px 0 14px;margin:-8px 0 0;cursor:grab;touch-action:none}
+  #sheet .grab::after{content:'';display:block;width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto}
+  #sheet .grab:active{cursor:grabbing}
+  #sheet .sheetclose{display:none}
+  /* sheet-style option B: centered modal (compare via bottom-right pill / ?sheet=) */
+  body[data-sheet="modal"] #sheet{
+    bottom:auto;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    border-radius:14px;border-bottom:1px solid var(--line);max-height:80vh;
+    width:min(560px,calc(100% - 32px));padding-bottom:24px;
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+  }
+  body[data-sheet="modal"] #sheet:not(.open){visibility:hidden}
+  body[data-sheet="modal"] #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1}
+  body[data-sheet="modal"] #sheet .grab{display:none}
+  body[data-sheet="modal"] #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  body[data-sheet="modal"] #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheetswitch{
+    position:fixed;right:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:30;
+    font-family:var(--mono);font-size:11px;letter-spacing:.04em;
+    background:var(--bg2);border:1px solid var(--line);border-radius:999px;
+    padding:8px 14px;color:var(--tx-dim);box-shadow:var(--sheet-shadow);
+  }
+  #sheetswitch:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.envpopX,innerWidth-230)+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.min(S.legendpopX,innerWidth-352)+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div><button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div><button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div><button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+/* drag-to-dismiss on the sheet grab handle (delegated — the sheet re-renders) */
+(function(){
+  const sheet=document.getElementById('sheet');
+  let sy=null,dy=0;
+  sheet.addEventListener('pointerdown',e=>{
+    if(!e.target.closest('.grab'))return;
+    sy=e.clientY;dy=0;
+    sheet.style.transition='none';
+    sheet.setPointerCapture(e.pointerId);
+  });
+  sheet.addEventListener('pointermove',e=>{
+    if(sy===null)return;
+    dy=Math.max(0,e.clientY-sy);
+    sheet.style.transform=`translate(-50%,${dy}px)`;
+  });
+  const end=()=>{
+    if(sy===null)return;
+    sheet.style.transition='';
+    sheet.style.transform='';
+    if(dy>110)closeSheet();
+    sy=null;
+  };
+  sheet.addEventListener('pointerup',end);
+  sheet.addEventListener('pointercancel',end);
+})();
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+/* sheet-style comparison: bottom sheet vs centered modal (?sheet=bottom|modal) */
+(function(){
+  const btn=document.createElement('button');
+  btn.id='sheetswitch';
+  const set=v=>{
+    document.body.dataset.sheet=v;
+    btn.textContent='sheet: '+v+' ▸';
+    const u=new URL(location);u.searchParams.set('sheet',v);history.replaceState(null,'',u);
+  };
+  btn.onclick=()=>set(document.body.dataset.sheet==='modal'?'bottom':'modal');
+  document.body.appendChild(btn);
+  set(new URL(location).searchParams.get('sheet')==='modal'?'modal':'bottom');
+})();
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/28/index.html
+++ b/docs/site/public/prototypes/env-matrix/28/index.html
@@ -1,0 +1,1309 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  const folderField=folder?'':`<div class="vrow">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)"
+        onkeydown="if(event.key==='Escape')closeSheet()">
+    </div>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder?folder+'/':''}</span></h2>
+    ${folderField.replace('<div class="vrow">','<div class="vrow" style="margin-top:14px">')}
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  let{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  if(!folder){
+    folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+    if(!folder)return err('group required, e.g. app');
+  }
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/29/index.html
+++ b/docs/site/public/prototypes/env-matrix/29/index.html
@@ -1,0 +1,1308 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <button class="srow" style="color:var(--tx-faint)" onclick="openCreate(null)">+ group</button>
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById(folder?'nk-name':'nk-folder')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key</h2>
+    <div class="vrow" style="margin-top:14px">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)" value="${esc(folder||'')}"
+        list="nk-groups" onkeydown="if(event.key==='Escape')closeSheet()">
+      <datalist id="nk-groups">${folders().map(f=>`<option value="${esc(f)}">`).join('')}</datalist>
+    </div>
+    <div class="sub">a new group name creates that group — declared into the environments you pick, no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  /* group field is always live — an unseen name creates that group */
+  const folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+  if(!folder)return err('group required, e.g. app');
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  if(last===-1)KEYS.push(k);          /* brand-new group → appears at the end */
+  else KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/3/index.html
+++ b/docs/site/public/prototypes/env-matrix/3/index.html
@@ -1,0 +1,703 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 2.
+  Variant C (Cascade) won round 1; editorial style dropped project-wide.
+  This iteration: dark default + light theme, mobile-first, in-place editing
+  via a bottom sheet, permission-gated reveal (role simulator), mask-vs-secret
+  clarity, env show/hide chips, collapsible groups with comma key list.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:0;background:var(--bg);z-index:10;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--line);border-radius:999px;padding:6px 12px;
+  }
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:61px;background:var(--bg);z-index:9;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .b{color:var(--tx-faint);font-size:11px}
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{overflow-x:auto;overscroll-behavior-x:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:3;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);margin-top:2px}
+  thead th .base b{color:var(--accent);font-weight:500}
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;left:0;background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.own{background:var(--accent);color:var(--on-accent);font-weight:500}
+  .pill.inh{border-color:var(--line);color:var(--tx-dim)}
+  .pill.inh .from,.pill.def .from{color:var(--accent);font-weight:600;font-size:10px}
+  .pill.own .from{color:var(--on-accent);font-weight:600;font-size:10px;opacity:.75}
+  .pill.def{background:var(--accent-soft);color:var(--tx-dim)}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.masked{
+    background:repeating-linear-gradient(45deg,transparent 0 4px,oklch(from var(--tx) l c h/.09) 4px 7px);
+    border-color:var(--line);color:var(--tx-dim);font-style:italic}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill.own .d{color:var(--on-accent)}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    display:flex;gap:10px 20px;flex-wrap:wrap;align-items:center;
+    padding:18px 16px 120px;font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .chain{
+    display:flex;align-items:center;flex-wrap:wrap;gap:6px;margin:14px 0 0;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);
+  }
+  #sheet .chain .hop{padding:5px 10px;border:1px solid var(--line);border-radius:6px}
+  #sheet .chain .hop.win{border-color:var(--accent);color:var(--accent);font-weight:600}
+  #sheet .chain .hop.stop{text-decoration:line-through;color:var(--tx-dim)}
+  #sheet .chain .arr{color:var(--tx-faint)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .acts button:disabled{opacity:.4;cursor:not-allowed}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+
+  /* ---------------- add key form ---------------- */
+  tr.addrow td{padding:10px 16px}
+  .addform{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:12.5px}
+  .addform input[type=text],.addform select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:9px 12px;border-radius:6px;font-family:var(--mono);font-size:12px;min-height:40px}
+  .addform label{display:flex;align-items:center;gap:5px;color:var(--tx-dim);font-size:12px}
+  .addform button.go{background:var(--accent);color:var(--on-accent);border-radius:6px;padding:9px 16px;font-weight:600;min-height:40px}
+  .addform button.x{color:var(--tx-faint);padding:9px 6px}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{top:57px;padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <span class="drafts" id="drafts" hidden></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission and inheritance visibility">
+      <option value="admin">admin · reveal everywhere · sees inheritance</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+const ENVS=[
+  {id:'dev',name:'development',base:null},
+  {id:'stg',name:'staging',base:'dev'},
+  {id:'prd',name:'production',base:'stg',protected:true},
+  {id:'pre',name:'preview',base:'stg'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,required,defaults,layers,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,defaults,layers:layers||{},invalid:invalid||{},changed:changed||[],desc});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all','Hikyo Demo',{},{},[]),
+  K('app','APP_URL','url',false,'all','http://localhost:8080',
+    {stg:{v:'https://stg.hikyo.dev'},prd:{v:'https://hikyo.dev'},pre:{v:'https://pr-{n}.preview.hikyo.dev'}},{},['prd']),
+  K('app','PORT','int',false,'all','8080',{},{},[]),
+  K('app','LOG_LEVEL','string',false,'all','info',{dev:{v:'debug'}},{},[]),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none','false',{pre:{v:'true'}},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',undefined,
+    {dev:{v:'postgres://hikyo:hikyo@localhost:5432/hikyo'},stg:{v:'postgres://hikyo@db.stg:5432/hikyo'},prd:{v:'postgres://hikyo@db.prd:5432/hikyo'}},{},[],
+    'Preview inherits staging’s database on purpose.'),
+  K('database','DB_POOL_SIZE','int',false,'all','10',
+    {stg:{v:'ten'},prd:{v:'40'}},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],undefined,{prd:{v:'verify-full'}},{},[]),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all','true',{prd:{v:'false'}},{},[]),
+  K('auth','SESSION_SECRET','string',true,'all',undefined,
+    {dev:{v:'dev-only-not-secret'},stg:{v:'s3cr3t-stg-9f2e'},prd:{v:'s3cr3t-prd-77aa'}},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],'https://id.example.dev',
+    {pre:{v:'localhost:8080'}},{pre:'url must be absolute'},[]),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],undefined,
+    {stg:{v:'ew-stg'},prd:{v:'ew-prd'}},{},[]),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],undefined,
+    {stg:{v:'oidc-stg-secret'}},{},[],
+    'Required in production; currently satisfied only by inheriting staging’s value.'),
+  K('mail','SMTP_HOST','string',false,'none','mail.internal',{prd:{v:'smtp.eu.mailer.dev'}},{},[]),
+  K('mail','SMTP_PORT','int',false,'none','587',{},{},[]),
+  K('mail','SMTP_PASSWORD','string',true,'none',undefined,
+    {dev:{masked:true},stg:{v:'stg-smtp-pass'},prd:{v:'prd-smtp-pass'}},{},[],
+    'Deliberately masked in development: no mail from dev boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',undefined,{prd:{v:'hik_1_at_x9k2m4'}},{},[]),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all','AKIADEFAULT0000',
+    {prd:{v:'AKIAPRODONLY9999'}},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all','wJalrXUtnFEMI/DEMO',
+    {prd:{masked:true}},{},[],'Masked in production while required: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',undefined,
+    {stg:{v:'https://s1@sentry.io/11'},prd:{v:'https://s2@sentry.io/12'}},{},[]),
+  K('observability','OTEL_ENDPOINT','url',false,'none','http://otel.internal:4317',{},{},[]),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',val,{},{},[]);
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.layers[e]={v:type==='int'?String(Math.floor(rnd()*90)+10):val};}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ resolution ============================ */
+function chainOf(envId){const c=[];let e=envById(envId);while(e){c.push(e.id);e=e.base?envById(e.base):null}return c}
+function resolve(key,envId){
+  for(const id of chainOf(envId)){
+    const l=key.layers[id];
+    if(l){ if(l.masked)return{state:'masked',origin:id};
+      return{state:id===envId?'own':'inh',origin:id,value:l.v}; }
+  }
+  if(key.defaults!==undefined)return{state:'def',origin:'defaults',value:key.defaults};
+  return{state:'absent'};
+}
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+function cellInfo(k,envId){
+  const r=resolve(k,envId);
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&(r.state==='absent'||r.state==='masked');
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{...r,required,invalid,missing,changed};
+}
+function rowDiff(k){
+  /* computed over readable envs only — an unreadable env must not move any signal */
+  const vals=readableEnvs().map(e=>resolve(k,e.id)).filter(r=>r.value!==undefined).map(r=>r.value);
+  return new Set(vals).size>1;
+}
+function provChain(k,envId){
+  const ids=chainOf(envId).reverse();
+  const hops=[{layer:'defaults',has:k.defaults!==undefined}];
+  for(const id of ids)hops.push({layer:id,has:!!k.layers[id],masked:!!(k.layers[id]&&k.layers[id].masked)});
+  const r=resolve(k,envId);
+  for(const h of hops)h.win=(h.layer===(r.origin||''));
+  return{hops,r};
+}
+/* light client-side validation for in-place edits (prototype only) */
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+
+/* ============================ ui state ============================ */
+const S={
+  theme:'dark',
+  role:'dev',                     // admin | dev | viewer
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),             // `${key}:${env}`
+  drafts:new Set(),               // local unpublished edits `${key}:${env}`
+  sheet:null,                     // {key,envId,mode:'view'|'edit'}
+  adding:null,
+};
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent).
+   inherit ⇒ may see origin markers / provenance / base topology — hidden
+   otherwise, because "prod inherits stg" + reveal(stg) = prod plaintext. */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,inherit:true},
+  dev:{read:e=>true,reveal:e=>!e.protected,inherit:false},
+  viewer:{read:e=>true,reveal:e=>false,inherit:false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected,inherit:false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const seesInherit=()=>role().inherit;
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      const base=seesInherit()?(e.base?`<span class="b">◂ ${e.base}</span>`:'<span class="b">◂ defaults</span>'):'';
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${base}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  let inner;
+  if(c.invalid)inner=`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  else if(c.missing)inner=`<span class="pill missing" ${open}><span class="tx">! required · ${c.state==='masked'?'masked':'unset'}</span></span>`;
+  else if(c.state==='masked')inner=`<span class="pill masked" ${open}><span class="tx">∅ masked</span></span>`;
+  else if(c.state==='absent')inner=`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  else if(!seesInherit()){
+    /* origin hidden: own / inherited / defaults all render identically —
+       an origin marker on an unrevealable env is a comparison oracle */
+    const v=esc(shownValue(k,e.id,c));
+    inner=`<span class="pill inh" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+  }else{
+    const v=esc(shownValue(k,e.id,c));
+    if(c.state==='own')inner=`<span class="pill own" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+    else if(c.state==='def')inner=`<span class="pill def" ${open}><span class="from">◂ def</span><span class="tx">${v}</span>${d}${draft}</span>`;
+    else inner=`<span class="pill inh" ${open}><span class="from">◂ ${c.origin}</span><span class="tx">${v}</span>${d}${draft}</span>`;
+  }
+  return inner;
+}
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+     ${seesInherit()?`<span class="base">inherits <b>◂ ${e.base?envById(e.base).name:'project defaults'}</b></span>`:''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();S.adding='${f}';render()" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    if(S.adding===f)body+=`<tr class="addrow"><td colspan="${envs.length+1}">
+      <span class="addform">
+        <input type="text" id="nk-name" placeholder="KEY_NAME" size="16">
+        <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+        <label><input type="checkbox" id="nk-sec"> secret</label>
+        <button class="go" onclick="addKey('${f}')">declare</button>
+        <button class="x" onclick="S.adding=null;render()">cancel</button>
+      </span></td></tr>`;
+    for(const k of ks){
+      /* drift on a secret row is itself a cross-env comparison signal — admin-only, like origin */
+      const drift=rowDiff(k)&&(seesInherit()||!k.secret);
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  const inheritBits=seesInherit()?`
+    <span class="pill own">value</span> set in this environment
+    <span class="pill inh"><span class="from">◂ stg</span>value</span> inherited
+    <span class="pill def"><span class="from">◂ def</span>value</span> from project defaults`:`
+    <span class="pill inh">value</span> resolved value (origin visible to admins only)`;
+  document.getElementById('legend').innerHTML=`${inheritBits}
+    <span class="pill masked">∅ masked</span> no value here, on purpose
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed${seesInherit()?' · amber row = values drift':' · amber row = config values drift'} · tap any cell to inspect or edit</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''}`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const{hops}=provChain(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  /* provenance is admin-only: naming the origin env of an unrevealable cell
+     turns reveal(origin) into that cell's plaintext */
+  const chain=!seesInherit()?'':hops.map((h,i)=>{
+    const t=h.layer==='defaults'?'defaults':h.layer;
+    const cls=h.win?'win':h.masked?'stop':'';
+    const inner=h.masked?`${t} ∅`:h.has?t:`<span style="opacity:.45">${t}</span>`;
+    return`${i?'<span class="arr">→</span>':''}<span class="hop ${cls}">${inner}</span>`;
+  }).join('');
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and ${c.state==='masked'?'masked':'unset'}</b> — publish is blocked`;
+  else if(c.state==='masked')stateLine=`<b>masked</b> in ${env.name}`;
+  else if(c.state==='absent')stateLine=`unset — no layer provides a value`;
+  else if(!seesInherit())stateLine=`has a value in <b>${env.name}</b>`;
+  else if(c.state==='own')stateLine=`set in <b>${env.name}</b>`;
+  else stateLine=`inherited from <b>${c.origin==='defaults'?'project defaults':c.origin}</b>`;
+
+  /* value row */
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">${c.state==='masked'?'∅ masked':'—'}</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can still replace the value write-only.</div>`:''}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${!seesInherit()?'edit value':c.state==='own'?'edit value':'override here'}</button>
+      ${seesInherit()&&c.state==='own'&&!k.draft?`<button onclick="clearOverride()">clear override</button>`:''}
+      ${c.state!=='masked'?`<button class="danger" onclick="maskHere()">mask here</button>`:`<button onclick="clearOverride()">unmask</button>`}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc&&seesInherit()?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${chain?`<div class="chain">${chain}</div>`:''}
+    ${vrow}
+    <div class="explain">
+      <b>secret vs mask</b> — <b>secret</b> is what a key <i>is</i> (classification): its values exist but are hidden; seeing one takes reveal permission. <b>mask</b> is a per-environment value state: “no value here, on purpose” — it also stops inheritance from filling this cell.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.layers[envId]={v:val};
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearOverride(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.layers[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function maskHere(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  k.layers[envId]={masked:true};delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function addKey(folder){
+  const name=document.getElementById('nk-name').value;
+  if(!name||KEYS.some(k=>k.name===name.toUpperCase()))return;
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),
+    document.getElementById('nk-type').value,document.getElementById('nk-sec').checked,'none',undefined,{},{},[]);
+  k.draft=true;
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/30/index.html
+++ b/docs/site/public/prototypes/env-matrix/30/index.html
@@ -1,0 +1,1312 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  /* navigating to a group leaves the problems view — a filtered-out group
+     otherwise made this button silently dead ("locked in problems view") */
+  S.filter=null;
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <button class="srow" style="color:var(--tx-faint)" onclick="openCreate(null)">+ group</button>
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()"
+      title="${S.filter==='problems'?'back to all keys':'show only keys with problems'}">⚠ problems${totalProblems()?`<span class="pb">${totalProblems()}</span>`:''}${S.filter==='problems'?'<span style="margin-left:auto;font-size:11px">✕</span>':''}</button>
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no unpublished edits"'}>Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById(folder?'nk-name':'nk-folder')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key</h2>
+    <div class="vrow" style="margin-top:14px">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)" value="${esc(folder||'')}"
+        list="nk-groups" onkeydown="if(event.key==='Escape')closeSheet()">
+      <datalist id="nk-groups">${folders().map(f=>`<option value="${esc(f)}">`).join('')}</datalist>
+    </div>
+    <div class="sub">a new group name creates that group — declared into the environments you pick, no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  /* group field is always live — an unseen name creates that group */
+  const folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+  if(!folder)return err('group required, e.g. app');
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  if(last===-1)KEYS.push(k);          /* brand-new group → appears at the end */
+  else KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/31/index.html
+++ b/docs/site/public/prototypes/env-matrix/31/index.html
@@ -1,0 +1,1334 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 22.
+  Cell affordance decided: PENCIL — every editable slot carries a faint
+  trailing ✎ (accent on hover). The affordance switcher and the other
+  three options are removed. Rail + panel is the shell. Otherwise 21:
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  #filterbar{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:8px 14px;font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    background:color-mix(in oklch,var(--bad) 8%,var(--bg2));
+    border-bottom:1px solid var(--line);border-left:3px solid var(--bad);
+  }
+  #filterbar button{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:999px;padding:4px 12px;min-height:28px;
+  }
+  #filterbar button:hover{border-color:var(--accent);color:var(--accent)}
+  #side .srow.hiddenby{opacity:.4;cursor:default}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px)}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div id="filterbar" hidden></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function renderFilterBar(){
+  const bar=document.getElementById('filterbar');
+  if(!S.filter){bar.hidden=true;return}
+  const n=KEYS.filter(keyHasProblem).length;
+  bar.hidden=false;
+  bar.innerHTML=`<span>⚠ filter active: <b style="color:var(--tx)">problems</b> — showing ${n} of ${KEYS.length} keys</span>
+    <button onclick="toggleProblemFilter()">✕ show all keys</button>`;
+}
+function render(){
+  renderFilterBar();renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  /* the filter survives navigation (Alex, iteration 31) — groups the filter
+     hides are rendered inert in the panel instead of silently dead */
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.collapsed.clear();S.filter=null;closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>{
+      const hid=S.filter==='problems'&&!g.p;
+      return`<button class="srow ${hid?'hiddenby':''}" ${hid?'disabled title="hidden by the problems filter"':`onclick="jumpGroup('${g.f}')"`}><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`}).join('')}
+    <button class="srow" style="color:var(--tx-faint)" onclick="openCreate(null)">+ group</button>
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()"
+      title="${S.filter==='problems'?'back to all keys':'show only keys with problems'}">⚠ problems${S.filter==='problems'?'<span style="margin-left:auto;font-size:11px">✕</span>':''}${totalProblems()?`<span class="pb" ${S.filter==='problems'?'style="margin-left:8px"':''}>${totalProblems()}</span>`:''}</button>
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no unpublished edits"'}>Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById(folder?'nk-name':'nk-folder')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?'hide value':'reveal value'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm(`Reveal the production value of ${key}?\n\nRe-authentication would be required here (prototype stand-in — ticket #21).`))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Copy this value into ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in).`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`Publish a new revision to ${prot.join(', ')} (protected)?\n\nRe-authentication would be required (prototype stand-in — ticket #21).`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key</h2>
+    <div class="vrow" style="margin-top:14px">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)" value="${esc(folder||'')}"
+        list="nk-groups" onkeydown="if(event.key==='Escape')closeSheet()">
+      <datalist id="nk-groups">${folders().map(f=>`<option value="${esc(f)}">`).join('')}</datalist>
+    </div>
+    <div class="sub">a new group name creates that group — declared into the environments you pick, no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  /* group field is always live — an unseen name creates that group */
+  const folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+  if(!folder)return err('group required, e.g. app');
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  if(last===-1)KEYS.push(k);          /* brand-new group → appears at the end */
+  else KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/4/index.html
+++ b/docs/site/public/prototypes/env-matrix/4/index.html
@@ -1,0 +1,707 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 2.
+  Variant C (Cascade) won round 1; editorial style dropped project-wide.
+  This iteration: dark default + light theme, mobile-first, in-place editing
+  via a bottom sheet, permission-gated reveal (role simulator), mask-vs-secret
+  clarity, env show/hide chips, collapsible groups with comma key list.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:0;background:var(--bg);z-index:10;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--line);border-radius:999px;padding:6px 12px;
+  }
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    position:sticky;top:61px;background:var(--bg);z-index:9;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .b{color:var(--tx-faint);font-size:11px}
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{overflow-x:auto;overscroll-behavior-x:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:3;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);margin-top:2px}
+  thead th .base b{color:var(--accent);font-weight:500}
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;left:0;background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.own{background:var(--accent);color:var(--on-accent);font-weight:500}
+  .pill.inh{border-color:var(--line);color:var(--tx-dim)}
+  .pill.inh .from,.pill.def .from{color:var(--accent);font-weight:600;font-size:10px}
+  .pill.own .from{color:var(--on-accent);font-weight:600;font-size:10px;opacity:.75}
+  .pill.def{background:var(--accent-soft);color:var(--tx-dim)}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.masked{
+    background:repeating-linear-gradient(45deg,transparent 0 4px,oklch(from var(--tx) l c h/.09) 4px 7px);
+    border-color:var(--line);color:var(--tx-dim);font-style:italic}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill.own .d{color:var(--on-accent)}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    display:flex;gap:10px 20px;flex-wrap:wrap;align-items:center;
+    padding:18px 16px 120px;font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .chain{
+    display:flex;align-items:center;flex-wrap:wrap;gap:6px;margin:14px 0 0;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);
+  }
+  #sheet .chain .hop{padding:5px 10px;border:1px solid var(--line);border-radius:6px}
+  #sheet .chain .hop.win{border-color:var(--accent);color:var(--accent);font-weight:600}
+  #sheet .chain .hop.stop{text-decoration:line-through;color:var(--tx-dim)}
+  #sheet .chain .arr{color:var(--tx-faint)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .acts button:disabled{opacity:.4;cursor:not-allowed}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+
+  /* ---------------- add key form ---------------- */
+  tr.addrow td{padding:10px 16px}
+  .addform{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:12.5px}
+  .addform input[type=text],.addform select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:9px 12px;border-radius:6px;font-family:var(--mono);font-size:12px;min-height:40px}
+  .addform label{display:flex;align-items:center;gap:5px;color:var(--tx-dim);font-size:12px}
+  .addform button.go{background:var(--accent);color:var(--on-accent);border-radius:6px;padding:9px 16px;font-weight:600;min-height:40px}
+  .addform button.x{color:var(--tx-faint);padding:9px 6px}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{top:57px;padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <span class="drafts" id="drafts" hidden></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission and inheritance visibility">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+const ENVS=[
+  {id:'dev',name:'development',base:null},
+  {id:'stg',name:'staging',base:'dev'},
+  {id:'prd',name:'production',base:'stg',protected:true},
+  {id:'pre',name:'preview',base:'stg'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,required,defaults,layers,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,defaults,layers:layers||{},invalid:invalid||{},changed:changed||[],desc});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all','Hikyo Demo',{},{},[]),
+  K('app','APP_URL','url',false,'all','http://localhost:8080',
+    {stg:{v:'https://stg.hikyo.dev'},prd:{v:'https://hikyo.dev'},pre:{v:'https://pr-{n}.preview.hikyo.dev'}},{},['prd']),
+  K('app','PORT','int',false,'all','8080',{},{},[]),
+  K('app','LOG_LEVEL','string',false,'all','info',{dev:{v:'debug'}},{},[]),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none','false',{pre:{v:'true'}},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',undefined,
+    {dev:{v:'postgres://hikyo:hikyo@localhost:5432/hikyo'},stg:{v:'postgres://hikyo@db.stg:5432/hikyo'},prd:{v:'postgres://hikyo@db.prd:5432/hikyo'}},{},[],
+    'Preview inherits staging’s database on purpose.'),
+  K('database','DB_POOL_SIZE','int',false,'all','10',
+    {stg:{v:'ten'},prd:{v:'40'}},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],undefined,{prd:{v:'verify-full'}},{},[]),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all','true',{prd:{v:'false'}},{},[]),
+  K('auth','SESSION_SECRET','string',true,'all',undefined,
+    {dev:{v:'dev-only-not-secret'},stg:{v:'s3cr3t-stg-9f2e'},prd:{v:'s3cr3t-prd-77aa'}},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],'https://id.example.dev',
+    {pre:{v:'localhost:8080'}},{pre:'url must be absolute'},[]),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],undefined,
+    {stg:{v:'ew-stg'},prd:{v:'ew-prd'}},{},[]),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],undefined,
+    {stg:{v:'oidc-stg-secret'}},{},[],
+    'Required in production; currently satisfied only by inheriting staging’s value.'),
+  K('mail','SMTP_HOST','string',false,'none','mail.internal',{prd:{v:'smtp.eu.mailer.dev'}},{},[]),
+  K('mail','SMTP_PORT','int',false,'none','587',{},{},[]),
+  K('mail','SMTP_PASSWORD','string',true,'none',undefined,
+    {dev:{masked:true},stg:{v:'stg-smtp-pass'},prd:{v:'prd-smtp-pass'}},{},[],
+    'Deliberately masked in development: no mail from dev boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',undefined,{prd:{v:'hik_1_at_x9k2m4'}},{},[]),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all','AKIADEFAULT0000',
+    {prd:{v:'AKIAPRODONLY9999'}},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all','wJalrXUtnFEMI/DEMO',
+    {prd:{masked:true}},{},[],'Masked in production while required: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',undefined,
+    {stg:{v:'https://s1@sentry.io/11'},prd:{v:'https://s2@sentry.io/12'}},{},[]),
+  K('observability','OTEL_ENDPOINT','url',false,'none','http://otel.internal:4317',{},{},[]),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',val,{},{},[]);
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.layers[e]={v:type==='int'?String(Math.floor(rnd()*90)+10):val};}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ resolution ============================ */
+function chainOf(envId){const c=[];let e=envById(envId);while(e){c.push(e.id);e=e.base?envById(e.base):null}return c}
+function resolve(key,envId){
+  for(const id of chainOf(envId)){
+    const l=key.layers[id];
+    if(l){ if(l.masked)return{state:'masked',origin:id};
+      return{state:id===envId?'own':'inh',origin:id,value:l.v}; }
+  }
+  if(key.defaults!==undefined)return{state:'def',origin:'defaults',value:key.defaults};
+  return{state:'absent'};
+}
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+function cellInfo(k,envId){
+  const r=resolve(k,envId);
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&(r.state==='absent'||r.state==='masked');
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{...r,required,invalid,missing,changed};
+}
+function rowDiff(k){
+  /* computed over readable envs only — an unreadable env must not move any signal */
+  const vals=readableEnvs().map(e=>resolve(k,e.id)).filter(r=>r.value!==undefined).map(r=>r.value);
+  return new Set(vals).size>1;
+}
+function provChain(k,envId){
+  const ids=chainOf(envId).reverse();
+  const hops=[{layer:'defaults',has:k.defaults!==undefined}];
+  for(const id of ids)hops.push({layer:id,has:!!k.layers[id],masked:!!(k.layers[id]&&k.layers[id].masked)});
+  const r=resolve(k,envId);
+  for(const h of hops)h.win=(h.layer===(r.origin||''));
+  return{hops,r};
+}
+/* light client-side validation for in-place edits (prototype only) */
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+
+/* ============================ ui state ============================ */
+const S={
+  theme:'dark',
+  role:'dev',                     // admin | dev | viewer
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),             // `${key}:${env}`
+  drafts:new Set(),               // local unpublished edits `${key}:${env}`
+  sheet:null,                     // {key,envId,mode:'view'|'edit'}
+  adding:null,
+};
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+/* origin rule ("sharp"): config keys always show provenance (values are
+   readable anyway, no oracle); a secret cell shows provenance only where the
+   viewer holds reveal for THAT env — "prod inherits stg" + reveal(stg) would
+   otherwise be prod plaintext (the comparison oracle ADR #11 closes). */
+const showOrigin=(k,envId)=>!k.secret||canReveal(envId);
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env, i.e. the comparison adds nothing new */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      const base=e.base?`<span class="b">◂ ${e.base}</span>`:'<span class="b">◂ defaults</span>';
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${base}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  let inner;
+  if(c.invalid)inner=`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  else if(c.missing)inner=`<span class="pill missing" ${open}><span class="tx">! required · ${c.state==='masked'?'masked':'unset'}</span></span>`;
+  else if(c.state==='masked')inner=`<span class="pill masked" ${open}><span class="tx">∅ masked</span></span>`;
+  else if(c.state==='absent')inner=`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  else if(!showOrigin(k,e.id)){
+    /* secret cell without reveal here: own / inherited / defaults render
+       identically — an origin marker would be a comparison oracle */
+    const v=esc(shownValue(k,e.id,c));
+    inner=`<span class="pill inh" ${open}><span class="from">🔒</span><span class="tx">${v}</span>${d}${draft}</span>`;
+  }else{
+    const v=esc(shownValue(k,e.id,c));
+    if(c.state==='own')inner=`<span class="pill own" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+    else if(c.state==='def')inner=`<span class="pill def" ${open}><span class="from">◂ def</span><span class="tx">${v}</span>${d}${draft}</span>`;
+    else inner=`<span class="pill inh" ${open}><span class="from">◂ ${c.origin}</span><span class="tx">${v}</span>${d}${draft}</span>`;
+  }
+  return inner;
+}
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+     <span class="base">inherits <b>◂ ${e.base?envById(e.base).name:'project defaults'}</b></span></th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();S.adding='${f}';render()" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    if(S.adding===f)body+=`<tr class="addrow"><td colspan="${envs.length+1}">
+      <span class="addform">
+        <input type="text" id="nk-name" placeholder="KEY_NAME" size="16">
+        <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+        <label><input type="checkbox" id="nk-sec"> secret</label>
+        <button class="go" onclick="addKey('${f}')">declare</button>
+        <button class="x" onclick="S.adding=null;render()">cancel</button>
+      </span></td></tr>`;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill own">value</span> set in this environment
+    <span class="pill inh"><span class="from">◂ stg</span>value</span> inherited
+    <span class="pill def"><span class="from">◂ def</span>value</span> from project defaults
+    <span class="pill inh"><span class="from">🔒</span>value</span> secret where you lack reveal — origin deliberately not shown
+    <span class="pill masked">∅ masked</span> no value here, on purpose
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values drift · tap any cell to inspect or edit</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''}`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const{hops}=provChain(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  /* provenance shown per the sharp rule: config always; secret only with
+     reveal here — naming the origin env of an unrevealable cell turns
+     reveal(origin) into that cell's plaintext */
+  const chain=!showOrigin(k,envId)?'':hops.map((h,i)=>{
+    const t=h.layer==='defaults'?'defaults':h.layer;
+    const cls=h.win?'win':h.masked?'stop':'';
+    const inner=h.masked?`${t} ∅`:h.has?t:`<span style="opacity:.45">${t}</span>`;
+    return`${i?'<span class="arr">→</span>':''}<span class="hop ${cls}">${inner}</span>`;
+  }).join('');
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and ${c.state==='masked'?'masked':'unset'}</b> — publish is blocked`;
+  else if(c.state==='masked')stateLine=`<b>masked</b> in ${env.name}`;
+  else if(c.state==='absent')stateLine=`unset — no layer provides a value`;
+  else if(!showOrigin(k,envId))stateLine=`has a value in <b>${env.name}</b>`;
+  else if(c.state==='own')stateLine=`set in <b>${env.name}</b>`;
+  else stateLine=`inherited from <b>${c.origin==='defaults'?'project defaults':c.origin}</b>`;
+
+  /* value row */
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">${c.state==='masked'?'∅ masked':'—'}</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can still replace the value write-only.</div>`:''}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${!showOrigin(k,envId)?'edit value':c.state==='own'?'edit value':'override here'}</button>
+      ${showOrigin(k,envId)&&c.state==='own'&&!k.draft?`<button onclick="clearOverride()">clear override</button>`:''}
+      ${c.state!=='masked'?`<button class="danger" onclick="maskHere()">mask here</button>`:`<button onclick="clearOverride()">unmask</button>`}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc&&showOrigin(k,envId)?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${chain?`<div class="chain">${chain}</div>`:''}
+    ${vrow}
+    <div class="explain">
+      <b>secret vs mask</b> — <b>secret</b> is what a key <i>is</i> (classification): its values exist but are hidden; seeing one takes reveal permission. <b>mask</b> is a per-environment value state: “no value here, on purpose” — it also stops inheritance from filling this cell.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.layers[envId]={v:val};
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearOverride(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.layers[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function maskHere(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  k.layers[envId]={masked:true};delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function addKey(folder){
+  const name=document.getElementById('nk-name').value;
+  if(!name||KEYS.some(k=>k.name===name.toUpperCase()))return;
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),
+    document.getElementById('nk-type').value,document.getElementById('nk-sec').checked,'none',undefined,{},{},[]);
+  k.draft=true;
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/5/index.html
+++ b/docs/site/public/prototypes/env-matrix/5/index.html
@@ -1,0 +1,706 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 5.
+  On top of iteration 4 (sharp origin rule): inheritance is OPAQUE in the
+  grid — cells show only the resolved value; provenance appears only in the
+  cell sheet (still gated: config always, secrets only with reveal there).
+  Sticky env header row and sticky group headers while scrolling.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--line);border-radius:999px;padding:6px 12px;
+  }
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .b{color:var(--tx-faint);font-size:11px}
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);margin-top:2px}
+  thead th .base b{color:var(--accent);font-weight:500}
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.own{background:var(--accent);color:var(--on-accent);font-weight:500}
+  .pill.inh{border-color:var(--line);color:var(--tx-dim)}
+  .pill.inh .from,.pill.def .from{color:var(--accent);font-weight:600;font-size:10px}
+  .pill.own .from{color:var(--on-accent);font-weight:600;font-size:10px;opacity:.75}
+  .pill.def{background:var(--accent-soft);color:var(--tx-dim)}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.masked{
+    background:repeating-linear-gradient(45deg,transparent 0 4px,oklch(from var(--tx) l c h/.09) 4px 7px);
+    border-color:var(--line);color:var(--tx-dim);font-style:italic}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill.own .d{color:var(--on-accent)}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .chain{
+    display:flex;align-items:center;flex-wrap:wrap;gap:6px;margin:14px 0 0;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);
+  }
+  #sheet .chain .hop{padding:5px 10px;border:1px solid var(--line);border-radius:6px}
+  #sheet .chain .hop.win{border-color:var(--accent);color:var(--accent);font-weight:600}
+  #sheet .chain .hop.stop{text-decoration:line-through;color:var(--tx-dim)}
+  #sheet .chain .arr{color:var(--tx-faint)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .acts button:disabled{opacity:.4;cursor:not-allowed}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+
+  /* ---------------- add key form ---------------- */
+  tr.addrow td{padding:10px 16px}
+  .addform{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:12.5px}
+  .addform input[type=text],.addform select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:9px 12px;border-radius:6px;font-family:var(--mono);font-size:12px;min-height:40px}
+  .addform label{display:flex;align-items:center;gap:5px;color:var(--tx-dim);font-size:12px}
+  .addform button.go{background:var(--accent);color:var(--on-accent);border-radius:6px;padding:9px 16px;font-weight:600;min-height:40px}
+  .addform button.x{color:var(--tx-faint);padding:9px 6px}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <span class="drafts" id="drafts" hidden></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission and inheritance visibility">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+const ENVS=[
+  {id:'dev',name:'development',base:null},
+  {id:'stg',name:'staging',base:'dev'},
+  {id:'prd',name:'production',base:'stg',protected:true},
+  {id:'pre',name:'preview',base:'stg'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,required,defaults,layers,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,defaults,layers:layers||{},invalid:invalid||{},changed:changed||[],desc});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all','Hikyo Demo',{},{},[]),
+  K('app','APP_URL','url',false,'all','http://localhost:8080',
+    {stg:{v:'https://stg.hikyo.dev'},prd:{v:'https://hikyo.dev'},pre:{v:'https://pr-{n}.preview.hikyo.dev'}},{},['prd']),
+  K('app','PORT','int',false,'all','8080',{},{},[]),
+  K('app','LOG_LEVEL','string',false,'all','info',{dev:{v:'debug'}},{},[]),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none','false',{pre:{v:'true'}},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',undefined,
+    {dev:{v:'postgres://hikyo:hikyo@localhost:5432/hikyo'},stg:{v:'postgres://hikyo@db.stg:5432/hikyo'},prd:{v:'postgres://hikyo@db.prd:5432/hikyo'}},{},[],
+    'Preview inherits staging’s database on purpose.'),
+  K('database','DB_POOL_SIZE','int',false,'all','10',
+    {stg:{v:'ten'},prd:{v:'40'}},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],undefined,{prd:{v:'verify-full'}},{},[]),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all','true',{prd:{v:'false'}},{},[]),
+  K('auth','SESSION_SECRET','string',true,'all',undefined,
+    {dev:{v:'dev-only-not-secret'},stg:{v:'s3cr3t-stg-9f2e'},prd:{v:'s3cr3t-prd-77aa'}},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],'https://id.example.dev',
+    {pre:{v:'localhost:8080'}},{pre:'url must be absolute'},[]),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],undefined,
+    {stg:{v:'ew-stg'},prd:{v:'ew-prd'}},{},[]),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],undefined,
+    {stg:{v:'oidc-stg-secret'}},{},[],
+    'Required in production; currently satisfied only by inheriting staging’s value.'),
+  K('mail','SMTP_HOST','string',false,'none','mail.internal',{prd:{v:'smtp.eu.mailer.dev'}},{},[]),
+  K('mail','SMTP_PORT','int',false,'none','587',{},{},[]),
+  K('mail','SMTP_PASSWORD','string',true,'none',undefined,
+    {dev:{masked:true},stg:{v:'stg-smtp-pass'},prd:{v:'prd-smtp-pass'}},{},[],
+    'Deliberately excluded in development: no mail from dev boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',undefined,{prd:{v:'hik_1_at_x9k2m4'}},{},[]),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all','AKIADEFAULT0000',
+    {prd:{v:'AKIAPRODONLY9999'}},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all','wJalrXUtnFEMI/DEMO',
+    {prd:{masked:true}},{},[],'Excluded in production while required: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',undefined,
+    {stg:{v:'https://s1@sentry.io/11'},prd:{v:'https://s2@sentry.io/12'}},{},[]),
+  K('observability','OTEL_ENDPOINT','url',false,'none','http://otel.internal:4317',{},{},[]),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',val,{},{},[]);
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.layers[e]={v:type==='int'?String(Math.floor(rnd()*90)+10):val};}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ resolution ============================ */
+function chainOf(envId){const c=[];let e=envById(envId);while(e){c.push(e.id);e=e.base?envById(e.base):null}return c}
+function resolve(key,envId){
+  for(const id of chainOf(envId)){
+    const l=key.layers[id];
+    if(l){ if(l.masked)return{state:'masked',origin:id};
+      return{state:id===envId?'own':'inh',origin:id,value:l.v}; }
+  }
+  if(key.defaults!==undefined)return{state:'def',origin:'defaults',value:key.defaults};
+  return{state:'absent'};
+}
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+function cellInfo(k,envId){
+  const r=resolve(k,envId);
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&(r.state==='absent'||r.state==='masked');
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{...r,required,invalid,missing,changed};
+}
+function rowDiff(k){
+  /* computed over readable envs only — an unreadable env must not move any signal */
+  const vals=readableEnvs().map(e=>resolve(k,e.id)).filter(r=>r.value!==undefined).map(r=>r.value);
+  return new Set(vals).size>1;
+}
+function provChain(k,envId){
+  const ids=chainOf(envId).reverse();
+  const hops=[{layer:'defaults',has:k.defaults!==undefined}];
+  for(const id of ids)hops.push({layer:id,has:!!k.layers[id],masked:!!(k.layers[id]&&k.layers[id].masked)});
+  const r=resolve(k,envId);
+  for(const h of hops)h.win=(h.layer===(r.origin||''));
+  return{hops,r};
+}
+/* light client-side validation for in-place edits (prototype only) */
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+
+/* ============================ ui state ============================ */
+const S={
+  theme:'dark',
+  role:'dev',                     // admin | dev | viewer
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),             // `${key}:${env}`
+  drafts:new Set(),               // local unpublished edits `${key}:${env}`
+  sheet:null,                     // {key,envId,mode:'view'|'edit'}
+  adding:null,
+};
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+/* origin rule ("sharp"): config keys always show provenance (values are
+   readable anyway, no oracle); a secret cell shows provenance only where the
+   viewer holds reveal for THAT env — "prod inherits stg" + reveal(stg) would
+   otherwise be prod plaintext (the comparison oracle ADR #11 closes). */
+const showOrigin=(k,envId)=>!k.secret||canReveal(envId);
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env, i.e. the comparison adds nothing new */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  let inner;
+  if(c.invalid)inner=`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  else if(c.missing)inner=`<span class="pill missing" ${open}><span class="tx">! required · ${c.state==='masked'?'excluded':'unset'}</span></span>`;
+  else if(c.state==='masked')inner=`<span class="pill masked" ${open}><span class="tx">∅ excluded</span></span>`;
+  else if(c.state==='absent')inner=`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  else{
+    /* inheritance is opaque in the grid: every resolved value renders the
+       same, wherever it comes from — provenance lives in the cell sheet */
+    const v=esc(shownValue(k,e.id,c));
+    inner=`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+  }
+  return inner;
+}
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();S.adding='${f}';render()" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    if(S.adding===f)body+=`<tr class="addrow"><td colspan="${envs.length+1}">
+      <span class="addform">
+        <input type="text" id="nk-name" placeholder="KEY_NAME" size="16">
+        <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+        <label><input type="checkbox" id="nk-sec"> secret</label>
+        <button class="go" onclick="addKey('${f}')">declare</button>
+        <button class="x" onclick="S.adding=null;render()">cancel</button>
+      </span></td></tr>`;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> resolved value — tap for where it comes from
+    <span class="pill masked">∅ excluded</span> deliberately nothing here — stops inheritance
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values drift</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''}`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  /* group headers stick right under the measured thead */
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const{hops}=provChain(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  /* provenance shown per the sharp rule: config always; secret only with
+     reveal here — naming the origin env of an unrevealable cell turns
+     reveal(origin) into that cell's plaintext */
+  const chain=!showOrigin(k,envId)?'':hops.map((h,i)=>{
+    const t=h.layer==='defaults'?'defaults':h.layer;
+    const cls=h.win?'win':h.masked?'stop':'';
+    const inner=h.masked?`${t} ∅`:h.has?t:`<span style="opacity:.45">${t}</span>`;
+    return`${i?'<span class="arr">→</span>':''}<span class="hop ${cls}">${inner}</span>`;
+  }).join('');
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and ${c.state==='masked'?'excluded':'unset'}</b> — publish is blocked`;
+  else if(c.state==='masked')stateLine=`<b>excluded</b> in ${env.name} — nothing delivered, inheritance stopped`;
+  else if(c.state==='absent')stateLine=`unset — no layer provides a value`;
+  else if(!showOrigin(k,envId))stateLine=`has a value in <b>${env.name}</b>`;
+  else if(c.state==='own')stateLine=`set in <b>${env.name}</b>`;
+  else stateLine=`inherited from <b>${c.origin==='defaults'?'project defaults':c.origin}</b>`;
+
+  /* value row */
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">${c.state==='masked'?'∅ excluded':'—'}</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can still replace the value write-only.</div>`:''}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${!showOrigin(k,envId)?'edit value':c.state==='own'?'edit value':'override here'}</button>
+      ${showOrigin(k,envId)&&c.state==='own'&&!k.draft?`<button onclick="clearOverride()">clear override</button>`:''}
+      ${c.state!=='masked'?`<button class="danger" onclick="maskHere()">exclude here</button>`:`<button onclick="clearOverride()">include again</button>`}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc&&showOrigin(k,envId)?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${chain?`<div class="chain">${chain}</div>`:''}
+    ${vrow}
+    <div class="explain">
+      <b>secret vs excluded</b> — <b>secret</b> is what a key <i>is</i> (classification): its values exist but are hidden; seeing one takes reveal permission. <b>excluded</b> is a per-environment value state: deliberately nothing here — nothing is delivered, and inheritance is stopped from filling this cell.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.layers[envId]={v:val};
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearOverride(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.layers[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function maskHere(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  k.layers[envId]={masked:true};delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function addKey(folder){
+  const name=document.getElementById('nk-name').value;
+  if(!name||KEYS.some(k=>k.name===name.toUpperCase()))return;
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),
+    document.getElementById('nk-type').value,document.getElementById('nk-sec').checked,'none',undefined,{},{},[]);
+  k.draft=true;
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/6/index.html
+++ b/docs/site/public/prototypes/env-matrix/6/index.html
@@ -1,0 +1,670 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 6.
+  NO INHERITANCE (trial, supersedes ADR #10 pending formal amendment +
+  cross-model grill): no base chains, no project-defaults layer. Every value
+  is explicit per environment; value states collapse to set | absent.
+  Ergonomics instead of inheritance: declare-into-N-envs on key creation,
+  copy-across-envs per cell (secret copy gated on reveal of the source env,
+  per ADR #15 disclosure-by-proxy). Secret drift stays gated (still a
+  cross-env comparison). Sticky headers and everything else from iteration 5.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--line);border-radius:999px;padding:6px 12px;
+  }
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  /* ---------------- add key form ---------------- */
+  tr.addrow td{padding:10px 16px}
+  .addform{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:12.5px}
+  .addform input[type=text],.addform select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:9px 12px;border-radius:6px;font-family:var(--mono);font-size:12px;min-height:40px}
+  .addform label{display:flex;align-items:center;gap:5px;color:var(--tx-dim);font-size:12px}
+  .addform .envck{font-family:var(--mono);display:flex;gap:8px}
+  .addform button.go{background:var(--accent);color:var(--on-accent);border-radius:6px;padding:9px 16px;font-weight:600;min-height:40px}
+  .addform button.x{color:var(--tx-faint);padding:9px 6px}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <span class="drafts" id="drafts" hidden></span>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'}
+  adding:null,
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();S.adding='${f}';render()" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    if(S.adding===f)body+=`<tr class="addrow"><td colspan="${envs.length+1}">
+      <span class="addform">
+        <input type="text" id="nk-name" placeholder="KEY_NAME" size="14">
+        <select id="nk-type"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+        <label><input type="checkbox" id="nk-sec"> secret</label>
+        <input type="text" id="nk-val" placeholder="first value" size="12">
+        <span class="envck">${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}</label>`).join('')}</span>
+        <button class="go" onclick="addKey('${f}')">declare</button>
+        <button class="x" onclick="S.adding=null;render()">cancel</button>
+      </span></td></tr>`;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> set in that environment — everything explicit, nothing inherits
+    <span class="pill absent">·</span> not set
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values differ</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''}`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+function addKey(folder){
+  const name=document.getElementById('nk-name').value;
+  if(!name||KEYS.some(k=>k.name===name.toUpperCase()))return;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  const k=K(folder,name.toUpperCase().replace(/[^A-Z0-9_]/g,'_'),
+    document.getElementById('nk-type').value,document.getElementById('nk-sec').checked,'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  S.adding=null;render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/7/index.html
+++ b/docs/site/public/prototypes/env-matrix/7/index.html
@@ -1,0 +1,796 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 7.
+  On top of iteration 6 (no-inheritance trial): key creation moves into the
+  bottom sheet (same design language as editing), a publish review sheet
+  (per-env atomic revision, selective publish, protected-env confirm,
+  violation/missing-required veto per revision ADR #11), and a per-key
+  required-in editor (schema ADR #12 presence modes) whose changes ride the
+  same publish as schema drafts.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<header>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> demo</span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> set in that environment — everything explicit, nothing inherits
+    <span class="pill absent">·</span> not set
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values differ</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/8/index.html
+++ b/docs/site/public/prototypes/env-matrix/8/index.html
@@ -1,0 +1,923 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 8.
+  App-shell variants on top of iteration 7 — the desktop full-width question:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:14px;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="document.getElementById('side').classList.toggle('open')" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> set in that environment — everything explicit, nothing inherits
+    <span class="pill absent">·</span> not set
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values differ</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();renderShell();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  document.getElementById('side').classList.remove('open');
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  document.getElementById('side').classList.remove('open')}
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  document.getElementById('side').innerHTML=`
+    <div class="stitle">projects</div>
+    ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}" onclick="pickProject('${p}')">${p[0].toUpperCase()}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  document.getElementById('side').classList.remove('open');
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/9/index.html
+++ b/docs/site/public/prototypes/env-matrix/9/index.html
@@ -1,0 +1,940 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo environment matrix (ticket #20)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #20, iteration 9.
+  Refines iteration 8's variant C after Alex's feedback: the rail owns
+  project switching, the panel navigates inside the current project (name
+  header, groups, views, settings placeholder); rail avatars are two-letter
+  monograms with per-project hues. Project-level configuration (icon,
+  access, metadata) recorded as map fog for a later prototype.
+  Shell variants otherwise unchanged from 8:
+  ?variant=a  Sidebar: 250px panel with project switcher, group links
+              (problem badges), views.
+  ?variant=b  Centered + jump bar: no sidebar, capped content width,
+              horizontal group-jump pills.
+  ?variant=c  Rail + panel: 56px project icon rail + 210px group panel.
+  Floating bottom switcher / arrow keys flip variants; on mobile every shell
+  collapses to a hamburger drawer. Matrix behaviour identical to 7.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --drift:oklch(0.82 0.08 80/.1);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --drift:oklch(0.75 0.1 80/.14);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 12px;font-size:13px;color:var(--tx-dim);
+    min-height:36px;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env chips ---------------- */
+  .envbar{
+    display:flex;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:10px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  .envbar::-webkit-scrollbar{display:none}
+  .envbar .hint{font-size:11.5px;color:var(--tx-faint);white-space:nowrap;margin-right:2px}
+  .chip{
+    display:inline-flex;align-items:center;gap:7px;white-space:nowrap;
+    border:1px solid var(--line);border-radius:999px;padding:7px 14px;
+    font-size:12.5px;color:var(--tx-dim);min-height:36px;
+    transition:border-color .15s,color .15s,background .15s;
+  }
+  .chip .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600}
+  .chip.on{background:var(--accent-soft);border-color:var(--accent);color:var(--tx)}
+  .chip.on .eye{color:var(--accent)}
+  .chip .eye{font-size:12px}
+  .chip:not(.on){opacity:.55}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;overflow:hidden;text-overflow:ellipsis;
+  }
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:var(--gh,55px);z-index:3;
+    background:var(--bg);padding:0;border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.drift td:not(.key){background:var(--drift)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .pill.val{border-color:var(--line);color:var(--tx)}
+  .pill.val .from{color:var(--bad);font-size:10px}
+  .pill.absent{border:1px dashed var(--line);color:var(--tx-faint)}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  .pill .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- legend ---------------- */
+  .legend{
+    flex:none;display:flex;gap:8px 18px;flex-wrap:wrap;align-items:center;
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:1px solid var(--line);font-size:11.5px;color:var(--tx-dim);
+  }
+  .legend .pill{cursor:default;min-height:24px;padding:4px 10px}
+  .legend .pill:hover{filter:none}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;left:50%;bottom:0;transform:translate(-50%,105%);
+    width:min(600px,100%);max-height:82vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);border-bottom:none;
+    border-radius:14px 14px 0 0;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1);
+    padding:18px 20px calc(24px + env(safe-area-inset-bottom));
+  }
+  #sheet.open{transform:translate(-50%,0)}
+  #sheet .grab{width:36px;height:4px;border-radius:2px;background:var(--line);margin:0 auto 14px}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .explain{
+    font-size:12px;color:var(--tx-dim);line-height:1.55;margin:12px 0 0;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .explain b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet input.editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet input.editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .acts button{
+    border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;
+    color:var(--tx-dim);min-height:44px;
+  }
+  #sheet .acts button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .acts button.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  #sheet .acts button.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  #sheet .acts button.danger{color:var(--bad)}
+  #sheet .acts button.danger:hover{border-color:var(--bad)}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #vswitch{
+    position:fixed;bottom:calc(16px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:15;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.015 250);color:oklch(0.97 0.01 90);
+    border-radius:999px;padding:5px 8px;box-shadow:0 6px 24px oklch(0 0 0/.4);
+    font-size:12.5px;letter-spacing:.02em;
+  }
+  #vswitch button{padding:4px 10px;border-radius:999px;font-size:14px}
+  #vswitch button:hover{background:oklch(0.28 0.02 250)}
+  #vswitch .lbl{padding:0 8px;min-width:160px;text-align:center}
+  #vswitch .lbl b{font-weight:600}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    .envbar{padding:8px 12px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="document.getElementById('side').classList.toggle('open')" title="menu">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="toggle theme">◐</button>
+</header>
+
+<div class="envbar" id="envbar"></div>
+<div id="jumpbar"></div>
+<div class="wrap"><table id="matrix"></table></div>
+<div class="legend" id="legend"></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true"></div>
+<div id="vswitch">
+  <button onclick="cycleShell(-1)" title="previous shell (←)">‹</button>
+  <span class="lbl" id="vs-lbl"></span>
+  <button onclick="cycleShell(1)" title="next shell (→)">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'expected int64, got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'url must be absolute'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const FOLDERS=[...new Set(KEYS.map(k=>k.folder))];
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Set(),
+  drafts:new Set(),
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+/* drift on a secret row compares envs pairwise — visible only when the viewer
+   could reveal every readable env (the comparison then adds nothing new) */
+const secretDriftVisible=()=>readableEnvs().every(e=>role().reveal(e));
+function rowDiff(k){
+  const vals=readableEnvs().map(e=>k.values[e.id]).filter(v=>v!==undefined);
+  return new Set(vals).size>1;
+}
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'expected int64';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'expected true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'url must be absolute';
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvbar(){
+  document.getElementById('envbar').innerHTML=
+    `<span class="hint">environments</span>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<button class="chip ${on?'on':''}" onclick="toggleEnv('${e.id}')" aria-pressed="${on}">
+        <span class="eye">${on?'●':'○'}</span>${e.name}
+        ${e.protected?'<span class="p">PROT</span>':''}
+      </button>`;
+    }).join('');
+}
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid)return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(shownValue(k,e.id,c))}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="pill absent" ${open}><span class="tx">·</span></span>`;
+  const v=esc(shownValue(k,e.id,c));
+  return`<span class="pill val" ${open}>${k.secret?'<span class="from">🔒</span>':''}<span class="tx">${v}</span>${d}${draft}</span>`;
+}
+function renderMatrix(){
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of FOLDERS){
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      const drift=rowDiff(k)&&(!k.secret||secretDriftVisible());
+      body+=`<tr class="${drift?'drift':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}${esc(k.name)}<span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegend(){
+  document.getElementById('legend').innerHTML=`
+    <span class="pill val">value</span> set in that environment — everything explicit, nothing inherits
+    <span class="pill absent">·</span> not set
+    <span class="pill missing">! required · unset</span> blocks publish
+    <span>🔒 secret (tap to reveal, if permitted) · Δ changed · amber row = values differ</span>`;
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function render(){
+  renderEnvbar();renderMatrix();renderLegend();renderDrafts();renderShell();
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.offsetHeight+'px');
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const SHELLS=[{key:'a',name:'Sidebar'},{key:'b',name:'Centered + jump bar'},{key:'c',name:'Rail + panel'}];
+let VAR=(()=>{try{return new URLSearchParams(location.search).get('variant')||'a'}catch(_){return'a'}})();
+if(!SHELLS.some(v=>v.key===VAR))VAR='a';
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  document.getElementById('side').classList.remove('open');
+}
+function pickProject(p){PROJ=p;document.getElementById('projname').textContent=p.replace('hikyo-','');renderShell();
+  document.getElementById('side').classList.remove('open')}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>[...p].reduce((a,c)=>a+c.charCodeAt(0),0)%360;
+function renderShell(){
+  const groups=FOLDERS.map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="stitle" style="padding-top:18px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>`<button class="srow" onclick="jumpGroup('${g.f}')"><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`).join('')}
+    <div class="stitle">views</div>
+    <button class="srow" onclick="alert('prototype: saved views are future scope')">⚠ problems</button>
+    <button class="srow" onclick="if(S.drafts.size)openPublish()">Δ drafts<span class="cnt">${S.drafts.size}</span></button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+  const v=SHELLS.find(x=>x.key===VAR);
+  document.getElementById('vs-lbl').innerHTML=`<b>${v.key.toUpperCase()}</b> — ${v.name}`;
+}
+function cycleShell(d){
+  const i=SHELLS.findIndex(v=>v.key===VAR);
+  VAR=SHELLS[(i+d+SHELLS.length)%SHELLS.length].key;
+  try{history.replaceState(null,'','?variant='+VAR)}catch(_){/* file:// */}
+  document.body.dataset.v=VAR;
+  document.getElementById('side').classList.remove('open');
+  renderShell();
+}
+document.addEventListener('keydown',e=>{
+  const t=e.target;
+  if(t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable))return;
+  if(S.sheet)return;
+  if(e.key==='ArrowLeft')cycleShell(-1);
+  if(e.key==='ArrowRight')cycleShell(1);
+});
+document.body.dataset.v=VAR;
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById('nk-name')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    vrow=`<div class="vrow">
+      <input class="editor" id="editval" type="text"
+        placeholder="${writeOnly?'write-only replacement — current value stays hidden':'new value ('+k.type+')'}"
+        value="${!k.secret&&c.value!==undefined?esc(c.value):''}"
+        onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">
+    </div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else cur=`<span class="cur ${c.invalid?'err':''}">${esc(c.value)}</span>`;
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button onclick="doReveal('${key}','${envId}')">${revealed?'hide':'reveal'}</button>`:'')
+      :'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">your role (${S.role}) has no reveal permission ${env.protected?'in protected environments':'here'} — you can replace the value write-only, but not copy it out.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="danger" onclick="clearValue()">clear value</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>`;
+  }
+
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${mode==='view'?`<div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      <span style="font-size:11px;color:var(--tx-faint)">key-level (schema) — a required env without a value blocks its publish</span>
+    </div>`:''}
+    <div class="explain">
+      <b>no inheritance</b> — every environment holds its own values; nothing flows between them. <b>secret</b> is what a key <i>is</i> (classification): values exist but are hidden; seeing one takes reveal permission, and copying one to another environment takes reveal here first.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  if(envById(envId).protected&&!confirm('production is protected — reveal requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?'))return;
+  S.revealed.add(id);render();
+  setTimeout(()=>{if(S.revealed.delete(id))render()},8000);
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; this violation would block publish';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`copying into protected environment${prot.length>1?'s':''} (${prot.join(', ')}) — confirm?`))return;
+  for(const t of targets){
+    k.values[t]=k.values[envId];
+    delete k.invalid[t];
+    S.drafts.add(key+':'+t);
+  }
+  S.sheet.mode='view';
+  render();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="primary" onclick="doPublish()">publish selected</button>`:''}
+      <button onclick="closeSheet()">close</button>
+    </div>
+    <div class="explain">
+      an environment with a schema violation or a missing required key cannot publish —
+      delivery only ever sees valid revisions. drafts stay yours until published.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length&&!confirm(`publishing to protected environment${prot.length>1?'s':''} (${prot.join(', ')}) requires re-authentication.\n\n(prototype stand-in; real ceremony is ticket #21)\n\nProceed?`))return;
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <div class="grab"></div>
+    <h2>new key
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${folder}/</span></h2>
+    <div class="sub">declared into the environments you pick — no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <input class="editor" id="nk-val" type="text" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="primary" onclick="addKey()">declare</button>
+      <button onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="explain">
+      <b>secret</b> is permanent classification: values will be hidden and reveal-gated everywhere. Environments left unchecked start <b>not set</b> — required-ness comes from the schema, set per key later.
+    </div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const{folder}=S.sheet;
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=closeSheet;
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet()});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/env-matrix/index.html
+++ b/docs/site/public/prototypes/env-matrix/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Environment matrix — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,64px) clamp(18px,6vw,64px)}
+  .back{font-size:12.5px;color:var(--tx-faint);text-decoration:none}
+  .back:hover{color:var(--accent)}
+  h1{font-size:clamp(22px,4vw,30px);font-weight:700;letter-spacing:-0.01em;margin:10px 0 4px}
+  h1 span{color:var(--accent)}
+  .q{font-size:13.5px;color:var(--tx-dim);max-width:60ch;line-height:1.6;margin-bottom:32px}
+  ul{list-style:none;display:grid;gap:10px;max-width:760px}
+  li a{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:10px;background:var(--bg2);transition:border-color .15s}
+  li a:hover{border-color:var(--accent)}
+  li a:hover .name{color:var(--accent)}
+  .num{font-family:var(--mono);font-size:13px;color:var(--tx-faint);min-width:22px}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+  footer a{color:var(--tx-dim)}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>environment matrix <span>/</span> iterations</h1>
+  <p class="q">Question (ticket #20): does a side-by-side environment matrix communicate inheritance, overrides, gaps, validation, and drift legibly? Newest first; each earlier iteration is kept runnable.</p>
+  <ul>
+    <li><a href="31/">
+      <span class="num">31</span><span class="name">Filter survives navigation, visibly</span><span class="latest">LATEST</span>
+      <span class="desc">Alex: keep the filter when jumping to a group, but show what's active — a filter bar above the matrix ("filter active: problems — showing n of m keys · ✕ show all"), groups the filter hides render dimmed and inert in the panel.</span>
+    </a></li>
+    <li><a href="30/">
+      <span class="num">30</span><span class="name">Problems view no longer traps you</span>
+      <span class="desc">Tester feedback: in problems view every other nav row went dead. Now group links clear the filter and jump, the drafts row is visibly disabled at zero drafts, and the active problems row carries an explicit ✕.</span>
+    </a></li>
+    <li><a href="29/">
+      <span class="num">29</span><span class="name">Group creation everywhere</span>
+      <span class="desc">Groups were only creatable from the empty state — now the panel has "+ group", and the create modal's group field is always live: prefilled from "+ key", editable, with a datalist of existing groups; an unseen name creates that group.</span>
+    </a></li>
+    <li><a href="28/">
+      <span class="num">28</span><span class="name">Modal locked</span>
+      <span class="desc">Alex picked the centered modal — bottom sheet retired: switcher, ?sheet= param, grab handle and drag-to-dismiss all removed. ✕, backdrop and Escape close; no parameters left again.</span>
+    </a></li>
+    <li><a href="27/">
+      <span class="num">27</span><span class="name">Bottom sheet vs centered modal</span>
+      <span class="desc">Compare the create/edit surface as a bottom sheet or a centered modal — toggle live with the bottom-right "sheet:" pill or ?sheet=bottom|modal, even while one is open. Modal gets a ✕ (no drag), sheet keeps the grab handle.</span>
+    </a></li>
+    <li><a href="26/">
+      <span class="num">26</span><span class="name">Sheet grab handle drags for real</span>
+      <span class="desc">The pill at the top of every bottom sheet implied drag-to-dismiss but did nothing — now the sheet follows the finger (full-width hit zone), snaps back under 110px, dismisses beyond. All three sheets: cell, create, publish.</span>
+    </a></li>
+    <li><a href="25/">
+      <span class="num">25</span><span class="name">Schema builder — no JSON Schema knowledge needed</span>
+      <span class="desc">json keys get a structured "value shape" builder: property rows (name · type · required), an "other properties" rule, and one-click "infer from current value". Raw JSON Schema moves behind an advanced disclosure; schemas beyond the builder subset fall back to it automatically.</span>
+    </a></li>
+    <li><a href="24/">
+      <span class="num">24</span><span class="name">Schema defined where the key lives</span>
+      <span class="desc">The sheet's schema disclosure is an editor now: per-type constraints (pattern · length · int range · url schemes · JSON Schema textarea) applied as schema drafts that re-validate every environment. Create sheet takes an optional JSON Schema. Value rules on secrets stay reveal-gated (ADR #12 oracle).</span>
+    </a></li>
+    <li><a href="23/">
+      <span class="num">23</span><span class="name">JSON keys — multiline editor + schema validator</span>
+      <span class="desc">The json type is real now (schema ADR #12): keys carry an inline JSON Schema, cells show a compact one-line preview, the sheet gets a pretty-printed view and a multiline editor (⌘↵ saves), and the validator reports paths for config keys but redacts instance details on secrets.</span>
+    </a></li>
+    <li><a href="22/">
+      <span class="num">22</span><span class="name">Pencil affordance locked</span>
+      <span class="desc">Alex picked pencil: every editable slot carries a faint trailing ✎ (accent on hover). Affordance switcher and the other three options removed; no parameters left.</span>
+    </a></li>
+    <li><a href="21/">
+      <span class="num">21</span><span class="name">Cell-affordance options</span>
+      <span class="desc">Underline judged too subtle — four selectable strengths via the bottom-right pill or ?cell=: underline · well (filled input slot) · baseline (solid bottom edge) · pencil (trailing ✎). Shell selector removed — rail + panel is the shell.</span>
+    </a></li>
+    <li><a href="20/?variant=c">
+      <span class="num">20</span><span class="name">Editable-slot underline</span>
+      <span class="desc">Plain-text cells read as input fields again: quiet dotted underline under every value (accent on hover) — the inline-edit convention, visible on mobile, no border chrome returned.</span>
+    </a></li>
+    <li><a href="19/?variant=c">
+      <span class="num">19</span><span class="name">Normalize — problems filter, one button system</span>
+      <span class="desc">Problems view is a real filter (badge with total, matrix shows only problem keys, calm all-valid state); pending/error badges vanish at zero; one .btn vocabulary replaces three duplicate rule-sets.</span>
+    </a></li>
+    <li><a href="18/?variant=c">
+      <span class="num">18</span><span class="name">Empty state + real projects</span>
+      <span class="desc">Projects hold their own keys — switching to an un-seeded one shows a real empty state: value prop, declare-first-key (create sheet gains a group field), .env import stub (scaffold flow).</span>
+    </a></li>
+    <li><a href="17/?variant=c">
+      <span class="num">17</span><span class="name">Polish pass</span>
+      <span class="desc">Unified focus rings; req badge survives key truncation; monogram hues via golden angle; stronger light zebra; optically equal icon buttons; inline favicon (console now clean); dead CSS removed.</span>
+    </a></li>
+    <li><a href="16/?variant=c">
+      <span class="num">16</span><span class="name">Clarify pass</span>
+      <span class="desc">Reveal is a real button ("reveal value"); confirms name the action + consequence; validation messages human with examples; icon buttons get aria-labels and clearer titles.</span>
+    </a></li>
+    <li><a href="15/?variant=c">
+      <span class="num">15</span><span class="name">Distilled sheet</span>
+      <span class="desc">Teaching paragraph gone (the ? legend owns vocabulary); required-in collapses to a one-line schema disclosure; redundant close button dropped; hint copy halved. Create + publish sheets trimmed the same way.</span>
+    </a></li>
+    <li><a href="14/?variant=c">
+      <span class="num">14</span><span class="name">Distilled cells</span>
+      <span class="desc">Ordinary values are plain mono text — border chrome reserved for missing/invalid (228 pills → 4). Per-cell 🔒 dropped (key column carries it); secrets are dim dots; hover tint + focus ring keep the tap affordance.</span>
+    </a></li>
+    <li><a href="13/?variant=c">
+      <span class="num">13</span><span class="name">Drawer backdrop + mobile project select</span>
+      <span class="desc">Tapping outside an open drawer closes it (backdrop swallows the tap — no more accidental cell opens); small screens get a project switcher: customizable &lt;select&gt; (appearance:base-select, graceful fallback) atop the panel.</span>
+    </a></li>
+    <li><a href="12/?variant=c">
+      <span class="num">12</span><span class="name">Zebra rows, drift tint removed</span>
+      <span class="desc">Every other data row gets a slightly raised hue; the amber tint on rows with differing values is gone (with its machinery).</span>
+    </a></li>
+    <li><a href="11/?variant=c">
+      <span class="num">11</span><span class="name">Legend as header tooltip</span>
+      <span class="desc">The footer legend is gone — its content lives in a "?" icon popover in the header. One more row of matrix on every screen.</span>
+    </a></li>
+    <li><a href="10/?variant=c">
+      <span class="num">10</span><span class="name">Env picker in header</span>
+      <span class="desc">The environment chips bar is gone — show/hide moves into the matrix header: an "envs n/m ▾" checkbox popover in the sticky corner cell.</span>
+    </a></li>
+    <li><a href="9/?variant=c">
+      <span class="num">9</span><span class="name">Rail + panel de-duped</span>
+      <span class="desc">Variant C refined: rail owns project switching (two-letter monogram avatars, per-project hue); panel navigates inside the current project — name header, groups, views, ⚙ settings placeholder. Project config = later prototype (map fog).</span>
+    </a></li>
+    <li><a href="8/">
+      <span class="num">8</span><span class="name">App-shell variants</span>
+      <span class="desc">Desktop layout question: A sidebar (projects, group links with problem badges, views) · B centered content + horizontal jump bar · C icon rail + group panel. ?variant=a|b|c, floating switcher, hamburger drawer on mobile.</span>
+    </a></li>
+    <li><a href="7/">
+      <span class="num">7</span><span class="name">Publish, required-in, create sheet</span>
+      <span class="desc">Key creation in the bottom sheet (same language as editing); publish review sheet — per-env atomic revisions, selective publish, protected confirm, violation veto; per-key required-in editor riding publish as schema drafts.</span>
+    </a></li>
+    <li><a href="6/">
+      <span class="num">6</span><span class="name">No inheritance</span>
+      <span class="desc">Flat model trial: no base chains, no project defaults — every value explicit per env. Declare-into-N-envs on key creation, per-cell copy-across (secret copy needs reveal of the source). Supersedes ADR #10 pending formal amendment.</span>
+    </a></li>
+    <li><a href="5/">
+      <span class="num">5</span><span class="name">Opaque inheritance, sticky headers</span>
+      <span class="desc">Grid shows only resolved values — provenance moves entirely into the cell sheet (still permission-gated). Env header row and group headers stay pinned while scrolling.</span>
+    </a></li>
+    <li><a href="4/">
+      <span class="num">4</span><span class="name">Sharp origin rule</span>
+      <span class="desc">Config keys always show provenance; secret cells show origin only where you hold reveal (uniform 🔒 pill otherwise); secret-row drift gated the same way.</span>
+    </a></li>
+    <li><a href="3/">
+      <span class="num">3</span><span class="name">Inheritance admin-only, hidden envs</span>
+      <span class="desc">First cut at the comparison-oracle fix (flat: origin admin-only) + the external role showing whole-environment hiding.</span>
+    </a></li>
+    <li><a href="2/">
+      <span class="num">2</span><span class="name">Cascade, dark, mobile-first</span>
+      <span class="desc">Cascade chosen as the base; dark default + light theme, bottom-sheet in-place editing, permission-gated reveal, env chips, collapsible groups.</span>
+    </a></li>
+    <li><a href="1/?variant=c">
+      <span class="num">1</span><span class="name">Three variants — Ledger · Panel · Cascade</span>
+      <span class="desc">Round 1 exploration, switch with the floating bar or ?variant=a|b|c. Editorial (Ledger) later rejected.</span>
+    </a></li>
+  </ul>
+  <footer>
+    frozen reference · <a href="/prototypes/">all prototypes</a>
+  </footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/index.html
+++ b/docs/site/public/prototypes/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hikyo prototypes</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,72px) clamp(18px,6vw,72px)}
+  h1{font-size:clamp(22px,4vw,32px);font-weight:700;letter-spacing:-0.01em}
+  h1 span{color:var(--accent)}
+  .lede{font-size:13.5px;color:var(--tx-dim);margin:10px 0 36px;max-width:52ch;line-height:1.6}
+  ul{list-style:none;display:grid;gap:10px;max-width:720px}
+  li a{display:block;text-decoration:none;color:inherit;padding:18px 20px;
+    border:1px solid var(--line);border-radius:10px;background:var(--bg2);
+    transition:border-color .15s}
+  li a:hover{border-color:var(--accent)}
+  .name{font-size:17px;font-weight:600;display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
+  .name .tkt{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  .st{font-family:var(--mono);font-size:9.5px;letter-spacing:.1em;font-weight:700;border-radius:999px;
+    padding:2.5px 9px;margin-left:auto;white-space:nowrap}
+  .st.locked{color:var(--bg);background:var(--accent)}
+  .st.wip{color:var(--tx-dim);border:1px solid var(--line)}
+  .desc{font-size:12.5px;color:var(--tx-dim);margin-top:6px;line-height:1.55;max-width:58ch}
+  footer{margin-top:40px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+  footer code{color:var(--tx-dim)}
+</style>
+</head>
+<body>
+  <h1>Hikyo <span>/</span> prototypes</h1>
+  <p class="lede">Throwaway UI explorations from the wayfinder map. Each answers one open design question; deleted once its ticket resolves.</p>
+  <ul>
+    <!-- newest on top -->
+    <li><a href="landing-opus-4.8/">
+      <div class="name">Landing prototype — opus 4.8 <span class="tkt">as &ldquo;hikyo&rdquo; · 2 iterations</span><span class="st wip">WIP</span></div>
+      <div class="desc">Public marketing page under the product name Hikyo. Iteration 2 (latest) is a single committed design in the locked Hikyo language: the env matrix as the hero, four asymmetric feature rows (provenance, reveal ceremony, doctor, Compose/K8s render), self-hosted band, "why" POV and a real footer, structured for SaaS sellability à la Kaneo / Plane. Iteration 1 was a 3-variant explorer (off-brand, superseded).</div>
+    </a></li>
+    <li><a href="landing-opus-5/">
+      <div class="name">Landing prototype — opus 5 <span class="tkt">as &ldquo;hikyo&rdquo; · 2 iterations</span><span class="st wip">WIP</span></div>
+      <div class="desc">Public marketing page under the product name hikyo. Three page architectures kept side by side in the locked design language: <em>a</em> product first (Kaneo/Plane), <em>b</em> typographic argument (Resend/Linear), <em>c</em> live console (Better Auth/Unkey). Iteration 2 (latest) gives all three the commercial layer read off the live reference sites: hero-level cloud-vs-self-host, a why-now headline, Cloud pricing, an objection-handling FAQ, founder note, honest pre-launch proof and a compare group. Each sells in its own idiom, so the architecture comparison stays live. <code>?variant=a|b|c</code>.</div>
+    </a></li>
+    <li><a href="machine-access/">
+      <div class="name">Workload integration &amp; machine identity<span class="tkt">#31 · 3 iterations</span><span class="st locked">LOCKED</span></div>
+      <div class="desc">Service-account &amp; write-only credential surfaces (#17), the five-step delivery journey (#18), federation bindings with the pull_request refusal, restore reconciliation, and the K8s CR-condition vocabulary (#19). Tabbed inventory; row expansion = credentials/bindings/targets with the journey rail below. Iteration 3 is the reference.</div>
+    </a></li>
+    <li><a href="revision-history/">
+      <div class="name">Version history &amp; rollback<span class="tkt">#30 · 6 iterations</span><span class="st locked">LOCKED</span></div>
+      <div class="desc">Panes drawer won (rev list + detail): secret-safe diffs — write-presence without reveal-history, comparison + per-key ceremony with it — pin = workload binding (≤1 per workload/env, re-pin = move, sole-keeper release confirm), restore through the normal publish pipeline, retention in the settings surfaces (app-chrome 16). Iteration 6 is the reference.</div>
+    </a></li>
+    <li><a href="app-chrome/">
+      <div class="name">App chrome<span class="tkt">#29 · 15 iterations</span><span class="st locked">LOCKED</span></div>
+      <div class="desc">Rail owns orgs; merged single sidebar; role-scale shape (DESIGN.md amended); sticky jump index on every settings surface; grouped grants with checklist modal, blast warning and undo; org &amp; project settings with policy and danger zones; instance admin with CLI↔UI parity. Reference chrome = iteration 15 + retention surfaces (16, locked) + sidebar treatment e (18, locked).</div>
+    </a></li>
+    <li><a href="reveal-edit/">
+      <div class="name">Reveal &amp; multi-env editing<span class="tkt">#21</span><span class="st locked">LOCKED</span></div>
+      <div class="desc">Ceremony modal won: reauth (passkey/TOTP, enumerated key set), sliding reveal window with protected zero-cap, auto-remask countdown, clipboard as audited disclosure, row edit across all environments in one motion.</div>
+    </a></li>
+    <li><a href="env-matrix/">
+      <div class="name">Environment matrix<span class="tkt">#20 · 31 iterations</span><span class="st locked">LOCKED</span></div>
+      <div class="desc">Cascade: dark default + light theme, mobile-first, tap-to-edit bottom sheet, permission-gated reveal, env show/hide chips, collapsible groups. Iteration 31 is the frozen reference design.</div>
+    </a></li>
+  </ul>
+  <footer>
+    published at <code>/prototypes/</code> · choose a family above
+  </footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-4.8/1/index.html
+++ b/docs/site/public/prototypes/landing-opus-4.8/1/index.html
@@ -1,0 +1,539 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>hikyo — landing prototype</title>
+<!--
+  PROTOTYPE — throwaway. prototype/hikyo-landing/1/index.html
+  Question: what should the hikyo (self-hostable secrets/env manager) landing page look like?
+  3 structurally-different variants, switch via #A / #B / #C or the floating bar / arrow keys.
+  A — Kaneo/Plane: clean white surface, centered value prop, product UI as hero.
+  B — SYNTHESIS: Kaneo/Plane structure + Linear finish + Resend technical clarity (dark).
+  C — Unkey/Better Auth: demo-led, the product explains itself through small UI/code blocks.
+  State lives in location.hash (works on file://). Open directly in a browser.
+-->
+<style>
+  :root {
+    --sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { -webkit-text-size-adjust: 100%; }
+  body { font-family: var(--sans); line-height: 1.5; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  a { color: inherit; text-decoration: none; }
+  img, svg { display: block; }
+  code, kbd, pre { font-family: var(--mono); }
+  .stage { display: none; }
+  .stage.active { display: block; }
+  ::selection { background: #3b82f6; color: #fff; }
+
+  /* ---------- floating prototype switcher (shared) ---------- */
+  #switcher {
+    position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+    z-index: 9999; display: flex; align-items: center; gap: 4px;
+    background: #0b0d12; color: #fff; border: 1px solid #2a2f3a;
+    border-radius: 999px; padding: 5px 6px; box-shadow: 0 8px 30px rgba(0,0,0,.35);
+    font-family: var(--sans); font-size: 13px; user-select: none;
+  }
+  #switcher button {
+    all: unset; cursor: pointer; width: 30px; height: 30px; border-radius: 999px;
+    display: grid; place-items: center; color: #cbd3e1;
+  }
+  #switcher button:hover { background: #1a1e27; color: #fff; }
+  #switcher .label { padding: 0 10px; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  #switcher .label b { color: #fff; }
+  #switcher .label span { color: #7c8698; }
+</style>
+</head>
+<body>
+
+<!-- ============================================================ VARIANT A -->
+<!-- Kaneo / Plane: clean white surface, big restrained headline, product UI as hero -->
+<section class="stage" id="stage-A">
+  <style>
+    #stage-A {
+      --bg:#ffffff; --fg:#0d1117; --muted:#5b6472; --line:#e8ebef; --soft:#f6f7f9;
+      --accent:#0d1117; --brand:#2563eb;
+      background:var(--bg); color:var(--fg);
+      font-size:16px; letter-spacing:-.011em;
+    }
+    #stage-A .wrap { max-width:1080px; margin:0 auto; padding:0 24px; }
+    #stage-A nav { display:flex; align-items:center; justify-content:space-between; height:64px; }
+    #stage-A .logo { display:flex; align-items:center; gap:9px; font-weight:640; font-size:17px; letter-spacing:-.02em; }
+    #stage-A .logo .mark { width:22px; height:22px; border-radius:6px; background:var(--fg); color:#fff; display:grid; place-items:center; font-size:13px; font-weight:800; }
+    #stage-A .navlinks { display:flex; gap:28px; color:var(--muted); font-size:14.5px; font-weight:500; }
+    #stage-A .navlinks a:hover { color:var(--fg); }
+    #stage-A .navright { display:flex; align-items:center; gap:18px; font-size:14.5px; font-weight:540; }
+    #stage-A .btn { background:var(--fg); color:#fff; padding:8px 15px; border-radius:8px; font-weight:560; }
+    #stage-A .btn:hover { opacity:.88; }
+    #stage-A .btn-ghost { color:var(--muted); }
+    #stage-A .btn-ghost:hover { color:var(--fg); }
+
+    #stage-A .hero { text-align:center; padding:76px 0 48px; }
+    #stage-A .pill { display:inline-flex; align-items:center; gap:8px; border:1px solid var(--line); background:var(--soft); color:var(--muted); font-size:13px; font-weight:520; padding:5px 12px 5px 8px; border-radius:999px; margin-bottom:30px; }
+    #stage-A .pill b { color:var(--fg); font-weight:620; }
+    #stage-A .dot { width:7px; height:7px; border-radius:999px; background:#16a34a; box-shadow:0 0 0 3px rgba(22,163,74,.16); }
+    #stage-A h1 { font-size:clamp(38px, 6.2vw, 66px); line-height:1.02; letter-spacing:-.035em; font-weight:680; max-width:16ch; margin:0 auto; }
+    #stage-A h1 em { font-style:normal; color:var(--muted); }
+    #stage-A .sub { margin:24px auto 0; max-width:52ch; font-size:clamp(16px,2vw,19px); color:var(--muted); font-weight:440; letter-spacing:-.01em; }
+    #stage-A .cta { display:flex; gap:12px; justify-content:center; margin-top:34px; }
+    #stage-A .cta .btn { padding:11px 20px; font-size:15px; border-radius:9px; }
+    #stage-A .cta .btn-line { background:#fff; border:1px solid var(--line); color:var(--fg); }
+    #stage-A .cta .btn-line:hover { border-color:#cfd5dd; opacity:1; }
+    #stage-A .cta .btn-line code { font-size:13.5px; color:var(--muted); }
+    #stage-A .trust { margin-top:22px; color:#8b94a3; font-size:13px; }
+    #stage-A .trust b { color:var(--muted); font-weight:600; }
+
+    /* product UI hero */
+    #stage-A .shot { margin:20px auto 0; max-width:1000px; border:1px solid var(--line); border-radius:16px; overflow:hidden; box-shadow:0 24px 60px -30px rgba(13,17,23,.28); background:#fff; }
+    #stage-A .shot-bar { display:flex; align-items:center; gap:8px; padding:12px 16px; border-bottom:1px solid var(--line); background:var(--soft); }
+    #stage-A .tl { width:11px; height:11px; border-radius:999px; background:#dfe3e9; }
+    #stage-A .shot-path { margin-left:8px; color:#9aa3b2; font-size:12.5px; font-family:var(--mono); }
+    #stage-A .shot-badge { margin-left:auto; display:flex; align-items:center; gap:6px; color:var(--muted); font-size:12px; font-weight:560; }
+    #stage-A .matrix { width:100%; border-collapse:collapse; font-size:13.5px; }
+    #stage-A .matrix th { text-align:left; padding:11px 16px; color:var(--muted); font-weight:600; border-bottom:1px solid var(--line); background:#fcfcfd; font-size:12px; letter-spacing:.02em; text-transform:uppercase; }
+    #stage-A .matrix th.env { text-align:center; }
+    #stage-A .matrix td { padding:11px 16px; border-bottom:1px solid var(--line); white-space:nowrap; }
+    #stage-A .matrix td.k { font-family:var(--mono); color:var(--fg); font-size:13px; }
+    #stage-A .matrix td.v { text-align:center; }
+    #stage-A .matrix tr:last-child td { border-bottom:0; }
+    #stage-A .cell { display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:6px; font-family:var(--mono); font-size:12px; }
+    #stage-A .cell.set { background:#eef2ff; color:#3b4ba8; }
+    #stage-A .cell.inh { background:var(--soft); color:#9aa3b2; }
+    #stage-A .cell.miss { color:#c2492f; background:#fdecea; }
+    #stage-A .mtag { font-size:11px; }
+    #stage-A .logos { margin:56px 0 0; padding:34px 0 8px; border-top:1px solid var(--line); text-align:center; }
+    #stage-A .logos p { color:#98a1b0; font-size:12.5px; letter-spacing:.06em; text-transform:uppercase; font-weight:600; margin-bottom:20px; }
+    #stage-A .logos .row { display:flex; flex-wrap:wrap; gap:14px; justify-content:center; }
+    #stage-A .logos .row span { color:#aeb6c2; font-weight:640; font-size:15px; padding:6px 14px; border:1px solid var(--line); border-radius:8px; }
+
+    /* three plain feature columns — no bento */
+    #stage-A .feat { display:grid; grid-template-columns:repeat(3,1fr); gap:40px; padding:72px 0 88px; }
+    #stage-A .feat h3 { font-size:16px; letter-spacing:-.02em; margin-bottom:9px; display:flex; align-items:center; gap:9px; }
+    #stage-A .feat h3 .fi { width:26px; height:26px; border-radius:7px; background:var(--soft); display:grid; place-items:center; }
+    #stage-A .feat p { color:var(--muted); font-size:14.5px; }
+    #stage-A .feat code { font-size:13px; color:var(--brand); background:#eef2ff; padding:1px 6px; border-radius:5px; }
+    #stage-A footer { border-top:1px solid var(--line); padding:28px 0; color:#98a1b0; font-size:13px; display:flex; justify-content:space-between; }
+    @media (max-width:760px){
+      #stage-A .navlinks{display:none;}
+      #stage-A .hero{padding:44px 0 30px;}
+      #stage-A .cta{flex-direction:column;}
+      #stage-A .cta .btn{justify-content:center;}
+      #stage-A .feat{grid-template-columns:1fr;gap:34px;padding:52px 0 68px;}
+      #stage-A .shot{border-radius:12px;}
+      #stage-A .matrix .opt{display:none;}
+      #stage-A footer{flex-direction:column;gap:10px;}
+    }
+  </style>
+  <div class="wrap">
+    <nav>
+      <div class="logo"><span class="mark">h</span> hikyo</div>
+      <div class="navlinks"><a>Product</a><a>Self-hosting</a><a>Docs</a><a>Pricing</a><a>Changelog</a></div>
+      <div class="navright"><a class="btn-ghost">Sign in</a><a class="btn">Get started</a></div>
+    </nav>
+  </div>
+
+  <div class="wrap">
+    <div class="hero">
+      <span class="pill"><span class="dot"></span> <b>v0.4</b> &nbsp;·&nbsp; single signed binary, self-hosted</span>
+      <h1>All your secrets. <em>None of your trust.</em></h1>
+      <p class="sub">hikyo is an open-source environment &amp; secrets manager you run yourself. Envelope-encrypted at rest, proof-carrying access on every read, one Go binary from laptop to production.</p>
+      <div class="cta">
+        <a class="btn">Start self-hosting →</a>
+        <a class="btn btn-line"><code>$ curl -fsSL hikyo.dev/install | sh</code></a>
+      </div>
+      <p class="trust"><b>MIT-licensed.</b> No account required. sqlite for dev, postgres for prod — same binary.</p>
+    </div>
+
+    <div class="shot">
+      <div class="shot-bar">
+        <span class="tl"></span><span class="tl"></span><span class="tl"></span>
+        <span class="shot-path">acme / payments-api</span>
+        <span class="shot-badge">🔒 42 keys · envelope-sealed</span>
+      </div>
+      <table class="matrix">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th class="env">dev</th>
+            <th class="env">staging</th>
+            <th class="env">prod</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="k">DATABASE_URL</td><td class="v"><span class="cell set">postgres://…</span></td><td class="v"><span class="cell set">postgres://…</span></td><td class="v"><span class="cell set">postgres://…</span></td></tr>
+          <tr><td class="k">STRIPE_SECRET_KEY</td><td class="v"><span class="cell set">sk_test_…</span></td><td class="v"><span class="cell set">sk_test_…</span></td><td class="v"><span class="cell set">sk_live_…</span></td></tr>
+          <tr><td class="k">LOG_LEVEL</td><td class="v"><span class="cell set">debug</span></td><td class="v"><span class="cell inh">↑ inherited</span></td><td class="v"><span class="cell set">info</span></td></tr>
+          <tr><td class="k">SENTRY_DSN</td><td class="v"><span class="cell inh">—</span></td><td class="v"><span class="cell set">https://…</span></td><td class="v"><span class="cell set">https://…</span></td></tr>
+          <tr><td class="k">SESSION_SIGNING_KEY</td><td class="v"><span class="cell set">•••••••</span></td><td class="v"><span class="cell set">•••••••</span></td><td class="v"><span class="cell miss">⚠ unset</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="logos">
+      <p>Runs on the boring stack you already trust</p>
+      <div class="row"><span>Go 1.26</span><span>SQLite</span><span>Postgres</span><span>OpenAPI 3.1</span><span>cosign</span><span>OIDC</span></div>
+    </div>
+
+    <div class="feat">
+      <div>
+        <h3><span class="fi">🔐</span> Encrypted, not hosted</h3>
+        <p>Every value is envelope-encrypted with a per-tenant data key. hikyo never stores a plaintext secret and neither does your database backup.</p>
+      </div>
+      <div>
+        <h3><span class="fi">✅</span> Proof on every read</h3>
+        <p>Access is proof-carrying: unauthorized is indistinguishable from nonexistent. No accidental enumeration, no leaky 403s. <code>authorize()</code> is the only door.</p>
+      </div>
+      <div>
+        <h3><span class="fi">⚡</span> One binary, everywhere</h3>
+        <p>Point your app at hikyo and run. <code>hikyo run -- ./server</code> injects the right env, <code>hikyo render</code> writes a file, <code>hikyo doctor</code> tells you what's missing.</p>
+      </div>
+    </div>
+
+    <footer><span>© 2026 hikyo · MIT</span><span>Self-host · Docs · GitHub</span></footer>
+  </div>
+</section>
+
+<!-- ============================================================ VARIANT B -->
+<!-- SYNTHESIS: Kaneo/Plane structure + Linear finish + Resend technical clarity (dark, premium) -->
+<section class="stage" id="stage-B">
+  <style>
+    #stage-B {
+      --bg:#08090c; --panel:#0e1017; --panel2:#12141d; --fg:#f3f5f9; --muted:#8b93a7;
+      --dim:#5a6274; --line:#1c1f2b; --brand:#6d8bff; --brand2:#a78bfa; --green:#3ecf8e;
+      background:
+        radial-gradient(1200px 520px at 50% -8%, rgba(109,139,255,.16), transparent 60%),
+        radial-gradient(900px 500px at 88% 8%, rgba(167,139,250,.10), transparent 55%),
+        var(--bg);
+      color:var(--fg); font-size:16px; letter-spacing:-.012em; min-height:100vh;
+    }
+    #stage-B .wrap { max-width:1120px; margin:0 auto; padding:0 24px; }
+    #stage-B nav { display:flex; align-items:center; justify-content:space-between; height:66px; }
+    #stage-B .logo { display:flex; align-items:center; gap:9px; font-weight:600; font-size:16.5px; letter-spacing:-.02em; }
+    #stage-B .logo .mark { width:23px; height:23px; border-radius:7px; background:linear-gradient(150deg,var(--brand),var(--brand2)); display:grid; place-items:center; font-size:13px; font-weight:800; color:#0a0a10; }
+    #stage-B .navlinks { display:flex; gap:26px; color:var(--muted); font-size:14px; font-weight:500; }
+    #stage-B .navlinks a:hover{color:var(--fg);}
+    #stage-B .navright{display:flex;align-items:center;gap:16px;font-size:14px;}
+    #stage-B .navright .gh{color:var(--muted);display:flex;align-items:center;gap:7px;}
+    #stage-B .navright .gh b{color:var(--fg);font-variant-numeric:tabular-nums;}
+    #stage-B .btn{background:var(--fg);color:#0a0b0f;padding:8px 15px;border-radius:8px;font-weight:600;font-size:14px;}
+    #stage-B .btn:hover{opacity:.9;}
+
+    #stage-B .hero{display:grid;grid-template-columns:1.05fr .95fr;gap:56px;align-items:center;padding:70px 0 40px;}
+    #stage-B .tagline{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;color:var(--muted);border:1px solid var(--line);background:rgba(255,255,255,.02);padding:5px 12px;border-radius:999px;margin-bottom:26px;font-weight:520;}
+    #stage-B .tagline b{color:var(--brand);}
+    #stage-B h1{font-size:clamp(40px,5.4vw,60px);line-height:1.03;letter-spacing:-.038em;font-weight:600;}
+    #stage-B h1 .g{background:linear-gradient(100deg,#fff,#9fb0ff 60%,#c4b5fd);-webkit-background-clip:text;background-clip:text;color:transparent;}
+    #stage-B .sub{margin-top:22px;font-size:18px;color:var(--muted);max-width:44ch;font-weight:420;letter-spacing:-.008em;}
+    #stage-B .cta{display:flex;gap:12px;margin-top:32px;align-items:center;}
+    #stage-B .cta .btn{padding:11px 20px;font-size:15px;}
+    #stage-B .cta .ghost{color:var(--fg);font-weight:540;font-size:15px;display:flex;align-items:center;gap:7px;}
+    #stage-B .cta .ghost:hover{color:var(--brand);}
+    #stage-B .metrics{display:flex;gap:30px;margin-top:40px;padding-top:26px;border-top:1px solid var(--line);}
+    #stage-B .metrics div b{display:block;font-size:22px;font-weight:640;letter-spacing:-.02em;font-variant-numeric:tabular-nums;}
+    #stage-B .metrics div span{font-size:12.5px;color:var(--dim);}
+
+    /* right: the CLI/product is the visual language (Resend) */
+    #stage-B .term{background:var(--panel);border:1px solid var(--line);border-radius:14px;overflow:hidden;box-shadow:0 30px 80px -40px rgba(0,0,0,.8), inset 0 1px 0 rgba(255,255,255,.03);}
+    #stage-B .term-bar{display:flex;align-items:center;gap:7px;padding:11px 14px;border-bottom:1px solid var(--line);}
+    #stage-B .term-bar .tl{width:11px;height:11px;border-radius:999px;background:#242835;}
+    #stage-B .term-bar .t{margin-left:8px;color:var(--dim);font-size:12px;font-family:var(--mono);}
+    #stage-B pre{padding:18px 18px 20px;font-size:13px;line-height:1.85;color:#cdd4e2;overflow:auto;}
+    #stage-B .c-dim{color:var(--dim);}
+    #stage-B .c-p{color:var(--green);}
+    #stage-B .c-cmd{color:#fff;}
+    #stage-B .c-flag{color:var(--brand);}
+    #stage-B .c-ok{color:var(--green);}
+    #stage-B .c-key{color:var(--brand2);}
+    #stage-B .c-warn{color:#f0a020;}
+
+    #stage-B .strip{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:14px;overflow:hidden;margin:48px 0 0;}
+    #stage-B .strip > div{background:var(--panel);padding:26px 24px;}
+    #stage-B .strip h3{font-size:15px;font-weight:600;letter-spacing:-.02em;margin-bottom:8px;display:flex;align-items:center;gap:8px;}
+    #stage-B .strip h3 .fi{color:var(--brand);}
+    #stage-B .strip p{color:var(--muted);font-size:13.5px;font-weight:420;}
+    #stage-B .strip code{font-family:var(--mono);font-size:12.5px;color:var(--brand2);}
+
+    #stage-B .os{margin:64px 0 20px;padding:30px 32px;border:1px solid var(--line);border-radius:16px;background:linear-gradient(120deg,var(--panel2),var(--panel));display:flex;align-items:center;justify-content:space-between;gap:24px;}
+    #stage-B .os h4{font-size:20px;letter-spacing:-.02em;font-weight:600;}
+    #stage-B .os p{color:var(--muted);font-size:14px;margin-top:6px;max-width:52ch;}
+    #stage-B .os .btn{white-space:nowrap;}
+    #stage-B footer{border-top:1px solid var(--line);margin-top:40px;padding:26px 0;color:var(--dim);font-size:13px;display:flex;justify-content:space-between;}
+    @media (max-width:860px){
+      #stage-B .navlinks{display:none;}
+      #stage-B .hero{grid-template-columns:1fr;gap:34px;padding:40px 0 26px;}
+      #stage-B .metrics{gap:20px;flex-wrap:wrap;}
+      #stage-B .strip{grid-template-columns:1fr;}
+      #stage-B .os{flex-direction:column;align-items:flex-start;}
+      #stage-B pre{font-size:12px;}
+      #stage-B footer{flex-direction:column;gap:10px;}
+    }
+  </style>
+  <div class="wrap">
+    <nav>
+      <div class="logo"><span class="mark">h</span> hikyo</div>
+      <div class="navlinks"><a>Product</a><a>Self-hosting</a><a>Security</a><a>Docs</a><a>Changelog</a></div>
+      <div class="navright"><a class="gh">★ <b>4.2k</b></a><a class="btn">Get started</a></div>
+    </nav>
+
+    <div class="hero">
+      <div>
+        <span class="tagline"><b>●</b> Open source · self-hosted · zero plaintext at rest</span>
+        <h1>Secrets that <span class="g">stay yours</span>, from laptop to prod.</h1>
+        <p class="sub">One signed Go binary. Envelope-encrypted storage, proof-carrying access, and an env matrix your whole team can read. Own the keys, own the data.</p>
+        <div class="cta">
+          <a class="btn">Deploy hikyo →</a>
+          <a class="ghost">Read the docs ↗</a>
+        </div>
+        <div class="metrics">
+          <div><b>1</b><span>static binary</span></div>
+          <div><b>0</b><span>plaintext secrets stored</span></div>
+          <div><b>&lt;5&nbsp;min</b><span>to self-host</span></div>
+        </div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="t">~/payments-api</span></div>
+<pre><span class="c-dim"># adopt an existing .env — encrypted on the way in</span>
+<span class="c-p">$</span> <span class="c-cmd">hikyo adopt</span> <span class="c-flag">--env</span> prod .env
+  <span class="c-ok">✓</span> sealed 42 secrets <span class="c-dim">(envelope, per-tenant DEK)</span>
+
+<span class="c-dim"># run your app with the right env injected</span>
+<span class="c-p">$</span> <span class="c-cmd">hikyo run</span> <span class="c-flag">--env</span> prod <span class="c-dim">--</span> ./server
+  <span class="c-ok">✓</span> authorize() ok <span class="c-dim">·</span> <span class="c-key">18</span> keys resolved
+  <span class="c-dim">→ cascade: prod ▸ default</span>
+  <span class="c-warn">⚠</span> SENTRY_DSN unset in prod <span class="c-dim">(hikyo doctor)</span>
+
+<span class="c-p">$</span> <span class="c-cmd">hikyo render</span> <span class="c-flag">--format</span> dotenv <span class="c-flag">&gt;</span> .env.prod
+  <span class="c-ok">✓</span> wrote 18 vars <span class="c-dim">· 0 plaintext left on disk after run</span></pre>
+      </div>
+    </div>
+
+    <div class="strip">
+      <div><h3><span class="fi">◆</span> Envelope encryption</h3><p>Per-tenant data keys wrap every value. Your DB never sees a plaintext secret — <code>render</code>/<code>run</code> decrypt only in memory, only after authorize.</p></div>
+      <div><h3><span class="fi">◆</span> Proof-carrying access</h3><p>Unauthorized ≡ nonexistent. Every read carries a proof through one chokepoint — no enumeration, no leaky errors, no bypass path.</p></div>
+      <div><h3><span class="fi">◆</span> Reproducible &amp; signed</h3><p>Releases are cosign-signed with an SBOM and offline trust. <code>hikyo doctor</code> verifies the binary you're running is the one that was built.</p></div>
+    </div>
+
+    <div class="os">
+      <div>
+        <h4>Self-host it in the time it takes to read this.</h4>
+        <p>sqlite for dev, postgres for prod, same binary. Refuses a non-TLS postgres by design. No SaaS tier to age out of, no seat you can't afford.</p>
+      </div>
+      <a class="btn">Start self-hosting →</a>
+    </div>
+
+    <footer><span>© 2026 hikyo · MIT-licensed · self-hostable</span><span>Docs · Security · GitHub</span></footer>
+  </div>
+</section>
+
+<!-- ============================================================ VARIANT C -->
+<!-- Unkey / Better Auth: demo-led. The product explains itself through small live UI/code blocks. -->
+<section class="stage" id="stage-C">
+  <style>
+    #stage-C {
+      --bg:#0a0b0e; --card:#111318; --card2:#15171e; --fg:#eef1f6; --muted:#949cad;
+      --dim:#616a7c; --line:#20232d; --brand:#4ade80; --blue:#5b8bff; --purple:#c084fc;
+      background:var(--bg); color:var(--fg); font-size:16px; letter-spacing:-.011em;
+    }
+    #stage-C .wrap{max-width:960px;margin:0 auto;padding:0 22px;}
+    #stage-C nav{display:flex;align-items:center;justify-content:space-between;height:62px;}
+    #stage-C .logo{display:flex;align-items:center;gap:9px;font-weight:600;font-size:16px;}
+    #stage-C .logo .mark{width:22px;height:22px;border-radius:6px;background:var(--brand);color:#06210f;display:grid;place-items:center;font-size:12px;font-weight:800;}
+    #stage-C .navlinks{display:flex;gap:22px;color:var(--muted);font-size:13.5px;}
+    #stage-C .navlinks a:hover{color:var(--fg);}
+    #stage-C .navright .btn{background:var(--brand);color:#06210f;padding:7px 14px;border-radius:7px;font-weight:640;font-size:13.5px;}
+
+    #stage-C .hero{padding:56px 0 20px;}
+    #stage-C .eyebrow{color:var(--brand);font-family:var(--mono);font-size:12.5px;letter-spacing:.02em;margin-bottom:16px;}
+    #stage-C h1{font-size:clamp(32px,5vw,50px);line-height:1.06;letter-spacing:-.032em;font-weight:640;max-width:20ch;}
+    #stage-C .sub{margin-top:18px;font-size:17px;color:var(--muted);max-width:56ch;}
+    #stage-C .install{margin-top:26px;display:inline-flex;align-items:center;gap:12px;background:var(--card);border:1px solid var(--line);border-radius:10px;padding:10px 12px 10px 16px;font-family:var(--mono);font-size:13.5px;}
+    #stage-C .install .p{color:var(--dim);}
+    #stage-C .install .cp{margin-left:6px;background:var(--card2);border:1px solid var(--line);color:var(--muted);border-radius:6px;padding:4px 9px;font-size:11px;font-family:var(--sans);cursor:pointer;}
+    #stage-C .install .cp:hover{color:var(--fg);}
+
+    /* demo blocks — functionality is the content */
+    #stage-C .demos{display:flex;flex-direction:column;gap:18px;padding:44px 0 20px;}
+    #stage-C .demo{border:1px solid var(--line);border-radius:14px;background:var(--card);overflow:hidden;}
+    #stage-C .demo-head{display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1px solid var(--line);}
+    #stage-C .demo-head .n{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);border-radius:5px;padding:2px 7px;}
+    #stage-C .demo-head h3{font-size:14.5px;font-weight:580;letter-spacing:-.015em;}
+    #stage-C .demo-head p{margin-left:auto;color:var(--dim);font-size:12.5px;}
+    #stage-C .demo-body{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--line);}
+    #stage-C .demo-body > div{background:var(--card);padding:16px 18px;}
+    #stage-C .demo-body .cap{font-size:11px;color:var(--dim);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px;font-weight:640;}
+    #stage-C pre{font-family:var(--mono);font-size:12.5px;line-height:1.8;color:#cbd2e0;overflow:auto;}
+    #stage-C .g{color:var(--dim);} #stage-C .p{color:var(--brand);} #stage-C .cmd{color:#fff;}
+    #stage-C .fl{color:var(--blue);} #stage-C .ok{color:var(--brand);} #stage-C .ky{color:var(--purple);} #stage-C .wn{color:#f0a83a;}
+
+    /* mini env matrix inside a demo */
+    #stage-C .mini{width:100%;border-collapse:collapse;font-size:12px;}
+    #stage-C .mini th{color:var(--dim);font-weight:600;text-align:center;padding:6px 8px;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em;}
+    #stage-C .mini th:first-child{text-align:left;}
+    #stage-C .mini td{padding:6px 8px;border-top:1px solid var(--line);text-align:center;font-family:var(--mono);}
+    #stage-C .mini td:first-child{text-align:left;color:var(--fg);}
+    #stage-C .b{display:inline-block;padding:2px 7px;border-radius:5px;font-size:11px;}
+    #stage-C .b.s{background:rgba(91,139,255,.14);color:#9db4ff;}
+    #stage-C .b.i{color:var(--dim);}
+    #stage-C .b.w{background:rgba(240,168,58,.14);color:#f0a83a;}
+
+    #stage-C .why{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;padding:36px 0 8px;}
+    #stage-C .why > div{border:1px solid var(--line);border-radius:12px;padding:18px;background:var(--card);}
+    #stage-C .why b{display:block;font-size:14px;letter-spacing:-.015em;margin-bottom:6px;}
+    #stage-C .why span{color:var(--muted);font-size:13px;}
+    #stage-C .close{text-align:center;padding:64px 0 40px;}
+    #stage-C .close h2{font-size:30px;letter-spacing:-.03em;font-weight:640;}
+    #stage-C .close p{color:var(--muted);margin-top:12px;}
+    #stage-C .close .btn{display:inline-block;margin-top:22px;background:var(--fg);color:#0a0b0e;padding:11px 22px;border-radius:9px;font-weight:620;}
+    #stage-C footer{border-top:1px solid var(--line);padding:24px 0;color:var(--dim);font-size:12.5px;text-align:center;}
+    @media (max-width:760px){
+      #stage-C .navlinks{display:none;}
+      #stage-C .demo-body{grid-template-columns:1fr;}
+      #stage-C .why{grid-template-columns:1fr;}
+      #stage-C .demo-head p{display:none;}
+    }
+  </style>
+  <div class="wrap">
+    <nav>
+      <div class="logo"><span class="mark">h</span> hikyo</div>
+      <div class="navlinks"><a>Docs</a><a>Self-hosting</a><a>Security model</a><a>GitHub</a></div>
+      <div class="navright"><a class="btn">Get started</a></div>
+    </nav>
+
+    <div class="hero">
+      <div class="eyebrow">// open-source secrets manager you run yourself</div>
+      <h1>Understand your environments by reading them.</h1>
+      <p class="sub">hikyo doesn't hide your config behind a dashboard. Here's exactly what it does — no marketing screenshots, just the four things you'll actually run.</p>
+      <div class="install"><span class="p">$</span> curl -fsSL hikyo.dev/install | sh <span class="cp">copy</span></div>
+    </div>
+
+    <div class="demos">
+      <!-- demo 1: adopt -->
+      <div class="demo">
+        <div class="demo-head"><span class="n">01</span><h3>Adopt an existing .env — it's encrypted before it lands</h3><p>hikyo adopt</p></div>
+        <div class="demo-body">
+          <div><div class="cap">you run</div>
+<pre><span class="p">$</span> <span class="cmd">hikyo adopt</span> <span class="fl">--env</span> prod .env</pre></div>
+          <div><div class="cap">hikyo does</div>
+<pre><span class="ok">✓</span> 42 secrets <span class="ky">envelope-sealed</span>
+<span class="g">  per-tenant DEK · no plaintext</span>
+<span class="g">  stored in postgres/sqlite</span></pre></div>
+        </div>
+      </div>
+
+      <!-- demo 2: env matrix / cascade -->
+      <div class="demo">
+        <div class="demo-head"><span class="n">02</span><h3>See every env at once — inheritance made obvious</h3><p>hikyo definitions</p></div>
+        <div class="demo-body">
+          <div><div class="cap">the matrix</div>
+            <table class="mini">
+              <thead><tr><th>key</th><th>dev</th><th>stg</th><th>prod</th></tr></thead>
+              <tbody>
+                <tr><td>DATABASE_URL</td><td><span class="b s">set</span></td><td><span class="b s">set</span></td><td><span class="b s">set</span></td></tr>
+                <tr><td>LOG_LEVEL</td><td><span class="b s">debug</span></td><td><span class="b i">↑</span></td><td><span class="b s">info</span></td></tr>
+                <tr><td>SENTRY_DSN</td><td><span class="b i">—</span></td><td><span class="b s">set</span></td><td><span class="b w">unset</span></td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div><div class="cap">what ↑ means</div>
+<pre><span class="g"># prod inherits from default</span>
+<span class="p">$</span> <span class="cmd">hikyo render</span> <span class="fl">--env</span> stg
+LOG_LEVEL=<span class="ky">debug</span> <span class="g">← from default</span>
+<span class="g"># cascade: env ▸ default,</span>
+<span class="g"># resolved left-to-right.</span></pre></div>
+        </div>
+      </div>
+
+      <!-- demo 3: run with proof -->
+      <div class="demo">
+        <div class="demo-head"><span class="n">03</span><h3>Run your app — access is proof-carrying</h3><p>hikyo run</p></div>
+        <div class="demo-body">
+          <div><div class="cap">you run</div>
+<pre><span class="p">$</span> <span class="cmd">hikyo run</span> <span class="fl">--env</span> prod \
+    <span class="g">--</span> ./server</pre></div>
+          <div><div class="cap">hikyo does</div>
+<pre><span class="ok">✓</span> <span class="ky">authorize()</span> ok <span class="g">· 18 keys</span>
+<span class="g">  unauthorized ≡ nonexistent</span>
+<span class="g">  → injected into child env</span>
+<span class="g">  → 0 plaintext on disk</span></pre></div>
+        </div>
+      </div>
+
+      <!-- demo 4: doctor -->
+      <div class="demo">
+        <div class="demo-head"><span class="n">04</span><h3>Ship with confidence — doctor catches the gaps</h3><p>hikyo doctor</p></div>
+        <div class="demo-body">
+          <div><div class="cap">you run</div>
+<pre><span class="p">$</span> <span class="cmd">hikyo doctor</span> <span class="fl">--env</span> prod</pre></div>
+          <div><div class="cap">hikyo does</div>
+<pre><span class="ok">✓</span> 17/18 resolved
+<span class="wn">⚠</span> <span class="ky">SENTRY_DSN</span> unset in prod
+<span class="ok">✓</span> release cosign-verified
+<span class="g">  exit 1 → your CI fails loud</span></pre></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="why">
+      <div><b>Own the keys</b><span>Envelope encryption with per-tenant data keys. Your backups are ciphertext.</span></div>
+      <div><b>One binary</b><span>sqlite → postgres on the same build. Deploy in minutes, no SaaS lock-in.</span></div>
+      <div><b>Signed &amp; reproducible</b><span>cosign + SBOM + offline trust. Verify what you run.</span></div>
+    </div>
+
+    <div class="close">
+      <h2>Config you can actually reason about.</h2>
+      <p>Self-hosted, MIT-licensed, and boring on purpose.</p>
+      <a class="btn">Read the docs →</a>
+    </div>
+    <footer>© 2026 hikyo · MIT · self-hostable</footer>
+  </div>
+</section>
+
+<!-- ============================================================ SWITCHER -->
+<div id="switcher" role="group" aria-label="Prototype variant switcher">
+  <button id="prev" aria-label="Previous variant">‹</button>
+  <span class="label"><b id="vkey">A</b> <span id="vname">— Kaneo / Plane</span></span>
+  <button id="next" aria-label="Next variant">›</button>
+</div>
+
+<script>
+  const VARIANTS = [
+    { key: 'A', name: '— Kaneo / Plane (clean white)' },
+    { key: 'B', name: '— Synthesis: Kaneo + Linear + Resend (dark)' },
+    { key: 'C', name: '— Unkey / Better Auth (demo-led)' },
+  ];
+  const keys = VARIANTS.map(v => v.key);
+
+  function current() {
+    const h = (location.hash || '').replace('#', '').toUpperCase();
+    return keys.includes(h) ? h : 'A';
+  }
+  function show(k) {
+    for (const v of VARIANTS) {
+      document.getElementById('stage-' + v.key).classList.toggle('active', v.key === k);
+    }
+    const meta = VARIANTS.find(v => v.key === k);
+    document.getElementById('vkey').textContent = k;
+    document.getElementById('vname').textContent = meta.name;
+    if ((location.hash || '').replace('#', '').toUpperCase() !== k) location.hash = k;
+    window.scrollTo(0, 0);
+    document.title = 'hikyo — landing prototype ' + k;
+  }
+  function step(d) {
+    const i = keys.indexOf(current());
+    show(keys[(i + d + keys.length) % keys.length]);
+  }
+  document.getElementById('prev').onclick = () => step(-1);
+  document.getElementById('next').onclick = () => step(1);
+  window.addEventListener('hashchange', () => show(current()));
+  document.addEventListener('keydown', e => {
+    const t = e.target;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+    if (e.key === 'ArrowLeft') step(-1);
+    else if (e.key === 'ArrowRight') step(1);
+  });
+  show(current());
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-4.8/2/index.html
+++ b/docs/site/public/prototypes/landing-opus-4.8/2/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hikyo: self-hosted secrets &amp; config across environments</title>
+<!--
+  PROTOTYPE — landing-opus-4.8 / iteration 2 (frozen once announced).
+  Rebuilt on the LOCKED hikyo design language (DESIGN.md): dark-default graphite tinted
+  teal, system-ui + ui-monospace, radius roles (6/4/3), 999px pill reserved for matrix
+  state + counts + avatars, restrained OKLCH, AAA contrast, state pills carry a glyph.
+  Structure follows Kaneo's restraint + Plane's sellability: short value prop → the
+  env matrix as the hero (the product's signature surface) → provenance/reveal/validate
+  feature rows → self-hosted band → why → final CTA → real footer.
+  Single committed design (the A/B/C explorer was iteration 1). No build, no deps.
+-->
+<style>
+  :root{
+    /* dark (default) — DESIGN.md tokens */
+    --bg:oklch(0.19 0.012 220);
+    --bg-raise:oklch(0.225 0.014 220);
+    --bg-sink:oklch(0.165 0.011 220);
+    --line:oklch(0.34 0.016 220);
+    --line-soft:oklch(0.27 0.014 220);
+    --tx:oklch(0.94 0.008 200);
+    --tx-dim:oklch(0.77 0.01 210);
+    --tx-faint:oklch(0.62 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --accent-quiet:oklch(0.82 0.09 195 / .12);
+    --on-accent:oklch(0.2 0.02 220);
+    --danger:oklch(0.72 0.13 25);
+    --danger-quiet:oklch(0.72 0.13 25 / .14);
+    --warn:oklch(0.82 0.1 85);
+    --mono:ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:system-ui,-apple-system,sans-serif;
+    --r6:6px; --r4:4px; --r3:3px;
+    --maxw:1120px;
+    --ease:cubic-bezier(.22,1,.36,1);
+  }
+  @media (prefers-color-scheme: light){
+    :root{
+      --bg:oklch(0.965 0.008 200);
+      --bg-raise:oklch(0.995 0.004 200);
+      --bg-sink:oklch(0.93 0.008 200);
+      --line:oklch(0.86 0.012 210);
+      --line-soft:oklch(0.9 0.01 210);
+      --tx:oklch(0.25 0.03 225);
+      --tx-dim:oklch(0.42 0.025 220);
+      --tx-faint:oklch(0.55 0.02 218);
+      --accent:oklch(0.55 0.09 205);
+      --accent-quiet:oklch(0.55 0.09 205 / .1);
+      --on-accent:oklch(0.99 0.01 200);
+      --danger:oklch(0.5 0.15 30);
+      --danger-quiet:oklch(0.5 0.15 30 / .1);
+      --warn:oklch(0.62 0.12 75);
+    }
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  @media (prefers-reduced-motion:reduce){html{scroll-behavior:auto}*{transition:none!important;animation:none!important}}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    line-height:1.55;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;
+    font-size:16px;letter-spacing:-.006em;
+  }
+  a{color:inherit;text-decoration:none}
+  ::selection{background:var(--accent-quiet);color:var(--tx)}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 clamp(18px,4vw,40px)}
+  .mono{font-family:var(--mono)}
+  .r6{border-radius:var(--r6)} .r4{border-radius:var(--r4)} .r3{border-radius:var(--r3)}
+
+  /* ---- entrance ---- */
+  .rise{opacity:0;transform:translateY(14px);animation:rise .7s var(--ease) forwards}
+  @keyframes rise{to{opacity:1;transform:none}}
+  .d1{animation-delay:.05s}.d2{animation-delay:.12s}.d3{animation-delay:.19s}.d4{animation-delay:.26s}.d5{animation-delay:.34s}
+
+  /* ---------- nav ---------- */
+  header{position:sticky;top:0;z-index:50;background:color-mix(in oklab,var(--bg) 82%,transparent);
+    backdrop-filter:saturate(1.4) blur(8px);border-bottom:1px solid var(--line-soft)}
+  nav{display:flex;align-items:center;gap:22px;height:60px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:17px;letter-spacing:-.02em}
+  .brand .glyph{width:24px;height:24px;border-radius:var(--r6);background:var(--accent);color:var(--on-accent);
+    display:grid;place-items:center;font-weight:800;font-size:14px;font-family:var(--mono)}
+  .navlinks{display:flex;gap:22px;margin-left:12px;color:var(--tx-dim);font-size:14px;font-weight:500}
+  .navlinks a{padding:4px 0;border-bottom:1px solid transparent;transition:color .15s}
+  .navlinks a:hover{color:var(--tx)}
+  .navright{margin-left:auto;display:flex;align-items:center;gap:16px;font-size:14px;font-weight:500}
+  .stars{display:flex;align-items:center;gap:7px;color:var(--tx-dim);font-family:var(--mono);font-size:13px}
+  .stars b{color:var(--tx);font-weight:600}
+  .signin{color:var(--tx-dim)}.signin:hover{color:var(--tx)}
+  .btn{display:inline-flex;align-items:center;gap:8px;font-weight:600;font-size:14px;
+    padding:8px 15px;border-radius:var(--r4);transition:transform .15s var(--ease),background .15s,border-color .15s}
+  .btn-primary{background:var(--accent);color:var(--on-accent)}
+  .btn-primary:hover{transform:translateY(-1px)}
+  .btn-line{border:1px solid var(--line);color:var(--tx);background:transparent}
+  .btn-line:hover{border-color:var(--accent);color:var(--tx)}
+
+  /* ---------- hero ---------- */
+  .hero{padding:clamp(56px,9vw,104px) 0 clamp(30px,5vw,46px)}
+  .eyebrow{display:inline-flex;align-items:center;gap:9px;font-family:var(--mono);font-size:12.5px;
+    color:var(--tx-dim);border:1px solid var(--line-soft);background:var(--bg-raise);
+    padding:5px 12px 5px 9px;border-radius:var(--r3);margin-bottom:24px}
+  .eyebrow .live{width:7px;height:7px;border-radius:999px;background:var(--accent);
+    box-shadow:0 0 0 3px var(--accent-quiet)}
+  h1{font-size:clamp(38px,6.4vw,68px);line-height:1.015;letter-spacing:-.035em;font-weight:800;
+    max-width:15ch}
+  h1 .fade{color:var(--tx-dim);font-weight:700}
+  .lede{margin-top:22px;font-size:clamp(16px,2vw,19px);color:var(--tx-dim);max-width:60ch;
+    font-weight:440;line-height:1.6;letter-spacing:-.008em}
+  .cta{display:flex;flex-wrap:wrap;gap:12px;align-items:center;margin-top:32px}
+  .cta .btn{padding:11px 19px;font-size:15px}
+  .install{display:inline-flex;align-items:center;gap:12px;font-family:var(--mono);font-size:13.5px;
+    color:var(--tx-dim);border:1px solid var(--line);border-radius:var(--r4);padding:9px 10px 9px 15px;background:var(--bg-raise)}
+  .install .p{color:var(--accent)}
+  .install .cp{border:1px solid var(--line);color:var(--tx-faint);border-radius:var(--r3);
+    padding:3px 9px;font-family:var(--sans);font-size:11px;cursor:pointer;transition:color .15s,border-color .15s}
+  .install .cp:hover{color:var(--tx);border-color:var(--accent)}
+  .subtrust{margin-top:18px;color:var(--tx-faint);font-size:13px}
+  .subtrust b{color:var(--tx-dim);font-weight:600}
+
+  /* ---------- product hero: the env matrix ---------- */
+  .surface{margin-top:clamp(34px,5vw,54px);border:1px solid var(--line);border-radius:var(--r6);
+    overflow:hidden;background:var(--bg-raise);box-shadow:0 40px 80px -50px oklch(0 0 0 / .7)}
+  .surface-bar{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg-sink)}
+  .crumb{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--tx-dim)}
+  .crumb .av{width:20px;height:20px;border-radius:999px;background:var(--accent-quiet);color:var(--accent);
+    display:grid;place-items:center;font-size:10px;font-weight:700;font-family:var(--mono)}
+  .crumb b{color:var(--tx);font-weight:600}
+  .crumb .sep{color:var(--tx-faint)}
+  .chips{margin-left:auto;display:flex;gap:6px}
+  .chip{font-family:var(--mono);font-size:11px;color:var(--tx-dim);border:1px solid var(--line);
+    border-radius:var(--r3);padding:3px 8px;background:var(--bg-raise)}
+  .chip.off{opacity:.42;text-decoration:line-through}
+  .mwrap{overflow-x:auto}
+  table.matrix{width:100%;border-collapse:collapse;font-size:13px;min-width:660px}
+  .matrix thead th{position:sticky;top:0;text-align:left;padding:11px 16px;font-weight:600;font-size:11px;
+    letter-spacing:.04em;text-transform:uppercase;color:var(--tx-faint);border-bottom:1px solid var(--line);
+    background:var(--bg-raise)}
+  .matrix thead th.env{text-align:left}
+  .matrix tbody td{padding:9px 16px;border-bottom:1px solid var(--line-soft);white-space:nowrap;vertical-align:middle}
+  .matrix tbody tr:hover{background:color-mix(in oklab,var(--accent) 4%,transparent)}
+  .matrix tbody tr:last-child td{border-bottom:0}
+  .k{font-family:var(--mono);font-size:12.5px;color:var(--tx)}
+  .grp td{background:var(--bg-sink);color:var(--tx-faint);font-family:var(--mono);font-size:11px;
+    letter-spacing:.06em;text-transform:uppercase;padding:7px 16px}
+  .grp td .cnt{display:inline-grid;place-items:center;min-width:18px;height:16px;border-radius:999px;
+    background:var(--line);color:var(--tx-dim);font-size:10px;margin-left:8px;padding:0 5px}
+  /* state pills — 999px is allowed here (matrix vocabulary) */
+  .pill{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11.5px;
+    padding:3px 9px;border-radius:999px;line-height:1.3}
+  .pill.set{background:var(--accent);color:var(--on-accent);font-weight:600}
+  .pill.inh{border:1px solid var(--line);color:var(--tx-dim)}
+  .pill.def{background:var(--accent-quiet);color:var(--accent)}
+  .pill.mask{color:var(--tx-dim);background:var(--bg-sink);border:1px solid var(--line);
+    background-image:repeating-linear-gradient(135deg,transparent 0 4px,color-mix(in oklab,var(--tx-faint) 22%,transparent) 4px 5px)}
+  .pill.miss{background:var(--danger-quiet);color:var(--danger);font-weight:600}
+  .pill .o{opacity:.72;font-size:10.5px}
+  .surface-foot{display:flex;align-items:center;gap:14px;padding:10px 16px;border-top:1px solid var(--line);
+    background:var(--bg-sink);font-size:12px;color:var(--tx-faint);font-family:var(--mono);flex-wrap:wrap}
+  .legend{display:inline-flex;align-items:center;gap:6px}
+  .legend .sw{width:9px;height:9px;border-radius:999px}
+  .sw.set{background:var(--accent)} .sw.inh{border:1px solid var(--line)} .sw.def{background:var(--accent-quiet)}
+  .sw.mask{background:var(--tx-faint)} .sw.miss{background:var(--danger)}
+
+  /* ---------- boring-stack strip ---------- */
+  .stack{border-top:1px solid var(--line-soft);border-bottom:1px solid var(--line-soft);margin-top:clamp(48px,7vw,80px)}
+  .stack .wrap{display:flex;align-items:center;gap:clamp(16px,4vw,42px);padding:20px 0;flex-wrap:wrap}
+  .stack p{font-size:12px;color:var(--tx-faint);letter-spacing:.05em;text-transform:uppercase;font-weight:600}
+  .stack .items{display:flex;gap:clamp(14px,3vw,30px);flex-wrap:wrap;color:var(--tx-dim);
+    font-family:var(--mono);font-size:14px}
+
+  /* ---------- section scaffold ---------- */
+  section.block{padding:clamp(56px,9vw,104px) 0}
+  .kicker{font-family:var(--mono);font-size:12.5px;color:var(--accent);letter-spacing:.02em;margin-bottom:14px}
+  h2{font-size:clamp(28px,3.8vw,42px);line-height:1.08;letter-spacing:-.028em;font-weight:750;max-width:20ch}
+  .h2sub{margin-top:14px;color:var(--tx-dim);font-size:clamp(15px,1.7vw,17px);max-width:56ch;line-height:1.6}
+
+  /* alternating feature rows (asymmetric, not a card grid) */
+  .row{display:grid;grid-template-columns:1fr 1.05fr;gap:clamp(28px,5vw,68px);align-items:center;
+    padding:clamp(40px,6vw,72px) 0;border-top:1px solid var(--line-soft)}
+  .row.flip .copy{order:2}
+  .row h3{font-size:clamp(20px,2.6vw,27px);letter-spacing:-.02em;font-weight:700;line-height:1.15}
+  .row p{margin-top:12px;color:var(--tx-dim);font-size:15.5px;line-height:1.62;max-width:46ch}
+  .row .note{margin-top:16px;display:flex;align-items:center;gap:9px;font-family:var(--mono);
+    font-size:12.5px;color:var(--tx-faint)}
+  .row .note .tick{color:var(--accent)}
+
+  /* artifact frames */
+  .frame{border:1px solid var(--line);border-radius:var(--r6);background:var(--bg-raise);overflow:hidden}
+  .frame-head{display:flex;align-items:center;gap:8px;padding:9px 13px;border-bottom:1px solid var(--line);
+    background:var(--bg-sink);font-family:var(--mono);font-size:11.5px;color:var(--tx-faint)}
+  .tl{width:10px;height:10px;border-radius:999px;background:var(--line)}
+  .frame-body{padding:16px}
+
+  /* provenance chain artifact */
+  .prov{display:flex;flex-direction:column;gap:0}
+  .prov .head{display:flex;align-items:center;justify-content:space-between;padding:2px 0 12px}
+  .prov .head .key{font-family:var(--mono);font-size:13px;color:var(--tx)}
+  .prov .head .env{font-family:var(--mono);font-size:11px;color:var(--tx-faint);border:1px solid var(--line);
+    border-radius:var(--r3);padding:2px 8px}
+  .step{display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:center;padding:10px 12px;
+    border:1px solid var(--line-soft);border-radius:var(--r4);margin-bottom:8px;background:var(--bg-sink)}
+  .step.active{border-color:var(--accent);background:var(--accent-quiet)}
+  .step .lvl{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);text-transform:uppercase;letter-spacing:.05em}
+  .step.active .lvl{color:var(--accent)}
+  .step .val{font-family:var(--mono);font-size:12.5px;color:var(--tx-dim)}
+  .step.active .val{color:var(--tx)}
+  .step .flag{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  .step.active .flag{color:var(--accent)}
+  .prov .rule{padding-left:12px;color:var(--tx-faint);font-family:var(--mono);font-size:11px;margin-top:2px}
+
+  /* reveal ceremony artifact */
+  .reveal .stage{display:flex;align-items:center;gap:12px;padding:13px;border:1px solid var(--line-soft);
+    border-radius:var(--r4);background:var(--bg-sink);margin-bottom:10px}
+  .reveal .stage .kk{font-family:var(--mono);font-size:12.5px;color:var(--tx);flex:1}
+  .reveal .val{font-family:var(--mono);font-size:12.5px}
+  .reveal .val.masked{color:var(--tx-faint)}
+  .reveal .val.shown{color:var(--accent)}
+  .reveal .count{font-family:var(--mono);font-size:11px;color:var(--warn);display:flex;align-items:center;gap:6px}
+  .reveal .gate{display:flex;align-items:center;gap:10px;padding:11px 13px;border:1px solid var(--line);
+    border-radius:var(--r4);font-size:12.5px;color:var(--tx-dim)}
+  .reveal .gate .lock{color:var(--accent)}
+  .reveal .gate .m{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+
+  /* cli transcript artifact */
+  pre.cli{font-family:var(--mono);font-size:12.5px;line-height:1.85;color:var(--tx-dim);
+    padding:16px;overflow-x:auto}
+  pre.cli .p{color:var(--accent)} pre.cli .c{color:var(--tx)} pre.cli .f{color:var(--tx-faint)}
+  pre.cli .ok{color:var(--accent)} pre.cli .w{color:var(--warn)} pre.cli .b{color:var(--danger)}
+
+  /* validate / doctor artifact */
+  .doctor{display:flex;flex-direction:column;gap:8px}
+  .drow{display:grid;grid-template-columns:auto 1fr auto;gap:11px;align-items:center;padding:9px 12px;
+    border:1px solid var(--line-soft);border-radius:var(--r4);background:var(--bg-sink);font-size:12.5px}
+  .drow .ic{width:18px;height:18px;border-radius:var(--r3);display:grid;place-items:center;font-size:11px;font-weight:700}
+  .drow .ic.ok{background:var(--accent-quiet);color:var(--accent)}
+  .drow .ic.bad{background:var(--danger-quiet);color:var(--danger)}
+  .drow .msg{font-family:var(--mono);color:var(--tx-dim)}
+  .drow .msg b{color:var(--tx)}
+  .drow .tag{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+
+  /* ---------- self-host band ---------- */
+  .band{background:var(--bg-sink);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+  .band .grid{display:grid;grid-template-columns:1.1fr 1fr;gap:clamp(28px,5vw,60px);align-items:center;
+    padding:clamp(48px,8vw,90px) 0}
+  .specs{display:grid;gap:1px;background:var(--line-soft);border:1px solid var(--line-soft);border-radius:var(--r6);overflow:hidden}
+  .spec{display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:baseline;padding:15px 18px;background:var(--bg-raise)}
+  .spec dt{font-family:var(--mono);font-size:12px;color:var(--accent);white-space:nowrap}
+  .spec dd{color:var(--tx-dim);font-size:14px;line-height:1.5}
+  .spec dd b{color:var(--tx);font-weight:600}
+
+  /* ---------- why ---------- */
+  .why{max-width:64ch;margin:0 auto;text-align:left}
+  .why h2{max-width:22ch}
+  .why .body{margin-top:22px;display:flex;flex-direction:column;gap:16px;color:var(--tx-dim);
+    font-size:clamp(16px,1.9vw,18.5px);line-height:1.65}
+  .why .body b{color:var(--tx);font-weight:600}
+  .why .sig{margin-top:26px;font-family:var(--mono);font-size:13px;color:var(--tx-faint)}
+
+  /* ---------- final cta ---------- */
+  .final{text-align:center;padding:clamp(64px,10vw,120px) 0}
+  .final h2{margin:0 auto;max-width:18ch}
+  .final .lede{margin:18px auto 0}
+  .final .cta{justify-content:center;margin-top:30px}
+
+  /* ---------- footer ---------- */
+  footer.site{border-top:1px solid var(--line);background:var(--bg-sink)}
+  .fgrid{display:grid;grid-template-columns:1.6fr repeat(3,1fr);gap:clamp(24px,4vw,48px);padding:clamp(40px,6vw,64px) 0 30px}
+  .fbrand .brand{margin-bottom:14px}
+  .fbrand p{color:var(--tx-faint);font-size:13.5px;max-width:34ch;line-height:1.6}
+  .fcol h4{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--tx-faint);
+    font-weight:600;margin-bottom:14px;font-family:var(--mono)}
+  .fcol a{display:block;color:var(--tx-dim);font-size:14px;padding:5px 0;transition:color .15s}
+  .fcol a:hover{color:var(--tx)}
+  .fbar{display:flex;justify-content:space-between;align-items:center;gap:14px;padding:18px 0;
+    border-top:1px solid var(--line-soft);color:var(--tx-faint);font-size:12.5px;flex-wrap:wrap}
+  .fbar .mono{font-family:var(--mono)}
+
+  /* ---------- responsive ---------- */
+  @media (max-width:900px){
+    .row,.band .grid,.fgrid{grid-template-columns:1fr}
+    .row.flip .copy{order:0}
+    .row .art{order:2}
+    .fgrid{gap:32px}
+    .band .grid .art{order:2}
+  }
+  @media (max-width:680px){
+    .navlinks,.stars,.signin{display:none}
+    .navright{margin-left:auto}
+    h1{font-size:clamp(33px,10vw,44px)}
+    .install{width:100%;justify-content:space-between}
+    .cta{gap:10px}
+    .cta .btn,.install{flex:1 1 auto}
+    .fgrid{grid-template-columns:1fr 1fr}
+    .fbrand{grid-column:1/-1}
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap"><nav>
+    <a class="brand"><span class="glyph">h</span> hikyo</a>
+    <div class="navlinks">
+      <a href="#matrix">Product</a>
+      <a href="#self-host">Self-hosting</a>
+      <a href="#why">Why</a>
+      <a href="#">Docs</a>
+      <a href="#">Pricing</a>
+    </div>
+    <div class="navright">
+      <a class="stars" href="#">★ <b>4,210</b></a>
+      <a class="signin" href="#">Sign in</a>
+      <a class="btn btn-primary" href="#">Get started</a>
+    </div>
+  </nav></div>
+</header>
+
+<main>
+  <!-- ===== hero ===== -->
+  <section class="hero"><div class="wrap">
+    <span class="eyebrow rise d1"><span class="live"></span> v0.4 · one signed binary · self-hosted</span>
+    <h1 class="rise d2">See every value.<br><span class="fade">Trust every source.</span></h1>
+    <p class="lede rise d3">hikyo is a self-hosted control plane for validated, inherited secrets and configuration across environments. From a single <span class="mono">.env</span> to Compose and Kubernetes, every resolved value can tell you exactly where it came from.</p>
+    <div class="cta rise d4">
+      <a class="btn btn-primary" href="#">Start self-hosting</a>
+      <span class="install"><span><span class="p">$</span> curl -fsSL hikyo.dev/install | sh</span><span class="cp" data-copy="curl -fsSL hikyo.dev/install | sh">copy</span></span>
+      <a class="btn btn-line" href="#">★ GitHub</a>
+    </div>
+    <p class="subtrust rise d4"><b>MPL-2.0 licensed.</b> No account required. sqlite for dev, postgres for prod, the same binary.</p>
+
+    <!-- the env matrix: signature surface as the hero -->
+    <div class="surface rise d5" id="matrix">
+      <div class="surface-bar">
+        <div class="crumb"><span class="av">AC</span> <b>acme</b><span class="sep">/</span> payments-api</div>
+        <div class="chips"><span class="chip">dev</span><span class="chip">staging</span><span class="chip">prod</span><span class="chip off">preview</span></div>
+      </div>
+      <div class="mwrap">
+      <table class="matrix">
+        <thead><tr>
+          <th>Key</th><th class="env">dev</th><th class="env">staging</th><th class="env">prod</th>
+        </tr></thead>
+        <tbody>
+          <tr class="grp"><td colspan="4">database <span class="cnt">3</span></td></tr>
+          <tr>
+            <td class="k">DATABASE_URL</td>
+            <td><span class="pill set">postgres://…</span></td>
+            <td><span class="pill set">postgres://…</span></td>
+            <td><span class="pill set">postgres://…</span></td>
+          </tr>
+          <tr>
+            <td class="k">DATABASE_POOL_MAX</td>
+            <td><span class="pill def">10 <span class="o">◂ def</span></span></td>
+            <td><span class="pill def">10 <span class="o">◂ def</span></span></td>
+            <td><span class="pill set">40</span></td>
+          </tr>
+          <tr>
+            <td class="k">DATABASE_SSLMODE</td>
+            <td><span class="pill inh">disable</span></td>
+            <td><span class="pill set">verify-full</span></td>
+            <td><span class="pill set">verify-full</span></td>
+          </tr>
+          <tr class="grp"><td colspan="4">observability <span class="cnt">2</span></td></tr>
+          <tr>
+            <td class="k">LOG_LEVEL</td>
+            <td><span class="pill set">debug</span></td>
+            <td><span class="pill inh">info <span class="o">◂ base</span></span></td>
+            <td><span class="pill set">info</span></td>
+          </tr>
+          <tr>
+            <td class="k">SENTRY_DSN</td>
+            <td><span class="pill inh">unset</span></td>
+            <td><span class="pill set">https://…</span></td>
+            <td><span class="pill miss">! required</span></td>
+          </tr>
+          <tr class="grp"><td colspan="4">secrets <span class="cnt">2</span></td></tr>
+          <tr>
+            <td class="k">STRIPE_SECRET_KEY</td>
+            <td><span class="pill mask">∅ masked</span></td>
+            <td><span class="pill mask">∅ masked</span></td>
+            <td><span class="pill mask">∅ masked</span></td>
+          </tr>
+          <tr>
+            <td class="k">SESSION_SIGNING_KEY</td>
+            <td><span class="pill mask">∅ masked</span></td>
+            <td><span class="pill mask">∅ masked</span></td>
+            <td><span class="pill mask">∅ masked</span></td>
+          </tr>
+        </tbody>
+      </table>
+      </div>
+      <div class="surface-foot">
+        <span class="legend"><span class="sw set"></span> set here</span>
+        <span class="legend"><span class="sw inh"></span> inherited</span>
+        <span class="legend"><span class="sw def"></span> from defaults</span>
+        <span class="legend"><span class="sw mask"></span> masked</span>
+        <span class="legend"><span class="sw miss"></span> required, unset</span>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ===== boring stack strip ===== -->
+  <div class="stack"><div class="wrap">
+    <p>Runs on the stack you already trust</p>
+    <div class="items"><span>Go 1.26</span><span>SQLite</span><span>Postgres</span><span>Docker Compose</span><span>Kubernetes</span><span>cosign</span></div>
+  </div></div>
+
+  <!-- ===== features ===== -->
+  <section class="block"><div class="wrap">
+    <div class="kicker">// minimal surface, maximum provenance</div>
+    <h2>A dense surface that stays honest.</h2>
+    <p class="h2sub">Fifty keys across four environments should stay scannable, and no value should ever surprise you. hikyo shows you the resolved config and, for every cell, the exact reason it resolved that way.</p>
+
+    <!-- 1 provenance -->
+    <div class="row">
+      <div class="copy">
+        <h3>Every value explains its origin.</h3>
+        <p>Config inherits: project defaults, then a base environment, then the environment you are looking at. Click any cell and hikyo shows the full chain, so you never guess whether prod is overriding staging or quietly falling through to a default.</p>
+        <div class="note"><span class="tick">▸</span> Resolution: defaults ▸ base ▸ environment, left to right.</div>
+      </div>
+      <div class="art">
+        <div class="frame">
+          <div class="frame-head"><span class="tl"></span><span class="tl"></span><span class="tl"></span> &nbsp;provenance · DATABASE_POOL_MAX @ prod</div>
+          <div class="frame-body">
+            <div class="prov">
+              <div class="head"><span class="key">DATABASE_POOL_MAX</span><span class="env">prod</span></div>
+              <div class="step"><span class="lvl">defaults</span><span class="val">10</span><span class="flag">◂ def</span></div>
+              <div class="step"><span class="lvl">base · shared</span><span class="val">10</span><span class="flag">inherited</span></div>
+              <div class="step active"><span class="lvl">prod</span><span class="val">40</span><span class="flag">set here ✓</span></div>
+              <div class="rule">resolved: <b style="color:var(--tx)">40</b> (set in prod, overrides the default of 10)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 2 reveal ceremony -->
+    <div class="row flip">
+      <div class="copy">
+        <h3>Revealing a secret is a ceremony.</h3>
+        <p>Secrets stay masked until you ask, and asking is deliberate: reauth with a passkey or TOTP, a reveal window that remasks itself on a countdown, and clipboard copies recorded as audited disclosures. Editing without ever revealing is a first-class path.</p>
+        <div class="note"><span class="tick">▸</span> Write-only edits never decrypt the current value.</div>
+      </div>
+      <div class="art">
+        <div class="frame">
+          <div class="frame-head"><span class="tl"></span><span class="tl"></span><span class="tl"></span> &nbsp;reveal · STRIPE_SECRET_KEY @ prod</div>
+          <div class="frame-body">
+            <div class="reveal">
+              <div class="gate"><span class="lock">⛨</span> Reauth required to reveal <span class="m">passkey · TOTP</span></div>
+              <div class="stage"><span class="kk">before</span><span class="val masked mono">∅ ••••••••••••</span></div>
+              <div class="stage"><span class="kk">after reauth</span><span class="val shown mono">sk_live_51Kp…9aQ</span><span class="count">⧗ remask 0:18</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 3 validate / doctor -->
+    <div class="row">
+      <div class="copy">
+        <h3>Gaps and drift caught before deploy.</h3>
+        <p>Mark keys required or give them a schema, and hikyo refuses to let an environment ship incomplete. <span class="mono">hikyo doctor</span> runs in CI and exits non-zero on a missing required value or a policy violation, so a broken prod config fails the pipeline, not the pager.</p>
+        <div class="note"><span class="tick">▸</span> Non-zero exit on any required-but-unset or invalid value.</div>
+      </div>
+      <div class="art">
+        <div class="frame">
+          <div class="frame-head"><span class="tl"></span><span class="tl"></span><span class="tl"></span> &nbsp;$ hikyo doctor --env prod</div>
+          <div class="frame-body">
+            <div class="doctor">
+              <div class="drow"><span class="ic ok">✓</span><span class="msg">17 of 18 keys resolved</span><span class="tag">ok</span></div>
+              <div class="drow"><span class="ic bad">!</span><span class="msg"><b>SENTRY_DSN</b> required, unset in prod</span><span class="tag">violation</span></div>
+              <div class="drow"><span class="ic ok">✓</span><span class="msg">DATABASE_SSLMODE = verify-full</span><span class="tag">policy</span></div>
+              <div class="drow"><span class="ic bad">✕</span><span class="msg">exit 1, pipeline blocked</span><span class="tag">ci</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 4 render targets -->
+    <div class="row flip">
+      <div class="copy">
+        <h3>Compose and Kubernetes, first class.</h3>
+        <p>Point your app at hikyo and run. <span class="mono">hikyo run</span> injects the resolved env into a child process with nothing written to disk. <span class="mono">hikyo render</span> writes a dotenv, a Compose fragment, or a sealed Kubernetes Secret, whichever your target speaks.</p>
+        <div class="note"><span class="tick">▸</span> Access is proof-carrying: unauthorized is indistinguishable from nonexistent.</div>
+      </div>
+      <div class="art">
+        <div class="frame">
+          <div class="frame-head"><span class="tl"></span><span class="tl"></span><span class="tl"></span> &nbsp;~/payments-api</div>
+<pre class="cli"><span class="f"># run your app with prod config injected, nothing on disk</span>
+<span class="p">$</span> <span class="c">hikyo run</span> --env prod -- ./server
+  <span class="ok">✓</span> authorize() ok <span class="f">· 18 keys resolved</span>
+  <span class="f">→ cascade: prod ▸ shared ▸ defaults</span>
+  <span class="w">⚠</span> SENTRY_DSN required, unset <span class="f">(hikyo doctor)</span>
+
+<span class="f"># or hand a target the shape it wants</span>
+<span class="p">$</span> <span class="c">hikyo render</span> --env prod --as k8s-secret
+  <span class="ok">✓</span> wrote Secret/payments-api <span class="f">· 18 keys · sealed</span></pre>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ===== self-host band ===== -->
+  <section class="band" id="self-host"><div class="wrap"><div class="grid">
+    <div class="copy">
+      <div class="kicker">// runs where you do</div>
+      <h2>Own the keys. Own the data.</h2>
+      <p class="h2sub">hikyo is not a SaaS with a self-host tier bolted on. Self-hosting is the product. Every value is envelope-encrypted with a per-tenant data key, so your database backups are ciphertext and no plaintext secret is ever stored, not even by you.</p>
+      <div class="cta"><a class="btn btn-primary" href="#">Read the deploy guide</a><a class="btn btn-line" href="#">Compare to Vault &amp; Doppler</a></div>
+    </div>
+    <div class="art">
+      <dl class="specs">
+        <div class="spec"><dt>one binary</dt><dd><b>sqlite</b> for dev, <b>postgres</b> for prod, the same signed build. Refuses a non-TLS postgres by design.</dd></div>
+        <div class="spec"><dt>encryption</dt><dd>Envelope, <b>per-tenant DEK</b>. Decrypted only in memory, only after authorize.</dd></div>
+        <div class="spec"><dt>verifiable</dt><dd>Releases are <b>cosign-signed</b> with an SBOM and offline trust. Verify what you run.</dd></div>
+        <div class="spec"><dt>deploy</dt><dd>Docker Compose or Kubernetes, first class. Under <b>5 minutes</b> to a running instance.</dd></div>
+      </dl>
+    </div>
+  </div></div></section>
+
+  <!-- ===== why ===== -->
+  <section class="block" id="why"><div class="wrap"><div class="why">
+    <div class="kicker">// why hikyo exists</div>
+    <h2>Secrets tooling forces a bad trade.</h2>
+    <div class="body">
+      <p>Every option asks you to give something up. A managed service means your production secrets live on someone else's infrastructure, behind an SSO tax and a per-seat bill. A pile of <span class="mono">.env</span> files means no inheritance, no validation, and no honest answer to "why is this value what it is in prod?"</p>
+      <p>hikyo is the tool I wanted for my own homelab: <b>self-hosted from the first commit</b>, calm enough to run production through, and precise about provenance. The environment matrix is the whole idea. Everything resolves to a value, and every value can show its work.</p>
+      <p>No drama. No badge walls. No fear-based copy. Just infrastructure you can reason about.</p>
+    </div>
+    <div class="sig">Built in the open. MPL-2.0 licensed.</div>
+  </div></div></section>
+
+  <!-- ===== final cta ===== -->
+  <section class="final"><div class="wrap">
+    <h2>Config you can actually reason about.</h2>
+    <p class="lede">Self-hosted, encrypted, and boring on purpose. Stand up an instance in the time it took to read this page.</p>
+    <div class="cta">
+      <a class="btn btn-primary" href="#">Start self-hosting</a>
+      <span class="install"><span><span class="p">$</span> curl -fsSL hikyo.dev/install | sh</span><span class="cp" data-copy="curl -fsSL hikyo.dev/install | sh">copy</span></span>
+    </div>
+  </div></section>
+</main>
+
+<footer class="site">
+  <div class="wrap">
+    <div class="fgrid">
+      <div class="fbrand">
+        <a class="brand"><span class="glyph">h</span> hikyo</a>
+        <p>A self-hosted control plane for validated, inherited secrets and configuration across environments.</p>
+      </div>
+      <div class="fcol"><h4>Product</h4><a href="#">Overview</a><a href="#">The matrix</a><a href="#">Self-hosting</a><a href="#">Pricing</a><a href="#">Changelog</a></div>
+      <div class="fcol"><h4>Resources</h4><a href="#">Documentation</a><a href="#">Deploy guide</a><a href="#">GitHub</a><a href="#">License (MIT)</a><a href="#">Security model</a></div>
+      <div class="fcol"><h4>Community</h4><a href="#">Discord</a><a href="#">Sponsor</a><a href="#">Contributing</a><a href="#">Status</a></div>
+    </div>
+    <div class="fbar">
+      <span class="mono">© 2026 hikyo · MIT · self-hostable</span>
+      <span class="mono">Privacy · Terms</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // copy buttons — the only JS this page needs
+  for (const el of document.querySelectorAll('.cp')) {
+    el.addEventListener('click', async () => {
+      try { await navigator.clipboard.writeText(el.dataset.copy); const t = el.textContent; el.textContent = 'copied'; setTimeout(() => el.textContent = t, 1400); } catch (e) {}
+    });
+  }
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-4.8/index.html
+++ b/docs/site/public/prototypes/landing-opus-4.8/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Landing page (opus 4.8) — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,72px) clamp(18px,6vw,72px)}
+  .back{font-size:12px;color:var(--tx-dim);text-decoration:none;display:inline-block;margin-bottom:18px}
+  .back:hover{color:var(--tx)}
+  h1{font-size:clamp(20px,4vw,28px);font-weight:700}
+  h1 span{color:var(--accent)}
+  .q{font-size:13px;color:var(--tx-dim);margin:10px 0 30px;max-width:60ch;line-height:1.6}
+  ul{list-style:none;display:grid;gap:10px;max-width:680px}
+  li a{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:10px;background:var(--bg2)}
+  li a:hover{border-color:var(--accent)}
+  .num{font-family:var(--mono);font-size:11px;color:var(--accent)}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>landing page <span>·</span> opus 4.8</h1>
+  <p class="q">What should the public marketing landing page look like? Product-led, self-hosted/open-source angle in the spirit of Kaneo / Plane / Resend / Unkey — short value proposition immediately above a believable product surface, not a generic SaaS template. Three structurally-different variants inside one page, switchable via the floating bar, <kbd>←</kbd>/<kbd>→</kbd>, or the URL hash. (Uses the placeholder brand name "hikyo".)</p>
+  <ul>
+    <li><a href="2/">
+      <span class="num">2</span><span class="name">On-brand &amp; sellable — one committed design</span><span class="latest">LATEST</span>
+      <span class="desc">Rebuilt in the LOCKED Hikyo design language (DESIGN.md): dark-default graphite + teal, system-ui / ui-monospace, radius roles, 999px pill reserved for the matrix state vocabulary, AAA, prefers-color-scheme light. Structure borrows Kaneo's restraint + Plane's sellability: short value prop → the <em>env matrix as the hero</em> (set / inherited / from-defaults / masked / required-unset, each with a glyph) → four asymmetric feature rows (provenance chain, reveal ceremony, doctor/validate, Compose+K8s render) → self-hosted band → "why Hikyo" POV → final CTA → real footer. Fixes iteration 1's brand violations (purple-blue gradients + gradient text, both anti-referenced). No switcher: this pass commits.</span>
+    </a></li>
+    <li><a href="1/#B">
+      <span class="num">1</span><span class="name">Three variants — clean-white / dark synthesis / demo-led</span>
+      <span class="desc">Exploration: A — Kaneo/Plane clean white surface, centred value prop, env-matrix product UI as the hero. B — the synthesis (Kaneo structure + Linear finish + Resend technical clarity), dark, split hero with a live CLI transcript. C — Unkey/Better-Auth demo-led, four "you run → hikyo does" blocks. Off-brand (generic Inter + blue/purple, not the locked teal system) — superseded by iteration 2. Opens on B.</span>
+    </a></li>
+  </ul>
+  <footer>every change is a new numbered iteration — published ones never mutate · <a href="/prototypes/">all prototypes</a></footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-5/1/index.html
+++ b/docs/site/public/prototypes/landing-opus-5/1/index.html
@@ -1,0 +1,1381 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — hikyo landing page (iteration 1)</title>
+<!--
+  THROWAWAY PROTOTYPE — marketing landing page, iteration 1.
+
+  Plan: three structurally different landing pages for the product under the
+  name "hikyo", switchable via ?variant=a|b|c and a floating bottom bar.
+
+  The design language is NOT the question here — it is the locked one from
+  DESIGN.md (system-ui / ui-monospace, OKLCH graphite + teal, dark default,
+  radius by role 6/4/3px, 999px pill reserved for the matrix cell-state
+  vocabulary and count badges). What varies is the page architecture:
+
+    ?variant=a  PRODUCT FIRST (Kaneo / Plane / Dub)
+                Short headline, install line, then the environment matrix at
+                full width immediately underneath. Everything below the fold
+                is a caption for that one screenshot.
+
+    ?variant=b  TYPOGRAPHIC ARGUMENT (Resend / Linear)
+                No product shot in the hero. The page is a sequence of
+                numbered claims set in large type; each claim carries exactly
+                one technical artifact (a provenance chain, a validation
+                failure, a CLI transcript, a CR condition) instead of a
+                screenshot or an illustration.
+
+    ?variant=c  LIVE CONSOLE (Better Auth / Unkey)
+                The hero is the product, running. Pick an environment, pick a
+                key, watch the value resolve and the provenance chain redraw;
+                the CLI pane mirrors every click. The sections below are more
+                working demos, not descriptions of them.
+
+  Shared, deliberately: the same tokens, the same matrix cell vocabulary, the
+  same copy discipline (no gradients, no glow, no shield icons, no logo soup,
+  no bento grid, no fear copy). Mobile-first — every variant is built at
+  375px first and widened.
+
+  Numbers, orgs and URLs are invented. Nothing here talks to a backend.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+/* ============================ tokens (DESIGN.md) ============================ */
+:root{
+  --mono:ui-monospace,monospace;
+  --sans:system-ui,sans-serif;
+  --bg:oklch(0.19 0.012 220);
+  --bg2:oklch(0.225 0.014 220);
+  --bg3:oklch(0.27 0.016 220);
+  --line:oklch(0.34 0.016 220);
+  --tx:oklch(0.93 0.008 200);
+  --tx-dim:oklch(0.76 0.01 210);
+  --tx-faint:oklch(0.60 0.012 215);
+  --accent:oklch(0.82 0.09 195);
+  --on-accent:oklch(0.2 0.02 220);
+  --accent-soft:oklch(0.82 0.09 195/.14);
+  --bad:oklch(0.74 0.13 25);
+  --bad-soft:oklch(0.74 0.13 25/.14);
+  --chg:oklch(0.8 0.06 250);
+  --rowalt:oklch(0.93 0.008 200/.045);
+  /* radius carries a role — app-chrome it8, DESIGN.md */
+  --r-container:6px;
+  --r-control:4px;
+  --r-badge:3px;
+  --shadow:0 18px 50px oklch(0 0 0/.45);
+}
+[data-theme=light]{
+  --bg:oklch(0.965 0.008 200);
+  --bg2:oklch(0.935 0.01 200);
+  --bg3:oklch(0.895 0.012 200);
+  --line:oklch(0.82 0.014 210);
+  --tx:oklch(0.25 0.03 225);
+  --tx-dim:oklch(0.4 0.025 220);
+  --tx-faint:oklch(0.52 0.02 218);
+  --accent:oklch(0.45 0.085 210);
+  --on-accent:oklch(0.97 0.008 200);
+  --accent-soft:oklch(0.45 0.085 210/.1);
+  --bad:oklch(0.48 0.14 30);
+  --bad-soft:oklch(0.48 0.14 30/.1);
+  --chg:oklch(0.45 0.08 255);
+  --rowalt:oklch(0.25 0.03 225/.06);
+  --shadow:0 18px 50px oklch(0.3 0.02 220/.18);
+}
+
+/* ============================ base ============================ */
+*{box-sizing:border-box;margin:0;padding:0}
+html{background:var(--bg);scroll-behavior:smooth}
+body{
+  background:var(--bg);color:var(--tx);font-family:var(--sans);font-size:15px;
+  -webkit-font-smoothing:antialiased;line-height:1.55;
+  padding-bottom:calc(84px + env(safe-area-inset-bottom));
+}
+button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+input,select{font:inherit}
+a{color:inherit}
+:is(a,button,input,[tabindex]):focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:var(--r-control)}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important;scroll-behavior:auto}}
+.mono{font-family:var(--mono)}
+.shell{width:100%;max-width:1140px;margin:0 auto;padding:0 20px}
+@media (min-width:760px){.shell{padding:0 40px}}
+.variant[hidden]{display:none}
+/* grid/flex children default to min-content width — a <pre> inside one blows the
+   page out sideways on a phone. Everything here scrolls internally instead. */
+.grid>*,.g>*{min-width:0}
+
+/* ---- shared: site nav ---- */
+.nav{
+  display:flex;align-items:center;gap:18px;
+  padding:18px 0;border-bottom:1px solid var(--line);
+}
+.brand{display:inline-flex;align-items:center;gap:9px;text-decoration:none;font-weight:700;font-size:17px;letter-spacing:-.01em}
+.brand svg{display:block;border-radius:var(--r-badge)}
+.nav .grow{flex:1}
+.nav a.lnk{font-size:13.5px;color:var(--tx-dim);text-decoration:none}
+.nav a.lnk:hover{color:var(--tx)}
+.nav .hide-s{display:none}
+@media (min-width:700px){.nav .hide-s{display:inline}}
+
+/* ---- shared: buttons (controls = 4px, never pills) ---- */
+.btn{
+  display:inline-flex;align-items:center;justify-content:center;gap:8px;
+  min-height:44px;padding:0 18px;border-radius:var(--r-control);
+  border:1px solid var(--line);color:var(--tx);font-size:14px;font-weight:500;
+  text-decoration:none;transition:border-color .15s,color .15s;
+}
+.btn:hover{border-color:var(--accent);color:var(--accent)}
+.btn.primary{background:var(--accent);border-color:var(--accent);color:var(--on-accent);font-weight:600}
+.btn.primary:hover{filter:brightness(1.07);color:var(--on-accent)}
+
+/* ---- shared: install line ---- */
+.install{
+  display:flex;align-items:center;gap:10px;
+  border:1px solid var(--line);border-radius:var(--r-control);background:var(--bg2);
+  padding:0 6px 0 14px;min-height:44px;max-width:100%;overflow:hidden;
+}
+.install code{font-family:var(--mono);font-size:12.5px;color:var(--tx-dim);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.install code b{color:var(--tx);font-weight:500}
+.install .cp{
+  flex:none;font-family:var(--mono);font-size:11px;letter-spacing:.06em;color:var(--tx-faint);
+  border:1px solid var(--line);border-radius:var(--r-badge);padding:0 10px;min-height:30px;
+}
+.install .cp:hover{color:var(--accent);border-color:var(--accent)}
+
+/* ---- shared: eyebrow / section label ---- */
+.eyebrow{
+  font-family:var(--mono);font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--tx-faint);
+}
+
+/* ---- shared: matrix (cell vocabulary lifted from env-matrix/31) ---- */
+.mx{border-collapse:separate;border-spacing:0;min-width:100%;font-size:13px}
+.mx thead th{
+  text-align:left;padding:11px 12px 9px;border-bottom:1px solid var(--line);
+  font-size:12px;font-weight:600;white-space:nowrap;background:var(--bg);
+  position:sticky;top:0;z-index:2;
+}
+.mx thead th.keyh{
+  font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--tx-faint);min-width:170px;position:sticky;left:0;z-index:3;
+}
+.mx thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);font-family:var(--mono);letter-spacing:0}
+.mx tbody td{padding:4px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+.mx td.key{
+  position:sticky;left:0;background:var(--bg);z-index:1;
+  font-family:var(--mono);font-size:12px;white-space:nowrap;
+}
+.mx td.key .lock{color:var(--bad);margin-right:5px}
+.mx tr.alt td{background:var(--rowalt)}
+.mx tr.alt td.key{background:color-mix(in oklch,var(--tx) 4%,var(--bg))}
+.mx tr.grp td{
+  padding:0;background:var(--bg);
+  border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+}
+.mx tr.grp .g{
+  display:flex;align-items:center;gap:10px;position:sticky;left:0;
+  padding:11px 12px;font-size:11px;font-weight:700;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent);
+}
+.mx tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none;font-family:var(--mono)}
+/* cell states — a glyph always rides along with the colour */
+.cellv{
+  display:inline-flex;align-items:center;gap:6px;max-width:240px;
+  font-family:var(--mono);font-size:11.5px;line-height:1;
+  padding:7px 9px;min-height:30px;border-radius:var(--r-control);
+}
+.cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cellv.dim{color:var(--tx-dim)}
+.cellv.absent{color:var(--tx-faint)}
+.cellv .inh{color:var(--tx-faint);font-size:10px}
+.cellv .d{color:var(--chg);font-weight:700}
+.pill{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--mono);font-size:11.5px;line-height:1;
+  padding:7px 12px;border-radius:999px;min-height:30px;white-space:nowrap;
+  border:1px solid transparent;
+}
+.pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+.pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+
+/* ---- shared: legend ---- */
+.legend{display:flex;flex-wrap:wrap;gap:8px 20px;font-size:12px;color:var(--tx-dim)}
+.legend span.k{display:inline-flex;align-items:center;gap:7px}
+
+/* ---- shared: terminal block ---- */
+.term{
+  border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);
+  font-family:var(--mono);font-size:12.5px;line-height:1.75;overflow-x:auto;
+}
+.term .bar{
+  display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid var(--line);
+  font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--tx-faint);
+}
+.term pre{padding:14px 16px;white-space:pre;color:var(--tx-dim)}
+.term .p{color:var(--accent)}
+.term .ok{color:var(--accent)}
+.term .er{color:var(--bad)}
+.term .c{color:var(--tx-faint)}
+.term b{color:var(--tx);font-weight:500}
+
+/* ---- shared: footer ---- */
+.foot{border-top:1px solid var(--line);margin-top:72px;padding:34px 0 20px}
+.foot .row{display:flex;flex-wrap:wrap;gap:16px 34px;align-items:baseline}
+.foot a{font-size:13px;color:var(--tx-dim);text-decoration:none}
+.foot a:hover{color:var(--tx)}
+.foot .fine{width:100%;font-family:var(--mono);font-size:11px;color:var(--tx-faint);margin-top:22px;line-height:1.8}
+
+/* ======================================================================== */
+/* VARIANT A — product first                                                */
+/* ======================================================================== */
+#v-a .hero{padding:clamp(48px,9vw,96px) 0 clamp(28px,4vw,40px)}
+#v-a h1{
+  font-size:clamp(33px,7.2vw,60px);line-height:1.04;letter-spacing:-.03em;font-weight:700;
+  max-width:15ch;
+}
+#v-a h1 em{font-style:normal;color:var(--accent)}
+#v-a .sub{margin-top:20px;font-size:clamp(15px,2.1vw,18px);color:var(--tx-dim);max-width:56ch;line-height:1.6}
+#v-a .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:30px;align-items:center}
+#v-a .cta .install{flex:1 1 320px;min-width:0}
+#v-a .facts{
+  display:flex;flex-wrap:wrap;gap:8px 22px;margin-top:22px;
+  font-family:var(--mono);font-size:11.5px;color:var(--tx-faint);
+}
+#v-a .facts b{color:var(--tx-dim);font-weight:400}
+
+/* the screenshot frame */
+#v-a .frame{
+  border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg);
+  box-shadow:var(--shadow);overflow:hidden;
+}
+#v-a .frame .chrome{
+  display:flex;align-items:center;gap:10px;padding:9px 12px;
+  border-bottom:1px solid var(--line);background:var(--bg2);
+}
+#v-a .frame .chrome .dot{width:9px;height:9px;border-radius:999px;background:var(--line);flex:none}
+#v-a .frame .chrome .url{
+  flex:1;font-family:var(--mono);font-size:11px;color:var(--tx-faint);
+  text-align:center;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+}
+#v-a .frame .app{display:flex;min-height:0}
+#v-a .frame .rail{
+  display:none;flex:none;width:190px;border-right:1px solid var(--line);padding:14px 0;background:var(--bg2);
+}
+@media (min-width:900px){#v-a .frame .rail{display:block}}
+#v-a .rail .rt{padding:0 16px 8px;font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+#v-a .rail .ri{display:flex;align-items:center;gap:9px;padding:8px 16px;font-size:13px;color:var(--tx-dim)}
+#v-a .rail .ri.on{color:var(--tx);background:var(--accent-soft);border-left:2px solid var(--accent);padding-left:14px}
+#v-a .rail .ri .n{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+#v-a .rail .ri .n.bad{color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:2px 7px}
+#v-a .rail hr{border:none;border-top:1px solid var(--line);margin:12px 0}
+#v-a .frame .pane{flex:1;min-width:0}
+#v-a .frame .top{
+  display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+  padding:11px 14px;border-bottom:1px solid var(--line);
+}
+#v-a .frame .top .crumb{font-weight:600;font-size:14px}
+#v-a .frame .top .crumb i{font-style:normal;color:var(--tx-faint);font-weight:400;margin:0 6px}
+#v-a .frame .top .chip{
+  font-family:var(--mono);font-size:10.5px;color:var(--tx-dim);
+  border:1px solid var(--line);border-radius:var(--r-badge);padding:4px 9px;
+}
+#v-a .frame .top .chip.warn{color:var(--bad);border-color:var(--bad);background:var(--bad-soft)}
+#v-a .frame .scroll{overflow-x:auto;max-height:min(78vh,660px);overflow-y:auto}
+#v-a .capbar{
+  display:flex;flex-wrap:wrap;gap:14px 26px;align-items:baseline;
+  margin-top:16px;padding-bottom:6px;
+}
+#v-a .capbar .legend{flex:1 1 320px}
+#v-a .capbar .note{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+
+/* three statements, hairline-separated, no cards */
+#v-a .three{
+  display:grid;gap:0;margin-top:clamp(56px,8vw,96px);
+  border-top:1px solid var(--line);
+}
+@media (min-width:820px){#v-a .three{grid-template-columns:repeat(3,1fr)}}
+#v-a .three .col{padding:26px 0;border-bottom:1px solid var(--line)}
+@media (min-width:820px){
+  #v-a .three .col{padding:30px 28px 34px;border-bottom:none;border-right:1px solid var(--line)}
+  #v-a .three .col:first-child{padding-left:0}
+  #v-a .three .col:last-child{border-right:none;padding-right:0}
+}
+#v-a .three h3{font-size:17px;font-weight:600;margin:12px 0 8px;letter-spacing:-.01em}
+#v-a .three p{font-size:13.5px;color:var(--tx-dim);line-height:1.65;max-width:40ch}
+#v-a .three .art{margin-top:16px}
+
+/* provenance strip */
+#v-a .prov{margin-top:clamp(56px,8vw,96px)}
+#v-a .prov .grid{display:grid;gap:26px;margin-top:22px}
+@media (min-width:880px){#v-a .prov .grid{grid-template-columns:1.05fr .95fr;gap:44px;align-items:center}}
+#v-a .prov h2,#v-a .self h2{font-size:clamp(23px,3.6vw,32px);font-weight:700;letter-spacing:-.02em;margin-top:10px;max-width:20ch}
+#v-a .prov p,#v-a .self p{font-size:14.5px;color:var(--tx-dim);margin-top:14px;max-width:52ch;line-height:1.65}
+#v-a .self{margin-top:clamp(56px,8vw,96px)}
+#v-a .self .grid{display:grid;gap:26px;margin-top:22px}
+@media (min-width:880px){#v-a .self .grid{grid-template-columns:.95fr 1.05fr;gap:44px;align-items:center}}
+
+/* chain component (shared by a and c) */
+.chain{
+  border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);
+  padding:16px;font-family:var(--mono);font-size:12px;
+}
+.chain .ct{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+.chain .lnk2{display:flex;align-items:flex-start;gap:10px;padding:8px 0}
+.chain .lnk2+.lnk2{border-top:1px dashed oklch(from var(--line) l c h/.7)}
+.chain .lnk2 .src{flex:none;width:88px;color:var(--tx-faint)}
+.chain .lnk2 .val{flex:1;min-width:0;color:var(--tx-dim);word-break:break-all}
+.chain .lnk2 .mark{flex:none;font-size:10px;color:var(--tx-faint)}
+.chain .lnk2.win .val{color:var(--tx)}
+.chain .lnk2.win .src{color:var(--accent)}
+.chain .lnk2.win .mark{color:var(--accent)}
+.chain .lnk2.dead .val{text-decoration:line-through;opacity:.55}
+.chain .out{
+  margin-top:12px;padding-top:12px;border-top:1px solid var(--line);
+  display:flex;gap:10px;align-items:baseline;flex-wrap:wrap;
+}
+.chain .out .lbl{color:var(--tx-faint);font-size:10px;letter-spacing:.16em;text-transform:uppercase}
+.chain .out .v{color:var(--tx);word-break:break-all}
+
+/* ======================================================================== */
+/* VARIANT B — typographic argument                                         */
+/* ======================================================================== */
+#v-b .hero{padding:clamp(64px,14vw,150px) 0 clamp(40px,7vw,80px)}
+#v-b h1{
+  font-size:clamp(36px,8.4vw,82px);line-height:1.0;letter-spacing:-.04em;font-weight:700;
+  max-width:13ch;text-wrap:balance;
+}
+#v-b h1 .q{color:var(--tx-faint);font-weight:400}
+#v-b .hero .sub{
+  margin-top:clamp(24px,4vw,38px);font-size:clamp(15px,2.2vw,19px);color:var(--tx-dim);
+  max-width:50ch;line-height:1.55;
+}
+#v-b .hero .meta{
+  display:flex;flex-wrap:wrap;gap:10px 24px;margin-top:clamp(26px,4vw,40px);
+  font-family:var(--mono);font-size:12px;color:var(--tx-faint);align-items:center;
+}
+#v-b .hero .meta a{color:var(--tx-dim);text-decoration:none;border-bottom:1px solid var(--line);padding-bottom:2px}
+#v-b .hero .meta a:hover{color:var(--accent);border-color:var(--accent)}
+
+#v-b .claim{border-top:1px solid var(--line);padding:clamp(38px,6vw,64px) 0}
+#v-b .claim .g{display:grid;gap:22px}
+@media (min-width:900px){
+  #v-b .claim .g{grid-template-columns:112px minmax(0,1fr) minmax(0,1.05fr);gap:36px;align-items:start}
+}
+#v-b .claim .n{font-family:var(--mono);font-size:11px;letter-spacing:.2em;color:var(--tx-faint);padding-top:8px}
+#v-b .claim h2{
+  font-size:clamp(22px,3.6vw,34px);line-height:1.16;letter-spacing:-.025em;font-weight:600;
+  max-width:22ch;text-wrap:balance;
+}
+#v-b .claim h2 em{font-style:normal;color:var(--accent)}
+#v-b .claim p{margin-top:16px;font-size:14.5px;color:var(--tx-dim);line-height:1.7;max-width:46ch}
+#v-b .claim .art{min-width:0}
+/* claim 05 carries a wide artifact — it gets the full measure under the prose */
+@media (min-width:900px){
+  #v-b .claim.wide .g{grid-template-columns:112px minmax(0,1fr)}
+  #v-b .claim.wide .art{grid-column:1 / -1;margin-top:8px}
+}
+#v-b .closing{border-top:1px solid var(--line);padding:clamp(56px,9vw,110px) 0 0}
+#v-b .closing h2{font-size:clamp(28px,5.4vw,52px);letter-spacing:-.03em;line-height:1.06;font-weight:700;max-width:16ch}
+#v-b .closing .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:30px;align-items:center}
+#v-b .closing .cta .install{flex:1 1 340px;min-width:0}
+
+/* inline artifacts for b */
+.viol{
+  border:1px solid var(--bad);border-left-width:3px;border-radius:var(--r-container);
+  background:var(--bad-soft);padding:14px 16px;font-family:var(--mono);font-size:12px;line-height:1.7;
+}
+.viol .h{color:var(--bad);font-weight:500}
+.viol .l{color:var(--tx-dim)}
+.viol .l b{color:var(--tx);font-weight:500}
+.cond{
+  border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);
+  font-family:var(--mono);font-size:12px;overflow:hidden;
+}
+.cond .r{display:flex;gap:12px;padding:11px 14px;align-items:baseline}
+.cond .r+.r{border-top:1px solid oklch(from var(--line) l c h/.6)}
+.cond .r .t{flex:none;width:96px;color:var(--tx-faint)}
+.cond .r .s{flex:none;width:56px;color:var(--accent);font-weight:500}
+.cond .r .s.no{color:var(--bad)}
+.cond .r .m{flex:1;min-width:0;color:var(--tx-dim)}
+.strip{
+  border:1px solid var(--line);border-radius:var(--r-container);overflow:hidden;background:var(--bg2);
+}
+.strip .sh{
+  padding:9px 14px;border-bottom:1px solid var(--line);
+  font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);
+}
+.strip .sb{overflow-x:auto}
+.strip .mx{font-size:12.5px}
+.strip .mx thead th{background:var(--bg2)}
+.strip .mx td.key{background:var(--bg2)}
+.strip .mx tr.alt td.key{background:color-mix(in oklch,var(--tx) 4%,var(--bg2))}
+
+/* ======================================================================== */
+/* VARIANT C — live console                                                 */
+/* ======================================================================== */
+#v-c .hero{padding:clamp(40px,6.5vw,66px) 0 0}
+#v-c h1{font-size:clamp(29px,5.6vw,46px);line-height:1.08;letter-spacing:-.03em;font-weight:700;max-width:18ch}
+#v-c h1 em{font-style:normal;color:var(--accent)}
+#v-c .hero .sub{margin-top:16px;font-size:15px;color:var(--tx-dim);max-width:54ch;line-height:1.6}
+#v-c .hero .hint{
+  margin-top:14px;font-family:var(--mono);font-size:11.5px;color:var(--tx-faint);
+  display:inline-flex;align-items:center;gap:8px;
+}
+#v-c .hero .hint::before{content:'▾';color:var(--accent)}
+#v-c .hero .heroLinks{
+  display:flex;flex-wrap:wrap;gap:10px 22px;margin-top:16px;align-items:center;
+  font-family:var(--mono);font-size:12px;color:var(--tx-faint);
+}
+#v-c .hero .heroLinks a{color:var(--tx-dim);text-decoration:none;border-bottom:1px solid var(--line);padding-bottom:2px}
+#v-c .hero .heroLinks a:hover{color:var(--accent);border-color:var(--accent)}
+
+.console{
+  margin-top:26px;border:1px solid var(--line);border-radius:var(--r-container);
+  background:var(--bg2);overflow:hidden;box-shadow:var(--shadow);
+}
+.console .envs{display:flex;gap:0;border-bottom:1px solid var(--line);overflow-x:auto}
+.console .envs button{
+  flex:none;padding:13px 16px;font-size:13px;color:var(--tx-dim);min-height:46px;
+  border-bottom:2px solid transparent;white-space:nowrap;display:inline-flex;align-items:center;gap:8px;
+}
+.console .envs button .lk{font-size:11px;color:var(--tx-faint)}
+.console .envs button[aria-selected=true]{color:var(--tx);border-bottom-color:var(--accent);font-weight:600}
+.console .envs button[aria-selected=true] .lk{color:var(--accent)}
+.console .envs .prot{
+  font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;color:var(--bad);
+  border:1px solid var(--bad);border-radius:var(--r-badge);padding:2px 6px;
+}
+.console .body{display:grid}
+@media (min-width:880px){.console .body{grid-template-columns:290px minmax(0,1fr)}}
+.console .keys{border-bottom:1px solid var(--line);max-height:280px;overflow-y:auto}
+@media (min-width:880px){.console .keys{border-bottom:none;border-right:1px solid var(--line);max-height:none}}
+.console .keys .kg{
+  padding:10px 14px 6px;font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--tx-faint);
+}
+.console .keys button{
+  display:flex;width:100%;align-items:center;gap:10px;text-align:left;
+  padding:10px 14px;min-height:44px;font-family:var(--mono);font-size:12px;color:var(--tx-dim);
+  border-left:2px solid transparent;
+}
+.console .keys button:hover{background:oklch(from var(--tx) l c h/.05)}
+.console .keys button[aria-current=true]{
+  background:var(--accent-soft);border-left-color:var(--accent);color:var(--tx);
+}
+.console .keys button .lock{color:var(--bad)}
+.console .keys button .st{margin-left:auto;font-size:10px;color:var(--tx-faint)}
+.console .keys button .st.bad{color:var(--bad)}
+.console .detail{padding:18px 16px 20px;min-width:0}
+@media (min-width:880px){.console .detail{padding:22px 24px 26px}}
+.console .detail .kn{
+  display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;
+  font-family:var(--mono);font-size:15px;color:var(--tx);
+}
+.console .detail .kn .type{
+  font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);
+  border:1px solid var(--line);border-radius:var(--r-badge);padding:2px 7px;
+}
+.console .detail .desc{margin-top:8px;font-size:13px;color:var(--tx-dim);max-width:52ch;line-height:1.6}
+.console .detail .resolved{
+  margin-top:16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;
+  border:1px solid var(--line);border-radius:var(--r-control);background:var(--bg);padding:12px 14px;
+}
+.console .detail .resolved .rl{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+.console .detail .resolved .rv{font-family:var(--mono);font-size:13.5px;flex:1;min-width:120px;word-break:break-all}
+.console .detail .chain{margin-top:16px;background:var(--bg)}
+.console .detail .acts{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
+.console .detail .acts .btn{min-height:38px;font-size:13px;padding:0 14px}
+.console .detail .refusal{
+  margin-top:14px;border:1px solid var(--bad);border-left-width:3px;border-radius:var(--r-container);
+  background:var(--bad-soft);padding:13px 15px;font-size:12.5px;color:var(--tx-dim);line-height:1.65;
+}
+.console .detail .refusal b{color:var(--bad);font-family:var(--mono);font-size:12px;display:block;margin-bottom:5px}
+.console .detail .challenge{
+  margin-top:14px;border:1px solid var(--accent);border-left-width:3px;border-radius:var(--r-container);
+  background:var(--accent-soft);padding:13px 15px;font-size:12.5px;color:var(--tx-dim);line-height:1.65;
+}
+.console .detail .challenge b{color:var(--accent);font-family:var(--mono);font-size:11px;
+  letter-spacing:.14em;text-transform:uppercase;display:block;margin-bottom:6px}
+.console .detail .challenge .mono{font-family:var(--mono);color:var(--tx)}
+.console .detail .revealed{
+  margin-top:14px;border:1px solid var(--accent);border-radius:var(--r-container);
+  background:var(--accent-soft);padding:13px 15px;font-family:var(--mono);font-size:12.5px;
+  display:flex;gap:12px;align-items:baseline;flex-wrap:wrap;
+}
+.console .detail .revealed .cd{margin-left:auto;color:var(--tx-faint);font-size:11px}
+.console .cli{border-top:1px solid var(--line);background:var(--bg)}
+.console .cli .bar{
+  padding:8px 14px;font-family:var(--mono);font-size:10px;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--tx-faint);border-bottom:1px solid var(--line);
+  display:flex;gap:10px;align-items:center;
+}
+.console .cli pre{padding:13px 16px;font-family:var(--mono);font-size:12.5px;line-height:1.7;color:var(--tx-dim);overflow-x:auto;white-space:pre}
+.console .cli .p{color:var(--accent)}
+.console .cli b{color:var(--tx);font-weight:500}
+
+#v-c .demos{margin-top:clamp(56px,8vw,92px);display:grid;gap:clamp(38px,6vw,60px)}
+#v-c .demo h2{font-size:clamp(20px,3vw,27px);font-weight:600;letter-spacing:-.02em;margin-top:10px}
+#v-c .demo p{margin-top:10px;font-size:14px;color:var(--tx-dim);max-width:52ch;line-height:1.65}
+#v-c .demo .box{margin-top:18px}
+.vform{
+  border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);padding:16px;
+}
+.vform label{display:block;font-family:var(--mono);font-size:11px;color:var(--tx-faint);margin-bottom:8px}
+.vform .in{display:flex;gap:10px;flex-wrap:wrap}
+.vform input{
+  flex:1 1 200px;min-width:0;min-height:44px;padding:0 12px;
+  background:var(--bg);border:1px solid var(--line);border-radius:var(--r-control);
+  color:var(--tx);font-family:var(--mono);font-size:13px;
+}
+.vform input:focus{outline:2px solid var(--accent);outline-offset:1px}
+.vform .verdict{margin-top:12px;font-family:var(--mono);font-size:12.5px;line-height:1.6;display:flex;gap:9px;align-items:flex-start}
+.vform .verdict.ok{color:var(--accent)}
+.vform .verdict.no{color:var(--bad)}
+.vform .rules{margin-top:12px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.7}
+#v-c .self{margin-top:clamp(56px,8vw,92px)}
+#v-c .self h2{font-size:clamp(23px,3.6vw,32px);font-weight:700;letter-spacing:-.02em;max-width:20ch}
+#v-c .self p{margin-top:14px;font-size:14.5px;color:var(--tx-dim);max-width:52ch;line-height:1.65}
+#v-c .self .grid{display:grid;gap:24px;margin-top:24px}
+@media (min-width:880px){#v-c .self .grid{grid-template-columns:.9fr 1.1fr;gap:44px;align-items:start}}
+
+/* ======================================================================== */
+/* prototype switcher — deliberately not part of the design being judged    */
+/* ======================================================================== */
+#switcher{
+  position:fixed;left:50%;transform:translateX(-50%);
+  bottom:calc(14px + env(safe-area-inset-bottom));z-index:9999;
+  display:flex;align-items:stretch;gap:2px;
+  background:oklch(0.12 0.01 260);border:1px solid oklch(0.45 0.02 260);
+  border-radius:10px;padding:4px;box-shadow:0 10px 34px oklch(0 0 0/.55);
+  font-family:var(--mono);max-width:calc(100vw - 20px);
+}
+#switcher button{
+  color:oklch(0.95 0 0);border-radius:7px;min-height:38px;padding:0 12px;
+  display:inline-flex;align-items:center;justify-content:center;font-size:14px;
+}
+#switcher button:hover{background:oklch(0.24 0.02 260)}
+#switcher .lab{
+  color:oklch(0.95 0 0);font-size:11.5px;letter-spacing:.02em;
+  display:flex;align-items:center;gap:8px;padding:0 8px;white-space:nowrap;
+  overflow:hidden;text-overflow:ellipsis;
+}
+#switcher .lab .kk{
+  color:oklch(0.12 0.01 260);background:oklch(0.82 0.09 195);
+  border-radius:3px;padding:2px 6px;font-weight:700;font-size:10.5px;
+}
+#switcher .sep{width:1px;background:oklch(0.35 0.02 260);margin:6px 2px}
+#switcher .lab .nm{overflow:hidden;text-overflow:ellipsis}
+@media (max-width:480px){#switcher .lab .nm{display:none}}
+</style>
+</head>
+<body>
+
+<!-- ==================================================================== -->
+<!-- VARIANT A — product first                                            -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-a" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk hide-s" href="#">Self-hosting</a>
+      <a class="lnk" href="#">Changelog</a>
+      <a class="lnk" href="#">GitHub</a>
+    </nav>
+
+    <header class="hero">
+      <h1>Every environment. <em>One screen.</em></h1>
+      <p class="sub">hikyo is a self-hosted control plane for secrets and configuration.
+        Values inherit, get validated before they ship, and always say where they came from.</p>
+      <div class="cta">
+        <a class="btn primary" href="#">Read the docs</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+      </div>
+      <p class="facts">
+        <span><b>MPL-2.0</b> · fully open source</span>
+        <span><b>Single binary</b> · Postgres or SQLite</span>
+        <span><b>Compose &amp; Kubernetes</b> first-class</span>
+      </p>
+    </header>
+  </div>
+
+  <div class="shell">
+    <div class="frame">
+      <div class="chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">hikyo.internal / acme / checkout-api</span>
+      </div>
+      <div class="app">
+        <aside class="rail">
+          <div class="rt">acme</div>
+          <div class="ri on">checkout-api <span class="n bad">2</span></div>
+          <div class="ri">ledger <span class="n">61</span></div>
+          <div class="ri">notifier <span class="n">28</span></div>
+          <div class="ri">edge-proxy <span class="n">17</span></div>
+          <hr>
+          <div class="rt">this project</div>
+          <div class="ri">Matrix</div>
+          <div class="ri">History</div>
+          <div class="ri">Workloads</div>
+          <div class="ri">Settings</div>
+        </aside>
+        <div class="pane">
+          <div class="top">
+            <span class="crumb">checkout-api<i>/</i>matrix</span>
+            <span class="chip">4 environments</span>
+            <span class="chip">86 keys</span>
+            <span class="chip warn">! 2 block publish</span>
+          </div>
+          <div class="scroll"><table class="mx" id="mx-a"></table></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="capbar">
+      <div class="legend" id="legend-a"></div>
+      <div class="note">real product surface — not a mockup of one</div>
+    </div>
+
+    <!-- three statements, no cards, no icons -->
+    <section class="three">
+      <div class="col">
+        <span class="eyebrow">Inheritance</span>
+        <h3>A value written once, everywhere it belongs</h3>
+        <p>Environments inherit from a base. Overriding is explicit and visible in the same row —
+          you never have to diff two files to find out which one wins.</p>
+        <div class="art"><div class="cellv dim"><span class="tx">info</span><span class="inh">◂ base</span></div></div>
+      </div>
+      <div class="col">
+        <span class="eyebrow">Validation</span>
+        <h3>Broken config fails here, not at 3am</h3>
+        <p>Every key carries a type, constraints and an optional JSON Schema. Required-but-unset and
+          schema violations block the publish instead of the deploy.</p>
+        <div class="art"><span class="pill missing">! required · unset</span></div>
+      </div>
+      <div class="col">
+        <span class="eyebrow">Disclosure</span>
+        <h3>Reading a secret is an event</h3>
+        <p>Secrets are write-only by default. Revealing one is permission-gated, time-boxed,
+          auto-remasked and written to the audit log — including the copy to your clipboard.</p>
+        <div class="art"><div class="cellv dim"><span class="tx">••••••••</span></div></div>
+      </div>
+    </section>
+
+    <!-- provenance -->
+    <section class="prov">
+      <span class="eyebrow">Provenance</span>
+      <div class="grid">
+        <div>
+          <h2>Every resolved value can explain itself.</h2>
+          <p>Tap a cell and hikyo shows the whole chain: the schema default, the base value, the
+            environment override, and which one actually won. No tribal knowledge, no reading the
+            deployment repo to find out why staging is different.</p>
+          <p class="mono" style="font-size:12.5px;color:var(--tx-faint)">Same panel on desktop and on a phone.</p>
+        </div>
+        <div class="chain">
+          <div class="ct">LOG_LEVEL · staging</div>
+          <div class="lnk2 dead"><span class="src">defaults</span><span class="val">warn</span><span class="mark">schema</span></div>
+          <div class="lnk2 dead"><span class="src">base</span><span class="val">info</span><span class="mark">◂ inherited</span></div>
+          <div class="lnk2 win"><span class="src">staging</span><span class="val">debug</span><span class="mark">set here</span></div>
+          <div class="out"><span class="lbl">resolved</span><span class="v">debug</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- self-hosting -->
+    <section class="self">
+      <span class="eyebrow">Self-hosted</span>
+      <div class="grid">
+        <div>
+          <h2>Runs on your box. Only on your box.</h2>
+          <p>One container, one database, one signed release. No control-plane callback, no telemetry,
+            no seat count. Bring your own KMS or let hikyo hold the keyring — either way the ciphertext
+            never leaves the machine you put it on.</p>
+          <a class="btn" href="#" style="margin-top:22px">Self-hosting guide →</a>
+        </div>
+        <div class="term">
+          <div class="bar">docker-compose.yml</div>
+<pre><span class="c">services:</span>
+  <b>hikyo:</b>
+    image: ghcr.io/hikyo/hikyo:<b>1.4.0</b>
+    ports: [<b>"8080:8080"</b>]
+    environment:
+      HIKYO_DB: <b>postgres://hikyo@db/hikyo</b>
+      HIKYO_KEYRING: <b>file:///keys/root.age</b>
+    volumes: [<b>./keys:/keys:ro</b>]
+</pre>
+        </div>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <div class="row">
+        <a href="#">Docs</a><a href="#">Self-hosting</a><a href="#">CLI reference</a>
+        <a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a>
+        <span class="grow"></span>
+      </div>
+      <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype — every number, org and URL on this page is invented</div>
+    </footer>
+  </div>
+</main>
+
+<!-- ==================================================================== -->
+<!-- VARIANT B — typographic argument                                      -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-b" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk" href="#">Changelog</a>
+      <a class="lnk" href="#">GitHub</a>
+    </nav>
+
+    <header class="hero">
+      <h1>The value that ships <span class="q">is not</span> the value you wrote.</h1>
+      <p class="sub">Config inherits, gets overridden, drifts, and then explains none of it.
+        hikyo is a self-hosted control plane that makes the whole chain visible — and refuses to
+        publish it when it is wrong.</p>
+      <p class="meta">
+        <a href="#">Read the docs</a>
+        <a href="#">Self-host in 4 minutes</a>
+        <span>MPL-2.0</span>
+        <span>single binary</span>
+        <span>no telemetry</span>
+      </p>
+    </header>
+  </div>
+
+  <div class="shell">
+    <section class="claim">
+      <div class="g">
+        <div class="n">01 / ORIGIN</div>
+        <div>
+          <h2>Four environments, one row, <em>no diffing</em>.</h2>
+          <p>Base holds what is true everywhere. Each environment states only its disagreements.
+            The row shows which of them won, and the arrow says where the rest came from —
+            so an override is a decision you can see, not one you discover.</p>
+        </div>
+        <div class="art">
+          <div class="chain">
+            <div class="ct">LOG_LEVEL</div>
+            <div class="lnk2 dead"><span class="src">defaults</span><span class="val">warn</span><span class="mark">schema</span></div>
+            <div class="lnk2 dead"><span class="src">base</span><span class="val">info</span><span class="mark">◂ inherited</span></div>
+            <div class="lnk2 win"><span class="src">staging</span><span class="val">debug</span><span class="mark">set here</span></div>
+            <div class="out"><span class="lbl">resolved · staging</span><span class="v">debug</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">02 / VALIDATION</div>
+        <div>
+          <h2>The bad value never reaches the deploy.</h2>
+          <p>Keys are declared before they are filled: type, constraints, required-in-which-environments,
+            and JSON Schema when the shape matters. Publishing runs the whole set — a violation stops
+            the publish, not the pod.</p>
+        </div>
+        <div class="art">
+          <div class="viol">
+            <div class="h">✕ publish refused · production</div>
+            <div class="l"><b>SMTP_PORT</b> = "587 " — expected <b>int</b>, got string</div>
+            <div class="l"><b>STRIPE_WEBHOOK_SECRET</b> — required in production, unset</div>
+            <div class="l" style="color:var(--tx-faint);margin-top:6px">2 violations · 84 keys checked · nothing was written</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">03 / DISCLOSURE</div>
+        <div>
+          <h2>Writing a secret does not require <em>reading</em> it.</h2>
+          <p>Rotation, seeding and correction all work write-only. Reveal is a separate, gated act:
+            reauth, a fixed window, an automatic remask, and a line in the audit log — the clipboard
+            counts as a disclosure too.</p>
+        </div>
+        <div class="art">
+          <div class="term">
+            <div class="bar">terminal</div>
+<pre><span class="p">$</span> hikyo set <b>DATABASE_URL</b> --env prod --stdin
+<span class="c">reading value from stdin, not echoed…</span>
+<span class="ok">✓</span> wrote prod/DATABASE_URL <span class="c">(rev 30, write-only)</span>
+
+<span class="p">$</span> hikyo get <b>DATABASE_URL</b> --env prod
+<span class="er">✕</span> refused: reveal in <b>production</b> requires reauth
+  <span class="c">run: hikyo auth reveal --env prod   (window 60s)</span></pre>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">04 / DELIVERY</div>
+        <div>
+          <h2>Compose and Kubernetes are not an afterthought.</h2>
+          <p>A workload gets a machine identity, not a copy of your .env. The operator reconciles a
+            pinned revision into a Secret and reports what it did in conditions you can read with
+            kubectl — no sidecar, no init-container hack.</p>
+        </div>
+        <div class="art">
+          <div class="cond">
+            <div class="r"><span class="t">Ready</span><span class="s">✓ True</span><span class="m">Synced revision 41 to secret/checkout-api-env</span></div>
+            <div class="r"><span class="t">Validated</span><span class="s">✓ True</span><span class="m">84 keys, 0 violations</span></div>
+            <div class="r"><span class="t">Drifted</span><span class="s no">! True</span><span class="m">secret edited outside hikyo — restored, 1 key</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim wide">
+      <div class="g">
+        <div class="n">05 / THE SURFACE</div>
+        <div>
+          <h2>And it stays readable at eighty keys.</h2>
+          <p>Grouping, collapsing and per-environment visibility are how the matrix earns its room —
+            on a 27-inch display and on the phone you are holding in the server closet. State is
+            never carried by colour alone.</p>
+        </div>
+        <div class="art">
+          <div class="strip">
+            <div class="sh">checkout-api · matrix</div>
+            <div class="sb"><table class="mx" id="mx-b"></table></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="closing">
+      <h2>Take the whole thing home.</h2>
+      <div class="cta">
+        <a class="btn primary" href="#">Read the docs</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+      </div>
+      <footer class="foot">
+        <div class="row">
+          <a href="#">Docs</a><a href="#">Self-hosting</a><a href="#">CLI reference</a>
+          <a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a>
+        </div>
+        <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype — every number, org and URL on this page is invented</div>
+      </footer>
+    </section>
+  </div>
+</main>
+
+<!-- ==================================================================== -->
+<!-- VARIANT C — live console                                              -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-c" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk hide-s" href="#">Self-hosting</a>
+      <a class="lnk" href="#">GitHub</a>
+    </nav>
+
+    <header class="hero">
+      <h1>Watch a value <em>resolve</em>.</h1>
+      <p class="sub">hikyo is a self-hosted control plane for inherited, validated secrets and
+        configuration. This is the real thing, running on sample data — click around.</p>
+      <p class="hint">pick an environment, then a key</p>
+      <p class="heroLinks"><a href="#">Read the docs</a><a href="#">Self-host in 4 minutes</a><span>MPL-2.0 · no hosted tier</span></p>
+    </header>
+
+    <div class="console">
+      <div class="envs" role="tablist" aria-label="environment" id="c-envs"></div>
+      <div class="body">
+        <div class="keys" id="c-keys"></div>
+        <div class="detail" id="c-detail"></div>
+      </div>
+      <div class="cli">
+        <div class="bar">the same thing, from the terminal</div>
+        <pre id="c-cli"></pre>
+      </div>
+    </div>
+
+    <div class="demos">
+      <section class="demo">
+        <span class="eyebrow">Validation</span>
+        <h2>Type a bad port. See what the publish would do.</h2>
+        <p>Every key is declared before it is filled. <span class="mono">SMTP_PORT</span> is an
+          <span class="mono">int</span> with range <span class="mono">1–65535</span> and is required in
+          production — so a stray space is a refused publish, not a paged engineer.</p>
+        <div class="box">
+          <div class="vform">
+            <label for="c-val">SMTP_PORT · production</label>
+            <div class="in">
+              <input id="c-val" value="587 " autocomplete="off" spellcheck="false" aria-describedby="c-verdict">
+            </div>
+            <div class="verdict" id="c-verdict"></div>
+            <div class="rules">declared: int · min 1 · max 65535 · required in [staging, production]</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo">
+        <span class="eyebrow">Blast radius</span>
+        <h2>Change the base value. Watch who follows.</h2>
+        <p>Overrides are the only thing that stays put. Everything inheriting from base moves with it,
+          and hikyo tells you how many environments that is <em>before</em> you publish.</p>
+        <div class="box">
+          <div class="vform">
+            <label for="c-base">base · LOG_LEVEL</label>
+            <div class="in">
+              <input id="c-base" value="info" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="verdict" id="c-blast" style="color:var(--tx-dim)"></div>
+            <div class="rules" id="c-blastrows"></div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="self">
+      <span class="eyebrow">Self-hosted</span>
+      <h2>One container. Your keys. No callback home.</h2>
+      <div class="grid">
+        <div>
+          <p>Signed releases, SBOM in the box, Postgres or SQLite, and a keyring you can point at your
+            own KMS. hikyo has no hosted tier to upsell you into — the whole thing is MPL-2.0.</p>
+          <div class="install" style="margin-top:20px">
+            <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+            <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+          </div>
+        </div>
+        <div class="term">
+          <div class="bar">first five minutes</div>
+<pre><span class="p">$</span> hikyo serve --db sqlite:///var/hikyo.db
+<span class="ok">✓</span> listening on <b>:8080</b> · keyring unlocked · 0 projects
+
+<span class="p">$</span> hikyo scaffold --from .env --project checkout-api
+<span class="c">wrote 84 key definitions — review before applying</span>
+
+<span class="p">$</span> hikyo publish --env staging
+<span class="ok">✓</span> revision <b>41</b> · 84 keys · 0 violations</pre>
+        </div>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <div class="row">
+        <a href="#">Docs</a><a href="#">Self-hosting</a><a href="#">CLI reference</a>
+        <a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a>
+      </div>
+      <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype — every number, org and URL on this page is invented</div>
+    </footer>
+  </div>
+</main>
+
+<!-- floating variant switcher -->
+<div id="switcher" role="group" aria-label="prototype variant switcher">
+  <button id="sw-prev" title="previous variant (←)" aria-label="previous variant">‹</button>
+  <span class="sep"></span>
+  <span class="lab"><span class="kk" id="sw-key">A</span><span class="nm" id="sw-name"></span></span>
+  <span class="sep"></span>
+  <button id="sw-next" title="next variant (→)" aria-label="next variant">›</button>
+  <span class="sep"></span>
+  <button id="sw-theme" title="light / dark" aria-label="switch light or dark theme">◐</button>
+</div>
+
+<script>
+/* ===================== shared sample data ===================== */
+const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+const ENVS = [
+  {id:'dev',  name:'development', base:null,  protected:false},
+  {id:'stg',  name:'staging',     base:'base',protected:false},
+  {id:'pre',  name:'preview',     base:'base',protected:false},
+  {id:'prd',  name:'production',  base:'base',protected:true},
+];
+
+// value shapes: {v:'x'} set here · {inh:'base'} inherited · {def:true} from defaults
+// null = not set · {missing:true} required+unset · {invalid:'reason', v:'x'}
+const GROUPS = [
+  {name:'app', keys:[
+    {k:'APP_ENV',    secret:false, cells:{dev:{v:'development'}, stg:{v:'staging'}, pre:{v:'preview'}, prd:{v:'production'}}},
+    {k:'LOG_LEVEL',  secret:false, cells:{dev:{v:'debug'}, stg:{v:'debug', changed:true}, pre:{inh:'base', v:'info'}, prd:{inh:'base', v:'info'}}},
+    {k:'PORT',       secret:false, cells:{dev:{inh:'base', v:'8080'}, stg:{inh:'base', v:'8080'}, pre:{inh:'base', v:'8080'}, prd:{inh:'base', v:'8080'}}},
+    {k:'FEATURE_FLAGS', secret:false, cells:{dev:{v:'{"beta":true}'}, stg:{v:'{"beta":true}'}, pre:{v:'{"beta":true}'}, prd:{v:'{"beta":false}'}}},
+  ]},
+  {name:'database', keys:[
+    {k:'DATABASE_URL', secret:true, cells:{dev:{v:'••••••••'}, stg:{v:'••••••••'}, pre:{v:'••••••••'}, prd:{v:'••••••••'}}},
+    {k:'DB_POOL_MAX',  secret:false, cells:{dev:{inh:'base', v:'10'}, stg:{inh:'base', v:'10'}, pre:{inh:'base', v:'10'}, prd:{v:'60'}}},
+    {k:'DB_SSLMODE',   secret:false, cells:{dev:{def:true, v:'prefer'}, stg:{def:true, v:'prefer'}, pre:{def:true, v:'prefer'}, prd:{v:'verify-full'}}},
+  ]},
+  {name:'mail & billing', keys:[
+    {k:'SMTP_HOST',   secret:false, cells:{dev:{v:'mailpit:1025'}, stg:{inh:'base', v:'smtp.eu.example'}, pre:{inh:'base', v:'smtp.eu.example'}, prd:{inh:'base', v:'smtp.eu.example'}}},
+    {k:'SMTP_PORT',   secret:false, cells:{dev:{v:'1025'}, stg:{inh:'base', v:'587'}, pre:{inh:'base', v:'587'}, prd:{invalid:'expected int', v:'587 '}}},
+    {k:'STRIPE_WEBHOOK_SECRET', secret:true, cells:{dev:{v:'••••••••'}, stg:{v:'••••••••'}, pre:null, prd:{missing:true}}},
+  ]},
+];
+
+function cellHTML(cell){
+  if(!cell) return `<span class="cellv absent"><span class="tx">·</span></span>`;
+  if(cell.missing) return `<span class="pill missing">! required · unset</span>`;
+  if(cell.invalid) return `<span class="pill invalid" title="${esc(cell.invalid)}">✕ ${esc(cell.v)}</span>`;
+  const cls = ['cellv'];
+  if(cell.inh || cell.def) cls.push('dim');
+  const inh = cell.inh ? `<span class="inh">◂ ${esc(cell.inh)}</span>`
+            : cell.def ? `<span class="inh">◂ def</span>` : '';
+  const d = cell.changed ? `<span class="d" title="changed since last publish">Δ</span>` : '';
+  return `<span class="${cls.join(' ')}"><span class="tx">${esc(cell.v)}</span>${inh}${d}</span>`;
+}
+
+function renderMatrix(tableId, envIds){
+  const table = document.getElementById(tableId);
+  if(!table) return;
+  const envs = ENVS.filter(e => envIds.includes(e.id));
+  let html = `<thead><tr><th class="keyh">key</th>` + envs.map(e =>
+    `<th>${esc(e.name)}${e.base ? `<span class="base">◂ ${esc(e.base)}</span>` : `<span class="base">standalone</span>`}</th>`
+  ).join('') + `</tr></thead><tbody>`;
+  for(const g of GROUPS){
+    html += `<tr class="grp"><td colspan="${envs.length+1}"><div class="g">▾ ${esc(g.name)}<span class="gcnt">${g.keys.length} keys</span></div></td></tr>`;
+    g.keys.forEach((k, i) => {
+      html += `<tr class="${i%2 ? 'alt' : ''}"><td class="key">${k.secret ? '<span class="lock" title="secret">🔒</span>' : ''}${esc(k.k)}</td>`;
+      html += envs.map(e => `<td>${cellHTML(k.cells[e.id])}</td>`).join('');
+      html += `</tr>`;
+    });
+  }
+  return table.innerHTML = html + `</tbody>`;
+}
+
+function renderLegend(id){
+  const el = document.getElementById(id);
+  if(!el) return;
+  el.innerHTML = [
+    `<span class="k"><span class="cellv"><span class="tx">value</span></span> set here</span>`,
+    `<span class="k"><span class="cellv dim"><span class="tx">value</span><span class="inh">◂ base</span></span> inherited</span>`,
+    `<span class="k"><span class="cellv absent"><span class="tx">·</span></span> not set</span>`,
+    `<span class="k"><span class="pill missing">! required · unset</span></span>`,
+    `<span class="k"><span class="pill invalid">✕ value</span> schema violation</span>`,
+  ].join('');
+}
+
+/* ===================== variant C — live console ===================== */
+const C = {
+  env: 'stg',
+  key: 'LOG_LEVEL',
+  revealed: false,
+  reauth: false,
+  timer: null,
+  left: 0,
+};
+
+// resolution model: defaults ← base ← environment
+const C_KEYS = [
+  {g:'app', k:'LOG_LEVEL', type:'string', secret:false,
+   desc:'How chatty the service is. Staging overrides base so we can follow a request end to end.',
+   def:'warn', base:'info', over:{dev:'debug', stg:'debug'}},
+  {g:'app', k:'PORT', type:'int', secret:false,
+   desc:'Listen port. Nobody has ever needed to override this — so nobody has.',
+   def:'8080', base:'8080', over:{}},
+  {g:'database', k:'DATABASE_URL', type:'url', secret:true,
+   desc:'Written per environment, never inherited. Production is protected: revealing it needs reauth.',
+   def:null, base:null, over:{dev:'postgres://app:devpw@localhost:5432/app',
+                              stg:'postgres://app:s3cr3t@db.stg.internal:5432/app',
+                              prd:'postgres://app:hunter2@db.prd.internal:5432/app'}},
+  {g:'database', k:'DB_SSLMODE', type:'string', secret:false,
+   desc:'Nobody set this outside production — the rest ride the schema default, and the cell says so.',
+   def:'prefer', base:null, over:{prd:'verify-full'}},
+  {g:'mail & billing', k:'SMTP_PORT', type:'int', secret:false,
+   desc:'Declared int, range 1–65535, required in staging and production.',
+   def:null, base:'587', over:{dev:'1025'}, invalid:{prd:'587 '}},
+  {g:'mail & billing', k:'STRIPE_WEBHOOK_SECRET', type:'string', secret:true,
+   desc:'Required in production and not there yet — which is why production cannot publish.',
+   def:null, base:null, over:{dev:'whsec_dev_9f2c', stg:'whsec_stg_41ab'}, required:['prd']},
+];
+
+const cKey = () => C_KEYS.find(k => k.k === C.key);
+const cEnv = () => ENVS.find(e => e.id === C.env);
+
+function resolve(k, envId){
+  const chain = [];
+  if(k.invalid && k.invalid[envId] !== undefined){
+    return {invalid:k.invalid[envId], chain:[
+      {src:'defaults', val:k.def, state:'dead'},
+      {src:'base', val:k.base, state:'dead'},
+      {src:envId, val:k.invalid[envId], state:'invalid'},
+    ].filter(l => l.val !== null && l.val !== undefined)};
+  }
+  if(k.def !== null && k.def !== undefined) chain.push({src:'defaults', val:k.def, mark:'schema'});
+  if(k.base !== null && k.base !== undefined) chain.push({src:'base', val:k.base, mark:'◂ inherited'});
+  const o = k.over[envId];
+  if(o !== undefined) chain.push({src:envId, val:o, mark:'set here'});
+  if(!chain.length){
+    const required = (k.required || []).includes(envId);
+    return {missing:required, chain:[], value:null};
+  }
+  const winner = chain.length - 1;
+  chain.forEach((l, i) => l.state = i === winner ? 'win' : 'dead');
+  return {value:chain[winner].val, origin:chain[winner].src, chain};
+}
+
+function renderConsoleEnvs(){
+  document.getElementById('c-envs').innerHTML = ENVS.map(e => `
+    <button role="tab" aria-selected="${e.id === C.env}" data-env="${e.id}">
+      ${esc(e.name)}
+      ${e.base ? `<span class="lk">◂ ${esc(e.base)}</span>` : `<span class="lk">standalone</span>`}
+      ${e.protected ? `<span class="prot">PROTECTED</span>` : ''}
+    </button>`).join('');
+}
+
+function renderConsoleKeys(){
+  let html = '';
+  let group = null;
+  for(const k of C_KEYS){
+    if(k.g !== group){ group = k.g; html += `<div class="kg">${esc(group)}</div>`; }
+    const r = resolve(k, C.env);
+    const st = r.invalid ? `<span class="st bad">✕ invalid</span>`
+             : r.missing ? `<span class="st bad">! unset</span>`
+             : r.origin === C.env ? `<span class="st">set here</span>`
+             : r.value === null ? `<span class="st">·</span>`
+             : `<span class="st">◂ ${esc(r.origin)}</span>`;
+    html += `<button data-key="${esc(k.k)}" aria-current="${k.k === C.key}">
+      ${k.secret ? '<span class="lock" title="secret">🔒</span>' : ''}<span>${esc(k.k)}</span>${st}
+    </button>`;
+  }
+  document.getElementById('c-keys').innerHTML = html;
+}
+
+function renderConsoleDetail(){
+  const k = cKey(), e = cEnv(), r = resolve(k, C.env);
+  const masked = k.secret && !C.revealed;
+  let value;
+  if(r.invalid) value = `<span style="color:var(--bad)">✕ ${esc(r.invalid)}</span>`;
+  else if(r.missing) value = `<span style="color:var(--bad)">! required in ${esc(e.name)} · unset</span>`;
+  else if(r.value === null || r.value === undefined) value = `<span style="color:var(--tx-faint)">· not set anywhere</span>`;
+  else value = masked ? '••••••••••••••••' : esc(r.value);
+
+  const chain = r.chain.length ? `
+    <div class="chain">
+      <div class="ct">${esc(k.k)} · ${esc(e.name)}</div>
+      ${r.chain.map(l => `
+        <div class="lnk2 ${l.state === 'win' ? 'win' : l.state === 'invalid' ? 'win' : 'dead'}">
+          <span class="src">${esc(l.src === C.env ? e.name : l.src)}</span>
+          <span class="val">${k.secret && !C.revealed ? '••••••••' : esc(l.val)}</span>
+          <span class="mark">${l.state === 'invalid' ? '✕ rejected' : esc(l.mark || '')}</span>
+        </div>`).join('')}
+    </div>` : `
+    <div class="chain">
+      <div class="ct">${esc(k.k)} · ${esc(e.name)}</div>
+      <div class="lnk2"><span class="src">—</span><span class="val" style="color:var(--tx-faint)">nothing declares a value for this environment</span><span class="mark"></span></div>
+    </div>`;
+
+  let ceremony = '';
+  if(k.secret){
+    if(C.revealed){
+      ceremony = `<div class="revealed">
+        <span>revealed for this session</span>
+        <span class="cd">remasks in ${C.left}s</span>
+      </div>`;
+    } else if(e.protected && C.reauth){
+      ceremony = `<div class="challenge">
+        <b>reauth · ${esc(e.name)}</b>
+        <span>Disclosing <span class="mono">${esc(k.k)}</span> only. The window closes after 60 seconds
+        and the reveal is written to the audit log.</span>
+      </div>`;
+    } else if(e.protected){
+      ceremony = `<div class="refusal">
+        <b>✕ reveal refused · ${esc(e.name)}</b>
+        This environment is protected. Reveal needs a fresh passkey or TOTP challenge, is capped at a
+        60-second window, remasks itself, and lands in the audit log — copying to the clipboard counts
+        as a disclosure too. Writing a new value needs none of that.
+      </div>`;
+    }
+  }
+
+  const revealLabel = C.revealed ? 'remask now'
+    : e.protected ? (C.reauth ? 'confirm with passkey' : 'reveal (needs reauth)')
+    : 'reveal for 60s';
+  const acts = k.secret ? `
+    <div class="acts">
+      <button class="btn${e.protected && C.reauth && !C.revealed ? ' primary' : ''}" id="c-reveal">${revealLabel}</button>
+      ${e.protected && C.reauth && !C.revealed ? `<button class="btn" id="c-cancel">cancel</button>` : ''}
+      <button class="btn">set new value (write-only)</button>
+    </div>` : `
+    <div class="acts">
+      <button class="btn">override in ${esc(e.name)}</button>
+      <button class="btn">edit base</button>
+    </div>`;
+
+  document.getElementById('c-detail').innerHTML = `
+    <div class="kn">${k.secret ? '<span style="color:var(--bad)">🔒</span>' : ''}${esc(k.k)}<span class="type">${esc(k.type)}</span></div>
+    <p class="desc">${esc(k.desc)}</p>
+    <div class="resolved"><span class="rl">resolved</span><span class="rv">${value}</span></div>
+    ${chain}
+    ${ceremony}
+    ${acts}`;
+
+  const rev = document.getElementById('c-reveal');
+  if(rev) rev.onclick = toggleReveal;
+  const cancel = document.getElementById('c-cancel');
+  if(cancel) cancel.onclick = () => { C.reauth = false; renderConsole(); };
+}
+
+function renderConsoleCLI(){
+  const k = cKey(), e = cEnv(), r = resolve(k, C.env);
+  let out;
+  if(r.invalid) out = `<span class="er">✕</span> ${esc(k.k)}: expected <b>${esc(k.type)}</b>, got "${esc(r.invalid)}" <span class="c">— publish would refuse</span>`;
+  else if(r.missing) out = `<span class="er">✕</span> ${esc(k.k)}: required in <b>${esc(e.name)}</b>, unset <span class="c">— publish would refuse</span>`;
+  else if(r.value === null) out = `<span class="c">(no value declared)</span>`;
+  else if(k.secret && !C.revealed) out = `<span class="er">✕</span> refused: value is <b>write-only</b> here${e.protected ? ' · reveal needs reauth' : ''}\n  <span class="c">hikyo auth reveal --env ${esc(e.id)}</span>`;
+  else out = `<b>${esc(r.value)}</b>\n<span class="c">  origin: ${esc(r.origin === C.env ? e.name : r.origin)}${r.chain.length > 1 ? ` (shadowed ${r.chain.length - 1})` : ''}</span>`;
+  document.getElementById('c-cli').innerHTML =
+    `<span class="p">$</span> hikyo get <b>${esc(k.k)}</b> --env ${esc(e.id)} --explain\n${out}`;
+}
+
+function renderConsole(){
+  renderConsoleEnvs();
+  renderConsoleKeys();
+  renderConsoleDetail();
+  renderConsoleCLI();
+}
+
+function toggleReveal(){
+  clearInterval(C.timer);
+  if(C.revealed){ C.revealed = false; C.reauth = false; renderConsole(); return; }
+  // protected environments take the challenge first — one click is never enough
+  if(cEnv().protected && !C.reauth){ C.reauth = true; renderConsole(); return; }
+  C.revealed = true;
+  C.reauth = false;
+  C.left = 60;
+  C.timer = setInterval(() => {
+    C.left--;
+    if(C.left <= 0){ clearInterval(C.timer); C.revealed = false; renderConsole(); return; }
+    const cd = document.querySelector('#c-detail .revealed .cd');
+    if(cd) cd.textContent = `remasks in ${C.left}s`;
+  }, 1000);
+  renderConsole();
+}
+
+/* validation demo */
+function runValidation(){
+  const el = document.getElementById('c-val');
+  const out = document.getElementById('c-verdict');
+  if(!el || !out) return;
+  const raw = el.value;
+  let msg, ok = false;
+  if(raw === ''){
+    msg = '! required in production · unset — publish refused';
+  } else if(raw !== raw.trim()){
+    msg = `✕ expected int, got string — "${raw}" has surrounding whitespace`;
+  } else if(!/^-?\d+$/.test(raw)){
+    msg = `✕ expected int, got string — "${raw}"`;
+  } else if(Number(raw) < 1 || Number(raw) > 65535){
+    msg = `✕ out of range — ${raw} is not within 1–65535`;
+  } else {
+    ok = true;
+    msg = `✓ valid — publish would write ${raw} to production`;
+  }
+  out.className = 'verdict ' + (ok ? 'ok' : 'no');
+  out.textContent = msg;
+}
+
+/* blast-radius demo */
+function runBlast(){
+  const el = document.getElementById('c-base');
+  const out = document.getElementById('c-blast');
+  const rows = document.getElementById('c-blastrows');
+  if(!el || !out || !rows) return;
+  const base = el.value;
+  const over = {dev:'debug', stg:'debug'};
+  const followers = ENVS.filter(e => over[e.id] === undefined);
+  out.textContent = followers.length
+    ? `${followers.length} of ${ENVS.length} environments follow base → they become "${base}". ${ENVS.length - followers.length} override and stay put.`
+    : `every environment overrides LOG_LEVEL — changing base moves nothing.`;
+  rows.innerHTML = ENVS.map(e => over[e.id] !== undefined
+    ? `<div>${esc(e.name)} — <span style="color:var(--tx-dim)">${esc(over[e.id])}</span> <span style="color:var(--tx-faint)">(set here, unaffected)</span></div>`
+    : `<div>${esc(e.name)} — <span style="color:var(--accent)">${esc(base)}</span> <span style="color:var(--tx-faint)">◂ base</span></div>`
+  ).join('');
+}
+
+/* ===================== variant switcher ===================== */
+const VARIANTS = [
+  {key:'a', name:'Product first'},
+  {key:'b', name:'Typographic argument'},
+  {key:'c', name:'Live console'},
+];
+let current = 'a';
+
+function showVariant(key, push){
+  if(!VARIANTS.some(v => v.key === key)) key = 'a';
+  current = key;
+  for(const v of VARIANTS) document.getElementById('v-' + v.key).hidden = v.key !== key;
+  const meta = VARIANTS.find(v => v.key === key);
+  document.getElementById('sw-key').textContent = key.toUpperCase();
+  document.getElementById('sw-name').textContent = meta.name;
+  document.title = `PROTOTYPE — hikyo landing · ${key.toUpperCase()} ${meta.name}`;
+  if(push){
+    const u = new URL(location.href);
+    u.searchParams.set('variant', key);
+    history.replaceState(null, '', u);
+  }
+  window.scrollTo({top:0, behavior:'auto'});
+}
+
+function cycle(step){
+  const i = VARIANTS.findIndex(v => v.key === current);
+  showVariant(VARIANTS[(i + step + VARIANTS.length) % VARIANTS.length].key, true);
+}
+
+document.getElementById('sw-prev').onclick = () => cycle(-1);
+document.getElementById('sw-next').onclick = () => cycle(1);
+document.getElementById('sw-theme').onclick = () => {
+  const root = document.documentElement;
+  root.dataset.theme = root.dataset.theme === 'light' ? 'dark' : 'light';
+};
+
+addEventListener('keydown', ev => {
+  const t = ev.target;
+  if(t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  if(ev.key === 'ArrowLeft') cycle(-1);
+  else if(ev.key === 'ArrowRight') cycle(1);
+});
+
+/* copy buttons */
+addEventListener('click', ev => {
+  const b = ev.target.closest('[data-copy]');
+  if(!b) return;
+  navigator.clipboard?.writeText(b.dataset.copy);
+  const was = b.textContent;
+  b.textContent = 'copied';
+  setTimeout(() => { b.textContent = was; }, 1200);
+});
+
+/* console delegation */
+addEventListener('click', ev => {
+  const envBtn = ev.target.closest('#c-envs button');
+  if(envBtn){ C.env = envBtn.dataset.env; C.revealed = false; C.reauth = false; clearInterval(C.timer); renderConsole(); return; }
+  const keyBtn = ev.target.closest('#c-keys button');
+  if(keyBtn){ C.key = keyBtn.dataset.key; C.revealed = false; C.reauth = false; clearInterval(C.timer); renderConsole(); }
+});
+
+/* ===================== boot ===================== */
+renderMatrix('mx-a', ['dev','stg','pre','prd']);
+renderMatrix('mx-b', ['dev','stg','pre','prd']);
+renderLegend('legend-a');
+renderConsole();
+document.getElementById('c-val').addEventListener('input', runValidation);
+document.getElementById('c-base').addEventListener('input', runBlast);
+runValidation();
+runBlast();
+showVariant(new URL(location.href).searchParams.get('variant') || 'a', false);
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-5/2/index.html
+++ b/docs/site/public/prototypes/landing-opus-5/2/index.html
@@ -1,0 +1,1707 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — hikyo landing page (iteration 2)</title>
+<!--
+  THROWAWAY PROTOTYPE — marketing landing page, iteration 2.
+
+  Iteration 1 explained the product well and sold it not at all. Iteration 2
+  keeps all three page architectures and gives each one the commercial layer
+  that the reference sites actually run, expressed in that variant's own idiom.
+
+  Read from the live pages (kaneo.app, plane.so, openstatus.dev), not memory:
+    · cloud-vs-self-host is a hero-level choice, not a footnote
+      (Kaneo hero: "Cloud" / "Get Started"; Plane nav: "Self-host Plane";
+       OpenStatus header: "Free to start. Paid plans from $30/mo.")
+    · the headline is a why-now, not a what
+      (OpenStatus: "Ship your status page before your SOC 2 auditor asks")
+    · the FAQ does most of the selling (OpenStatus runs eleven of them)
+    · a founder note carries indie trust (Kaneo "Why Kaneo exists")
+    · proof is sized to the company: Plane runs a Fortune-500 logo cloud,
+      Kaneo has no customers to show so it names its sponsors instead
+    · comparison pages are a footer group (Kaneo: vs Jira, vs Trello, vs Linear)
+
+  Alex's calls on this iteration: portray a Cloud tier with real pricing
+  (Kaneo shape), and give the layer to all three variants so the architecture
+  comparison stays live.
+
+  What did NOT change: the design language. Tokens, type, radius roles and the
+  matrix cell vocabulary are still DESIGN.md and the frozen env-matrix/31.
+  Restrained colour and the system-ui / ui-monospace pair are identity here, so
+  the brand register's permission to go Committed is declined on purpose.
+
+    ?variant=a  PRODUCT FIRST (Kaneo / Plane / Dub)
+                Sells in plain sections stacked under the screenshot. Pricing
+                is a hairline table, the FAQ a stacked list.
+
+    ?variant=b  TYPOGRAPHIC ARGUMENT (Resend / Linear)
+                The commercial layer stays typographic. Prices are display
+                numerals, the FAQ continues the numbered claim rail, the
+                founder note is a signed pull-quote.
+
+    ?variant=c  LIVE CONSOLE (Better Auth / Unkey)
+                The commercial layer is interactive. Pricing is a self-host
+                versus cloud toggle that rewrites the CLI pane, the FAQ is an
+                accordion, the comparison is a working .env paste box.
+
+  Fixed from iteration 1: the 3px accent side-stripes on callouts (an absolute
+  ban) are now full hairline borders with a tinted ground, and the em dashes
+  are gone from the copy.
+
+  Every org, price, number, star count and URL on this page is invented.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+/* ============================ tokens (DESIGN.md) ============================ */
+:root{
+  --mono:ui-monospace,monospace;
+  --sans:system-ui,sans-serif;
+  --bg:oklch(0.19 0.012 220);
+  --bg2:oklch(0.225 0.014 220);
+  --bg3:oklch(0.27 0.016 220);
+  --line:oklch(0.34 0.016 220);
+  --tx:oklch(0.93 0.008 200);
+  --tx-dim:oklch(0.76 0.01 210);
+  --tx-faint:oklch(0.60 0.012 215);
+  --accent:oklch(0.82 0.09 195);
+  --on-accent:oklch(0.2 0.02 220);
+  --accent-soft:oklch(0.82 0.09 195/.14);
+  --bad:oklch(0.74 0.13 25);
+  --bad-soft:oklch(0.74 0.13 25/.14);
+  --chg:oklch(0.8 0.06 250);
+  --rowalt:oklch(0.93 0.008 200/.045);
+  --r-container:6px;
+  --r-control:4px;
+  --r-badge:3px;
+  --shadow:0 18px 50px oklch(0 0 0/.45);
+}
+[data-theme=light]{
+  --bg:oklch(0.965 0.008 200);
+  --bg2:oklch(0.935 0.01 200);
+  --bg3:oklch(0.895 0.012 200);
+  --line:oklch(0.82 0.014 210);
+  --tx:oklch(0.25 0.03 225);
+  --tx-dim:oklch(0.4 0.025 220);
+  --tx-faint:oklch(0.52 0.02 218);
+  --accent:oklch(0.45 0.085 210);
+  --on-accent:oklch(0.97 0.008 200);
+  --accent-soft:oklch(0.45 0.085 210/.1);
+  --bad:oklch(0.48 0.14 30);
+  --bad-soft:oklch(0.48 0.14 30/.1);
+  --chg:oklch(0.45 0.08 255);
+  --rowalt:oklch(0.25 0.03 225/.06);
+  --shadow:0 18px 50px oklch(0.3 0.02 220/.18);
+}
+
+/* ============================ base ============================ */
+*{box-sizing:border-box;margin:0;padding:0}
+html{background:var(--bg);scroll-behavior:smooth}
+body{
+  background:var(--bg);color:var(--tx);font-family:var(--sans);font-size:15px;
+  -webkit-font-smoothing:antialiased;line-height:1.55;
+  padding-bottom:calc(84px + env(safe-area-inset-bottom));
+}
+button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+input,select{font:inherit}
+a{color:inherit}
+:is(a,button,input,summary,[tabindex]):focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:var(--r-control)}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important;scroll-behavior:auto}}
+.mono{font-family:var(--mono)}
+.shell{width:100%;max-width:1140px;margin:0 auto;padding:0 20px}
+@media (min-width:760px){.shell{padding:0 40px}}
+.variant[hidden]{display:none}
+.grid>*,.g>*{min-width:0}
+
+/* ---- nav ---- */
+.nav{display:flex;align-items:center;gap:16px;padding:16px 0;border-bottom:1px solid var(--line);flex-wrap:wrap}
+.brand{display:inline-flex;align-items:center;gap:9px;text-decoration:none;font-weight:700;font-size:17px;letter-spacing:-.01em}
+.brand svg{display:block;border-radius:var(--r-badge)}
+.nav .grow{flex:1}
+.nav a.lnk{font-size:13.5px;color:var(--tx-dim);text-decoration:none}
+.nav a.lnk:hover{color:var(--tx)}
+.nav .navcta{
+  display:inline-flex;align-items:center;min-height:34px;padding:0 13px;
+  border:1px solid var(--line);border-radius:var(--r-control);
+  font-size:13px;font-weight:500;text-decoration:none;
+}
+.nav .navcta:hover{border-color:var(--accent);color:var(--accent)}
+.nav .navcta.solid{background:var(--accent);border-color:var(--accent);color:var(--on-accent);font-weight:600}
+.nav .navcta.solid:hover{filter:brightness(1.07);color:var(--on-accent)}
+.nav .hide-s{display:none}
+@media (min-width:820px){.nav .hide-s{display:inline-flex}}
+
+/* ---- buttons ---- */
+.btn{
+  display:inline-flex;align-items:center;justify-content:center;gap:8px;
+  min-height:44px;padding:0 18px;border-radius:var(--r-control);
+  border:1px solid var(--line);color:var(--tx);font-size:14px;font-weight:500;
+  text-decoration:none;transition:border-color .15s,color .15s;
+}
+.btn:hover{border-color:var(--accent);color:var(--accent)}
+.btn.primary{background:var(--accent);border-color:var(--accent);color:var(--on-accent);font-weight:600}
+.btn.primary:hover{filter:brightness(1.07);color:var(--on-accent)}
+
+/* ---- install line ---- */
+.install{
+  display:flex;align-items:center;gap:10px;
+  border:1px solid var(--line);border-radius:var(--r-control);background:var(--bg2);
+  padding:0 6px 0 14px;min-height:44px;max-width:100%;overflow:hidden;
+}
+.install code{font-family:var(--mono);font-size:12.5px;color:var(--tx-dim);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.install code b{color:var(--tx);font-weight:500}
+.install .cp{
+  flex:none;font-family:var(--mono);font-size:11px;letter-spacing:.06em;color:var(--tx-faint);
+  border:1px solid var(--line);border-radius:var(--r-badge);padding:0 10px;min-height:30px;
+}
+.install .cp:hover{color:var(--accent);border-color:var(--accent)}
+
+.eyebrow{font-family:var(--mono);font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint)}
+
+/* ---- matrix (cell vocabulary from env-matrix/31) ---- */
+.mx{border-collapse:separate;border-spacing:0;min-width:100%;font-size:13px}
+.mx thead th{
+  text-align:left;padding:11px 12px 9px;border-bottom:1px solid var(--line);
+  font-size:12px;font-weight:600;white-space:nowrap;background:var(--bg);
+  position:sticky;top:0;z-index:2;
+}
+.mx thead th.keyh{
+  font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--tx-faint);min-width:170px;position:sticky;left:0;z-index:3;
+}
+.mx thead th .base{display:block;font-weight:400;font-size:10.5px;color:var(--tx-faint);font-family:var(--mono);letter-spacing:0}
+.mx tbody td{padding:4px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+.mx td.key{position:sticky;left:0;background:var(--bg);z-index:1;font-family:var(--mono);font-size:12px;white-space:nowrap}
+.mx td.key .lock{color:var(--bad);margin-right:5px}
+.mx tr.alt td{background:var(--rowalt)}
+.mx tr.alt td.key{background:color-mix(in oklch,var(--tx) 4%,var(--bg))}
+.mx tr.grp td{padding:0;background:var(--bg);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.mx tr.grp .g{
+  display:flex;align-items:center;gap:10px;position:sticky;left:0;
+  padding:11px 12px;font-size:11px;font-weight:700;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent);
+}
+.mx tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none;font-family:var(--mono)}
+.cellv{
+  display:inline-flex;align-items:center;gap:6px;max-width:240px;
+  font-family:var(--mono);font-size:11.5px;line-height:1;
+  padding:7px 9px;min-height:30px;border-radius:var(--r-control);
+}
+.cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cellv.dim{color:var(--tx-dim)}
+.cellv.absent{color:var(--tx-faint)}
+.cellv .inh{color:var(--tx-faint);font-size:10px}
+.cellv .d{color:var(--chg);font-weight:700}
+.pill{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--mono);font-size:11.5px;line-height:1;
+  padding:7px 12px;border-radius:999px;min-height:30px;white-space:nowrap;
+  border:1px solid transparent;
+}
+.pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+.pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+.legend{display:flex;flex-wrap:wrap;gap:8px 20px;font-size:12px;color:var(--tx-dim)}
+.legend span.k{display:inline-flex;align-items:center;gap:7px}
+
+/* ---- terminal ---- */
+.term{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);font-family:var(--mono);font-size:12.5px;line-height:1.75;overflow-x:auto}
+.term .bar{display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid var(--line);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--tx-faint)}
+.term pre{padding:14px 16px;white-space:pre;color:var(--tx-dim)}
+.term .p,.term .ok{color:var(--accent)}
+.term .er{color:var(--bad)}
+.term .c{color:var(--tx-faint)}
+.term b{color:var(--tx);font-weight:500}
+
+/* ---- provenance chain ---- */
+.chain{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);padding:16px;font-family:var(--mono);font-size:12px}
+.chain .ct{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:12px}
+.chain .lnk2{display:flex;align-items:flex-start;gap:10px;padding:8px 0}
+.chain .lnk2+.lnk2{border-top:1px dashed oklch(from var(--line) l c h/.7)}
+.chain .lnk2 .src{flex:none;width:88px;color:var(--tx-faint)}
+.chain .lnk2 .val{flex:1;min-width:0;color:var(--tx-dim);word-break:break-all}
+.chain .lnk2 .mark{flex:none;font-size:10px;color:var(--tx-faint)}
+.chain .lnk2.win .val{color:var(--tx)}
+.chain .lnk2.win .src,.chain .lnk2.win .mark{color:var(--accent)}
+.chain .lnk2.dead .val{text-decoration:line-through;opacity:.55}
+.chain .out{margin-top:12px;padding-top:12px;border-top:1px solid var(--line);display:flex;gap:10px;align-items:baseline;flex-wrap:wrap}
+.chain .out .lbl{color:var(--tx-faint);font-size:10px;letter-spacing:.16em;text-transform:uppercase}
+.chain .out .v{color:var(--tx);word-break:break-all}
+
+/* ---- callouts (full hairline + tinted ground, never a side stripe) ---- */
+.viol{border:1px solid var(--bad);border-radius:var(--r-container);background:var(--bad-soft);padding:14px 16px;font-family:var(--mono);font-size:12px;line-height:1.7}
+.viol .h{color:var(--bad);font-weight:500}
+.viol .l{color:var(--tx-dim)}
+.viol .l b{color:var(--tx);font-weight:500}
+.cond{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);font-family:var(--mono);font-size:12px;overflow:hidden}
+.cond .r{display:flex;gap:12px;padding:11px 14px;align-items:baseline}
+.cond .r+.r{border-top:1px solid oklch(from var(--line) l c h/.6)}
+.cond .r .t{flex:none;width:96px;color:var(--tx-faint)}
+.cond .r .s{flex:none;width:56px;color:var(--accent);font-weight:500}
+.cond .r .s.no{color:var(--bad)}
+.cond .r .m{flex:1;min-width:0;color:var(--tx-dim)}
+.strip{border:1px solid var(--line);border-radius:var(--r-container);overflow:hidden;background:var(--bg2)}
+.strip .sh{padding:9px 14px;border-bottom:1px solid var(--line);font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+.strip .sb{overflow-x:auto}
+.strip .mx{font-size:12.5px}
+.strip .mx thead th,.strip .mx td.key{background:var(--bg2)}
+.strip .mx tr.alt td.key{background:color-mix(in oklch,var(--tx) 4%,var(--bg2))}
+
+/* ---- footer ---- */
+.foot{border-top:1px solid var(--line);margin-top:72px;padding:40px 0 20px}
+.foot .cols{display:grid;gap:26px 34px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr))}
+.foot .cols h4{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);font-weight:400;margin-bottom:10px}
+.foot .cols a{display:block;font-size:13px;color:var(--tx-dim);text-decoration:none;padding:3px 0}
+.foot .cols a:hover{color:var(--tx)}
+.foot .fine{font-family:var(--mono);font-size:11px;color:var(--tx-faint);margin-top:34px;padding-top:18px;border-top:1px solid var(--line);line-height:1.8}
+
+/* ============================ shared commercial layer ============================ */
+/* proof: pre-launch honest. No customer logo wall (an anti-reference), no
+   big-number hero-metric grid. Named humans and repository facts, inline. */
+.proof{display:flex;flex-wrap:wrap;gap:10px 28px;align-items:baseline;font-family:var(--mono);font-size:12px;color:var(--tx-faint)}
+.proof b{color:var(--tx);font-weight:500}
+.backers{display:flex;flex-wrap:wrap;gap:8px}
+.backer{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:var(--r-badge);padding:6px 11px;font-size:12px;color:var(--tx-dim)}
+.backer .av{width:20px;height:20px;border-radius:999px;background:var(--bg3);color:var(--tx-dim);font-family:var(--mono);font-size:9.5px;display:inline-flex;align-items:center;justify-content:center;flex:none}
+
+/* comparison */
+.cmp{width:100%;border-collapse:separate;border-spacing:0;font-size:13px;min-width:640px}
+.cmp th,.cmp td{text-align:left;padding:12px 14px;border-bottom:1px solid oklch(from var(--line) l c h/.55);vertical-align:top}
+.cmp thead th{font-size:12px;font-weight:600;border-bottom:1px solid var(--line);white-space:nowrap}
+.cmp thead th.us{color:var(--accent)}
+.cmp tbody th{font-weight:400;color:var(--tx-dim);font-size:13px;width:30%}
+.cmp td{font-family:var(--mono);font-size:11.5px;color:var(--tx-faint)}
+.cmp td.us{color:var(--tx)}
+.cmp .y{color:var(--accent)}
+.cmp .n{color:var(--tx-faint)}
+.cmpwrap{overflow-x:auto;border:1px solid var(--line);border-radius:var(--r-container)}
+.cmpwrap .cmp th:first-child,.cmpwrap .cmp td:first-child{padding-left:16px}
+.cmpwrap .cmp tr:last-child td,.cmpwrap .cmp tr:last-child th{border-bottom:none}
+
+/* faq */
+.faq details{border-bottom:1px solid var(--line)}
+.faq details:first-of-type{border-top:1px solid var(--line)}
+.faq summary{
+  display:flex;align-items:baseline;gap:14px;cursor:pointer;list-style:none;
+  padding:18px 0;font-size:15.5px;font-weight:500;
+}
+.faq summary::-webkit-details-marker{display:none}
+.faq summary::after{content:'+';margin-left:auto;color:var(--tx-faint);font-family:var(--mono);font-size:16px;flex:none}
+.faq details[open] summary::after{content:'\2212'}
+.faq summary:hover{color:var(--accent)}
+.faq .a{padding:0 0 20px;font-size:14px;color:var(--tx-dim);line-height:1.7;max-width:66ch}
+.faq .a p+p{margin-top:12px}
+.faq .a code{font-family:var(--mono);font-size:12.5px;color:var(--tx)}
+
+/* founder */
+.founder{display:grid;gap:22px}
+@media (min-width:820px){.founder{grid-template-columns:180px minmax(0,1fr);gap:40px}}
+.founder .who{display:flex;align-items:center;gap:12px}
+.founder .who .av{width:44px;height:44px;border-radius:999px;background:var(--bg3);color:var(--tx-dim);font-family:var(--mono);font-size:13px;display:inline-flex;align-items:center;justify-content:center;flex:none}
+.founder .who .nm{font-size:14px;font-weight:600}
+.founder .who .rl{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+.founder .said p{font-size:15.5px;line-height:1.7;max-width:62ch;color:var(--tx-dim)}
+.founder .said p+p{margin-top:16px}
+.founder .said p strong{color:var(--tx);font-weight:500}
+
+/* ============================================================ VARIANT A */
+#v-a .hero{padding:clamp(44px,8vw,86px) 0 clamp(26px,4vw,38px)}
+#v-a h1{font-size:clamp(31px,6.4vw,55px);line-height:1.05;letter-spacing:-.03em;font-weight:700;max-width:17ch}
+#v-a h1 em{font-style:normal;color:var(--accent)}
+#v-a .sub{margin-top:20px;font-size:clamp(15px,2.1vw,18px);color:var(--tx-dim);max-width:58ch;line-height:1.6}
+#v-a .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px;align-items:center}
+#v-a .cta .install{flex:1 1 320px;min-width:0}
+#v-a .cta .free{font-family:var(--mono);font-size:11.5px;color:var(--tx-faint);flex-basis:100%}
+#v-a .facts{display:flex;flex-wrap:wrap;gap:8px 22px;margin-top:22px;font-family:var(--mono);font-size:11.5px;color:var(--tx-faint)}
+#v-a .facts b{color:var(--tx-dim);font-weight:400}
+
+#v-a .frame{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg);box-shadow:var(--shadow);overflow:hidden}
+#v-a .frame .chrome{display:flex;align-items:center;gap:10px;padding:9px 12px;border-bottom:1px solid var(--line);background:var(--bg2)}
+#v-a .frame .chrome .dot{width:9px;height:9px;border-radius:999px;background:var(--line);flex:none}
+#v-a .frame .chrome .url{flex:1;font-family:var(--mono);font-size:11px;color:var(--tx-faint);text-align:center;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#v-a .frame .app{display:flex;min-height:0}
+#v-a .frame .rail{display:none;flex:none;width:190px;border-right:1px solid var(--line);padding:14px 0;background:var(--bg2)}
+@media (min-width:900px){#v-a .frame .rail{display:block}}
+#v-a .rail .rt{padding:0 16px 8px;font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+#v-a .rail .ri{display:flex;align-items:center;gap:9px;padding:8px 16px;font-size:13px;color:var(--tx-dim)}
+#v-a .rail .ri.on{color:var(--accent);background:var(--accent-soft);font-weight:500}
+#v-a .rail .ri .n{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+#v-a .rail .ri .n.bad{color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:2px 7px}
+#v-a .rail hr{border:none;border-top:1px solid var(--line);margin:12px 0}
+#v-a .frame .pane{flex:1;min-width:0}
+#v-a .frame .top{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:11px 14px;border-bottom:1px solid var(--line)}
+#v-a .frame .top .crumb{font-weight:600;font-size:14px}
+#v-a .frame .top .crumb i{font-style:normal;color:var(--tx-faint);font-weight:400;margin:0 6px}
+#v-a .frame .top .chip{font-family:var(--mono);font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:var(--r-badge);padding:4px 9px}
+#v-a .frame .top .chip.warn{color:var(--bad);border-color:var(--bad);background:var(--bad-soft)}
+#v-a .frame .scroll{overflow-x:auto;max-height:min(78vh,660px);overflow-y:auto}
+#v-a .capbar{display:flex;flex-wrap:wrap;gap:14px 26px;align-items:baseline;margin-top:16px}
+#v-a .capbar .legend{flex:1 1 320px}
+#v-a .capbar .note{font-size:12px;color:var(--tx-faint);font-family:var(--mono)}
+
+#v-a .proofbar{margin-top:26px;padding-top:22px;border-top:1px solid var(--line);display:grid;gap:18px}
+@media (min-width:900px){#v-a .proofbar{grid-template-columns:1fr auto;align-items:center;gap:34px}}
+
+#v-a .three{display:grid;gap:0;margin-top:clamp(52px,7vw,88px);border-top:1px solid var(--line)}
+@media (min-width:820px){#v-a .three{grid-template-columns:repeat(3,1fr)}}
+#v-a .three .col{padding:26px 0;border-bottom:1px solid var(--line)}
+@media (min-width:820px){
+  #v-a .three .col{padding:30px 28px 34px;border-bottom:none;border-right:1px solid var(--line)}
+  #v-a .three .col:first-child{padding-left:0}
+  #v-a .three .col:last-child{border-right:none;padding-right:0}
+}
+#v-a .three h3{font-size:17px;font-weight:600;margin:12px 0 8px;letter-spacing:-.01em}
+#v-a .three p{font-size:13.5px;color:var(--tx-dim);line-height:1.65;max-width:40ch}
+#v-a .three .art{margin-top:16px}
+
+#v-a section.blk{margin-top:clamp(52px,7vw,88px)}
+#v-a section.blk h2{font-size:clamp(23px,3.6vw,32px);font-weight:700;letter-spacing:-.02em;margin-top:10px;max-width:22ch}
+#v-a section.blk .lede{font-size:14.5px;color:var(--tx-dim);margin-top:14px;max-width:56ch;line-height:1.65}
+#v-a .split{display:grid;gap:26px;margin-top:22px}
+@media (min-width:880px){#v-a .split{grid-template-columns:1.05fr .95fr;gap:44px;align-items:start}}
+@media (min-width:880px){#v-a .split.rev{grid-template-columns:.95fr 1.05fr}}
+
+/* pricing: a hairline table, not three identical cards */
+#v-a .tiers{margin-top:24px;border:1px solid var(--line);border-radius:var(--r-container);overflow:hidden}
+#v-a .tier{display:grid;gap:12px;padding:22px 20px;border-bottom:1px solid var(--line)}
+#v-a .tier:last-child{border-bottom:none}
+@media (min-width:880px){
+  #v-a .tier{grid-template-columns:210px 190px minmax(0,1fr) auto;align-items:center;gap:26px;padding:20px 24px}
+}
+#v-a .tier.feat{background:var(--accent-soft)}
+#v-a .tier .nm{font-size:16px;font-weight:600;display:flex;align-items:baseline;gap:9px;flex-wrap:wrap}
+#v-a .tier .nm .tag{font-family:var(--mono);font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--on-accent);background:var(--accent);border-radius:var(--r-badge);padding:2px 7px}
+#v-a .tier .pr{font-family:var(--mono);font-size:19px;color:var(--tx)}
+#v-a .tier .pr small{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:3px}
+#v-a .tier .ft{font-size:13px;color:var(--tx-dim);line-height:1.6}
+#v-a .tier .go{white-space:nowrap}
+#v-a .tiernote{margin-top:16px;font-size:13.5px;color:var(--tx-dim);max-width:64ch;line-height:1.65}
+#v-a .tiernote strong{color:var(--tx);font-weight:500}
+
+#v-a .lastcta{margin-top:clamp(56px,8vw,96px);border-top:1px solid var(--line);padding-top:clamp(40px,6vw,64px)}
+#v-a .lastcta h2{font-size:clamp(26px,4.4vw,42px);letter-spacing:-.03em;font-weight:700;max-width:18ch;line-height:1.08}
+#v-a .lastcta .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:26px;align-items:center}
+
+/* ============================================================ VARIANT B */
+#v-b .hero{padding:clamp(56px,12vw,132px) 0 clamp(36px,6vw,72px)}
+#v-b h1{font-size:clamp(35px,8vw,78px);line-height:1.0;letter-spacing:-.04em;font-weight:700;max-width:13ch;text-wrap:balance}
+#v-b h1 .q{color:var(--tx-faint);font-weight:400}
+#v-b .hero .sub{margin-top:clamp(22px,3.6vw,34px);font-size:clamp(15px,2.2vw,19px);color:var(--tx-dim);max-width:52ch;line-height:1.55}
+#v-b .hero .meta{display:flex;flex-wrap:wrap;gap:10px 24px;margin-top:clamp(24px,3.6vw,36px);font-family:var(--mono);font-size:12px;color:var(--tx-faint);align-items:center}
+#v-b .hero .meta a{color:var(--tx-dim);text-decoration:none;border-bottom:1px solid var(--line);padding-bottom:2px}
+#v-b .hero .meta a:hover{color:var(--accent);border-color:var(--accent)}
+#v-b .hero .proof{margin-top:26px}
+
+#v-b .claim{border-top:1px solid var(--line);padding:clamp(36px,5.5vw,60px) 0}
+#v-b .claim .g{display:grid;gap:22px}
+@media (min-width:900px){#v-b .claim .g{grid-template-columns:112px minmax(0,1fr) minmax(0,1.05fr);gap:36px;align-items:start}}
+#v-b .claim .n{font-family:var(--mono);font-size:11px;letter-spacing:.2em;color:var(--tx-faint);padding-top:8px}
+#v-b .claim h2{font-size:clamp(22px,3.6vw,34px);line-height:1.16;letter-spacing:-.025em;font-weight:600;max-width:22ch;text-wrap:balance}
+#v-b .claim h2 em{font-style:normal;color:var(--accent)}
+#v-b .claim p{margin-top:16px;font-size:14.5px;color:var(--tx-dim);line-height:1.7;max-width:46ch}
+#v-b .claim p+p{margin-top:12px}
+#v-b .claim .art{min-width:0}
+@media (min-width:900px){
+  #v-b .claim.wide .g{grid-template-columns:112px minmax(0,1fr)}
+  #v-b .claim.wide .art{grid-column:1 / -1;margin-top:8px}
+}
+
+/* pricing as typography: display numerals, ruled rows, no cards */
+#v-b .prow{display:grid;gap:12px;padding:26px 0;border-top:1px solid var(--line)}
+@media (min-width:820px){#v-b .prow{grid-template-columns:minmax(0,1fr) 250px auto;gap:36px;align-items:baseline}}
+#v-b .prow .nm{font-size:clamp(19px,2.6vw,25px);font-weight:600;letter-spacing:-.02em}
+#v-b .prow .nm span{display:block;font-size:13.5px;font-weight:400;color:var(--tx-dim);margin-top:8px;line-height:1.6;max-width:44ch;letter-spacing:0}
+#v-b .prow .pr{font-family:var(--mono);font-size:clamp(26px,4.4vw,40px);line-height:1;color:var(--tx);letter-spacing:-.02em}
+#v-b .prow .pr small{display:block;font-size:11.5px;color:var(--tx-faint);margin-top:9px;letter-spacing:.02em}
+#v-b .prow.free .pr{color:var(--accent)}
+#v-b .pnote{padding:24px 0 0;border-top:1px solid var(--line);font-size:14.5px;color:var(--tx-dim);max-width:62ch;line-height:1.7}
+#v-b .pnote strong{color:var(--tx);font-weight:500}
+
+#v-b .qa{border-top:1px solid var(--line);padding:clamp(30px,4.5vw,48px) 0}
+#v-b .qa .g{display:grid;gap:18px}
+@media (min-width:900px){#v-b .qa .g{grid-template-columns:112px minmax(0,1fr) minmax(0,1.05fr);gap:36px;align-items:start}}
+#v-b .qa .n{font-family:var(--mono);font-size:11px;letter-spacing:.2em;color:var(--tx-faint);padding-top:6px}
+#v-b .qa h3{font-size:clamp(18px,2.5vw,23px);font-weight:600;letter-spacing:-.02em;line-height:1.25;max-width:24ch}
+#v-b .qa p{font-size:14.5px;color:var(--tx-dim);line-height:1.7;max-width:48ch}
+#v-b .qa p+p{margin-top:12px}
+#v-b .qa code{font-family:var(--mono);font-size:12.5px;color:var(--tx)}
+
+#v-b .signed{border-top:1px solid var(--line);padding:clamp(44px,7vw,84px) 0}
+#v-b .signed blockquote{font-size:clamp(19px,3vw,30px);line-height:1.4;letter-spacing:-.02em;max-width:24ch;font-weight:500;text-wrap:balance}
+#v-b .signed .rest{margin-top:24px;display:grid;gap:20px}
+@media (min-width:900px){#v-b .signed .rest{grid-template-columns:minmax(0,1fr) 260px;gap:44px;align-items:start}}
+#v-b .signed .rest p{font-size:14.5px;color:var(--tx-dim);line-height:1.7;max-width:52ch}
+#v-b .signed .rest p+p{margin-top:12px}
+#v-b .signed .sig{display:flex;align-items:center;gap:12px}
+#v-b .signed .sig .av{width:40px;height:40px;border-radius:999px;background:var(--bg3);color:var(--tx-dim);font-family:var(--mono);font-size:12px;display:inline-flex;align-items:center;justify-content:center;flex:none}
+#v-b .signed .sig .nm{font-size:14px;font-weight:600}
+#v-b .signed .sig .rl{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+
+#v-b .closing{border-top:1px solid var(--line);padding:clamp(52px,8vw,104px) 0 0}
+#v-b .closing h2{font-size:clamp(28px,5.4vw,52px);letter-spacing:-.03em;line-height:1.06;font-weight:700;max-width:16ch}
+#v-b .closing .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px;align-items:center}
+#v-b .closing .cta .install{flex:1 1 340px;min-width:0}
+#v-b .closing .free{font-family:var(--mono);font-size:11.5px;color:var(--tx-faint);margin-top:16px}
+
+/* ============================================================ VARIANT C */
+#v-c .hero{padding:clamp(36px,5.5vw,60px) 0 0}
+#v-c h1{font-size:clamp(28px,5.2vw,44px);line-height:1.08;letter-spacing:-.03em;font-weight:700;max-width:19ch}
+#v-c h1 em{font-style:normal;color:var(--accent)}
+#v-c .hero .sub{margin-top:16px;font-size:15px;color:var(--tx-dim);max-width:56ch;line-height:1.6}
+#v-c .hero .hint{margin-top:14px;font-family:var(--mono);font-size:11.5px;color:var(--tx-faint);display:inline-flex;align-items:center;gap:8px}
+#v-c .hero .hint::before{content:'\25BE';color:var(--accent)}
+#v-c .hero .heroLinks{display:flex;flex-wrap:wrap;gap:10px 22px;margin-top:16px;align-items:center;font-family:var(--mono);font-size:12px;color:var(--tx-faint)}
+#v-c .hero .heroLinks a{color:var(--tx-dim);text-decoration:none;border-bottom:1px solid var(--line);padding-bottom:2px}
+#v-c .hero .heroLinks a:hover{color:var(--accent);border-color:var(--accent)}
+
+.console{margin-top:24px;border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);overflow:hidden;box-shadow:var(--shadow)}
+.console .envs{display:flex;gap:0;border-bottom:1px solid var(--line);overflow-x:auto}
+.console .envs button{flex:none;padding:13px 16px;font-size:13px;color:var(--tx-dim);min-height:46px;border-bottom:2px solid transparent;white-space:nowrap;display:inline-flex;align-items:center;gap:8px}
+.console .envs button .lk{font-size:11px;color:var(--tx-faint)}
+.console .envs button[aria-selected=true]{color:var(--tx);border-bottom-color:var(--accent);font-weight:600}
+.console .envs button[aria-selected=true] .lk{color:var(--accent)}
+.console .envs .prot{font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;color:var(--bad);border:1px solid var(--bad);border-radius:var(--r-badge);padding:2px 6px}
+.console .body{display:grid}
+@media (min-width:880px){.console .body{grid-template-columns:290px minmax(0,1fr)}}
+.console .keys{border-bottom:1px solid var(--line);max-height:280px;overflow-y:auto}
+@media (min-width:880px){.console .keys{border-bottom:none;border-right:1px solid var(--line);max-height:none}}
+.console .keys .kg{padding:10px 14px 6px;font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+.console .keys button{display:flex;width:100%;align-items:center;gap:10px;text-align:left;padding:10px 14px;min-height:44px;font-family:var(--mono);font-size:12px;color:var(--tx-dim)}
+.console .keys button:hover{background:oklch(from var(--tx) l c h/.05)}
+.console .keys button[aria-current=true]{background:var(--accent-soft);color:var(--tx);font-weight:500}
+.console .keys button .lock{color:var(--bad)}
+.console .keys button .st{margin-left:auto;font-size:10px;color:var(--tx-faint)}
+.console .keys button .st.bad{color:var(--bad)}
+.console .detail{padding:18px 16px 20px;min-width:0}
+@media (min-width:880px){.console .detail{padding:22px 24px 26px}}
+.console .detail .kn{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;font-family:var(--mono);font-size:15px;color:var(--tx)}
+.console .detail .kn .type{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);border:1px solid var(--line);border-radius:var(--r-badge);padding:2px 7px}
+.console .detail .desc{margin-top:8px;font-size:13px;color:var(--tx-dim);max-width:52ch;line-height:1.6}
+.console .detail .resolved{margin-top:16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;border:1px solid var(--line);border-radius:var(--r-control);background:var(--bg);padding:12px 14px}
+.console .detail .resolved .rl{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint)}
+.console .detail .resolved .rv{font-family:var(--mono);font-size:13.5px;flex:1;min-width:120px;word-break:break-all}
+.console .detail .chain{margin-top:16px;background:var(--bg)}
+.console .detail .acts{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
+.console .detail .acts .btn{min-height:38px;font-size:13px;padding:0 14px}
+.console .detail .refusal{margin-top:14px;border:1px solid var(--bad);border-radius:var(--r-container);background:var(--bad-soft);padding:13px 15px;font-size:12.5px;color:var(--tx-dim);line-height:1.65}
+.console .detail .refusal b{color:var(--bad);font-family:var(--mono);font-size:12px;display:block;margin-bottom:5px}
+.console .detail .challenge{margin-top:14px;border:1px solid var(--accent);border-radius:var(--r-container);background:var(--accent-soft);padding:13px 15px;font-size:12.5px;color:var(--tx-dim);line-height:1.65}
+.console .detail .challenge b{color:var(--accent);font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;display:block;margin-bottom:6px}
+.console .detail .challenge .mono{font-family:var(--mono);color:var(--tx)}
+.console .detail .revealed{margin-top:14px;border:1px solid var(--accent);border-radius:var(--r-container);background:var(--accent-soft);padding:13px 15px;font-family:var(--mono);font-size:12.5px;display:flex;gap:12px;align-items:baseline;flex-wrap:wrap}
+.console .detail .revealed .cd{margin-left:auto;color:var(--tx-faint);font-size:11px}
+.console .cli{border-top:1px solid var(--line);background:var(--bg)}
+.console .cli .bar{padding:8px 14px;font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);border-bottom:1px solid var(--line);display:flex;gap:10px;align-items:center}
+.console .cli pre{padding:13px 16px;font-family:var(--mono);font-size:12.5px;line-height:1.7;color:var(--tx-dim);overflow-x:auto;white-space:pre}
+.console .cli .p{color:var(--accent)}
+.console .cli b{color:var(--tx);font-weight:500}
+
+#v-c .demos{margin-top:clamp(50px,7vw,84px);display:grid;gap:clamp(36px,5.5vw,56px)}
+#v-c .demo h2{font-size:clamp(20px,3vw,27px);font-weight:600;letter-spacing:-.02em;margin-top:10px}
+#v-c .demo p{margin-top:10px;font-size:14px;color:var(--tx-dim);max-width:54ch;line-height:1.65}
+#v-c .demo .box{margin-top:18px}
+.vform{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);padding:16px}
+.vform label{display:block;font-family:var(--mono);font-size:11px;color:var(--tx-faint);margin-bottom:8px}
+.vform .in{display:flex;gap:10px;flex-wrap:wrap}
+.vform input,.vform textarea{
+  flex:1 1 200px;min-width:0;min-height:44px;padding:11px 12px;
+  background:var(--bg);border:1px solid var(--line);border-radius:var(--r-control);
+  color:var(--tx);font-family:var(--mono);font-size:13px;line-height:1.6;resize:vertical;
+}
+.vform textarea{width:100%;min-height:112px}
+.vform input:focus,.vform textarea:focus{outline:2px solid var(--accent);outline-offset:1px}
+.vform .verdict{margin-top:12px;font-family:var(--mono);font-size:12.5px;line-height:1.6;display:flex;gap:9px;align-items:flex-start}
+.vform .verdict.ok{color:var(--accent)}
+.vform .verdict.no{color:var(--bad)}
+.vform .rules{margin-top:12px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.7}
+.vform .out{margin-top:14px;border-top:1px solid var(--line);padding-top:14px;font-family:var(--mono);font-size:12px;line-height:1.85;color:var(--tx-dim)}
+.vform .out .k{color:var(--tx)}
+.vform .out .t{color:var(--accent)}
+.vform .out .w{color:var(--bad)}
+.vform .out .n{color:var(--tx-faint)}
+
+#v-c section.blk{margin-top:clamp(50px,7vw,84px)}
+#v-c section.blk h2{font-size:clamp(22px,3.4vw,30px);font-weight:700;letter-spacing:-.02em;margin-top:10px;max-width:22ch}
+#v-c section.blk .lede{font-size:14.5px;color:var(--tx-dim);margin-top:14px;max-width:56ch;line-height:1.65}
+
+/* pricing as a live toggle */
+#v-c .ptoggle{display:inline-flex;margin-top:20px;border:1px solid var(--line);border-radius:var(--r-control);overflow:hidden}
+#v-c .ptoggle button{padding:0 18px;min-height:42px;font-size:13.5px;color:var(--tx-dim);white-space:nowrap}
+#v-c .ptoggle button[aria-pressed=true]{background:var(--accent);color:var(--on-accent);font-weight:600}
+#v-c .pbody{margin-top:22px;display:grid;gap:22px}
+@media (min-width:880px){#v-c .pbody{grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:38px;align-items:start}}
+#v-c .pcard{border:1px solid var(--line);border-radius:var(--r-container);background:var(--bg2);padding:22px 20px}
+#v-c .pcard .nm{font-size:17px;font-weight:600;display:flex;align-items:baseline;gap:9px;flex-wrap:wrap}
+#v-c .pcard .pr{font-family:var(--mono);font-size:29px;margin-top:14px;letter-spacing:-.02em}
+#v-c .pcard .pr small{font-size:12px;color:var(--tx-faint);display:block;margin-top:6px;letter-spacing:0}
+#v-c .pcard ul{list-style:none;margin-top:18px;display:grid;gap:9px}
+#v-c .pcard li{font-size:13.5px;color:var(--tx-dim);display:flex;gap:9px;align-items:flex-start;line-height:1.55}
+#v-c .pcard li::before{content:'\2713';color:var(--accent);font-family:var(--mono);font-size:12px;flex:none;margin-top:2px}
+#v-c .pcard .btn{margin-top:20px;width:100%}
+#v-c .pnote{margin-top:20px;font-size:14px;color:var(--tx-dim);max-width:64ch;line-height:1.7}
+#v-c .pnote strong{color:var(--tx);font-weight:500}
+
+#v-c .lastcta{margin-top:clamp(52px,8vw,92px);border-top:1px solid var(--line);padding-top:clamp(38px,6vw,60px)}
+#v-c .lastcta h2{font-size:clamp(25px,4.2vw,40px);letter-spacing:-.03em;font-weight:700;max-width:19ch;line-height:1.08}
+#v-c .lastcta .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:24px;align-items:center}
+
+/* ============================ prototype switcher ============================ */
+#switcher{
+  position:fixed;left:50%;transform:translateX(-50%);
+  bottom:calc(14px + env(safe-area-inset-bottom));z-index:9999;
+  display:flex;align-items:stretch;gap:2px;
+  background:oklch(0.12 0.01 260);border:1px solid oklch(0.45 0.02 260);
+  border-radius:10px;padding:4px;box-shadow:0 10px 34px oklch(0 0 0/.55);
+  font-family:var(--mono);max-width:calc(100vw - 20px);
+}
+#switcher button{color:oklch(0.95 0 0);border-radius:7px;min-height:38px;padding:0 12px;display:inline-flex;align-items:center;justify-content:center;font-size:14px}
+#switcher button:hover{background:oklch(0.24 0.02 260)}
+#switcher .lab{color:oklch(0.95 0 0);font-size:11.5px;display:flex;align-items:center;gap:8px;padding:0 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#switcher .lab .kk{color:oklch(0.12 0.01 260);background:oklch(0.82 0.09 195);border-radius:3px;padding:2px 6px;font-weight:700;font-size:10.5px}
+#switcher .sep{width:1px;background:oklch(0.35 0.02 260);margin:6px 2px}
+#switcher .lab .nm{overflow:hidden;text-overflow:ellipsis}
+@media (max-width:480px){#switcher .lab .nm{display:none}}
+</style>
+</head>
+<body>
+
+<!-- ==================================================================== -->
+<!-- VARIANT A — product first                                            -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-a" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk hide-s" href="#">Self-hosting</a>
+      <a class="lnk" href="#a-pricing">Pricing</a>
+      <a class="lnk hide-s" href="#">Changelog</a>
+      <a class="lnk" href="#">GitHub</a>
+      <a class="navcta hide-s" href="#">Sign in</a>
+      <a class="navcta solid" href="#">Start free</a>
+    </nav>
+
+    <header class="hero">
+      <h1>Find out who changed production <em>before</em> the postmortem does.</h1>
+      <p class="sub">hikyo is a control plane for secrets and configuration. Values inherit across
+        environments, get validated before they ship, and always say where they came from. Run it on
+        your own box or let us run it.</p>
+      <div class="cta">
+        <a class="btn primary" href="#">Start free on Cloud</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+        <span class="free">Free for one project. No credit card. Self-hosting is free forever.</span>
+      </div>
+      <p class="facts">
+        <span><b>MPL-2.0</b>, fully open source</span>
+        <span><b>Single binary</b>, Postgres or SQLite</span>
+        <span><b>Compose and Kubernetes</b> first-class</span>
+      </p>
+    </header>
+  </div>
+
+  <div class="shell">
+    <div class="frame">
+      <div class="chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">hikyo.internal / acme / checkout-api</span>
+      </div>
+      <div class="app">
+        <aside class="rail">
+          <div class="rt">acme</div>
+          <div class="ri on">checkout-api <span class="n bad">2</span></div>
+          <div class="ri">ledger <span class="n">61</span></div>
+          <div class="ri">notifier <span class="n">28</span></div>
+          <div class="ri">edge-proxy <span class="n">17</span></div>
+          <hr>
+          <div class="rt">this project</div>
+          <div class="ri">Matrix</div>
+          <div class="ri">History</div>
+          <div class="ri">Workloads</div>
+          <div class="ri">Settings</div>
+        </aside>
+        <div class="pane">
+          <div class="top">
+            <span class="crumb">checkout-api<i>/</i>matrix</span>
+            <span class="chip">4 environments</span>
+            <span class="chip">86 keys</span>
+            <span class="chip warn">! 2 block publish</span>
+          </div>
+          <div class="scroll"><table class="mx" id="mx-a"></table></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="capbar">
+      <div class="legend" id="legend-a"></div>
+      <div class="note">the real surface, not a mockup of one</div>
+    </div>
+
+    <div class="proofbar">
+      <p class="proof">
+        <span><b>4,180</b> stars</span>
+        <span><b>63</b> contributors</span>
+        <span><b>v1.4.0</b> shipped 6 days ago</span>
+        <span><b>1,900+</b> self-hosted instances checking in</span>
+      </p>
+      <div class="backers">
+        <span class="backer"><span class="av">DS</span>Daniel Sada</span>
+        <span class="backer"><span class="av">KH</span>Knud Hollander</span>
+        <span class="backer"><span class="av">MP</span>MakoPhil</span>
+        <span class="backer"><span class="av">+9</span>backers</span>
+      </div>
+    </div>
+
+    <section class="three">
+      <div class="col">
+        <span class="eyebrow">Inheritance</span>
+        <h3>A value written once, everywhere it belongs</h3>
+        <p>Environments inherit from a base. Overriding is explicit and visible in the same row, so you
+          never diff two files to find out which one wins.</p>
+        <div class="art"><div class="cellv dim"><span class="tx">info</span><span class="inh">◂ base</span></div></div>
+      </div>
+      <div class="col">
+        <span class="eyebrow">Validation</span>
+        <h3>Broken config fails here, not at 3am</h3>
+        <p>Every key carries a type, constraints and an optional JSON Schema. Required-but-unset and
+          schema violations block the publish instead of the deploy.</p>
+        <div class="art"><span class="pill missing">! required · unset</span></div>
+      </div>
+      <div class="col">
+        <span class="eyebrow">Disclosure</span>
+        <h3>Reading a secret is an event</h3>
+        <p>Secrets are write-only by default. Revealing one is permission-gated, time-boxed,
+          auto-remasked and written to the audit log, including the copy to your clipboard.</p>
+        <div class="art"><div class="cellv dim"><span class="tx">••••••••</span></div></div>
+      </div>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Provenance</span>
+      <div class="split">
+        <div>
+          <h2>Every resolved value can explain itself.</h2>
+          <p class="lede">Tap a cell and hikyo shows the whole chain: the schema default, the base value,
+            the environment override, and which one actually won. No tribal knowledge, no reading the
+            deployment repo to find out why staging is different.</p>
+        </div>
+        <div class="chain">
+          <div class="ct">LOG_LEVEL · staging</div>
+          <div class="lnk2 dead"><span class="src">defaults</span><span class="val">warn</span><span class="mark">schema</span></div>
+          <div class="lnk2 dead"><span class="src">base</span><span class="val">info</span><span class="mark">◂ inherited</span></div>
+          <div class="lnk2 win"><span class="src">staging</span><span class="val">debug</span><span class="mark">set here</span></div>
+          <div class="out"><span class="lbl">resolved</span><span class="v">debug</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Where it fits</span>
+      <h2>What you are probably doing instead.</h2>
+      <p class="lede">Nothing here is a knock on the alternatives. They solve a narrower problem, and
+        hikyo reads from most of them.</p>
+      <div class="cmpwrap" style="margin-top:22px">
+        <table class="cmp">
+          <thead><tr>
+            <th></th><th class="us">hikyo</th><th>.env files</th><th>SOPS, sealed-secrets</th><th>Vault</th>
+          </tr></thead>
+          <tbody>
+            <tr><th>Inheritance across environments</th><td class="us"><span class="y">✓ built in</span></td><td><span class="n">copy and paste</span></td><td><span class="n">per file</span></td><td><span class="n">by convention</span></td></tr>
+            <tr><th>Validated before it ships</th><td class="us"><span class="y">✓ blocks publish</span></td><td><span class="n">no</span></td><td><span class="n">no</span></td><td><span class="n">no</span></td></tr>
+            <tr><th>Where did this value come from</th><td class="us"><span class="y">✓ one gesture</span></td><td><span class="n">grep</span></td><td><span class="n">git log</span></td><td><span class="n">audit log</span></td></tr>
+            <tr><th>Reveal is a gated, audited event</th><td class="us"><span class="y">✓ reauth, remask</span></td><td><span class="n">it is a file</span></td><td><span class="n">decrypt locally</span></td><td><span class="y">✓ policy</span></td></tr>
+            <tr><th>A screen a teammate can use</th><td class="us"><span class="y">✓ the matrix</span></td><td><span class="n">no</span></td><td><span class="n">no</span></td><td><span class="n">token first</span></td></tr>
+            <tr><th>Runs entirely on your hardware</th><td class="us"><span class="y">✓ free forever</span></td><td><span class="y">✓</span></td><td><span class="y">✓</span></td><td><span class="y">✓</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="blk" id="a-pricing">
+      <span class="eyebrow">Pricing</span>
+      <h2>Self-hosting is not the crippled tier.</h2>
+      <p class="lede">It is the same binary with every feature on this page. Cloud is what you pay for
+        when you would rather not run Postgres at midnight.</p>
+      <div class="tiers">
+        <div class="tier feat">
+          <div class="nm">Self-hosted <span class="tag">MPL 2.0</span></div>
+          <div class="pr">Free<small>forever, no seat count</small></div>
+          <div class="ft">Unlimited projects, environments and members. Every feature. Your keyring, your database, your backups.</div>
+          <div class="go"><a class="btn" href="#">Install guide</a></div>
+        </div>
+        <div class="tier">
+          <div class="nm">Cloud Free</div>
+          <div class="pr">$0<small>no credit card</small></div>
+          <div class="ft">1 project, 3 environments, 2 members, 30-day audit history. For trying it on something real.</div>
+          <div class="go"><a class="btn" href="#">Start free</a></div>
+        </div>
+        <div class="tier">
+          <div class="nm">Cloud Team</div>
+          <div class="pr">$19<small>per member / month</small></div>
+          <div class="ft">Unlimited projects and environments, SSO, 1-year audit retention, daily backups, priority support.</div>
+          <div class="go"><a class="btn primary" href="#">Start 14-day trial</a></div>
+        </div>
+        <div class="tier">
+          <div class="nm">Enterprise</div>
+          <div class="pr">Talk to us<small>or supported self-host</small></div>
+          <div class="ft">SAML, air-gapped install, custom KMS, an SLA, and a human who answers on a Sunday.</div>
+          <div class="go"><a class="btn" href="#">Contact</a></div>
+        </div>
+      </div>
+      <p class="tiernote"><strong>The catch, stated plainly:</strong> there is no feature we hold back
+        from the self-hosted build to push you onto Cloud. If that ever changes, it changes in a
+        release note, not quietly.</p>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Why this exists</span>
+      <div class="founder" style="margin-top:22px">
+        <div class="who">
+          <span class="av">MW</span>
+          <span><span class="nm">Alex E.</span><br><span class="rl">building hikyo</span></span>
+        </div>
+        <div class="said">
+          <p>I spent an afternoon working out which <code class="mono">DATABASE_URL</code> production was
+            actually using. The answer lived in four places: a compose file, a sealed secret, a wiki page
+            that was wrong, and someone's memory.</p>
+          <p><strong>Config is a distributed system and we keep treating it like a text file.</strong>
+            hikyo is the screen I wanted that afternoon: every environment side by side, every value
+            able to say where it came from, and a reveal that costs something so nobody does it idly.</p>
+          <p>It is MPL 2.0 and self-hostable because the tool that holds your production secrets should
+            not be a tool you can lose access to.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Questions</span>
+      <h2>The things people ask before they trust it.</h2>
+      <div class="faq" id="faq-a" style="margin-top:24px"></div>
+    </section>
+
+    <section class="lastcta">
+      <h2>Put your production config somewhere it can explain itself.</h2>
+      <div class="cta">
+        <a class="btn primary" href="#">Start free on Cloud</a>
+        <a class="btn" href="#">Self-host in 4 minutes</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <div class="cols">
+        <div><h4>Product</h4>
+          <a href="#">The matrix</a><a href="#">Provenance</a><a href="#">Reveal and audit</a><a href="#">Kubernetes operator</a><a href="#">CLI</a></div>
+        <div><h4>Cloud</h4>
+          <a href="#a-pricing">Pricing</a><a href="#">Start free</a><a href="#">Sign in</a><a href="#">Status</a></div>
+        <div><h4>Self-hosting</h4>
+          <a href="#">Install guide</a><a href="#">Docker Compose</a><a href="#">Helm chart</a><a href="#">Backups and keyring</a></div>
+        <div><h4>Compare</h4>
+          <a href="#">vs .env files</a><a href="#">vs SOPS</a><a href="#">vs Vault</a><a href="#">vs Doppler</a><a href="#">vs Infisical</a></div>
+        <div><h4>Company</h4>
+          <a href="#">Docs</a><a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a><a href="#">Sponsor</a></div>
+      </div>
+      <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype: every price, number, org and URL on this page is invented</div>
+    </footer>
+  </div>
+</main>
+
+<!-- ==================================================================== -->
+<!-- VARIANT B — typographic argument                                      -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-b" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk" href="#b-pricing">Pricing</a>
+      <a class="lnk" href="#">GitHub</a>
+      <a class="navcta solid" href="#">Start free</a>
+    </nav>
+
+    <header class="hero">
+      <h1>The value that ships <span class="q">is not</span> the value you wrote.</h1>
+      <p class="sub">Config inherits, gets overridden, drifts, and then explains none of it. hikyo is a
+        control plane that makes the whole chain visible, and refuses to publish it when it is wrong.
+        Self-host it free, or start on Cloud in a minute.</p>
+      <p class="meta">
+        <a href="#">Start free on Cloud</a>
+        <a href="#">Self-host in 4 minutes</a>
+        <span>MPL-2.0</span>
+        <span>single binary</span>
+        <span>no telemetry</span>
+      </p>
+      <p class="proof">
+        <span><b>4,180</b> stars</span>
+        <span><b>63</b> contributors</span>
+        <span><b>1,900+</b> self-hosted instances</span>
+        <span><b>v1.4.0</b> six days ago</span>
+      </p>
+    </header>
+  </div>
+
+  <div class="shell">
+    <section class="claim">
+      <div class="g">
+        <div class="n">01 / ORIGIN</div>
+        <div>
+          <h2>Four environments, one row, <em>no diffing</em>.</h2>
+          <p>Base holds what is true everywhere. Each environment states only its disagreements. The row
+            shows which of them won, and the arrow says where the rest came from, so an override is a
+            decision you can see rather than one you discover.</p>
+        </div>
+        <div class="art">
+          <div class="chain">
+            <div class="ct">LOG_LEVEL</div>
+            <div class="lnk2 dead"><span class="src">defaults</span><span class="val">warn</span><span class="mark">schema</span></div>
+            <div class="lnk2 dead"><span class="src">base</span><span class="val">info</span><span class="mark">◂ inherited</span></div>
+            <div class="lnk2 win"><span class="src">staging</span><span class="val">debug</span><span class="mark">set here</span></div>
+            <div class="out"><span class="lbl">resolved · staging</span><span class="v">debug</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">02 / VALIDATION</div>
+        <div>
+          <h2>The bad value never reaches the deploy.</h2>
+          <p>Keys are declared before they are filled: type, constraints, required-in-which-environments,
+            and JSON Schema when the shape matters. Publishing runs the whole set. A violation stops the
+            publish, not the pod.</p>
+        </div>
+        <div class="art">
+          <div class="viol">
+            <div class="h">✕ publish refused · production</div>
+            <div class="l"><b>SMTP_PORT</b> = "587 ", expected <b>int</b>, got string</div>
+            <div class="l"><b>STRIPE_WEBHOOK_SECRET</b>, required in production, unset</div>
+            <div class="l" style="color:var(--tx-faint);margin-top:6px">2 violations · 84 keys checked · nothing was written</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">03 / DISCLOSURE</div>
+        <div>
+          <h2>Writing a secret does not require <em>reading</em> it.</h2>
+          <p>Rotation, seeding and correction all work write-only. Reveal is a separate, gated act:
+            reauth, a fixed window, an automatic remask, and a line in the audit log. The clipboard
+            counts as a disclosure too.</p>
+        </div>
+        <div class="art">
+          <div class="term">
+            <div class="bar">terminal</div>
+<pre><span class="p">$</span> hikyo set <b>DATABASE_URL</b> --env prod --stdin
+<span class="c">reading value from stdin, not echoed…</span>
+<span class="ok">✓</span> wrote prod/DATABASE_URL <span class="c">(rev 30, write-only)</span>
+
+<span class="p">$</span> hikyo get <b>DATABASE_URL</b> --env prod
+<span class="er">✕</span> refused: reveal in <b>production</b> requires reauth
+  <span class="c">run: hikyo auth reveal --env prod   (window 60s)</span></pre>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim">
+      <div class="g">
+        <div class="n">04 / DELIVERY</div>
+        <div>
+          <h2>Compose and Kubernetes are not an afterthought.</h2>
+          <p>A workload gets a machine identity, not a copy of your .env. The operator reconciles a
+            pinned revision into a Secret and reports what it did in conditions you can read with
+            kubectl. No sidecar, no init-container hack.</p>
+        </div>
+        <div class="art">
+          <div class="cond">
+            <div class="r"><span class="t">Ready</span><span class="s">✓ True</span><span class="m">Synced revision 41 to secret/checkout-api-env</span></div>
+            <div class="r"><span class="t">Validated</span><span class="s">✓ True</span><span class="m">84 keys, 0 violations</span></div>
+            <div class="r"><span class="t">Drifted</span><span class="s no">! True</span><span class="m">secret edited outside hikyo, restored, 1 key</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim wide">
+      <div class="g">
+        <div class="n">05 / THE SURFACE</div>
+        <div>
+          <h2>And it stays readable at eighty keys.</h2>
+          <p>Grouping, collapsing and per-environment visibility are how the matrix earns its room, on a
+            27-inch display and on the phone you are holding in the server closet. State is never
+            carried by colour alone.</p>
+        </div>
+        <div class="art">
+          <div class="strip">
+            <div class="sh">checkout-api · matrix</div>
+            <div class="sb"><table class="mx" id="mx-b"></table></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim" id="b-pricing">
+      <div class="g">
+        <div class="n">06 / THE DEAL</div>
+        <div>
+          <h2>Self-hosting is not the <em>crippled</em> tier.</h2>
+          <p>It is the same binary with every feature above. Cloud is what you pay for when you would
+            rather not run Postgres at midnight.</p>
+        </div>
+        <div class="art"></div>
+      </div>
+      <div style="margin-top:14px">
+        <div class="prow free">
+          <div class="nm">Self-hosted<span>Unlimited projects, environments and members. Your keyring, your database, your backups. MPL-2.0.</span></div>
+          <div class="pr">Free<small>forever, no seat count</small></div>
+          <div><a class="btn" href="#">Install guide</a></div>
+        </div>
+        <div class="prow">
+          <div class="nm">Cloud Free<span>One project, three environments, two members, 30-day audit history. For trying it on something real.</span></div>
+          <div class="pr">$0<small>no credit card</small></div>
+          <div><a class="btn" href="#">Start free</a></div>
+        </div>
+        <div class="prow">
+          <div class="nm">Cloud Team<span>Unlimited projects and environments, SSO, one-year audit retention, daily backups, priority support.</span></div>
+          <div class="pr">$19<small>per member / month</small></div>
+          <div><a class="btn primary" href="#">Start 14-day trial</a></div>
+        </div>
+        <div class="prow">
+          <div class="nm">Enterprise<span>SAML, air-gapped install, custom KMS, an SLA, and a human who answers on a Sunday.</span></div>
+          <div class="pr">Talk<small>or supported self-host</small></div>
+          <div><a class="btn" href="#">Contact</a></div>
+        </div>
+        <p class="pnote"><strong>The catch, stated plainly:</strong> there is no feature held back from
+          the self-hosted build to push you onto Cloud. If that ever changes, it changes in a release
+          note, not quietly.</p>
+      </div>
+    </section>
+
+    <section class="signed">
+      <blockquote>Config is a distributed system and we keep treating it like a text file.</blockquote>
+      <div class="rest">
+        <div>
+          <p>I spent an afternoon working out which <code class="mono">DATABASE_URL</code> production was
+            actually using. The answer lived in four places: a compose file, a sealed secret, a wiki page
+            that was wrong, and someone's memory.</p>
+          <p>hikyo is the screen I wanted that afternoon. It is MPL 2.0 and self-hostable because the tool
+            that holds your production secrets should not be a tool you can lose access to.</p>
+        </div>
+        <div class="sig">
+          <span class="av">MW</span>
+          <span><span class="nm">Alex E.</span><br><span class="rl">building hikyo</span></span>
+        </div>
+      </div>
+    </section>
+
+    <div id="b-qa"></div>
+
+    <section class="closing">
+      <h2>Take the whole thing home.</h2>
+      <div class="cta">
+        <a class="btn primary" href="#">Start free on Cloud</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+      </div>
+      <p class="free">Free for one project on Cloud. Free forever on your own hardware.</p>
+      <footer class="foot">
+        <div class="cols">
+          <div><h4>Product</h4><a href="#">The matrix</a><a href="#">Provenance</a><a href="#">Reveal and audit</a><a href="#">Kubernetes operator</a></div>
+          <div><h4>Cloud</h4><a href="#b-pricing">Pricing</a><a href="#">Start free</a><a href="#">Sign in</a><a href="#">Status</a></div>
+          <div><h4>Self-hosting</h4><a href="#">Install guide</a><a href="#">Helm chart</a><a href="#">Backups and keyring</a></div>
+          <div><h4>Compare</h4><a href="#">vs .env files</a><a href="#">vs SOPS</a><a href="#">vs Vault</a><a href="#">vs Doppler</a></div>
+          <div><h4>Company</h4><a href="#">Docs</a><a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a></div>
+        </div>
+        <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype: every price, number, org and URL on this page is invented</div>
+      </footer>
+    </section>
+  </div>
+</main>
+
+<!-- ==================================================================== -->
+<!-- VARIANT C — live console                                              -->
+<!-- ==================================================================== -->
+<main class="variant" id="v-c" hidden>
+  <div class="shell">
+    <nav class="nav">
+      <a class="brand" href="#"><svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="6" fill="var(--bg3)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.6" stroke-linecap="round"/></svg>hikyo</a>
+      <span class="grow"></span>
+      <a class="lnk hide-s" href="#">Docs</a>
+      <a class="lnk hide-s" href="#">Self-hosting</a>
+      <a class="lnk" href="#c-pricing">Pricing</a>
+      <a class="lnk" href="#">GitHub</a>
+      <a class="navcta solid" href="#">Start free</a>
+    </nav>
+
+    <header class="hero">
+      <h1>Watch a value <em>resolve</em>.</h1>
+      <p class="sub">hikyo is a control plane for inherited, validated secrets and configuration. This is
+        the real thing, running on sample data. Click around, then decide whether to host it yourself.</p>
+      <p class="hint">pick an environment, then a key</p>
+      <p class="heroLinks">
+        <a href="#">Start free on Cloud</a>
+        <a href="#">Self-host in 4 minutes</a>
+        <span>MPL-2.0 · 4,180 stars</span>
+      </p>
+    </header>
+
+    <div class="console">
+      <div class="envs" role="tablist" aria-label="environment" id="c-envs"></div>
+      <div class="body">
+        <div class="keys" id="c-keys"></div>
+        <div class="detail" id="c-detail"></div>
+      </div>
+      <div class="cli">
+        <div class="bar">the same thing, from the terminal</div>
+        <pre id="c-cli"></pre>
+      </div>
+    </div>
+
+    <div class="proofbar-c" style="margin-top:18px;display:flex;flex-wrap:wrap;gap:14px 28px;align-items:center;justify-content:space-between">
+      <p class="proof">
+        <span><b>4,180</b> stars</span>
+        <span><b>63</b> contributors</span>
+        <span><b>1,900+</b> self-hosted instances checking in</span>
+        <span><b>v1.4.0</b> six days ago</span>
+      </p>
+      <div class="backers">
+        <span class="backer"><span class="av">DS</span>Daniel Sada</span>
+        <span class="backer"><span class="av">KH</span>Knud Hollander</span>
+        <span class="backer"><span class="av">+10</span>backers</span>
+      </div>
+    </div>
+
+    <div class="demos">
+      <section class="demo">
+        <span class="eyebrow">Validation</span>
+        <h2>Type a bad port. See what the publish would do.</h2>
+        <p>Every key is declared before it is filled. <span class="mono">SMTP_PORT</span> is an
+          <span class="mono">int</span> with range 1 to 65535 and is required in production, so a stray
+          space is a refused publish rather than a paged engineer.</p>
+        <div class="box">
+          <div class="vform">
+            <label for="c-val">SMTP_PORT · production</label>
+            <div class="in"><input id="c-val" value="587 " autocomplete="off" spellcheck="false" aria-describedby="c-verdict"></div>
+            <div class="verdict" id="c-verdict"></div>
+            <div class="rules">declared: int · min 1 · max 65535 · required in [staging, production]</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo">
+        <span class="eyebrow">Blast radius</span>
+        <h2>Change the base value. Watch who follows.</h2>
+        <p>Overrides are the only thing that stays put. Everything inheriting from base moves with it,
+          and hikyo tells you how many environments that is before you publish.</p>
+        <div class="box">
+          <div class="vform">
+            <label for="c-base">base · LOG_LEVEL</label>
+            <div class="in"><input id="c-base" value="info" autocomplete="off" spellcheck="false"></div>
+            <div class="verdict" id="c-blast" style="color:var(--tx-dim)"></div>
+            <div class="rules" id="c-blastrows"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo">
+        <span class="eyebrow">Migration</span>
+        <h2>Paste a .env. See what hikyo would make of it.</h2>
+        <p>This is the actual first step: <span class="mono">hikyo scaffold --from .env</span> reads what
+          you already have, guesses a type per key, flags the ones that look like secrets, and writes
+          definitions for you to review before anything is applied.</p>
+        <div class="box">
+          <div class="vform">
+            <label for="c-env">paste or edit, nothing leaves your browser</label>
+            <textarea id="c-env" spellcheck="false" autocomplete="off">DATABASE_URL=postgres://app:hunter2@db:5432/app
+PORT=8080
+LOG_LEVEL=info
+SMTP_PORT=587
+STRIPE_SECRET_KEY=sk_live_51H8xQ2
+FEATURE_FLAGS={"beta":true}
+DEBUG=false</textarea>
+            <div class="out" id="c-scaffold"></div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="blk" id="c-pricing">
+      <span class="eyebrow">Pricing</span>
+      <h2>Self-hosting is not the crippled tier.</h2>
+      <p class="lede">Same binary, every feature. Pick who runs it.</p>
+      <div class="ptoggle" role="group" aria-label="deployment">
+        <button id="p-self" aria-pressed="true">I will host it</button>
+        <button id="p-cloud" aria-pressed="false">You host it</button>
+      </div>
+      <div class="pbody" id="c-pbody"></div>
+      <p class="pnote"><strong>The catch, stated plainly:</strong> there is no feature held back from the
+        self-hosted build to push you onto Cloud. If that ever changes, it changes in a release note,
+        not quietly.</p>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Why this exists</span>
+      <div class="founder" style="margin-top:22px">
+        <div class="who">
+          <span class="av">MW</span>
+          <span><span class="nm">Alex E.</span><br><span class="rl">building hikyo</span></span>
+        </div>
+        <div class="said">
+          <p>I spent an afternoon working out which <code class="mono">DATABASE_URL</code> production was
+            actually using. The answer lived in four places: a compose file, a sealed secret, a wiki page
+            that was wrong, and someone's memory.</p>
+          <p><strong>Config is a distributed system and we keep treating it like a text file.</strong>
+            hikyo is the screen I wanted that afternoon, and it is MPL 2.0 because the tool holding your
+            production secrets should not be one you can lose access to.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="blk">
+      <span class="eyebrow">Questions</span>
+      <h2>The things people ask before they trust it.</h2>
+      <div class="faq" id="faq-c" style="margin-top:24px"></div>
+    </section>
+
+    <section class="lastcta">
+      <h2>Put your production config somewhere it can explain itself.</h2>
+      <div class="cta">
+        <a class="btn primary" href="#">Start free on Cloud</a>
+        <div class="install">
+          <code><span class="c">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b></code>
+          <button class="cp" data-copy="curl -fsSL https://get.hikyo.dev | sh">copy</button>
+        </div>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <div class="cols">
+        <div><h4>Product</h4><a href="#">The matrix</a><a href="#">Provenance</a><a href="#">Reveal and audit</a><a href="#">Kubernetes operator</a><a href="#">CLI</a></div>
+        <div><h4>Cloud</h4><a href="#c-pricing">Pricing</a><a href="#">Start free</a><a href="#">Sign in</a><a href="#">Status</a></div>
+        <div><h4>Self-hosting</h4><a href="#">Install guide</a><a href="#">Docker Compose</a><a href="#">Helm chart</a><a href="#">Backups and keyring</a></div>
+        <div><h4>Compare</h4><a href="#">vs .env files</a><a href="#">vs SOPS</a><a href="#">vs Vault</a><a href="#">vs Doppler</a><a href="#">vs Infisical</a></div>
+        <div><h4>Company</h4><a href="#">Docs</a><a href="#">Changelog</a><a href="#">GitHub</a><a href="#">Security</a><a href="#">Sponsor</a></div>
+      </div>
+      <div class="fine">hikyo · MPL-2.0 · no analytics on this page<br>prototype: every price, number, org and URL on this page is invented</div>
+    </footer>
+  </div>
+</main>
+
+<div id="switcher" role="group" aria-label="prototype variant switcher">
+  <button id="sw-prev" title="previous variant (←)" aria-label="previous variant">‹</button>
+  <span class="sep"></span>
+  <span class="lab"><span class="kk" id="sw-key">A</span><span class="nm" id="sw-name"></span></span>
+  <span class="sep"></span>
+  <button id="sw-next" title="next variant (→)" aria-label="next variant">›</button>
+  <span class="sep"></span>
+  <button id="sw-theme" title="light / dark" aria-label="switch light or dark theme">◐</button>
+</div>
+
+<script>
+/* ===================== shared sample data ===================== */
+const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+const ENVS = [
+  {id:'dev',  name:'development', base:null,  protected:false},
+  {id:'stg',  name:'staging',     base:'base',protected:false},
+  {id:'pre',  name:'preview',     base:'base',protected:false},
+  {id:'prd',  name:'production',  base:'base',protected:true},
+];
+
+const GROUPS = [
+  {name:'app', keys:[
+    {k:'APP_ENV',    secret:false, cells:{dev:{v:'development'}, stg:{v:'staging'}, pre:{v:'preview'}, prd:{v:'production'}}},
+    {k:'LOG_LEVEL',  secret:false, cells:{dev:{v:'debug'}, stg:{v:'debug', changed:true}, pre:{inh:'base', v:'info'}, prd:{inh:'base', v:'info'}}},
+    {k:'PORT',       secret:false, cells:{dev:{inh:'base', v:'8080'}, stg:{inh:'base', v:'8080'}, pre:{inh:'base', v:'8080'}, prd:{inh:'base', v:'8080'}}},
+    {k:'FEATURE_FLAGS', secret:false, cells:{dev:{v:'{"beta":true}'}, stg:{v:'{"beta":true}'}, pre:{v:'{"beta":true}'}, prd:{v:'{"beta":false}'}}},
+  ]},
+  {name:'database', keys:[
+    {k:'DATABASE_URL', secret:true, cells:{dev:{v:'••••••••'}, stg:{v:'••••••••'}, pre:{v:'••••••••'}, prd:{v:'••••••••'}}},
+    {k:'DB_POOL_MAX',  secret:false, cells:{dev:{inh:'base', v:'10'}, stg:{inh:'base', v:'10'}, pre:{inh:'base', v:'10'}, prd:{v:'60'}}},
+    {k:'DB_SSLMODE',   secret:false, cells:{dev:{def:true, v:'prefer'}, stg:{def:true, v:'prefer'}, pre:{def:true, v:'prefer'}, prd:{v:'verify-full'}}},
+  ]},
+  {name:'mail & billing', keys:[
+    {k:'SMTP_HOST',   secret:false, cells:{dev:{v:'mailpit:1025'}, stg:{inh:'base', v:'smtp.eu.example'}, pre:{inh:'base', v:'smtp.eu.example'}, prd:{inh:'base', v:'smtp.eu.example'}}},
+    {k:'SMTP_PORT',   secret:false, cells:{dev:{v:'1025'}, stg:{inh:'base', v:'587'}, pre:{inh:'base', v:'587'}, prd:{invalid:'expected int', v:'587 '}}},
+    {k:'STRIPE_WEBHOOK_SECRET', secret:true, cells:{dev:{v:'••••••••'}, stg:{v:'••••••••'}, pre:null, prd:{missing:true}}},
+  ]},
+];
+
+function cellHTML(cell){
+  if(!cell) return `<span class="cellv absent"><span class="tx">·</span></span>`;
+  if(cell.missing) return `<span class="pill missing">! required · unset</span>`;
+  if(cell.invalid) return `<span class="pill invalid" title="${esc(cell.invalid)}">✕ ${esc(cell.v)}</span>`;
+  const cls = ['cellv'];
+  if(cell.inh || cell.def) cls.push('dim');
+  const inh = cell.inh ? `<span class="inh">◂ ${esc(cell.inh)}</span>`
+            : cell.def ? `<span class="inh">◂ def</span>` : '';
+  const d = cell.changed ? `<span class="d" title="changed since last publish">Δ</span>` : '';
+  return `<span class="${cls.join(' ')}"><span class="tx">${esc(cell.v)}</span>${inh}${d}</span>`;
+}
+
+function renderMatrix(tableId, envIds){
+  const table = document.getElementById(tableId);
+  if(!table) return;
+  const envs = ENVS.filter(e => envIds.includes(e.id));
+  let html = `<thead><tr><th class="keyh">key</th>` + envs.map(e =>
+    `<th>${esc(e.name)}${e.base ? `<span class="base">◂ ${esc(e.base)}</span>` : `<span class="base">standalone</span>`}</th>`
+  ).join('') + `</tr></thead><tbody>`;
+  for(const g of GROUPS){
+    html += `<tr class="grp"><td colspan="${envs.length+1}"><div class="g">▾ ${esc(g.name)}<span class="gcnt">${g.keys.length} keys</span></div></td></tr>`;
+    g.keys.forEach((k, i) => {
+      html += `<tr class="${i%2 ? 'alt' : ''}"><td class="key">${k.secret ? '<span class="lock" title="secret">🔒</span>' : ''}${esc(k.k)}</td>`;
+      html += envs.map(e => `<td>${cellHTML(k.cells[e.id])}</td>`).join('');
+      html += `</tr>`;
+    });
+  }
+  table.innerHTML = html + `</tbody>`;
+}
+
+function renderLegend(id){
+  const el = document.getElementById(id);
+  if(!el) return;
+  el.innerHTML = [
+    `<span class="k"><span class="cellv"><span class="tx">value</span></span> set here</span>`,
+    `<span class="k"><span class="cellv dim"><span class="tx">value</span><span class="inh">◂ base</span></span> inherited</span>`,
+    `<span class="k"><span class="cellv absent"><span class="tx">·</span></span> not set</span>`,
+    `<span class="k"><span class="pill missing">! required · unset</span></span>`,
+    `<span class="k"><span class="pill invalid">✕ value</span> schema violation</span>`,
+  ].join('');
+}
+
+/* ===================== commercial layer: shared copy ===================== */
+/* Data is shared; each variant renders it in its own idiom. */
+const FAQ = [
+  {q:'What is hikyo, in one paragraph?',
+   a:`<p>A control plane for the configuration and secrets your services read at boot. You declare each
+      key once (type, constraints, which environments require it), set values per environment with
+      inheritance from a shared base, and publish a revision. Workloads pull that revision through a
+      machine identity, on Docker Compose or through the Kubernetes operator. It is open source and
+      runs on your own hardware; a managed Cloud exists for people who would rather not.</p>`},
+  {q:'Is the self-hosted build missing features?',
+   a:`<p>No. It is the same binary as Cloud, with every feature on this page: the matrix, provenance,
+      validation, reveal ceremonies, the audit log, the operator, SSO. Unlimited projects,
+      environments and members.</p>
+      <p>Cloud sells operations, not features: we run the Postgres, take the backups, keep the thing
+      patched, and answer the phone. If a feature ever becomes Cloud-only it will be announced in a
+      release note, not discovered.</p>`},
+  {q:'Can you read my secrets on Cloud?',
+   a:`<p>By default, yes, technically: values are encrypted per project with a keyring we hold, so an
+      operator with database and key access could decrypt them. Anyone who tells you otherwise about a
+      hosted secrets product is selling something.</p>
+      <p>Two honest answers to that. Bring your own KMS on Cloud Team and up, so the root key lives in
+      your AWS or GCP account and we hold ciphertext we cannot open. Or self-host, where the question
+      does not arise. Every reveal is in your audit log either way, including ours.</p>`},
+  {q:'What happens if you disappear?',
+   a:`<p>The code is MPL-2.0 and the whole server is in the repository, so the project outlives the
+      company by construction. <code>hikyo export</code> writes every project, revision and value to a
+      plain archive you can import into a self-hosted instance, and Cloud accounts can trigger it any
+      time without asking us.</p>`},
+  {q:'What is actually free on Cloud?',
+   a:`<p>One project, three environments, two members, and thirty days of audit history. No credit
+      card, no trial clock on the free tier. It is enough to run one real service, which is the point.</p>`},
+  {q:'How is this different from Vault?',
+   a:`<p>Vault is a secrets engine: excellent at storage, leasing, dynamic credentials and policy.
+      hikyo is the layer above it, the one that knows <em>DATABASE_URL in staging inherits from base and
+      production overrides it</em>, and that shows the whole set on one screen.</p>
+      <p>They compose. hikyo can resolve values out of Vault, so you keep the engine and get the
+      environment matrix on top.</p>`},
+  {q:'Does it work with Kubernetes?',
+   a:`<p>Yes, through an operator rather than a sidecar. You pin a workload to a revision, the operator
+      reconciles it into a Secret, and it reports what happened in CR conditions you read with
+      <code>kubectl</code>: Ready, Validated, Drifted. Edit that Secret by hand and the drift condition
+      goes true and it gets restored.</p>`},
+  {q:'Who is behind this?',
+   a:`<p>One person, self-funded, working on it in the open. There is no runway to burn and no board
+      asking about seat expansion, which is why self-hosting is free forever rather than free until it
+      is inconvenient. Sponsorship pays for the release time.</p>`},
+];
+
+const TIERS = {
+  self: {
+    nm:'Self-hosted', tag:'MPL 2.0',
+    pr:'Free', sub:'forever, no seat count',
+    ft:['Unlimited projects, environments and members','Every feature: matrix, provenance, reveal ceremonies, audit log, operator, SSO','Your keyring, your database, your backups','Postgres or SQLite, one binary or one container','Community support on GitHub and Discord'],
+    cta:'Install guide', primary:false,
+    cli:`<span class="p">$</span> curl -fsSL https://get.hikyo.dev | <b>sh</b>\n<span class="ok">✓</span> hikyo 1.4.0 installed\n\n<span class="p">$</span> hikyo serve --db sqlite:///var/hikyo.db\n<span class="ok">✓</span> listening on <b>:8080</b> · keyring unlocked · 0 projects\n<span class="c">  no licence check, no callback, no seat count</span>`,
+  },
+  cloud: {
+    nm:'Cloud Team', tag:'',
+    pr:'$19', sub:'per member / month, billed monthly',
+    ft:['Everything in the self-hosted build','We run Postgres, backups and upgrades','SSO and one-year audit retention','Bring your own KMS, so we hold ciphertext we cannot open','Priority support, and a free tier to start on'],
+    cta:'Start 14-day trial', primary:true,
+    cli:`<span class="p">$</span> hikyo login\n<span class="ok">✓</span> authenticated as alex@example.com <span class="c">(acme, Cloud Team)</span>\n\n<span class="p">$</span> hikyo get <b>LOG_LEVEL</b> --env stg\n<b>debug</b>\n<span class="c">  origin: staging · same CLI, same API, someone else's Postgres</span>`,
+  },
+};
+
+/* faq: stacked disclosure (variants a and c) */
+function renderFAQ(id){
+  const el = document.getElementById(id);
+  if(!el) return;
+  el.innerHTML = FAQ.map((f, i) => `
+    <details${i === 0 ? ' open' : ''}>
+      <summary>${esc(f.q)}</summary>
+      <div class="a">${f.a}</div>
+    </details>`).join('');
+}
+
+/* faq: numbered claim rail (variant b keeps its own idiom) */
+function renderQA(){
+  const el = document.getElementById('b-qa');
+  if(!el) return;
+  el.innerHTML = FAQ.map((f, i) => `
+    <section class="qa">
+      <div class="g">
+        <div class="n">${String(i + 7).padStart(2, '0')} / ASKED</div>
+        <div><h3>${esc(f.q)}</h3></div>
+        <div>${f.a}</div>
+      </div>
+    </section>`).join('');
+}
+
+/* pricing toggle (variant c) */
+let pMode = 'self';
+function renderPricing(){
+  const el = document.getElementById('c-pbody');
+  if(!el) return;
+  const t = TIERS[pMode];
+  el.innerHTML = `
+    <div class="pcard">
+      <div class="nm">${esc(t.nm)}${t.tag ? `<span class="mono" style="font-size:10px;letter-spacing:.1em;color:var(--tx-faint)">${esc(t.tag)}</span>` : ''}</div>
+      <div class="pr">${esc(t.pr)}<small>${esc(t.sub)}</small></div>
+      <ul>${t.ft.map(f => `<li>${esc(f)}</li>`).join('')}</ul>
+      <a class="btn${t.primary ? ' primary' : ''}" href="#">${esc(t.cta)}</a>
+    </div>
+    <div class="term">
+      <div class="bar">what that looks like</div>
+      <pre>${t.cli}</pre>
+    </div>`;
+  document.getElementById('p-self').setAttribute('aria-pressed', String(pMode === 'self'));
+  document.getElementById('p-cloud').setAttribute('aria-pressed', String(pMode === 'cloud'));
+}
+
+/* ===================== variant C — live console ===================== */
+const C = {env:'stg', key:'LOG_LEVEL', revealed:false, reauth:false, timer:null, left:0};
+
+const C_KEYS = [
+  {g:'app', k:'LOG_LEVEL', type:'string', secret:false,
+   desc:'How chatty the service is. Staging overrides base so we can follow a request end to end.',
+   def:'warn', base:'info', over:{dev:'debug', stg:'debug'}},
+  {g:'app', k:'PORT', type:'int', secret:false,
+   desc:'Listen port. Nobody has ever needed to override this, so nobody has.',
+   def:'8080', base:'8080', over:{}},
+  {g:'database', k:'DATABASE_URL', type:'url', secret:true,
+   desc:'Written per environment, never inherited. Production is protected: revealing it needs reauth.',
+   def:null, base:null, over:{dev:'postgres://app:devpw@localhost:5432/app',
+                              stg:'postgres://app:s3cr3t@db.stg.internal:5432/app',
+                              prd:'postgres://app:hunter2@db.prd.internal:5432/app'}},
+  {g:'database', k:'DB_SSLMODE', type:'string', secret:false,
+   desc:'Nobody set this outside production, so the rest ride the schema default and the cell says so.',
+   def:'prefer', base:null, over:{prd:'verify-full'}},
+  {g:'mail & billing', k:'SMTP_PORT', type:'int', secret:false,
+   desc:'Declared int, range 1 to 65535, required in staging and production.',
+   def:null, base:'587', over:{dev:'1025'}, invalid:{prd:'587 '}},
+  {g:'mail & billing', k:'STRIPE_WEBHOOK_SECRET', type:'string', secret:true,
+   desc:'Required in production and not there yet, which is why production cannot publish.',
+   def:null, base:null, over:{dev:'whsec_dev_9f2c', stg:'whsec_stg_41ab'}, required:['prd']},
+];
+
+const cKey = () => C_KEYS.find(k => k.k === C.key);
+const cEnv = () => ENVS.find(e => e.id === C.env);
+
+function resolve(k, envId){
+  if(k.invalid && k.invalid[envId] !== undefined){
+    return {invalid:k.invalid[envId], chain:[
+      {src:'defaults', val:k.def, state:'dead'},
+      {src:'base', val:k.base, state:'dead'},
+      {src:envId, val:k.invalid[envId], state:'invalid'},
+    ].filter(l => l.val !== null && l.val !== undefined)};
+  }
+  const chain = [];
+  if(k.def !== null && k.def !== undefined) chain.push({src:'defaults', val:k.def, mark:'schema'});
+  if(k.base !== null && k.base !== undefined) chain.push({src:'base', val:k.base, mark:'◂ inherited'});
+  const o = k.over[envId];
+  if(o !== undefined) chain.push({src:envId, val:o, mark:'set here'});
+  if(!chain.length) return {missing:(k.required || []).includes(envId), chain:[], value:null};
+  const winner = chain.length - 1;
+  chain.forEach((l, i) => l.state = i === winner ? 'win' : 'dead');
+  return {value:chain[winner].val, origin:chain[winner].src, chain};
+}
+
+function renderConsoleEnvs(){
+  document.getElementById('c-envs').innerHTML = ENVS.map(e => `
+    <button role="tab" aria-selected="${e.id === C.env}" data-env="${e.id}">
+      ${esc(e.name)}
+      ${e.base ? `<span class="lk">◂ ${esc(e.base)}</span>` : `<span class="lk">standalone</span>`}
+      ${e.protected ? `<span class="prot">PROTECTED</span>` : ''}
+    </button>`).join('');
+}
+
+function renderConsoleKeys(){
+  let html = '', group = null;
+  for(const k of C_KEYS){
+    if(k.g !== group){ group = k.g; html += `<div class="kg">${esc(group)}</div>`; }
+    const r = resolve(k, C.env);
+    const st = r.invalid ? `<span class="st bad">✕ invalid</span>`
+             : r.missing ? `<span class="st bad">! unset</span>`
+             : r.origin === C.env ? `<span class="st">set here</span>`
+             : r.value === null ? `<span class="st">·</span>`
+             : `<span class="st">◂ ${esc(r.origin)}</span>`;
+    html += `<button data-key="${esc(k.k)}" aria-current="${k.k === C.key}">
+      ${k.secret ? '<span class="lock" title="secret">🔒</span>' : ''}<span>${esc(k.k)}</span>${st}
+    </button>`;
+  }
+  document.getElementById('c-keys').innerHTML = html;
+}
+
+function renderConsoleDetail(){
+  const k = cKey(), e = cEnv(), r = resolve(k, C.env);
+  const masked = k.secret && !C.revealed;
+  let value;
+  if(r.invalid) value = `<span style="color:var(--bad)">✕ ${esc(r.invalid)}</span>`;
+  else if(r.missing) value = `<span style="color:var(--bad)">! required in ${esc(e.name)} · unset</span>`;
+  else if(r.value === null || r.value === undefined) value = `<span style="color:var(--tx-faint)">· not set anywhere</span>`;
+  else value = masked ? '••••••••••••••••' : esc(r.value);
+
+  const chain = r.chain.length ? `
+    <div class="chain">
+      <div class="ct">${esc(k.k)} · ${esc(e.name)}</div>
+      ${r.chain.map(l => `
+        <div class="lnk2 ${l.state === 'dead' ? 'dead' : 'win'}">
+          <span class="src">${esc(l.src === C.env ? e.name : l.src)}</span>
+          <span class="val">${k.secret && !C.revealed ? '••••••••' : esc(l.val)}</span>
+          <span class="mark">${l.state === 'invalid' ? '✕ rejected' : esc(l.mark || '')}</span>
+        </div>`).join('')}
+    </div>` : `
+    <div class="chain">
+      <div class="ct">${esc(k.k)} · ${esc(e.name)}</div>
+      <div class="lnk2"><span class="src">—</span><span class="val" style="color:var(--tx-faint)">nothing declares a value for this environment</span><span class="mark"></span></div>
+    </div>`;
+
+  let ceremony = '';
+  if(k.secret){
+    if(C.revealed){
+      ceremony = `<div class="revealed"><span>revealed for this session</span><span class="cd">remasks in ${C.left}s</span></div>`;
+    } else if(e.protected && C.reauth){
+      ceremony = `<div class="challenge">
+        <b>reauth · ${esc(e.name)}</b>
+        <span>Disclosing <span class="mono">${esc(k.k)}</span> only. The window closes after 60 seconds
+        and the reveal is written to the audit log.</span></div>`;
+    } else if(e.protected){
+      ceremony = `<div class="refusal">
+        <b>✕ reveal refused · ${esc(e.name)}</b>
+        This environment is protected. Reveal needs a fresh passkey or TOTP challenge, is capped at a
+        60-second window, remasks itself, and lands in the audit log. Copying to the clipboard counts as
+        a disclosure too. Writing a new value needs none of that.</div>`;
+    }
+  }
+
+  const revealLabel = C.revealed ? 'remask now'
+    : e.protected ? (C.reauth ? 'confirm with passkey' : 'reveal (needs reauth)')
+    : 'reveal for 60s';
+  const acts = k.secret ? `
+    <div class="acts">
+      <button class="btn${e.protected && C.reauth && !C.revealed ? ' primary' : ''}" id="c-reveal">${revealLabel}</button>
+      ${e.protected && C.reauth && !C.revealed ? `<button class="btn" id="c-cancel">cancel</button>` : ''}
+      <button class="btn">set new value (write-only)</button>
+    </div>` : `
+    <div class="acts">
+      <button class="btn">override in ${esc(e.name)}</button>
+      <button class="btn">edit base</button>
+    </div>`;
+
+  document.getElementById('c-detail').innerHTML = `
+    <div class="kn">${k.secret ? '<span style="color:var(--bad)">🔒</span>' : ''}${esc(k.k)}<span class="type">${esc(k.type)}</span></div>
+    <p class="desc">${esc(k.desc)}</p>
+    <div class="resolved"><span class="rl">resolved</span><span class="rv">${value}</span></div>
+    ${chain}${ceremony}${acts}`;
+
+  const rev = document.getElementById('c-reveal');
+  if(rev) rev.onclick = toggleReveal;
+  const cancel = document.getElementById('c-cancel');
+  if(cancel) cancel.onclick = () => { C.reauth = false; renderConsole(); };
+}
+
+function renderConsoleCLI(){
+  const k = cKey(), e = cEnv(), r = resolve(k, C.env);
+  let out;
+  if(r.invalid) out = `<span class="er">✕</span> ${esc(k.k)}: expected <b>${esc(k.type)}</b>, got "${esc(r.invalid)}" <span class="c">— publish would refuse</span>`;
+  else if(r.missing) out = `<span class="er">✕</span> ${esc(k.k)}: required in <b>${esc(e.name)}</b>, unset <span class="c">— publish would refuse</span>`;
+  else if(r.value === null) out = `<span class="c">(no value declared)</span>`;
+  else if(k.secret && !C.revealed) out = `<span class="er">✕</span> refused: value is <b>write-only</b> here${e.protected ? ' · reveal needs reauth' : ''}\n  <span class="c">hikyo auth reveal --env ${esc(e.id)}</span>`;
+  else out = `<b>${esc(r.value)}</b>\n<span class="c">  origin: ${esc(r.origin === C.env ? e.name : r.origin)}${r.chain.length > 1 ? ` (shadowed ${r.chain.length - 1})` : ''}</span>`;
+  document.getElementById('c-cli').innerHTML =
+    `<span class="p">$</span> hikyo get <b>${esc(k.k)}</b> --env ${esc(e.id)} --explain\n${out}`;
+}
+
+function renderConsole(){ renderConsoleEnvs(); renderConsoleKeys(); renderConsoleDetail(); renderConsoleCLI(); }
+
+function toggleReveal(){
+  clearInterval(C.timer);
+  if(C.revealed){ C.revealed = false; C.reauth = false; renderConsole(); return; }
+  if(cEnv().protected && !C.reauth){ C.reauth = true; renderConsole(); return; }
+  C.revealed = true; C.reauth = false; C.left = 60;
+  C.timer = setInterval(() => {
+    C.left--;
+    if(C.left <= 0){ clearInterval(C.timer); C.revealed = false; renderConsole(); return; }
+    const cd = document.querySelector('#c-detail .revealed .cd');
+    if(cd) cd.textContent = `remasks in ${C.left}s`;
+  }, 1000);
+  renderConsole();
+}
+
+function runValidation(){
+  const el = document.getElementById('c-val'), out = document.getElementById('c-verdict');
+  if(!el || !out) return;
+  const raw = el.value;
+  let msg, ok = false;
+  if(raw === '') msg = '! required in production · unset, publish refused';
+  else if(raw !== raw.trim()) msg = `✕ expected int, got string: "${raw}" has surrounding whitespace`;
+  else if(!/^-?\d+$/.test(raw)) msg = `✕ expected int, got string: "${raw}"`;
+  else if(Number(raw) < 1 || Number(raw) > 65535) msg = `✕ out of range: ${raw} is not within 1 to 65535`;
+  else { ok = true; msg = `✓ valid, publish would write ${raw} to production`; }
+  out.className = 'verdict ' + (ok ? 'ok' : 'no');
+  out.textContent = msg;
+}
+
+function runBlast(){
+  const el = document.getElementById('c-base'), out = document.getElementById('c-blast'), rows = document.getElementById('c-blastrows');
+  if(!el || !out || !rows) return;
+  const base = el.value;
+  const over = {dev:'debug', stg:'debug'};
+  const followers = ENVS.filter(e => over[e.id] === undefined);
+  out.textContent = followers.length
+    ? `${followers.length} of ${ENVS.length} environments follow base, so they become "${base}". ${ENVS.length - followers.length} override and stay put.`
+    : `every environment overrides LOG_LEVEL, so changing base moves nothing.`;
+  rows.innerHTML = ENVS.map(e => over[e.id] !== undefined
+    ? `<div>${esc(e.name)} : <span style="color:var(--tx-dim)">${esc(over[e.id])}</span> <span style="color:var(--tx-faint)">(set here, unaffected)</span></div>`
+    : `<div>${esc(e.name)} : <span style="color:var(--accent)">${esc(base)}</span> <span style="color:var(--tx-faint)">◂ base</span></div>`
+  ).join('');
+}
+
+/* scaffold demo: the real first step, run locally on whatever is pasted */
+const SECRETISH = /(SECRET|TOKEN|KEY|PASSWORD|PASSWD|CREDENTIAL|DSN|_URL$|_URI$)/i;
+function guessType(v){
+  if(/^(true|false)$/i.test(v)) return 'bool';
+  if(/^-?\d+$/.test(v)) return 'int';
+  if(/^\s*[[{]/.test(v)) return 'json';
+  if(/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return 'url';
+  return 'string';
+}
+function runScaffold(){
+  const el = document.getElementById('c-env'), out = document.getElementById('c-scaffold');
+  if(!el || !out) return;
+  const lines = el.value.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+  if(!lines.length){ out.innerHTML = `<span class="n">nothing to read yet</span>`; return; }
+  let secrets = 0, defs = 0, skipped = 0;
+  const rows = lines.map(l => {
+    const i = l.indexOf('=');
+    if(i < 1){ skipped++; return `<div><span class="w">✕</span> <span class="n">${esc(l)} is not a KEY=value pair, skipped</span></div>`; }
+    defs++;
+    const k = l.slice(0, i).trim(), v = l.slice(i + 1).trim();
+    const secret = SECRETISH.test(k) || (v.length > 24 && /[a-z]/.test(v) && /\d/.test(v) && !v.includes(' '));
+    if(secret) secrets++;
+    const t = guessType(v);
+    return `<div><span class="k">${esc(k)}</span> <span class="n">:</span> <span class="t">${t}</span>${secret ? ` <span class="w">· secret, value not stored in the definition</span>` : ''}</div>`;
+  });
+  out.innerHTML =
+    `<div class="n">$ hikyo scaffold --from .env --project checkout-api</div>` + rows.join('') +
+    `<div class="n" style="margin-top:10px">wrote ${defs} definitions, ${secrets} marked secret` +
+    `${skipped ? `, ${skipped} line${skipped > 1 ? 's' : ''} skipped` : ''}. ` +
+    `Review, then <span class="k">hikyo apply</span>. Values are imported separately so a secret never lands in git.</div>`;
+}
+
+/* ===================== switcher ===================== */
+const VARIANTS = [
+  {key:'a', name:'Product first'},
+  {key:'b', name:'Typographic argument'},
+  {key:'c', name:'Live console'},
+];
+let current = 'a';
+
+function showVariant(key, push){
+  if(!VARIANTS.some(v => v.key === key)) key = 'a';
+  current = key;
+  for(const v of VARIANTS) document.getElementById('v-' + v.key).hidden = v.key !== key;
+  const meta = VARIANTS.find(v => v.key === key);
+  document.getElementById('sw-key').textContent = key.toUpperCase();
+  document.getElementById('sw-name').textContent = meta.name;
+  document.title = `PROTOTYPE — hikyo landing · ${key.toUpperCase()} ${meta.name}`;
+  if(push){
+    const u = new URL(location.href);
+    u.searchParams.set('variant', key);
+    history.replaceState(null, '', u);
+  }
+  window.scrollTo({top:0, behavior:'auto'});
+}
+
+function cycle(step){
+  const i = VARIANTS.findIndex(v => v.key === current);
+  showVariant(VARIANTS[(i + step + VARIANTS.length) % VARIANTS.length].key, true);
+}
+
+document.getElementById('sw-prev').onclick = () => cycle(-1);
+document.getElementById('sw-next').onclick = () => cycle(1);
+document.getElementById('sw-theme').onclick = () => {
+  const root = document.documentElement;
+  root.dataset.theme = root.dataset.theme === 'light' ? 'dark' : 'light';
+};
+
+addEventListener('keydown', ev => {
+  const t = ev.target;
+  if(t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  if(ev.key === 'ArrowLeft') cycle(-1);
+  else if(ev.key === 'ArrowRight') cycle(1);
+});
+
+addEventListener('click', ev => {
+  const b = ev.target.closest('[data-copy]');
+  if(b){
+    navigator.clipboard?.writeText(b.dataset.copy);
+    const was = b.textContent;
+    b.textContent = 'copied';
+    setTimeout(() => { b.textContent = was; }, 1200);
+    return;
+  }
+  const envBtn = ev.target.closest('#c-envs button');
+  if(envBtn){ C.env = envBtn.dataset.env; C.revealed = false; C.reauth = false; clearInterval(C.timer); renderConsole(); return; }
+  const keyBtn = ev.target.closest('#c-keys button');
+  if(keyBtn){ C.key = keyBtn.dataset.key; C.revealed = false; C.reauth = false; clearInterval(C.timer); renderConsole(); return; }
+  const pSelf = ev.target.closest('#p-self');
+  if(pSelf){ pMode = 'self'; renderPricing(); return; }
+  const pCloud = ev.target.closest('#p-cloud');
+  if(pCloud){ pMode = 'cloud'; renderPricing(); }
+});
+
+/* ===================== boot ===================== */
+renderMatrix('mx-a', ['dev','stg','pre','prd']);
+renderMatrix('mx-b', ['dev','stg','pre','prd']);
+renderLegend('legend-a');
+renderFAQ('faq-a');
+renderFAQ('faq-c');
+renderQA();
+renderPricing();
+renderConsole();
+document.getElementById('c-val').addEventListener('input', runValidation);
+document.getElementById('c-base').addEventListener('input', runBlast);
+document.getElementById('c-env').addEventListener('input', runScaffold);
+runValidation();
+runBlast();
+runScaffold();
+showVariant(new URL(location.href).searchParams.get('variant') || 'a', false);
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/landing-opus-5/index.html
+++ b/docs/site/public/prototypes/landing-opus-5/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Landing prototype — opus 5 — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,72px) clamp(18px,6vw,72px)}
+  .back{font-size:12px;color:var(--tx-dim);text-decoration:none;display:inline-block;margin-bottom:18px}
+  .back:hover{color:var(--tx)}
+  h1{font-size:clamp(20px,4vw,28px);font-weight:700}
+  h1 span{color:var(--accent)}
+  .q{font-size:13px;color:var(--tx-dim);margin:10px 0 30px;max-width:60ch;line-height:1.6}
+  ul{list-style:none;display:grid;gap:10px;max-width:680px}
+  li a{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:6px;background:var(--bg2)}
+  li a:hover{border-color:var(--accent)}
+  .num{font-family:var(--mono);font-size:11px;color:var(--accent)}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  .vars{flex-basis:100%;margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
+  .vars a{font-family:var(--mono);font-size:11px;color:var(--tx-dim);text-decoration:none;
+    border:1px solid var(--line);border-radius:4px;padding:5px 10px}
+  .vars a:hover{color:var(--accent);border-color:var(--accent)}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>landing prototype <span>·</span> opus 5</h1>
+  <p class="q">What does the public marketing page look like, under the product name <strong>hikyo</strong>? Reference points: Kaneo/Plane's structural philosophy (short value proposition, believable product UI immediately underneath), Linear/Resend's typographic finish, Better&nbsp;Auth/Unkey's habit of explaining a developer product through working UI instead of paragraphs. The design language is not in question — it is the locked one from DESIGN.md; what varies is the page architecture.</p>
+  <ul>
+    <li><a href="2/">
+      <span class="num">2</span><span class="name">All three, now selling</span><span class="latest">LATEST</span>
+      <span class="desc">
+        Iteration 1 explained the product and sold it not at all. Read from the live reference pages: cloud-vs-self-host is a hero-level choice, the headline is a why-now rather than a what, the FAQ does most of the selling, a founder note carries indie trust, and proof is sized to the company (Kaneo names sponsors because it has no customers to show).
+        Alex's calls: portray a <strong>Cloud tier with real pricing</strong>, and give the layer to <strong>all three</strong> architectures. Each sells in its own idiom, so the comparison stays live:
+        <strong>a</strong> hairline pricing table, stacked FAQ, plain sections under the screenshot ·
+        <strong>b</strong> prices as display numerals, FAQ continues the numbered claim rail (07-14), founder as a signed pull-quote ·
+        <strong>c</strong> pricing is a self-host/cloud toggle that rewrites the CLI pane, FAQ is an accordion, and a new demo scaffolds whatever <code>.env</code> you paste into it.
+        Also fixed from 1: 3px accent side-stripes (an absolute ban) and the em dashes in the copy.
+      </span>
+      <span class="vars">
+        <a href="2/?variant=a">a · product first</a>
+        <a href="2/?variant=b">b · typographic</a>
+        <a href="2/?variant=c">c · live console</a>
+      </span>
+    </a></li>
+    <li><a href="1/">
+      <span class="num">1</span><span class="name">Baseline — three page architectures</span>
+      <span class="desc">
+        <strong>a product first</strong> — short headline, install line, then the environment matrix at full width right under it; everything below is a caption for that one screenshot ·
+        <strong>b typographic argument</strong> — no hero shot, five numbered claims in large type, each carrying exactly one technical artifact (provenance chain, refused publish, CLI transcript, CR conditions, matrix strip) ·
+        <strong>c live console</strong> — the hero is the product running: pick an environment, pick a key, watch it resolve, hit the protected-reveal refusal, with the CLI pane mirroring every click; two more working demos below (validation, blast radius).
+        Switchable via <code>?variant=</code>, floating bar and ← / → keys. Theme toggle on the bar.
+      </span>
+      <span class="vars">
+        <a href="1/?variant=a">a · product first</a>
+        <a href="1/?variant=b">b · typographic</a>
+        <a href="1/?variant=c">c · live console</a>
+      </span>
+    </a></li>
+  </ul>
+  <footer>every change is a new numbered iteration — published ones never mutate · <a href="/prototypes/">all prototypes</a></footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/machine-access/1/index.html
+++ b/docs/site/public/prototypes/machine-access/1/index.html
@@ -1,0 +1,865 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo machine access (ticket #31)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #31, iteration 1.
+
+  Question: how do the workload-integration setup and service-account /
+  credential screens look and behave — against the locked machine-identity
+  (#17), Compose (#18) and Kubernetes (#19) ADRs, in the env-matrix-31
+  design language with the app-chrome reference chrome (15+16+18) and the
+  #21 ceremony vocabulary.
+
+  Three STRUCTURAL variants, switchable via ?variant= / floating bar / arrows:
+    a — inventory: tabbed admin console (Service accounts / Federation /
+        Kubernetes targets), expandable credential sub-rows.
+    b — journey board: one card per SA organized around the five-step
+        journey (#18); the failing step speaks in the CLI/CR-condition
+        voice verbatim.
+    c — master-detail: compact SA list left, detail pane right with the
+        sticky jump index (app-chrome it9 pattern).
+
+  Shared: scenario simulator (normal / expiring / post-restore — the last
+  swaps the surface into the #17 restore-reconciliation screen), display-once
+  mint ceremony, grant-mutation warning naming the newly-reachable plaintext
+  set, per-project machine-reveal opt-in warning, federation binding form
+  with the pull_request refusal, K8s CR-condition vocabulary reading the
+  same in kubectl and the UI.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --warn:oklch(0.82 0.11 85);
+    --warn-soft:oklch(0.82 0.11 85/.14);
+    --ok:oklch(0.8 0.1 155);
+    --ok-soft:oklch(0.8 0.1 155/.14);
+    --stepup:oklch(0.78 0.09 250);          /* blue "confirm it's you" — #21/#29 */
+    --stepup-soft:oklch(0.78 0.09 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --warn:oklch(0.55 0.12 80);
+    --warn-soft:oklch(0.55 0.12 80/.12);
+    --ok:oklch(0.5 0.11 155);
+    --ok-soft:oklch(0.5 0.11 155/.12);
+    --stepup:oklch(0.48 0.1 255);
+    --stepup-soft:oklch(0.48 0.1 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{background:var(--bg);color:var(--tx);font-family:var(--sans);font-size:14px;
+    -webkit-font-smoothing:antialiased;height:100dvh;display:flex;flex-direction:column;
+    overflow:hidden;padding-bottom:env(safe-area-inset-bottom)}
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  code,.mono{font-family:var(--mono)}
+
+  /* ---------- app shell (app-chrome 15/18e, simplified) ---------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;padding:14px 0 12px;
+    border-right:1px solid var(--line);background:var(--bg2)}
+  .orgav{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:11px;background:var(--bg3);outline:2px solid var(--accent);outline-offset:2px}
+  .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:12px;color:var(--tx-dim);border:1px solid transparent}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  #rail .spacer{flex:1}
+  #rail .me{width:36px;height:36px;border-radius:50%;background:var(--bg3);color:var(--tx);
+    font-weight:700;font-size:11px;display:flex;align-items:center;justify-content:center}
+
+  #side{display:flex;flex-direction:column;overflow-y:auto;border-right:1px solid var(--line);
+    background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--tx-faint);
+    padding:30px 16px 6px;font-weight:700}
+  #side .stitle:first-child{padding-top:16px}
+  /* sidebar treatment e (locked, app-chrome 18): sub-items on hairline left rule */
+  #side .srow{display:flex;align-items:center;gap:8px;text-align:left;font-size:13px;color:var(--tx-dim);
+    min-height:38px;padding:9px 16px 9px 13px;margin-left:19px;width:calc(100% - 19px);
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600;border-left-color:var(--accent)}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #hdr{display:flex;align-items:center;gap:14px;padding:12px 22px;border-bottom:1px solid var(--line);flex:none}
+  #hdr .crumb{font-size:14px;font-weight:600;display:flex;align-items:baseline;gap:8px;min-width:0}
+  #hdr .crumb .sep{color:var(--tx-faint);font-weight:400}
+  #hdr .right{margin-left:auto;display:flex;align-items:center;gap:10px}
+  .hsel{background:var(--bg2);border:1px solid var(--line);border-radius:4px;color:var(--tx);
+    font-size:12px;padding:6px 8px}
+  .hbtn{border:1px solid var(--line);border-radius:4px;padding:6px 10px;font-size:12px;color:var(--tx-dim)}
+  .hbtn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  #content{flex:1;overflow-y:auto;padding:22px 22px 96px}
+
+  /* ---------- shared bits ---------- */
+  .kind{font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;font-weight:600;border-radius:3px;
+    padding:2.5px 7px;white-space:nowrap;border:1px solid var(--line);color:var(--tx-dim)}
+  .kind.workload{color:var(--accent);border-color:oklch(from var(--accent) l c h/.5);background:var(--accent-soft)}
+  .kind.automation{color:var(--stepup);border-color:oklch(from var(--stepup) l c h/.5);background:var(--stepup-soft)}
+  .envchip{font-family:var(--mono);font-size:10.5px;border:1px solid var(--line);border-radius:3px;
+    padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .envchip.reveal{border-color:oklch(from var(--accent) l c h/.6);color:var(--accent)}
+  .envchip.reveal::after{content:" ◆";font-size:9px}
+  .badge{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2px 7px;white-space:nowrap}
+  .badge.ok{color:var(--ok);background:var(--ok-soft)}
+  .badge.warn{color:var(--warn);background:var(--warn-soft)}
+  .badge.bad{color:var(--bad);background:var(--bad-soft)}
+  .badge.dim{color:var(--tx-faint);border:1px solid var(--line)}
+  .badge.dead{color:var(--bad);border:1px solid oklch(from var(--bad) l c h/.5);text-decoration:line-through}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:7px 13px;font-size:12.5px;font-weight:500;color:var(--tx-dim)}
+  .btn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  .btn.pri{background:var(--accent);color:var(--on-accent);border-color:transparent;font-weight:600}
+  .btn.pri:hover{filter:brightness(1.06)}
+  .btn.danger{color:var(--bad);border-color:oklch(from var(--bad) l c h/.5)}
+  .btn.stepup{background:var(--stepup);color:var(--bg);border-color:transparent;font-weight:600}
+  .btn.sm{padding:4px 9px;font-size:11.5px}
+  .note{font-size:12px;color:var(--tx-dim);line-height:1.55}
+  .note.faint{color:var(--tx-faint);font-size:11.5px}
+  .callout{border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:6px;
+    padding:12px 14px;font-size:12.5px;line-height:1.55;color:var(--tx-dim);background:var(--bg2)}
+  .callout.warn{border-left-color:var(--warn)}
+  .callout.bad{border-left-color:var(--bad)}
+  .callout.stepup{border-left-color:var(--stepup)}
+  .callout code{font-size:11.5px;color:var(--tx)}
+  .keyset{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+  .keyset code{border:1px solid var(--line);border-radius:3px;padding:2px 7px;font-size:11px;background:var(--bg3)}
+
+  /* condition chips (K8s CR vocabulary) */
+  .cond{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2.5px 8px;
+    white-space:nowrap;cursor:pointer;border:1px solid transparent}
+  .cond.ok{color:var(--ok);background:var(--ok-soft)}
+  .cond.bad{color:var(--bad);background:var(--bad-soft)}
+  .cond.warn{color:var(--warn);background:var(--warn-soft)}
+  .cond:hover{border-color:currentColor}
+
+  /* ---------- variant a: inventory ---------- */
+  .tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);margin-bottom:18px}
+  .tab{padding:9px 16px;font-size:13px;color:var(--tx-dim);border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab:hover{color:var(--tx)}
+  .tab.act{color:var(--tx);font-weight:600;border-bottom-color:var(--accent)}
+  .tab .cnt{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-left:6px}
+  table.inv{width:100%;border-collapse:collapse;font-size:13px}
+  table.inv th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:8px 10px;border-bottom:1px solid var(--line)}
+  table.inv td{padding:10px;border-bottom:1px solid oklch(from var(--line) l c h/.5);vertical-align:middle}
+  table.inv tr.sarow{cursor:pointer}
+  table.inv tr.sarow:hover td{background:var(--rowalt)}
+  table.inv tr.sub td{background:oklch(from var(--bg2) l c h/.6);font-size:12.5px;padding:8px 10px 8px 26px}
+  .chev{display:inline-block;transition:transform .15s;color:var(--tx-faint);margin-right:8px;font-size:10px}
+  .open .chev{transform:rotate(90deg)}
+  .cell-envs{display:flex;flex-wrap:wrap;gap:5px}
+
+  /* ---------- variant b: journey board ---------- */
+  .board{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:14px}
+  .jcard{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:16px;display:flex;flex-direction:column;gap:12px}
+  .jcard .jhead{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .jcard .jhead .nm{font-weight:600;font-size:14.5px;font-family:var(--mono)}
+  .steps{display:flex;flex-direction:column;gap:0}
+  .step{display:flex;gap:12px;position:relative;padding:7px 0}
+  .step .dot{width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;
+    font-size:10px;font-weight:700;border:1.5px solid var(--line);color:var(--tx-faint);background:var(--bg);z-index:1;margin-top:1px}
+  .step.done .dot{background:var(--ok-soft);border-color:var(--ok);color:var(--ok)}
+  .step.fail .dot{background:var(--bad-soft);border-color:var(--bad);color:var(--bad)}
+  .step.next .dot{border-color:var(--accent);color:var(--accent)}
+  .step:not(:last-child)::before{content:'';position:absolute;left:8.5px;top:26px;bottom:-8px;width:1px;
+    background:oklch(from var(--line) l c h/.75)}
+  .step .stx{font-size:12.5px;color:var(--tx-dim);line-height:1.45;min-width:0}
+  .step.done .stx{color:var(--tx-faint)}
+  .step.fail .stx,.step.next .stx{color:var(--tx)}
+  .step .stx .who{font-family:var(--mono);font-size:10px;color:var(--tx-faint)}
+  .errblock{font-family:var(--mono);font-size:11px;line-height:1.6;background:var(--bg);
+    border:1px solid oklch(from var(--bad) l c h/.4);border-radius:4px;padding:10px 12px;margin-top:6px;
+    color:var(--tx-dim);white-space:pre-wrap;word-break:break-word}
+  .errblock b{color:var(--bad);font-weight:600}
+  .jcard .credline{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12px;color:var(--tx-dim)}
+  .jcard .tgts{display:flex;flex-direction:column;gap:6px}
+  .jcard .tgt{display:flex;align-items:center;gap:8px;font-size:12px;flex-wrap:wrap}
+  .jcard .tgt code{font-size:11px;color:var(--tx-dim)}
+
+  /* ---------- variant c: master-detail ---------- */
+  .md{display:grid;grid-template-columns:250px 1fr;gap:0;border:1px solid var(--line);border-radius:6px;
+    overflow:hidden;min-height:calc(100dvh - 190px)}
+  .mdlist{border-right:1px solid var(--line);background:var(--bg2);overflow-y:auto}
+  .mdrow{display:flex;flex-direction:column;gap:4px;width:100%;text-align:left;padding:12px 14px;
+    border-bottom:1px solid oklch(from var(--line) l c h/.5)}
+  .mdrow:hover{background:var(--bg3)}
+  .mdrow.act{background:var(--accent-soft)}
+  .mdrow .r1{display:flex;align-items:center;gap:8px}
+  .mdrow .r1 .nm{font-family:var(--mono);font-size:12.5px;font-weight:600}
+  .mdrow .r2{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+  .mddetail{padding:18px 22px;overflow-y:auto}
+  .jump{position:sticky;top:-18px;margin:-18px -22px 14px;padding:12px 22px;background:var(--bg);
+    border-bottom:1px solid var(--line);display:flex;gap:8px;flex-wrap:wrap;z-index:5}
+  .jchip{font-size:11.5px;border:1px solid var(--line);border-radius:3px;padding:4px 10px;color:var(--tx-dim)}
+  .jchip:hover{color:var(--tx);border-color:var(--tx-faint)}
+  .dsec{margin:0 0 26px}
+  .dsec h3{font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);margin-bottom:10px}
+  .kv{display:grid;grid-template-columns:150px 1fr;gap:6px 14px;font-size:12.5px}
+  .kv dt{color:var(--tx-faint)}
+  .kv dd{color:var(--tx);font-family:var(--mono);font-size:12px}
+
+  /* credential rows (shared a-sub/c) */
+  .credrow{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:8px 0;
+    border-bottom:1px solid oklch(from var(--line) l c h/.4);font-size:12.5px}
+  .credrow:last-child{border-bottom:none}
+  .credrow code.pfx{font-size:11.5px;color:var(--tx)}
+  .credrow .meta{color:var(--tx-faint);font-size:11.5px}
+  .credrow .acts{margin-left:auto;display:flex;gap:6px}
+
+  /* binding rows */
+  .bindrow{border:1px solid var(--line);border-radius:6px;padding:12px 14px;margin-bottom:10px;background:var(--bg2)}
+  .bindrow .b1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .bindrow .kv{grid-template-columns:90px 1fr}
+
+  /* section headers on the surface */
+  .shead{display:flex;align-items:center;gap:12px;margin:0 0 14px;flex-wrap:wrap}
+  .shead h2{font-size:16px;font-weight:700}
+  .shead .right{margin-left:auto;display:flex;gap:8px}
+  .policy{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;
+    display:flex;align-items:flex-start;gap:14px;margin-bottom:18px;flex-wrap:wrap}
+  .policy .ptx{flex:1;min-width:240px}
+  .policy .ptx .t{font-weight:600;font-size:13px;margin-bottom:3px}
+  .toggle{width:40px;height:22px;border-radius:999px;border:1px solid var(--line);background:var(--bg3);
+    position:relative;flex:none;margin-top:2px}
+  .toggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
+    background:var(--tx-faint);transition:left .15s,background .15s}
+  .toggle.on{background:var(--accent-soft);border-color:var(--accent)}
+  .toggle.on::after{left:20px;background:var(--accent)}
+
+  /* ---------- restore reconciliation ---------- */
+  .recban{border:1px solid oklch(from var(--bad) l c h/.55);background:var(--bad-soft);border-radius:6px;
+    padding:14px 16px;margin-bottom:18px;font-size:13px;line-height:1.55}
+  .recban b{color:var(--bad)}
+  .recrow{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;margin-bottom:12px}
+  .recrow .r1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .recrow .r1 .nm{font-family:var(--mono);font-weight:600;font-size:13.5px}
+  .recrow ul{list-style:none;display:flex;flex-direction:column;gap:5px;font-size:12.5px;color:var(--tx-dim);margin:6px 0 10px}
+  .recrow li{display:flex;gap:8px;align-items:baseline;flex-wrap:wrap}
+  .recrow.done{border-color:oklch(from var(--ok) l c h/.5)}
+
+  /* ---------- modal ---------- */
+  #ovl{position:fixed;inset:0;background:oklch(0 0 0/.55);display:none;align-items:center;justify-content:center;
+    z-index:40;padding:18px}
+  #ovl.show{display:flex}
+  #modal{background:var(--bg);border:1px solid var(--line);border-radius:6px;box-shadow:var(--sheet-shadow);
+    width:min(560px,100%);max-height:88dvh;display:flex;flex-direction:column}
+  #modal .mh{padding:16px 20px 0}
+  #modal .mh h3{font-size:15px;font-weight:700}
+  #modal .mh .sub{font-size:12px;color:var(--tx-faint);margin-top:3px}
+  #modal .mb{padding:14px 20px;overflow-y:auto;display:flex;flex-direction:column;gap:12px}
+  #modal .mf{padding:12px 20px 16px;display:flex;gap:8px;justify-content:flex-end;border-top:1px solid var(--line)}
+  .tokbox{font-family:var(--mono);font-size:12.5px;background:var(--bg2);border:1px solid var(--accent);
+    border-radius:4px;padding:14px;word-break:break-all;line-height:1.6;color:var(--tx)}
+  .field{display:flex;flex-direction:column;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input,.field select{background:var(--bg2);border:1px solid var(--line);border-radius:4px;
+    color:var(--tx);padding:8px 10px;font-size:13px;width:100%}
+  .field input.mono{font-family:var(--mono);font-size:12px}
+  .chk{display:flex;gap:10px;align-items:flex-start;font-size:12.5px;color:var(--tx-dim);line-height:1.5;cursor:pointer}
+  .chk input{margin-top:2px;accent-color:var(--accent)}
+  .presets{display:flex;gap:6px;flex-wrap:wrap}
+  .preset{font-size:11.5px;border:1px solid var(--line);border-radius:3px;padding:4px 10px;color:var(--tx-dim)}
+  .preset:hover{border-color:var(--accent);color:var(--tx)}
+  .yaml{font-family:var(--mono);font-size:11px;line-height:1.65;background:var(--bg2);border:1px solid var(--line);
+    border-radius:4px;padding:12px 14px;white-space:pre-wrap;word-break:break-word;color:var(--tx-dim)}
+  .yaml .k{color:var(--accent)}
+  .yaml .bad{color:var(--bad)}
+
+  /* toast */
+  #toast{position:fixed;bottom:76px;left:50%;transform:translateX(-50%);background:var(--bg3);
+    border:1px solid var(--line);border-radius:6px;padding:10px 16px;font-size:12.5px;display:none;z-index:60;
+    box-shadow:var(--sheet-shadow)}
+  #toast.show{display:block}
+
+  /* ---------- floating variant bar ---------- */
+  #vbar{position:fixed;bottom:14px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:4px;
+    background:var(--bg3);border:1px solid var(--tx-faint);border-radius:999px;padding:5px 8px;z-index:50;
+    box-shadow:var(--sheet-shadow);font-size:12px}
+  #vbar button{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    color:var(--tx-dim);font-size:14px}
+  #vbar button:hover{background:var(--bg2);color:var(--tx)}
+  #vbar .lbl{font-family:var(--mono);font-size:11px;padding:0 8px;min-width:150px;text-align:center;color:var(--tx)}
+
+  @media (max-width:860px){
+    #app{grid-template-columns:56px 1fr}
+    #side{display:none}
+    .md{grid-template-columns:1fr}
+    .mdlist{max-height:200px;border-right:none;border-bottom:1px solid var(--line)}
+    .board{grid-template-columns:1fr}
+    .kv{grid-template-columns:120px 1fr}
+  }
+</style>
+</head>
+<body>
+<div id="app">
+  <nav id="rail" aria-label="Organizations and projects">
+    <div class="orgav" title="example.com">WI</div>
+    <div class="raildiv"></div>
+    <div class="pav act" title="example-app">DB</div>
+    <div class="pav" title="sample-catalog">PT</div>
+    <div class="spacer"></div>
+    <div class="me" title="Alex">MW</div>
+  </nav>
+  <nav id="side" aria-label="Project sections">
+    <div class="stitle">example-app</div>
+    <button class="srow">Environment matrix</button>
+    <button class="srow">Version history</button>
+    <button class="srow act">Machine access <span class="cnt" id="side-cnt">5</span></button>
+    <button class="srow">Project settings</button>
+    <div class="stitle">Organization</div>
+    <button class="srow">Members &amp; grants</button>
+    <button class="srow">Org settings</button>
+  </nav>
+  <div id="main">
+    <header id="hdr">
+      <div class="crumb"><span>example-app</span><span class="sep">/</span><span>Machine access</span></div>
+      <div class="right">
+        <label class="note faint" for="scen">scenario</label>
+        <select id="scen" class="hsel" aria-label="Scenario simulator">
+          <option value="normal">normal</option>
+          <option value="expiring">expiring credentials</option>
+          <option value="restore">post-restore</option>
+        </select>
+        <button class="hbtn" id="themebtn" aria-label="Toggle theme">◐</button>
+      </div>
+    </header>
+    <div id="content"></div>
+  </div>
+</div>
+
+<div id="ovl" role="dialog" aria-modal="true"><div id="modal"></div></div>
+<div id="toast" role="status"></div>
+
+<div id="vbar" aria-label="Prototype variant switcher">
+  <button id="vprev" aria-label="Previous variant">←</button>
+  <div class="lbl" id="vlbl"></div>
+  <button id="vnext" aria-label="Next variant">→</button>
+</div>
+
+<script>
+/* ============ demo data (in-memory only — PROTOTYPE) ============ */
+const ENV_SECRETS = { // secret keys per environment — the "newly reachable plaintext set"
+  production:['DATABASE_URL','SMTP_PASSWORD','S3_SECRET_KEY','SESSION_PEPPER'],
+  staging:['DATABASE_URL','S3_SECRET_KEY'],
+  development:['DATABASE_URL'],
+};
+const state = {
+  variant:'a', tab:'sa', scenario:'normal', selected:'k3s-cluster', openRows:{},
+  revealOptIn:true,          // per-project machine-reveal opt-in (#18)
+  reactivated:{},            // restore scenario
+  minted:{},                 // sa -> fresh cred minted post-restore
+};
+const SAS = [
+  {id:'api-workload', kind:'workload', created:'2026-07-02', read:['production'], reveal:['production'],
+   creds:[{pfx:'hik_1_wl_9fK2mQ', created:'2026-07-02', expiry:'2026-10-01', days:57, last:'2 min ago'}],
+   bindings:[], targets:[]},
+  {id:'staging-runner', kind:'workload', created:'2026-06-18', read:['staging'], reveal:['staging'],
+   creds:[{pfx:'hik_1_wl_x7Rq0d', created:'2026-06-18', expiry:'2026-08-19', days:14, last:'41 min ago'},
+          {pfx:'hik_1_wl_p2Vn8s', created:'2026-08-01', expiry:'2026-11-01', days:88, last:'never'}],
+   bindings:[], targets:[]},
+  {id:'worker-beta', kind:'workload', created:'2026-08-04', read:['staging'], reveal:[],
+   creds:[{pfx:'hik_1_wl_c4Ht2z', created:'2026-08-04', expiry:'2026-11-04', days:91, last:'6 min ago'}],
+   bindings:[], targets:[]},
+  {id:'k3s-cluster', kind:'workload', created:'2026-05-30', read:['production','staging'], reveal:['production'],
+   creds:[],
+   bindings:[{issuer:'https://kubernetes.default.svc.cluster.local',
+              subject:'system:serviceaccount:hikyo-system:hikyo-fetch',
+              audience:'hikyo.example.com/main', expiry:'2026-11-30', days:117}],
+   targets:[
+     {name:'apps/api-env', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'ok', reason:'Completed'}]},
+     {name:'apps/worker-env', ns:'apps', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'UndeliverableKeys'}]},
+     {name:'batch/report-env', ns:'batch', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'LoaderControlAckRequired'}]},
+     {name:'apps/api-env (canary)', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'warn', reason:'Stalled'}]},
+     {name:'legacy/import-env', ns:'legacy', envK:'staging',
+      conds:[{t:'NotReconciled', s:'bad', reason:'DesignationMissing'}]},
+   ]},
+  {id:'ci-export', kind:'automation', created:'2026-06-01', read:['production'], reveal:[], caps:['read','audit-read'],
+   creds:[{pfx:'hik_1_au_m3Wb5k', created:'2026-06-01', expiry:'2026-09-01', days:27, last:'3 h ago'}],
+   bindings:[{issuer:'https://token.actions.githubusercontent.com',
+              subject:'repo:example-user/example-app:ref:refs/heads/main',
+              audience:'hikyo.example.com/main', expiry:'2026-08-07', days:2}],
+   targets:[]},
+];
+const CONDS = { // CR-condition vocabulary (#19) — kubectl YAML + the same sentence as UI copy
+  'UndeliverableKeys':{sev:'bad', ui:(sa,t)=>`Nothing was synced: the resolved manifest contains secret keys this service account cannot reveal. Delivery is all-or-nothing — partial sync would surface as the application's own crash three layers away.`,
+    keys:['DATABASE_URL','S3_SECRET_KEY'],
+    fix:`Grant <code>reveal(staging)</code> to <code>k3s-cluster</code> — requires <code>manage-identities(example-app)</code> ∧ <code>reveal</code> over the whole post-state, plus reauthentication.`,
+    yaml:(t)=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">UndeliverableKeys</span>
+    message: >-
+      refusing to sync: manifest contains secret occurrences this
+      principal cannot reveal: DATABASE_URL, S3_SECRET_KEY.
+      delivery is all-or-nothing. required: machine-reveal opt-in
+      on project example-app + reveal(staging) on service account
+      k3s-cluster.`},
+  'LoaderControlAckRequired':{sev:'bad', ui:()=>`The mapping delivers <code>PATH</code>, a key on the loader-control baseline. The refusal is enforced at delivery, consumption-agnostic — even a volume-mount-only Secret needs the acknowledgement, because delivery time cannot know how a key is consumed.`,
+    keys:['PATH'],
+    fix:`Add the acknowledgement to the <code>HikyoSecret</code> listing exactly these keys. The acknowledged list is carried on the fetch and recorded in Hikyo's audit event (#24) — regardless of cluster audit posture.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">LoaderControlAckRequired</span>
+    message: >-
+      mapping delivers loader-control baseline key: PATH.
+      add spec.loaderControlAck listing exactly these keys.
+      the acknowledged list is carried on every fetch and
+      recorded in the server audit log.`},
+  'Stalled':{sev:'warn', ui:()=>`The Secret is delivered and current, but the workload controller has not completed the rollout — this Deployment is paused. Delivered-but-not-rolled is a visible state, never a silent success; the operator claims completion only from the workload controller's own status.`,
+    keys:[], fix:`Resume the Deployment (<code>kubectl rollout resume</code>), or accept that pods roll on the next controller-driven restart.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">RolloutRequested</span>
+    status: "False"
+    reason: <span class="bad">Stalled</span>
+    message: >-
+      secret delivered (converged@rev41) but deployment
+      apps/api-canary is paused; rollout has not completed.
+      completion is claimed only from the workload
+      controller's own status.`},
+  'DesignationMissing':{sev:'bad', ui:()=>`The referenced bootstrap Secret is not designated for Hikyo delivery use. Designation is an act by someone holding <b>write</b> on that Secret — a strictly greater right than reading it — and must name the <code>HikyoInstance</code> it may be presented to.`,
+    keys:[], fix:`Label the bootstrap Secret with the designation naming <code>HikyoInstance/main</code> (spelling per #25), applied by a principal with write on the Secret.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">NotReconciled</span>
+    status: "True"
+    reason: <span class="bad">DesignationMissing</span>
+    message: >-
+      referenced Secret legacy/hikyo-bootstrap is not
+      designated for hikyo delivery use, or its designation
+      does not name HikyoInstance/main. designate it with
+      write authority on the Secret.`},
+};
+
+/* ============ helpers ============ */
+const $=s=>document.querySelector(s);
+const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+function toast(msg){const t=$('#toast');t.textContent=msg;t.classList.add('show');clearTimeout(t._h);t._h=setTimeout(()=>t.classList.remove('show'),3200)}
+function expiryBadge(days,label){ // in-product-first expiry signal (#17)
+  const hot=state.scenario==='expiring';
+  const d=hot?Math.max(1,Math.round(days/7)):days;
+  if(d<=7) return `<span class="badge bad">expires in ${d}d</span>`;
+  if(d<=30) return `<span class="badge warn">expires in ${d}d</span>`;
+  return `<span class="badge dim">${label||'expires'} ${d}d</span>`;
+}
+function journey(sa){ // five-step journey state (#18)
+  const s=[];
+  s.push({t:`Service account minted <span class="who">kind: ${sa.kind} — immutable at creation</span>`, st:'done'});
+  s.push({t:`<code>read</code> granted — ${sa.read.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">delivers config + secret-presence only</span>`, st:sa.read.length?'done':'next'});
+  const missing=sa.read.filter(e=>!sa.reveal.includes(e));
+  const failing=missing.length&&sa.kind==='workload';
+  s.push({t:failing?`Delivery fails, naming what it could not deliver`:`First delivery succeeded`, st:failing?'fail':'done',
+    err:failing?(sa.targets.length?`HikyoSecret apps/worker-env — SyncRefused
+<b>reason:</b> UndeliverableKeys
+manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was synced.
+required: reveal(${missing[0]}) on ${sa.id}`
+:`$ hikyo run --project example-app --env ${missing[0]} -- node worker.js
+<b>refused:</b> manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was started.
+required: reveal(${missing[0]}) on ${sa.id}`):null});
+  s.push({t:`Project machine-reveal opt-in ${state.revealOptIn?'acknowledged':'<b>not acknowledged</b>'} <span class="who">a credential holding reveal is a standing decryption capability</span>`, st:state.revealOptIn?'done':(failing?'next':'done')});
+  s.push({t:missing.length?`Grant <code>reveal</code> on ${missing.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">manage-identities ∧ reveal over the post-state + reauth</span>`:`<code>reveal</code> granted — full delivery`, st:missing.length?(state.revealOptIn?'next':''):'done'});
+  return s;
+}
+function credRow(sa,c){
+  return `<div class="credrow">
+    <code class="pfx">${c.pfx}…</code>
+    <span class="badge dim">bearer</span>
+    ${expiryBadge(c.days)}
+    <span class="meta">created ${c.created} · last used ${c.last}</span>
+    <span class="acts">
+      <button class="btn sm" onclick="openMint('${sa.id}',true)">Rotate</button>
+      <button class="btn sm danger" onclick="toast('Revoked — bites at the next fetch, never at expiry (#15). Undo…')">Revoke</button>
+    </span>
+  </div>`;
+}
+function bindRow(sa,b){
+  return `<div class="bindrow">
+    <div class="b1"><span class="badge dim">federated</span>${expiryBadge(b.days,'binding expires')}
+      <span class="note faint">byte-for-byte match — no wildcards, no case folding · renewal is a mint</span></div>
+    <dl class="kv">
+      <dt>issuer</dt><dd>${b.issuer}</dd>
+      <dt>subject</dt><dd>${b.subject}</dd>
+      <dt>audience</dt><dd>${b.audience}</dd>
+    </dl>
+  </div>`;
+}
+function condChips(sa,t){
+  return t.conds.map(c=>{
+    const key=CONDS[c.reason]?c.reason:null;
+    return `<span class="cond ${c.s}" ${key?`onclick="openCond('${sa.id}','${esc(t.name)}','${key}')"`:''} role="${key?'button':'status'}">${c.t}: ${c.reason}</span>`;
+  }).join(' ');
+}
+
+/* ============ variant a — inventory ============ */
+function renderA(){
+  const tabs=`<div class="tabs" role="tablist">
+    <button class="tab ${state.tab==='sa'?'act':''}" onclick="state.tab='sa';render()">Service accounts<span class="cnt">${SAS.length}</span></button>
+    <button class="tab ${state.tab==='fed'?'act':''}" onclick="state.tab='fed';render()">Federation<span class="cnt">${SAS.flatMap(s=>s.bindings).length}</span></button>
+    <button class="tab ${state.tab==='k8s'?'act':''}" onclick="state.tab='k8s';render()">Kubernetes targets<span class="cnt">${SAS.flatMap(s=>s.targets).length}</span></button>
+  </div>`;
+  if(state.tab==='sa'){
+    const rows=SAS.map(sa=>{
+      const open=state.openRows[sa.id];
+      const worst=Math.min(...sa.creds.map(c=>c.days),...sa.bindings.map(b=>b.days),999);
+      const miss=sa.read.filter(e=>!sa.reveal.includes(e));
+      const setup=sa.kind!=='workload'?'<span class="badge dim">n/a</span>':
+        miss.length?`<span class="badge bad">step ${state.revealOptIn?5:4} of 5</span>`:'<span class="badge ok">complete</span>';
+      let h=`<tr class="sarow ${open?'open':''}" onclick="state.openRows['${sa.id}']=!${!!open};render()">
+        <td><span class="chev">▶</span><code>${sa.id}</code></td>
+        <td><span class="kind ${sa.kind}">${sa.kind}</span></td>
+        <td><span class="cell-envs">${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join('')}</span></td>
+        <td>${sa.creds.length+sa.bindings.length} ${worst<999?expiryBadge(worst):''}</td>
+        <td class="mono" style="font-size:11.5px;color:var(--tx-faint)">${sa.creds[0]?.last??(sa.bindings.length?'via federation':'—')}</td>
+        <td>${setup}</td></tr>`;
+      if(open){
+        h+=`<tr class="sub"><td colspan="6">
+          ${sa.creds.map(c=>credRow(sa,c)).join('')||'<div class="note faint" style="padding:6px 0">No bearer credentials — authenticates by federation only.</div>'}
+          ${sa.bindings.map(b=>bindRow(sa,b)).join('')}
+          <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
+            <button class="btn sm pri" onclick="openMint('${sa.id}')">Mint credential</button>
+            <button class="btn sm" onclick="openBinding('${sa.id}')">Add federated binding</button>
+            <button class="btn sm" onclick="openGrant('${sa.id}')">Add environment grant…</button>
+          </div>
+        </td></tr>`;
+      }
+      return h;
+    }).join('');
+    return tabs+policyStrip()+`<table class="inv" aria-label="Service accounts">
+      <thead><tr><th>service account</th><th>kind</th><th>read scope <span style="text-transform:none;letter-spacing:0">(◆ = reveal)</span></th><th>credentials</th><th>last used</th><th>setup</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+      <p class="note faint" style="margin-top:12px">Credential list is metadata only — prefix, kind, scope, expiry, last-used. Values are write-only: displayed exactly once at mint, never retrievable, rotation never returns the prior value (#17).</p>`;
+  }
+  if(state.tab==='fed'){
+    const rows=SAS.flatMap(sa=>sa.bindings.map(b=>({sa,b})));
+    return tabs+`<div class="shead"><h2>Federated bindings</h2><div class="right"><button class="btn pri" onclick="openBinding('k3s-cluster')">New binding</button></div></div>
+      <p class="note" style="margin-bottom:14px">An external OIDC identity is bound to exactly one service account by a byte-exact <code>(issuer, subject)</code> pair — no wildcards, no JIT provisioning. An unbound identity is not a login. A binding is a standing permission to present tokens and expires on the same terms as a bearer credential; renewal is a mint.</p>
+      ${rows.map(({sa,b})=>`<div class="bindrow"><div class="b1"><code style="font-size:12px;font-weight:600">${sa.id}</code><span class="kind ${sa.kind}">${sa.kind}</span>${expiryBadge(b.days,'binding expires')}</div>
+        <dl class="kv"><dt>issuer</dt><dd>${b.issuer}</dd><dt>subject</dt><dd>${b.subject}</dd><dt>audience</dt><dd>${b.audience}</dd></dl></div>`).join('')}`;
+  }
+  const trows=SAS.flatMap(sa=>sa.targets.map(t=>({sa,t})));
+  return tabs+`<div class="shead"><h2>Kubernetes delivery targets</h2></div>
+    <p class="note" style="margin-bottom:14px">One <code>HikyoSecret</code> per managed Secret. Conditions read the same here and in <code>kubectl describe</code> — click one for both voices.</p>
+    <table class="inv" aria-label="Kubernetes targets"><thead><tr><th>hikyosecret</th><th>service account</th><th>environment</th><th>conditions</th></tr></thead>
+    <tbody>${trows.map(({sa,t})=>`<tr><td><code>${t.name}</code></td><td><code style="font-size:11.5px">${sa.id}</code></td>
+      <td><span class="envchip">${t.envK}</span></td><td style="display:flex;gap:5px;flex-wrap:wrap">${condChips(sa,t)}</td></tr>`).join('')}</tbody></table>`;
+}
+function policyStrip(){
+  return `<div class="policy">
+    <button class="toggle ${state.revealOptIn?'on':''}" role="switch" aria-checked="${state.revealOptIn}" aria-label="Machine reveal opt-in" onclick="openOptIn()"></button>
+    <div class="ptx"><div class="t">Machine secret delivery (per-project opt-in)</div>
+    <div class="note">${state.revealOptIn
+      ?'Acknowledged: workload credentials granted <code>reveal</code> are a standing decryption capability. Fresh service accounts still deliver config + secret-presence only until <code>reveal</code> is granted per account.'
+      :'Off: every workload delivery on this project is config + secret-presence only. <b>hikyo run on a fresh service account delivers no secrets</b> — this is step 4 of the setup journey.'}</div></div>
+  </div>`;
+}
+
+/* ============ variant b — journey board ============ */
+function renderB(){
+  const cards=SAS.map(sa=>{
+    const steps=sa.kind==='workload'?journey(sa):null;
+    return `<div class="jcard">
+      <div class="jhead"><span class="nm">${sa.id}</span><span class="kind ${sa.kind}">${sa.kind}</span>
+        ${sa.caps?`<span class="badge dim">${sa.caps.join(' · ')}</span>`:''}</div>
+      ${steps?`<div class="steps">${steps.map((s,i)=>`
+        <div class="step ${s.st}"><div class="dot">${s.st==='done'?'✓':s.st==='fail'?'✕':i+1}</div>
+        <div class="stx">${s.t}${s.err?`<div class="errblock">${s.err}</div>`:''}
+        ${s.st==='next'&&i===4?`<div style="margin-top:8px"><button class="btn sm pri" onclick="openGrant('${sa.id}',true)">Grant reveal…</button></div>`:''}
+        ${s.st==='next'&&i===3?`<div style="margin-top:8px"><button class="btn sm pri" onclick="openOptIn()">Review opt-in…</button></div>`:''}
+        </div></div>`).join('')}</div>`
+      :`<p class="note">Automation principal — runs off-box on a schedule or in CI. Capability allowlist: <code>${(sa.caps||['read']).join(', ')}</code>; never <code>manage-*</code>, never instance capabilities (#15).</p>`}
+      <div class="credline">
+        ${sa.creds.map(c=>`<code>${c.pfx}…</code> ${expiryBadge(c.days)}`).join(' ')}
+        ${sa.bindings.map(b=>`<span class="badge dim">federated</span> ${expiryBadge(b.days,'binding')}`).join(' ')}
+        ${!sa.creds.length&&!sa.bindings.length?'<span class="note faint">no credentials</span>':''}
+        <span style="margin-left:auto;display:flex;gap:6px">
+          <button class="btn sm" onclick="openMint('${sa.id}')">Mint</button>
+          <button class="btn sm" onclick="openBinding('${sa.id}')">Bind</button>
+        </span>
+      </div>
+      ${sa.targets.length?`<div class="tgts">${sa.targets.map(t=>`<div class="tgt"><code>${t.name}</code>${condChips(sa,t)}</div>`).join('')}</div>`:''}
+    </div>`;
+  }).join('');
+  return `<div class="shead"><h2>Machine access — setup journeys</h2>
+    <div class="right"><button class="btn pri" onclick="openMint('worker-beta')">New service account</button></div></div>
+    ${policyStrip()}<div class="board">${cards}</div>`;
+}
+
+/* ============ variant c — master-detail ============ */
+function renderC(){
+  const sa=SAS.find(s=>s.id===state.selected)||SAS[0];
+  const miss=sa.read.filter(e=>!sa.reveal.includes(e));
+  const list=SAS.map(s=>{
+    const worst=Math.min(...s.creds.map(c=>c.days),...s.bindings.map(b=>b.days),999);
+    return `<button class="mdrow ${s.id===sa.id?'act':''}" onclick="state.selected='${s.id}';render()">
+      <span class="r1"><span class="nm">${s.id}</span><span class="kind ${s.kind}">${s.kind}</span></span>
+      <span class="r2">${s.read.map(e=>`<span class="envchip ${s.reveal.includes(e)?'reveal':''}">${e}</span>`).join('')}${worst<999?expiryBadge(worst):''}</span>
+    </button>`;
+  }).join('');
+  const detail=`
+    <div class="jump">${['Identity & grants','Credentials','Federation','Delivery targets'].map((n,i)=>`<button class="jchip" onclick="document.getElementById('dsec${i}').scrollIntoView({behavior:'smooth'})">${n}</button>`).join('')}</div>
+    <section class="dsec" id="dsec0"><h3>Identity &amp; grants</h3>
+      <dl class="kv"><dt>name</dt><dd>${sa.id}</dd><dt>kind</dt><dd>${sa.kind} <span class="note faint">(immutable — guessed wrong = second service account)</span></dd>
+      <dt>created</dt><dd>${sa.created}</dd>
+      <dt>capabilities</dt><dd>${(sa.caps||['read']).join(', ')} <span class="note faint">(${sa.kind} allowlist, #15)</span></dd>
+      <dt>read scope</dt><dd>${sa.read.map(e=>`<span class="envchip">${e}</span>`).join(' ')}</dd>
+      <dt>reveal scope</dt><dd>${sa.reveal.length?sa.reveal.map(e=>`<span class="envchip reveal">${e}</span>`).join(' '):'<span class="note faint">none — delivers config + secret-presence only</span>'}</dd></dl>
+      <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+        <button class="btn sm" onclick="openGrant('${sa.id}')">Add environment grant…</button>
+        ${miss.length&&sa.kind==='workload'?`<button class="btn sm pri" onclick="openGrant('${sa.id}',true)">Grant reveal on ${miss.join(', ')}…</button>`:''}
+      </div>
+      ${miss.length&&sa.kind==='workload'?`<div class="callout bad" style="margin-top:12px"><b>Delivery is failing.</b> The resolved manifest for ${miss.map(e=>`<code>${e}</code>`).join(', ')} contains ${miss.flatMap(e=>ENV_SECRETS[e]).filter((v,i,a)=>a.indexOf(v)===i).map(k=>`<code>${k}</code>`).join(', ')} — secret occurrences this account cannot reveal. All-or-nothing: nothing syncs until reveal is granted or the mapping goes config-only.</div>`:''}
+    </section>
+    <section class="dsec" id="dsec1"><h3>Credentials <span style="text-transform:none;letter-spacing:0">— write-only: metadata, never the value</span></h3>
+      ${sa.creds.map(c=>credRow(sa,c)).join('')||'<p class="note faint">No bearer credentials.</p>'}
+      <div style="margin-top:10px"><button class="btn sm pri" onclick="openMint('${sa.id}')">Mint credential</button></div>
+    </section>
+    <section class="dsec" id="dsec2"><h3>Federated bindings</h3>
+      ${sa.bindings.map(b=>bindRow(sa,b)).join('')||'<p class="note faint">None. An external OIDC identity (Kubernetes, Forgejo/GitHub Actions) can authenticate this account with no at-rest credential.</p>'}
+      <div style="margin-top:6px"><button class="btn sm" onclick="openBinding('${sa.id}')">Add binding</button></div>
+    </section>
+    <section class="dsec" id="dsec3"><h3>Delivery targets</h3>
+      ${sa.targets.length?`<table class="inv"><thead><tr><th>hikyosecret</th><th>env</th><th>conditions</th></tr></thead><tbody>
+        ${sa.targets.map(t=>`<tr><td><code>${t.name}</code></td><td><span class="envchip">${t.envK}</span></td><td style="display:flex;gap:5px;flex-wrap:wrap">${condChips(sa,t)}</td></tr>`).join('')}</tbody></table>`
+      :'<p class="note faint">No Kubernetes targets fetch under this account.</p>'}
+    </section>`;
+  return `<div class="shead"><h2>Machine access</h2><div class="right"><button class="btn pri" onclick="openMint('worker-beta')">New service account</button></div></div>
+    ${policyStrip()}<div class="md"><div class="mdlist">${list}</div><div class="mddetail">${detail}</div></div>`;
+}
+
+/* ============ restore reconciliation (#17) ============ */
+function renderRestore(){
+  const rows=SAS.map(sa=>{
+    const re=state.reactivated[sa.id];
+    return `<div class="recrow ${re?'done':''}">
+      <div class="r1"><span class="nm">${sa.id}</span><span class="kind ${sa.kind}">${sa.kind}</span>
+        ${re?'<span class="badge ok">re-activated</span>':'<span class="badge warn">inert</span>'}</div>
+      <ul>
+        <li><span class="note faint" style="width:90px">grants</span>${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join(' ')} <span class="note faint">${re?'restored':'inert until re-activation'}</span></li>
+        ${sa.creds.map(c=>`<li><span class="note faint" style="width:90px">bearer</span><code>${c.pfx}…</code><span class="badge dead">permanently dead</span><span class="note faint">values never survive restore — re-establish by minting fresh</span></li>`).join('')}
+        ${sa.bindings.map(b=>`<li><span class="note faint" style="width:90px">federated</span><code style="font-size:11px">${b.subject}</code><span class="badge warn">quarantined</span><span class="note faint">binding survives; quarantined until the clock-skew window passes (ops spec)</span></li>`).join('')}
+      </ul>
+      ${re?`${state.minted[sa.id]?'<span class="badge ok">fresh credential minted</span>':(sa.creds.length?`<button class="btn sm pri" onclick="openMint('${sa.id}')">Mint fresh credential</button>`:'<span class="note faint">federation-only — no mint needed</span>')}`
+          :`<button class="btn sm stepup" onclick="state.reactivated['${sa.id}']=true;render();toast('${sa.id} re-activated — identity, kind and grants restored. Audited.')">Re-activate ${sa.id}</button>`}
+    </div>`;
+  }).join('');
+  return `<div class="recban"><b>RECOVERY MODE — reconciliation commit open.</b>
+    This instance was restored from the 2026-08-04 02:00 backup. Restore is a fail-closed security event (#8):
+    every service account below is <b>inert</b> until you re-activate it, explicitly, per principal.
+    <b>There is no bulk-accept</b> — each re-activation is an individual, audited decision.
+    Bearer credential values never survive restore; federated bindings do, under quarantine.</div>${rows}`;
+}
+
+/* ============ modals ============ */
+const ovl=$('#ovl'), modal=$('#modal');
+function openModal(html){modal.innerHTML=html;ovl.classList.add('show');modal.querySelector('button')?.focus()}
+function closeModal(){ovl.classList.remove('show')}
+ovl.addEventListener('click',e=>{if(e.target===ovl)closeModal()});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal()});
+
+/* display-once mint ceremony (#17): reauth step-up -> token shown exactly once */
+function openMint(said,rotate){
+  const sa=SAS.find(s=>s.id===said);
+  const envs=sa.reveal.length?sa.reveal:sa.read;
+  openModal(`<div class="mh"><h3>${rotate?'Rotate':'Mint'} credential — ${sa.id}</h3>
+    <div class="sub">${sa.kind} · scope ${sa.read.join(', ')}</div></div>
+  <div class="mb">
+    <div class="callout stepup"><b>Confirm it's you.</b> ${rotate?'Rotation':'Minting'} delivers the token display-once <b>to you</b> — the formula covers every environment reachable in the resulting post-state${envs.length?` (${envs.map(e=>`<code>${e}</code>`).join(', ')})`:''}, not just added ones. A replacement credential is not a smaller act than a new one (#17 amendment).</div>
+    ${rotate?'<p class="note">The prior value is never returned. The old credential keeps working until you revoke it — rotation and revocation are separate, deliberate acts.</p>':''}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="showToken('${said}')">Use passkey</button></div>`);
+}
+function showToken(said){
+  const sa=SAS.find(s=>s.id===said);
+  const t=`hik_1_${sa.kind==='workload'?'wl':'au'}_${randB62(43)}k7Qx`;
+  openModal(`<div class="mh"><h3>Credential minted — shown exactly once</h3>
+    <div class="sub">${sa.id} · expires 2026-11-05 (instance default)</div></div>
+  <div class="mb">
+    <div class="tokbox" id="tokval">${t}</div>
+    <button class="btn" onclick="navigator.clipboard&&navigator.clipboard.writeText(document.getElementById('tokval').textContent);toast('Copied. The clipboard is now the only copy outside your target.')">Copy to clipboard</button>
+    <div class="callout warn"><b>This value is never retrievable again.</b> The list shows metadata only; rotation never returns this value. Store it in the consuming system now — if it is lost, revoke and mint a fresh one.</div>
+    <label class="chk"><input type="checkbox" id="stored"> I have stored this credential in its target system.</label>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="if(document.getElementById('stored').checked){state.minted['${said}']=true;closeModal();render();toast('Minted. Audited: credential.minted, actor alex, display-once delivery.')}else{toast('Confirm you stored it — there is no second look.')}">Done</button></div>`);
+}
+function randB62(n){const a='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';let s='';const r=crypto.getRandomValues(new Uint8Array(n));for(const b of r)s+=a[b%62];return s}
+
+/* grant-mutation warning (#17 amends #15): names the newly-reachable plaintext set */
+function openGrant(said,revealMode){
+  const sa=SAS.find(s=>s.id===said);
+  const addable=revealMode?sa.read.filter(e=>!sa.reveal.includes(e))
+                          :Object.keys(ENV_SECRETS).filter(e=>!sa.read.includes(e));
+  const env=addable[0]||'production';
+  const newKeys=ENV_SECRETS[env]||[];
+  const nCreds=sa.creds.length+sa.bindings.length;
+  openModal(`<div class="mh"><h3>${revealMode?'Grant reveal':'Add environment grant'} — ${sa.id}</h3>
+    <div class="sub">grants attach to the service account, never to a credential</div></div>
+  <div class="mb">
+    <div class="field"><label>${revealMode?'reveal on environment':'environment (read)'}</label>
+      <select id="genv">${addable.map(e=>`<option>${e}</option>`).join('')}</select></div>
+    <div class="callout warn"><b>This grant re-scopes every credential already in circulation.</b>
+      ${sa.id} has <b>${nCreds} live credential${nCreds===1?'':'s'}</b>${sa.bindings.length?' (including federated bindings)':''} — each one ${revealMode?'gains standing decryption of':'gains read (secret-presence) on'} <code>${env}</code> the moment this lands. Newly reachable plaintext set:
+      <span class="keyset">${newKeys.map(k=>`<code>${k}</code>`).join('')}</span></div>
+    <p class="note faint">Formula: <code>manage-identities(example-app)</code> ∧ <code>reveal(${env})</code> — over the newly reachable set for a grant mutation — plus reauthentication.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="closeModal();${revealMode?`SAS.find(s=>s.id==='${said}').reveal.push(document.getElementById('genv').value)`:`SAS.find(s=>s.id==='${said}').read.push(document.getElementById('genv').value)`};render();toast('Granted after reauth. Audited: grant.widened, newly-reachable set recorded. Undo…')">Use passkey &amp; grant</button></div>`);
+}
+
+/* per-project machine-reveal opt-in (#18) */
+function openOptIn(){
+  const on=state.revealOptIn;
+  const workloads=SAS.filter(s=>s.kind==='workload'&&s.reveal.length);
+  openModal(`<div class="mh"><h3>${on?'Withdraw':'Acknowledge'} machine secret delivery — example-app</h3>
+    <div class="sub">per-project operator decision, step 4 of the setup journey</div></div>
+  <div class="mb">
+    ${on?`<div class="callout bad"><b>Withdrawing stops secret plaintext to every workload credential on this project at its next fetch.</b>
+      Currently delivering secrets: ${workloads.map(w=>`<code>${w.id}</code>`).join(', ')||'none'}.
+      Their deliveries become all-or-nothing refusals naming the undeliverable keys — workloads consuming secrets will fail loudly at next restart.</div>`
+    :`<div class="callout warn"><b>A workload credential granted <code>reveal</code> is a standing decryption capability.</b>
+      Anyone holding such a credential file can read those secrets for as long as it lives — this acknowledgement is what makes that a decision rather than an accident.
+      Granting reveal per account still requires the post-state formula + reauth afterwards.</div>`}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn ${on?'danger':'stepup'}" onclick="state.revealOptIn=!${on};closeModal();render();toast('${on?'Withdrawn — refusals begin at next fetch. Audited.':'Acknowledged after reauth. Audited: project.machine-reveal enabled.'}')">${on?'Withdraw opt-in':'Use passkey & acknowledge'}</button></div>`);
+}
+
+/* federation binding form (#17/#19): byte-exact, audience mandatory, pull_request refusal */
+function openBinding(said){
+  openModal(`<div class="mh"><h3>Add federated binding — ${said}</h3>
+    <div class="sub">byte-exact (issuer, subject) → exactly one service account · audience mandatory</div></div>
+  <div class="mb">
+    <div class="presets">
+      <button class="preset" onclick="fedPreset('k8s')">Kubernetes SA token</button>
+      <button class="preset" onclick="fedPreset('forgejo')">Forgejo Actions</button>
+      <button class="preset" onclick="fedPreset('gha')">GitHub Actions</button>
+    </div>
+    <div class="field"><label>issuer</label><input class="mono" id="fiss" placeholder="https://…" oninput="fedCheck()"></div>
+    <div class="field"><label>subject (matched byte-for-byte)</label><input class="mono" id="fsub" placeholder="system:serviceaccount:ns:name" oninput="fedCheck()"></div>
+    <div class="field"><label>audience</label><input class="mono" id="faud" value="hikyo.example.com/main" oninput="fedCheck()"></div>
+    <div class="field"><label>binding lifetime</label><select id="flt"><option>90 days (instance default)</option><option>180 days</option><option disabled>indefinite — requires allow_indefinite (off)</option></select></div>
+    <div id="fedwarn"></div>
+    <p class="note faint">No wildcards, no namespace patterns, no case folding — canonicalization merges distinct external identities. An unbound identity is not a login. Renewal is a mint; expiry warnings follow the in-product-first path.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" id="fedgo" onclick="fedSubmit()">Use passkey &amp; bind</button></div>`);
+}
+function fedPreset(k){
+  const iss=$('#fiss'),sub=$('#fsub');
+  if(k==='k8s'){iss.value='https://kubernetes.default.svc.cluster.local';sub.value='system:serviceaccount:hikyo-system:hikyo-fetch'}
+  if(k==='forgejo'){iss.value='https://git.example.com';sub.value='repo:example-org/example-app:ref:refs/heads/main'}
+  if(k==='gha'){iss.value='https://token.actions.githubusercontent.com';sub.value='repo:example-user/example-app:pull_request'}
+  fedCheck();
+}
+function fedCheck(){
+  const sub=$('#fsub').value, aud=$('#faud').value, w=$('#fedwarn'), go=$('#fedgo');
+  const pr=/:pull_request(_target)?\b/.test(sub);
+  const deliberate=$('#prbind')?.checked;
+  if(pr){
+    w.innerHTML=`<div class="callout bad"><b>Refused: subject binds <code>${sub.match(/pull_request(_target)?/)[0]}</code>.</b>
+      A pull-request workflow runs third-party code — binding it hands every PR author this service account's fetch authority.
+      Refused unless deliberately bound.</div>
+      <label class="chk" style="margin-top:8px"><input type="checkbox" id="prbind" onchange="fedCheck()"> I am deliberately binding a pull-request identity and accept that PR authors reach this account's scope.</label>`;
+    go.disabled=!deliberate; go.style.opacity=deliberate?'1':'.45';
+  } else if(!aud){
+    w.innerHTML=`<div class="callout bad"><b>Audience is mandatory.</b> A token minted for another consumer must not authenticate here.</div>`;
+    go.disabled=true; go.style.opacity='.45';
+  } else { w.innerHTML=''; go.disabled=false; go.style.opacity='1'; }
+}
+function fedSubmit(){
+  closeModal();
+  toast('Bound after reauth. Audited: binding.created — issuer, subject, audience, lifetime recorded.');
+}
+
+/* K8s CR-condition detail (#19): the same condition in kubectl and UI voice */
+function openCond(said,tname,key){
+  const c=CONDS[key];
+  openModal(`<div class="mh"><h3><code style="font-size:13px">${tname}</code> — ${key}</h3>
+    <div class="sub">the condition reads the same in kubectl and in the UI</div></div>
+  <div class="mb">
+    <div class="callout ${c.sev==='warn'?'warn':'bad'}">${c.ui(said,tname)}
+      ${c.keys.length?`<span class="keyset">${c.keys.map(k=>`<code>${k}</code>`).join('')}</span>`:''}</div>
+    <div><div class="note faint" style="margin-bottom:6px">kubectl describe hikyosecret ${tname.split('/').pop()}</div>
+    <div class="yaml">${c.yaml(tname)}</div></div>
+    <div class="callout"><b>Next step:</b> ${c.fix}</div>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="closeModal()">Close</button></div>`);
+}
+
+/* ============ shell ============ */
+const VARIANTS={a:'inventory',b:'journey board',c:'master-detail'};
+function render(){
+  const c=$('#content');
+  if(state.scenario==='restore'){c.innerHTML=renderRestore();}
+  else c.innerHTML=state.variant==='a'?renderA():state.variant==='b'?renderB():renderC();
+  $('#vlbl').textContent=`${state.variant} — ${VARIANTS[state.variant]}`;
+  const u=new URL(location);u.searchParams.set('variant',state.variant);history.replaceState(null,'',u);
+}
+function cycle(d){
+  const keys=Object.keys(VARIANTS);
+  state.variant=keys[(keys.indexOf(state.variant)+d+keys.length)%keys.length];
+  render();
+}
+$('#vprev').onclick=()=>cycle(-1);
+$('#vnext').onclick=()=>cycle(1);
+document.addEventListener('keydown',e=>{
+  if(['INPUT','TEXTAREA','SELECT'].includes(document.activeElement.tagName))return;
+  if(e.key==='ArrowLeft')cycle(-1);
+  if(e.key==='ArrowRight')cycle(1);
+});
+$('#scen').onchange=e=>{state.scenario=e.target.value;render()};
+$('#themebtn').onclick=()=>{
+  const b=document.documentElement;
+  b.dataset.theme=b.dataset.theme==='light'?'':'light';
+};
+const qp=new URL(location).searchParams.get('variant');
+if(qp&&VARIANTS[qp])state.variant=qp;
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/machine-access/2/index.html
+++ b/docs/site/public/prototypes/machine-access/2/index.html
@@ -1,0 +1,747 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo machine access (ticket #31)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #31, iteration 2.
+
+  Question: how do the workload-integration setup and service-account /
+  credential screens look and behave — against the locked machine-identity
+  (#17), Compose (#18) and Kubernetes (#19) ADRs, in the env-matrix-31
+  design language with the app-chrome reference chrome (15+16+18) and the
+  #21 ceremony vocabulary.
+
+  ITERATION 2 — structure DECIDED (Alex, it-1): variant a's tabbed
+  inventory is the surface; b's five-step journey rail becomes the row
+  EXPANSION (left column, beside credentials/bindings/targets). Variant
+  switcher removed; c discarded.
+
+  Shared: scenario simulator (normal / expiring / post-restore — the last
+  swaps the surface into the #17 restore-reconciliation screen), display-once
+  mint ceremony, grant-mutation warning naming the newly-reachable plaintext
+  set, per-project machine-reveal opt-in warning, federation binding form
+  with the pull_request refusal, K8s CR-condition vocabulary reading the
+  same in kubectl and the UI.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --warn:oklch(0.82 0.11 85);
+    --warn-soft:oklch(0.82 0.11 85/.14);
+    --ok:oklch(0.8 0.1 155);
+    --ok-soft:oklch(0.8 0.1 155/.14);
+    --stepup:oklch(0.78 0.09 250);          /* blue "confirm it's you" — #21/#29 */
+    --stepup-soft:oklch(0.78 0.09 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --warn:oklch(0.55 0.12 80);
+    --warn-soft:oklch(0.55 0.12 80/.12);
+    --ok:oklch(0.5 0.11 155);
+    --ok-soft:oklch(0.5 0.11 155/.12);
+    --stepup:oklch(0.48 0.1 255);
+    --stepup-soft:oklch(0.48 0.1 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{background:var(--bg);color:var(--tx);font-family:var(--sans);font-size:14px;
+    -webkit-font-smoothing:antialiased;height:100dvh;display:flex;flex-direction:column;
+    overflow:hidden;padding-bottom:env(safe-area-inset-bottom)}
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  code,.mono{font-family:var(--mono)}
+
+  /* ---------- app shell (app-chrome 15/18e, simplified) ---------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;padding:14px 0 12px;
+    border-right:1px solid var(--line);background:var(--bg2)}
+  .orgav{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:11px;background:var(--bg3);outline:2px solid var(--accent);outline-offset:2px}
+  .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:12px;color:var(--tx-dim);border:1px solid transparent}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  #rail .spacer{flex:1}
+  #rail .me{width:36px;height:36px;border-radius:50%;background:var(--bg3);color:var(--tx);
+    font-weight:700;font-size:11px;display:flex;align-items:center;justify-content:center}
+
+  #side{display:flex;flex-direction:column;overflow-y:auto;border-right:1px solid var(--line);
+    background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--tx-faint);
+    padding:30px 16px 6px;font-weight:700}
+  #side .stitle:first-child{padding-top:16px}
+  /* sidebar treatment e (locked, app-chrome 18): sub-items on hairline left rule */
+  #side .srow{display:flex;align-items:center;gap:8px;text-align:left;font-size:13px;color:var(--tx-dim);
+    min-height:38px;padding:9px 16px 9px 13px;margin-left:19px;width:calc(100% - 19px);
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600;border-left-color:var(--accent)}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #hdr{display:flex;align-items:center;gap:14px;padding:12px 22px;border-bottom:1px solid var(--line);flex:none}
+  #hdr .crumb{font-size:14px;font-weight:600;display:flex;align-items:baseline;gap:8px;min-width:0}
+  #hdr .crumb .sep{color:var(--tx-faint);font-weight:400}
+  #hdr .right{margin-left:auto;display:flex;align-items:center;gap:10px}
+  .hsel{background:var(--bg2);border:1px solid var(--line);border-radius:4px;color:var(--tx);
+    font-size:12px;padding:6px 8px}
+  .hbtn{border:1px solid var(--line);border-radius:4px;padding:6px 10px;font-size:12px;color:var(--tx-dim)}
+  .hbtn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  #content{flex:1;overflow-y:auto;padding:22px 22px 96px}
+
+  /* ---------- shared bits ---------- */
+  .kind{font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;font-weight:600;border-radius:3px;
+    padding:2.5px 7px;white-space:nowrap;border:1px solid var(--line);color:var(--tx-dim)}
+  .kind.workload{color:var(--accent);border-color:oklch(from var(--accent) l c h/.5);background:var(--accent-soft)}
+  .kind.automation{color:var(--stepup);border-color:oklch(from var(--stepup) l c h/.5);background:var(--stepup-soft)}
+  .envchip{font-family:var(--mono);font-size:10.5px;border:1px solid var(--line);border-radius:3px;
+    padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .envchip.reveal{border-color:oklch(from var(--accent) l c h/.6);color:var(--accent)}
+  .envchip.reveal::after{content:" ◆";font-size:9px}
+  .badge{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2px 7px;white-space:nowrap}
+  .badge.ok{color:var(--ok);background:var(--ok-soft)}
+  .badge.warn{color:var(--warn);background:var(--warn-soft)}
+  .badge.bad{color:var(--bad);background:var(--bad-soft)}
+  .badge.dim{color:var(--tx-faint);border:1px solid var(--line)}
+  .badge.dead{color:var(--bad);border:1px solid oklch(from var(--bad) l c h/.5);text-decoration:line-through}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:7px 13px;font-size:12.5px;font-weight:500;color:var(--tx-dim)}
+  .btn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  .btn.pri{background:var(--accent);color:var(--on-accent);border-color:transparent;font-weight:600}
+  .btn.pri:hover{filter:brightness(1.06)}
+  .btn.danger{color:var(--bad);border-color:oklch(from var(--bad) l c h/.5)}
+  .btn.stepup{background:var(--stepup);color:var(--bg);border-color:transparent;font-weight:600}
+  .btn.sm{padding:4px 9px;font-size:11.5px}
+  .note{font-size:12px;color:var(--tx-dim);line-height:1.55}
+  .note.faint{color:var(--tx-faint);font-size:11.5px}
+  .callout{border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:6px;
+    padding:12px 14px;font-size:12.5px;line-height:1.55;color:var(--tx-dim);background:var(--bg2)}
+  .callout.warn{border-left-color:var(--warn)}
+  .callout.bad{border-left-color:var(--bad)}
+  .callout.stepup{border-left-color:var(--stepup)}
+  .callout code{font-size:11.5px;color:var(--tx)}
+  .keyset{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+  .keyset code{border:1px solid var(--line);border-radius:3px;padding:2px 7px;font-size:11px;background:var(--bg3)}
+
+  /* condition chips (K8s CR vocabulary) */
+  .cond{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2.5px 8px;
+    white-space:nowrap;cursor:pointer;border:1px solid transparent}
+  .cond.ok{color:var(--ok);background:var(--ok-soft)}
+  .cond.bad{color:var(--bad);background:var(--bad-soft)}
+  .cond.warn{color:var(--warn);background:var(--warn-soft)}
+  .cond:hover{border-color:currentColor}
+
+  /* ---------- variant a: inventory ---------- */
+  .tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);margin-bottom:18px}
+  .tab{padding:9px 16px;font-size:13px;color:var(--tx-dim);border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab:hover{color:var(--tx)}
+  .tab.act{color:var(--tx);font-weight:600;border-bottom-color:var(--accent)}
+  .tab .cnt{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-left:6px}
+  table.inv{width:100%;border-collapse:collapse;font-size:13px}
+  table.inv th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:8px 10px;border-bottom:1px solid var(--line)}
+  table.inv td{padding:10px;border-bottom:1px solid oklch(from var(--line) l c h/.5);vertical-align:middle}
+  table.inv tr.sarow{cursor:pointer}
+  table.inv tr.sarow:hover td{background:var(--rowalt)}
+  table.inv tr.sub td{background:oklch(from var(--bg2) l c h/.6);font-size:12.5px;padding:14px 16px 16px 26px}
+  .subgrid{display:grid;grid-template-columns:minmax(300px,1fr) minmax(320px,1.2fr);gap:10px 34px}
+  .subh{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);font-weight:700;margin-bottom:6px}
+  @media (max-width:980px){.subgrid{grid-template-columns:1fr}}
+  .chev{display:inline-block;transition:transform .15s;color:var(--tx-faint);margin-right:8px;font-size:10px}
+  .open .chev{transform:rotate(90deg)}
+  .cell-envs{display:flex;flex-wrap:wrap;gap:5px}
+
+  /* ---------- journey rail (from it-1 variant b, now the row expansion) ---------- */
+  .steps{display:flex;flex-direction:column;gap:0}
+  .step{display:flex;gap:12px;position:relative;padding:7px 0}
+  .step .dot{width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;
+    font-size:10px;font-weight:700;border:1.5px solid var(--line);color:var(--tx-faint);background:var(--bg);z-index:1;margin-top:1px}
+  .step.done .dot{background:var(--ok-soft);border-color:var(--ok);color:var(--ok)}
+  .step.fail .dot{background:var(--bad-soft);border-color:var(--bad);color:var(--bad)}
+  .step.next .dot{border-color:var(--accent);color:var(--accent)}
+  .step:not(:last-child)::before{content:'';position:absolute;left:8.5px;top:26px;bottom:-8px;width:1px;
+    background:oklch(from var(--line) l c h/.75)}
+  .step .stx{font-size:12.5px;color:var(--tx-dim);line-height:1.45;min-width:0}
+  .step.done .stx{color:var(--tx-faint)}
+  .step.fail .stx,.step.next .stx{color:var(--tx)}
+  .step .stx .who{font-family:var(--mono);font-size:10px;color:var(--tx-faint)}
+  .errblock{font-family:var(--mono);font-size:11px;line-height:1.6;background:var(--bg);
+    border:1px solid oklch(from var(--bad) l c h/.4);border-radius:4px;padding:10px 12px;margin-top:6px;
+    color:var(--tx-dim);white-space:pre-wrap;word-break:break-word}
+  .errblock b{color:var(--bad);font-weight:600}
+  .tgts{display:flex;flex-direction:column;gap:6px}
+  .tgt{display:flex;align-items:center;gap:8px;font-size:12px;flex-wrap:wrap}
+  .tgt code{font-size:11px;color:var(--tx-dim)}
+
+
+  /* credential rows (shared a-sub/c) */
+  .credrow{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:8px 0;
+    border-bottom:1px solid oklch(from var(--line) l c h/.4);font-size:12.5px}
+  .credrow:last-child{border-bottom:none}
+  .credrow code.pfx{font-size:11.5px;color:var(--tx)}
+  .credrow .meta{color:var(--tx-faint);font-size:11.5px}
+  .credrow .acts{margin-left:auto;display:flex;gap:6px}
+
+  /* binding rows */
+  .kv{display:grid;grid-template-columns:150px 1fr;gap:6px 14px;font-size:12.5px}
+  .kv dt{color:var(--tx-faint)}
+  .kv dd{color:var(--tx);font-family:var(--mono);font-size:12px}
+  .bindrow{border:1px solid var(--line);border-radius:6px;padding:12px 14px;margin-bottom:10px;background:var(--bg2)}
+  .bindrow .b1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .bindrow .kv{grid-template-columns:90px 1fr}
+
+  /* section headers on the surface */
+  .shead{display:flex;align-items:center;gap:12px;margin:0 0 14px;flex-wrap:wrap}
+  .shead h2{font-size:16px;font-weight:700}
+  .shead .right{margin-left:auto;display:flex;gap:8px}
+  .policy{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;
+    display:flex;align-items:flex-start;gap:14px;margin-bottom:18px;flex-wrap:wrap}
+  .policy .ptx{flex:1;min-width:240px}
+  .policy .ptx .t{font-weight:600;font-size:13px;margin-bottom:3px}
+  .toggle{width:40px;height:22px;border-radius:999px;border:1px solid var(--line);background:var(--bg3);
+    position:relative;flex:none;margin-top:2px}
+  .toggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
+    background:var(--tx-faint);transition:left .15s,background .15s}
+  .toggle.on{background:var(--accent-soft);border-color:var(--accent)}
+  .toggle.on::after{left:20px;background:var(--accent)}
+
+  /* ---------- restore reconciliation ---------- */
+  .recban{border:1px solid oklch(from var(--bad) l c h/.55);background:var(--bad-soft);border-radius:6px;
+    padding:14px 16px;margin-bottom:18px;font-size:13px;line-height:1.55}
+  .recban b{color:var(--bad)}
+  .recrow{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;margin-bottom:12px}
+  .recrow .r1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .recrow .r1 .nm{font-family:var(--mono);font-weight:600;font-size:13.5px}
+  .recrow ul{list-style:none;display:flex;flex-direction:column;gap:5px;font-size:12.5px;color:var(--tx-dim);margin:6px 0 10px}
+  .recrow li{display:flex;gap:8px;align-items:baseline;flex-wrap:wrap}
+  .recrow.done{border-color:oklch(from var(--ok) l c h/.5)}
+
+  /* ---------- modal ---------- */
+  #ovl{position:fixed;inset:0;background:oklch(0 0 0/.55);display:none;align-items:center;justify-content:center;
+    z-index:40;padding:18px}
+  #ovl.show{display:flex}
+  #modal{background:var(--bg);border:1px solid var(--line);border-radius:6px;box-shadow:var(--sheet-shadow);
+    width:min(560px,100%);max-height:88dvh;display:flex;flex-direction:column}
+  #modal .mh{padding:16px 20px 0}
+  #modal .mh h3{font-size:15px;font-weight:700}
+  #modal .mh .sub{font-size:12px;color:var(--tx-faint);margin-top:3px}
+  #modal .mb{padding:14px 20px;overflow-y:auto;display:flex;flex-direction:column;gap:12px}
+  #modal .mf{padding:12px 20px 16px;display:flex;gap:8px;justify-content:flex-end;border-top:1px solid var(--line)}
+  .tokbox{font-family:var(--mono);font-size:12.5px;background:var(--bg2);border:1px solid var(--accent);
+    border-radius:4px;padding:14px;word-break:break-all;line-height:1.6;color:var(--tx)}
+  .field{display:flex;flex-direction:column;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input,.field select{background:var(--bg2);border:1px solid var(--line);border-radius:4px;
+    color:var(--tx);padding:8px 10px;font-size:13px;width:100%}
+  .field input.mono{font-family:var(--mono);font-size:12px}
+  .chk{display:flex;gap:10px;align-items:flex-start;font-size:12.5px;color:var(--tx-dim);line-height:1.5;cursor:pointer}
+  .chk input{margin-top:2px;accent-color:var(--accent)}
+  .presets{display:flex;gap:6px;flex-wrap:wrap}
+  .preset{font-size:11.5px;border:1px solid var(--line);border-radius:3px;padding:4px 10px;color:var(--tx-dim)}
+  .preset:hover{border-color:var(--accent);color:var(--tx)}
+  .yaml{font-family:var(--mono);font-size:11px;line-height:1.65;background:var(--bg2);border:1px solid var(--line);
+    border-radius:4px;padding:12px 14px;white-space:pre-wrap;word-break:break-word;color:var(--tx-dim)}
+  .yaml .k{color:var(--accent)}
+  .yaml .bad{color:var(--bad)}
+
+  /* toast */
+  #toast{position:fixed;bottom:76px;left:50%;transform:translateX(-50%);background:var(--bg3);
+    border:1px solid var(--line);border-radius:6px;padding:10px 16px;font-size:12.5px;display:none;z-index:60;
+    box-shadow:var(--sheet-shadow)}
+  #toast.show{display:block}
+
+
+  @media (max-width:860px){
+    #app{grid-template-columns:56px 1fr}
+    #side{display:none}
+    .kv{grid-template-columns:120px 1fr}
+  }
+</style>
+</head>
+<body>
+<div id="app">
+  <nav id="rail" aria-label="Organizations and projects">
+    <div class="orgav" title="example.com">WI</div>
+    <div class="raildiv"></div>
+    <div class="pav act" title="example-app">DB</div>
+    <div class="pav" title="sample-catalog">PT</div>
+    <div class="spacer"></div>
+    <div class="me" title="Alex">MW</div>
+  </nav>
+  <nav id="side" aria-label="Project sections">
+    <div class="stitle">example-app</div>
+    <button class="srow">Environment matrix</button>
+    <button class="srow">Version history</button>
+    <button class="srow act">Machine access <span class="cnt" id="side-cnt">5</span></button>
+    <button class="srow">Project settings</button>
+    <div class="stitle">Organization</div>
+    <button class="srow">Members &amp; grants</button>
+    <button class="srow">Org settings</button>
+  </nav>
+  <div id="main">
+    <header id="hdr">
+      <div class="crumb"><span>example-app</span><span class="sep">/</span><span>Machine access</span></div>
+      <div class="right">
+        <label class="note faint" for="scen">scenario</label>
+        <select id="scen" class="hsel" aria-label="Scenario simulator">
+          <option value="normal">normal</option>
+          <option value="expiring">expiring credentials</option>
+          <option value="restore">post-restore</option>
+        </select>
+        <button class="hbtn" id="themebtn" aria-label="Toggle theme">◐</button>
+      </div>
+    </header>
+    <div id="content"></div>
+  </div>
+</div>
+
+<div id="ovl" role="dialog" aria-modal="true"><div id="modal"></div></div>
+<div id="toast" role="status"></div>
+
+<script>
+/* ============ demo data (in-memory only — PROTOTYPE) ============ */
+const ENV_SECRETS = { // secret keys per environment — the "newly reachable plaintext set"
+  production:['DATABASE_URL','SMTP_PASSWORD','S3_SECRET_KEY','SESSION_PEPPER'],
+  staging:['DATABASE_URL','S3_SECRET_KEY'],
+  development:['DATABASE_URL'],
+};
+const state = {
+  tab:'sa', scenario:'normal', openRows:{},
+  revealOptIn:true,          // per-project machine-reveal opt-in (#18)
+  reactivated:{},            // restore scenario
+  minted:{},                 // sa -> fresh cred minted post-restore
+};
+const SAS = [
+  {id:'api-workload', kind:'workload', created:'2026-07-02', read:['production'], reveal:['production'],
+   creds:[{pfx:'hik_1_wl_9fK2mQ', created:'2026-07-02', expiry:'2026-10-01', days:57, last:'2 min ago'}],
+   bindings:[], targets:[]},
+  {id:'staging-runner', kind:'workload', created:'2026-06-18', read:['staging'], reveal:['staging'],
+   creds:[{pfx:'hik_1_wl_x7Rq0d', created:'2026-06-18', expiry:'2026-08-19', days:14, last:'41 min ago'},
+          {pfx:'hik_1_wl_p2Vn8s', created:'2026-08-01', expiry:'2026-11-01', days:88, last:'never'}],
+   bindings:[], targets:[]},
+  {id:'worker-beta', kind:'workload', created:'2026-08-04', read:['staging'], reveal:[],
+   creds:[{pfx:'hik_1_wl_c4Ht2z', created:'2026-08-04', expiry:'2026-11-04', days:91, last:'6 min ago'}],
+   bindings:[], targets:[]},
+  {id:'k3s-cluster', kind:'workload', created:'2026-05-30', read:['production','staging'], reveal:['production'],
+   creds:[],
+   bindings:[{issuer:'https://kubernetes.default.svc.cluster.local',
+              subject:'system:serviceaccount:hikyo-system:hikyo-fetch',
+              audience:'hikyo.example.com/main', expiry:'2026-11-30', days:117}],
+   targets:[
+     {name:'apps/api-env', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'ok', reason:'Completed'}]},
+     {name:'apps/worker-env', ns:'apps', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'UndeliverableKeys'}]},
+     {name:'batch/report-env', ns:'batch', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'LoaderControlAckRequired'}]},
+     {name:'apps/api-env (canary)', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'warn', reason:'Stalled'}]},
+     {name:'legacy/import-env', ns:'legacy', envK:'staging',
+      conds:[{t:'NotReconciled', s:'bad', reason:'DesignationMissing'}]},
+   ]},
+  {id:'ci-export', kind:'automation', created:'2026-06-01', read:['production'], reveal:[], caps:['read','audit-read'],
+   creds:[{pfx:'hik_1_au_m3Wb5k', created:'2026-06-01', expiry:'2026-09-01', days:27, last:'3 h ago'}],
+   bindings:[{issuer:'https://token.actions.githubusercontent.com',
+              subject:'repo:example-user/example-app:ref:refs/heads/main',
+              audience:'hikyo.example.com/main', expiry:'2026-08-07', days:2}],
+   targets:[]},
+];
+const CONDS = { // CR-condition vocabulary (#19) — kubectl YAML + the same sentence as UI copy
+  'UndeliverableKeys':{sev:'bad', ui:(sa,t)=>`Nothing was synced: the resolved manifest contains secret keys this service account cannot reveal. Delivery is all-or-nothing — partial sync would surface as the application's own crash three layers away.`,
+    keys:['DATABASE_URL','S3_SECRET_KEY'],
+    fix:`Grant <code>reveal(staging)</code> to <code>k3s-cluster</code> — requires <code>manage-identities(example-app)</code> ∧ <code>reveal</code> over the whole post-state, plus reauthentication.`,
+    yaml:(t)=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">UndeliverableKeys</span>
+    message: >-
+      refusing to sync: manifest contains secret occurrences this
+      principal cannot reveal: DATABASE_URL, S3_SECRET_KEY.
+      delivery is all-or-nothing. required: machine-reveal opt-in
+      on project example-app + reveal(staging) on service account
+      k3s-cluster.`},
+  'LoaderControlAckRequired':{sev:'bad', ui:()=>`The mapping delivers <code>PATH</code>, a key on the loader-control baseline. The refusal is enforced at delivery, consumption-agnostic — even a volume-mount-only Secret needs the acknowledgement, because delivery time cannot know how a key is consumed.`,
+    keys:['PATH'],
+    fix:`Add the acknowledgement to the <code>HikyoSecret</code> listing exactly these keys. The acknowledged list is carried on the fetch and recorded in Hikyo's audit event (#24) — regardless of cluster audit posture.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">LoaderControlAckRequired</span>
+    message: >-
+      mapping delivers loader-control baseline key: PATH.
+      add spec.loaderControlAck listing exactly these keys.
+      the acknowledged list is carried on every fetch and
+      recorded in the server audit log.`},
+  'Stalled':{sev:'warn', ui:()=>`The Secret is delivered and current, but the workload controller has not completed the rollout — this Deployment is paused. Delivered-but-not-rolled is a visible state, never a silent success; the operator claims completion only from the workload controller's own status.`,
+    keys:[], fix:`Resume the Deployment (<code>kubectl rollout resume</code>), or accept that pods roll on the next controller-driven restart.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">RolloutRequested</span>
+    status: "False"
+    reason: <span class="bad">Stalled</span>
+    message: >-
+      secret delivered (converged@rev41) but deployment
+      apps/api-canary is paused; rollout has not completed.
+      completion is claimed only from the workload
+      controller's own status.`},
+  'DesignationMissing':{sev:'bad', ui:()=>`The referenced bootstrap Secret is not designated for Hikyo delivery use. Designation is an act by someone holding <b>write</b> on that Secret — a strictly greater right than reading it — and must name the <code>HikyoInstance</code> it may be presented to.`,
+    keys:[], fix:`Label the bootstrap Secret with the designation naming <code>HikyoInstance/main</code> (spelling per #25), applied by a principal with write on the Secret.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">NotReconciled</span>
+    status: "True"
+    reason: <span class="bad">DesignationMissing</span>
+    message: >-
+      referenced Secret legacy/hikyo-bootstrap is not
+      designated for hikyo delivery use, or its designation
+      does not name HikyoInstance/main. designate it with
+      write authority on the Secret.`},
+};
+
+/* ============ helpers ============ */
+const $=s=>document.querySelector(s);
+const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+function toast(msg){const t=$('#toast');t.textContent=msg;t.classList.add('show');clearTimeout(t._h);t._h=setTimeout(()=>t.classList.remove('show'),3200)}
+function expiryBadge(days,label){ // in-product-first expiry signal (#17)
+  const hot=state.scenario==='expiring';
+  const d=hot?Math.max(1,Math.round(days/7)):days;
+  if(d<=7) return `<span class="badge bad">expires in ${d}d</span>`;
+  if(d<=30) return `<span class="badge warn">expires in ${d}d</span>`;
+  return `<span class="badge dim">${label||'expires'} ${d}d</span>`;
+}
+function journey(sa){ // five-step journey state (#18)
+  const s=[];
+  s.push({t:`Service account minted <span class="who">kind: ${sa.kind} — immutable at creation</span>`, st:'done'});
+  s.push({t:`<code>read</code> granted — ${sa.read.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">delivers config + secret-presence only</span>`, st:sa.read.length?'done':'next'});
+  const missing=sa.read.filter(e=>!sa.reveal.includes(e));
+  const failing=missing.length&&sa.kind==='workload';
+  s.push({t:failing?`Delivery fails, naming what it could not deliver`:`First delivery succeeded`, st:failing?'fail':'done',
+    err:failing?(sa.targets.length?`HikyoSecret apps/worker-env — SyncRefused
+<b>reason:</b> UndeliverableKeys
+manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was synced.
+required: reveal(${missing[0]}) on ${sa.id}`
+:`$ hikyo run --project example-app --env ${missing[0]} -- node worker.js
+<b>refused:</b> manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was started.
+required: reveal(${missing[0]}) on ${sa.id}`):null});
+  s.push({t:`Project machine-reveal opt-in ${state.revealOptIn?'acknowledged':'<b>not acknowledged</b>'} <span class="who">a credential holding reveal is a standing decryption capability</span>`, st:state.revealOptIn?'done':(failing?'next':'done')});
+  s.push({t:missing.length?`Grant <code>reveal</code> on ${missing.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">manage-identities ∧ reveal over the post-state + reauth</span>`:`<code>reveal</code> granted — full delivery`, st:missing.length?(state.revealOptIn?'next':''):'done'});
+  return s;
+}
+function credRow(sa,c){
+  return `<div class="credrow">
+    <code class="pfx">${c.pfx}…</code>
+    <span class="badge dim">bearer</span>
+    ${expiryBadge(c.days)}
+    <span class="meta">created ${c.created} · last used ${c.last}</span>
+    <span class="acts">
+      <button class="btn sm" onclick="openMint('${sa.id}',true)">Rotate</button>
+      <button class="btn sm danger" onclick="toast('Revoked — bites at the next fetch, never at expiry (#15). Undo…')">Revoke</button>
+    </span>
+  </div>`;
+}
+function bindRow(sa,b){
+  return `<div class="bindrow">
+    <div class="b1"><span class="badge dim">federated</span>${expiryBadge(b.days,'binding expires')}
+      <span class="note faint">byte-for-byte match — no wildcards, no case folding · renewal is a mint</span></div>
+    <dl class="kv">
+      <dt>issuer</dt><dd>${b.issuer}</dd>
+      <dt>subject</dt><dd>${b.subject}</dd>
+      <dt>audience</dt><dd>${b.audience}</dd>
+    </dl>
+  </div>`;
+}
+function condChips(sa,t){
+  return t.conds.map(c=>{
+    const key=CONDS[c.reason]?c.reason:null;
+    return `<span class="cond ${c.s}" ${key?`onclick="openCond('${sa.id}','${esc(t.name)}','${key}')"`:''} role="${key?'button':'status'}">${c.t}: ${c.reason}</span>`;
+  }).join(' ');
+}
+
+/* ============ variant a — inventory ============ */
+function renderA(){
+  const tabs=`<div class="tabs" role="tablist">
+    <button class="tab ${state.tab==='sa'?'act':''}" onclick="state.tab='sa';render()">Service accounts<span class="cnt">${SAS.length}</span></button>
+    <button class="tab ${state.tab==='fed'?'act':''}" onclick="state.tab='fed';render()">Federation<span class="cnt">${SAS.flatMap(s=>s.bindings).length}</span></button>
+    <button class="tab ${state.tab==='k8s'?'act':''}" onclick="state.tab='k8s';render()">Kubernetes targets<span class="cnt">${SAS.flatMap(s=>s.targets).length}</span></button>
+  </div>`;
+  if(state.tab==='sa'){
+    const rows=SAS.map(sa=>{
+      const open=state.openRows[sa.id];
+      const worst=Math.min(...sa.creds.map(c=>c.days),...sa.bindings.map(b=>b.days),999);
+      const miss=sa.read.filter(e=>!sa.reveal.includes(e));
+      const setup=sa.kind!=='workload'?'<span class="badge dim">n/a</span>':
+        miss.length?`<span class="badge bad">step ${state.revealOptIn?5:4} of 5</span>`:'<span class="badge ok">complete</span>';
+      let h=`<tr class="sarow ${open?'open':''}" onclick="state.openRows['${sa.id}']=!${!!open};render()">
+        <td><span class="chev">▶</span><code>${sa.id}</code></td>
+        <td><span class="kind ${sa.kind}">${sa.kind}</span></td>
+        <td><span class="cell-envs">${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join('')}</span></td>
+        <td>${sa.creds.length+sa.bindings.length} ${worst<999?expiryBadge(worst):''}</td>
+        <td class="mono" style="font-size:11.5px;color:var(--tx-faint)">${sa.creds[0]?.last??(sa.bindings.length?'via federation':'—')}</td>
+        <td>${setup}</td></tr>`;
+      if(open){
+        // expansion = b's journey rail (Alex's it-1 verdict) + credentials/bindings/targets
+        const steps=sa.kind==='workload'?journey(sa):null;
+        const left=steps?`<div class="steps">${steps.map((s,i)=>`
+            <div class="step ${s.st}"><div class="dot">${s.st==='done'?'✓':s.st==='fail'?'✕':i+1}</div>
+            <div class="stx">${s.t}${s.err?`<div class="errblock">${s.err}</div>`:''}
+            ${s.st==='next'&&i===4?`<div style="margin-top:8px"><button class="btn sm pri" onclick="event.stopPropagation();openGrant('${sa.id}',true)">Grant reveal…</button></div>`:''}
+            ${s.st==='next'&&i===3?`<div style="margin-top:8px"><button class="btn sm pri" onclick="event.stopPropagation();openOptIn()">Review opt-in…</button></div>`:''}
+            </div></div>`).join('')}</div>`
+          :`<p class="note" style="max-width:38ch">Automation principal — runs off-box on a schedule or in CI. Capability allowlist: <code>${(sa.caps||['read']).join(', ')}</code>; never <code>manage-*</code>, never instance capabilities (#15). No setup journey: automation never delivers to a workload.</p>`;
+        h+=`<tr class="sub"><td colspan="6"><div class="subgrid">
+          <div>${left}</div>
+          <div>
+            <div class="subh">credentials</div>
+            ${sa.creds.map(c=>credRow(sa,c)).join('')||'<div class="note faint" style="padding:4px 0 8px">No bearer credentials — authenticates by federation only.</div>'}
+            ${sa.bindings.length?`<div class="subh" style="margin-top:12px">federated bindings</div>${sa.bindings.map(b=>bindRow(sa,b)).join('')}`:''}
+            ${sa.targets.length?`<div class="subh" style="margin-top:12px">delivery targets</div><div class="tgts">${sa.targets.map(t=>`<div class="tgt"><code>${t.name}</code>${condChips(sa,t)}</div>`).join('')}</div>`:''}
+            <div style="display:flex;gap:8px;margin-top:14px;flex-wrap:wrap">
+              <button class="btn sm pri" onclick="event.stopPropagation();openMint('${sa.id}')">Mint credential</button>
+              <button class="btn sm" onclick="event.stopPropagation();openBinding('${sa.id}')">Add federated binding</button>
+              <button class="btn sm" onclick="event.stopPropagation();openGrant('${sa.id}')">Add environment grant…</button>
+            </div>
+          </div>
+        </div></td></tr>`;
+      }
+      return h;
+    }).join('');
+    return tabs+policyStrip()+`<table class="inv" aria-label="Service accounts">
+      <thead><tr><th>service account</th><th>kind</th><th>read scope <span style="text-transform:none;letter-spacing:0">(◆ = reveal)</span></th><th>credentials</th><th>last used</th><th>setup</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+      <p class="note faint" style="margin-top:12px">Credential list is metadata only — prefix, kind, scope, expiry, last-used. Values are write-only: displayed exactly once at mint, never retrievable, rotation never returns the prior value (#17).</p>`;
+  }
+  if(state.tab==='fed'){
+    const rows=SAS.flatMap(sa=>sa.bindings.map(b=>({sa,b})));
+    return tabs+`<div class="shead"><h2>Federated bindings</h2><div class="right"><button class="btn pri" onclick="openBinding('k3s-cluster')">New binding</button></div></div>
+      <p class="note" style="margin-bottom:14px">An external OIDC identity is bound to exactly one service account by a byte-exact <code>(issuer, subject)</code> pair — no wildcards, no JIT provisioning. An unbound identity is not a login. A binding is a standing permission to present tokens and expires on the same terms as a bearer credential; renewal is a mint.</p>
+      ${rows.map(({sa,b})=>`<div class="bindrow"><div class="b1"><code style="font-size:12px;font-weight:600">${sa.id}</code><span class="kind ${sa.kind}">${sa.kind}</span>${expiryBadge(b.days,'binding expires')}</div>
+        <dl class="kv"><dt>issuer</dt><dd>${b.issuer}</dd><dt>subject</dt><dd>${b.subject}</dd><dt>audience</dt><dd>${b.audience}</dd></dl></div>`).join('')}`;
+  }
+  const trows=SAS.flatMap(sa=>sa.targets.map(t=>({sa,t})));
+  return tabs+`<div class="shead"><h2>Kubernetes delivery targets</h2></div>
+    <p class="note" style="margin-bottom:14px">One <code>HikyoSecret</code> per managed Secret. Conditions read the same here and in <code>kubectl describe</code> — click one for both voices.</p>
+    <table class="inv" aria-label="Kubernetes targets"><thead><tr><th>hikyosecret</th><th>service account</th><th>environment</th><th>conditions</th></tr></thead>
+    <tbody>${trows.map(({sa,t})=>`<tr><td><code>${t.name}</code></td><td><code style="font-size:11.5px">${sa.id}</code></td>
+      <td><span class="envchip">${t.envK}</span></td><td style="display:flex;gap:5px;flex-wrap:wrap">${condChips(sa,t)}</td></tr>`).join('')}</tbody></table>`;
+}
+function policyStrip(){
+  return `<div class="policy">
+    <button class="toggle ${state.revealOptIn?'on':''}" role="switch" aria-checked="${state.revealOptIn}" aria-label="Machine reveal opt-in" onclick="openOptIn()"></button>
+    <div class="ptx"><div class="t">Machine secret delivery (per-project opt-in)</div>
+    <div class="note">${state.revealOptIn
+      ?'Acknowledged: workload credentials granted <code>reveal</code> are a standing decryption capability. Fresh service accounts still deliver config + secret-presence only until <code>reveal</code> is granted per account.'
+      :'Off: every workload delivery on this project is config + secret-presence only. <b>hikyo run on a fresh service account delivers no secrets</b> — this is step 4 of the setup journey.'}</div></div>
+  </div>`;
+}
+
+/* ============ restore reconciliation (#17) ============ */
+function renderRestore(){
+  const rows=SAS.map(sa=>{
+    const re=state.reactivated[sa.id];
+    return `<div class="recrow ${re?'done':''}">
+      <div class="r1"><span class="nm">${sa.id}</span><span class="kind ${sa.kind}">${sa.kind}</span>
+        ${re?'<span class="badge ok">re-activated</span>':'<span class="badge warn">inert</span>'}</div>
+      <ul>
+        <li><span class="note faint" style="width:90px">grants</span>${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join(' ')} <span class="note faint">${re?'restored':'inert until re-activation'}</span></li>
+        ${sa.creds.map(c=>`<li><span class="note faint" style="width:90px">bearer</span><code>${c.pfx}…</code><span class="badge dead">permanently dead</span><span class="note faint">values never survive restore — re-establish by minting fresh</span></li>`).join('')}
+        ${sa.bindings.map(b=>`<li><span class="note faint" style="width:90px">federated</span><code style="font-size:11px">${b.subject}</code><span class="badge warn">quarantined</span><span class="note faint">binding survives; quarantined until the clock-skew window passes (ops spec)</span></li>`).join('')}
+      </ul>
+      ${re?`${state.minted[sa.id]?'<span class="badge ok">fresh credential minted</span>':(sa.creds.length?`<button class="btn sm pri" onclick="openMint('${sa.id}')">Mint fresh credential</button>`:'<span class="note faint">federation-only — no mint needed</span>')}`
+          :`<button class="btn sm stepup" onclick="state.reactivated['${sa.id}']=true;render();toast('${sa.id} re-activated — identity, kind and grants restored. Audited.')">Re-activate ${sa.id}</button>`}
+    </div>`;
+  }).join('');
+  return `<div class="recban"><b>RECOVERY MODE — reconciliation commit open.</b>
+    This instance was restored from the 2026-08-04 02:00 backup. Restore is a fail-closed security event (#8):
+    every service account below is <b>inert</b> until you re-activate it, explicitly, per principal.
+    <b>There is no bulk-accept</b> — each re-activation is an individual, audited decision.
+    Bearer credential values never survive restore; federated bindings do, under quarantine.</div>${rows}`;
+}
+
+/* ============ modals ============ */
+const ovl=$('#ovl'), modal=$('#modal');
+function openModal(html){modal.innerHTML=html;ovl.classList.add('show');modal.querySelector('button')?.focus()}
+function closeModal(){ovl.classList.remove('show')}
+ovl.addEventListener('click',e=>{if(e.target===ovl)closeModal()});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal()});
+
+/* display-once mint ceremony (#17): reauth step-up -> token shown exactly once */
+function openMint(said,rotate){
+  const sa=SAS.find(s=>s.id===said);
+  const envs=sa.reveal.length?sa.reveal:sa.read;
+  openModal(`<div class="mh"><h3>${rotate?'Rotate':'Mint'} credential — ${sa.id}</h3>
+    <div class="sub">${sa.kind} · scope ${sa.read.join(', ')}</div></div>
+  <div class="mb">
+    <div class="callout stepup"><b>Confirm it's you.</b> ${rotate?'Rotation':'Minting'} delivers the token display-once <b>to you</b> — the formula covers every environment reachable in the resulting post-state${envs.length?` (${envs.map(e=>`<code>${e}</code>`).join(', ')})`:''}, not just added ones. A replacement credential is not a smaller act than a new one (#17 amendment).</div>
+    ${rotate?'<p class="note">The prior value is never returned. The old credential keeps working until you revoke it — rotation and revocation are separate, deliberate acts.</p>':''}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="showToken('${said}')">Use passkey</button></div>`);
+}
+function showToken(said){
+  const sa=SAS.find(s=>s.id===said);
+  const t=`hik_1_${sa.kind==='workload'?'wl':'au'}_${randB62(43)}k7Qx`;
+  openModal(`<div class="mh"><h3>Credential minted — shown exactly once</h3>
+    <div class="sub">${sa.id} · expires 2026-11-05 (instance default)</div></div>
+  <div class="mb">
+    <div class="tokbox" id="tokval">${t}</div>
+    <button class="btn" onclick="navigator.clipboard&&navigator.clipboard.writeText(document.getElementById('tokval').textContent);toast('Copied. The clipboard is now the only copy outside your target.')">Copy to clipboard</button>
+    <div class="callout warn"><b>This value is never retrievable again.</b> The list shows metadata only; rotation never returns this value. Store it in the consuming system now — if it is lost, revoke and mint a fresh one.</div>
+    <label class="chk"><input type="checkbox" id="stored"> I have stored this credential in its target system.</label>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="if(document.getElementById('stored').checked){state.minted['${said}']=true;closeModal();render();toast('Minted. Audited: credential.minted, actor alex, display-once delivery.')}else{toast('Confirm you stored it — there is no second look.')}">Done</button></div>`);
+}
+function randB62(n){const a='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';let s='';const r=crypto.getRandomValues(new Uint8Array(n));for(const b of r)s+=a[b%62];return s}
+
+/* grant-mutation warning (#17 amends #15): names the newly-reachable plaintext set */
+function openGrant(said,revealMode){
+  const sa=SAS.find(s=>s.id===said);
+  const addable=revealMode?sa.read.filter(e=>!sa.reveal.includes(e))
+                          :Object.keys(ENV_SECRETS).filter(e=>!sa.read.includes(e));
+  const env=addable[0]||'production';
+  const newKeys=ENV_SECRETS[env]||[];
+  const nCreds=sa.creds.length+sa.bindings.length;
+  openModal(`<div class="mh"><h3>${revealMode?'Grant reveal':'Add environment grant'} — ${sa.id}</h3>
+    <div class="sub">grants attach to the service account, never to a credential</div></div>
+  <div class="mb">
+    <div class="field"><label>${revealMode?'reveal on environment':'environment (read)'}</label>
+      <select id="genv">${addable.map(e=>`<option>${e}</option>`).join('')}</select></div>
+    <div class="callout warn"><b>This grant re-scopes every credential already in circulation.</b>
+      ${sa.id} has <b>${nCreds} live credential${nCreds===1?'':'s'}</b>${sa.bindings.length?' (including federated bindings)':''} — each one ${revealMode?'gains standing decryption of':'gains read (secret-presence) on'} <code>${env}</code> the moment this lands. Newly reachable plaintext set:
+      <span class="keyset">${newKeys.map(k=>`<code>${k}</code>`).join('')}</span></div>
+    <p class="note faint">Formula: <code>manage-identities(example-app)</code> ∧ <code>reveal(${env})</code> — over the newly reachable set for a grant mutation — plus reauthentication.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="closeModal();${revealMode?`SAS.find(s=>s.id==='${said}').reveal.push(document.getElementById('genv').value)`:`SAS.find(s=>s.id==='${said}').read.push(document.getElementById('genv').value)`};render();toast('Granted after reauth. Audited: grant.widened, newly-reachable set recorded. Undo…')">Use passkey &amp; grant</button></div>`);
+}
+
+/* per-project machine-reveal opt-in (#18) */
+function openOptIn(){
+  const on=state.revealOptIn;
+  const workloads=SAS.filter(s=>s.kind==='workload'&&s.reveal.length);
+  openModal(`<div class="mh"><h3>${on?'Withdraw':'Acknowledge'} machine secret delivery — example-app</h3>
+    <div class="sub">per-project operator decision, step 4 of the setup journey</div></div>
+  <div class="mb">
+    ${on?`<div class="callout bad"><b>Withdrawing stops secret plaintext to every workload credential on this project at its next fetch.</b>
+      Currently delivering secrets: ${workloads.map(w=>`<code>${w.id}</code>`).join(', ')||'none'}.
+      Their deliveries become all-or-nothing refusals naming the undeliverable keys — workloads consuming secrets will fail loudly at next restart.</div>`
+    :`<div class="callout warn"><b>A workload credential granted <code>reveal</code> is a standing decryption capability.</b>
+      Anyone holding such a credential file can read those secrets for as long as it lives — this acknowledgement is what makes that a decision rather than an accident.
+      Granting reveal per account still requires the post-state formula + reauth afterwards.</div>`}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn ${on?'danger':'stepup'}" onclick="state.revealOptIn=!${on};closeModal();render();toast('${on?'Withdrawn — refusals begin at next fetch. Audited.':'Acknowledged after reauth. Audited: project.machine-reveal enabled.'}')">${on?'Withdraw opt-in':'Use passkey & acknowledge'}</button></div>`);
+}
+
+/* federation binding form (#17/#19): byte-exact, audience mandatory, pull_request refusal */
+function openBinding(said){
+  openModal(`<div class="mh"><h3>Add federated binding — ${said}</h3>
+    <div class="sub">byte-exact (issuer, subject) → exactly one service account · audience mandatory</div></div>
+  <div class="mb">
+    <div class="presets">
+      <button class="preset" onclick="fedPreset('k8s')">Kubernetes SA token</button>
+      <button class="preset" onclick="fedPreset('forgejo')">Forgejo Actions</button>
+      <button class="preset" onclick="fedPreset('gha')">GitHub Actions</button>
+    </div>
+    <div class="field"><label>issuer</label><input class="mono" id="fiss" placeholder="https://…" oninput="fedCheck()"></div>
+    <div class="field"><label>subject (matched byte-for-byte)</label><input class="mono" id="fsub" placeholder="system:serviceaccount:ns:name" oninput="fedCheck()"></div>
+    <div class="field"><label>audience</label><input class="mono" id="faud" value="hikyo.example.com/main" oninput="fedCheck()"></div>
+    <div class="field"><label>binding lifetime</label><select id="flt"><option>90 days (instance default)</option><option>180 days</option><option disabled>indefinite — requires allow_indefinite (off)</option></select></div>
+    <div id="fedwarn"></div>
+    <p class="note faint">No wildcards, no namespace patterns, no case folding — canonicalization merges distinct external identities. An unbound identity is not a login. Renewal is a mint; expiry warnings follow the in-product-first path.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" id="fedgo" onclick="fedSubmit()">Use passkey &amp; bind</button></div>`);
+}
+function fedPreset(k){
+  const iss=$('#fiss'),sub=$('#fsub');
+  if(k==='k8s'){iss.value='https://kubernetes.default.svc.cluster.local';sub.value='system:serviceaccount:hikyo-system:hikyo-fetch'}
+  if(k==='forgejo'){iss.value='https://git.example.com';sub.value='repo:example-org/example-app:ref:refs/heads/main'}
+  if(k==='gha'){iss.value='https://token.actions.githubusercontent.com';sub.value='repo:example-user/example-app:pull_request'}
+  fedCheck();
+}
+function fedCheck(){
+  const sub=$('#fsub').value, aud=$('#faud').value, w=$('#fedwarn'), go=$('#fedgo');
+  const pr=/:pull_request(_target)?\b/.test(sub);
+  const deliberate=$('#prbind')?.checked;
+  if(pr){
+    w.innerHTML=`<div class="callout bad"><b>Refused: subject binds <code>${sub.match(/pull_request(_target)?/)[0]}</code>.</b>
+      A pull-request workflow runs third-party code — binding it hands every PR author this service account's fetch authority.
+      Refused unless deliberately bound.</div>
+      <label class="chk" style="margin-top:8px"><input type="checkbox" id="prbind" onchange="fedCheck()"> I am deliberately binding a pull-request identity and accept that PR authors reach this account's scope.</label>`;
+    go.disabled=!deliberate; go.style.opacity=deliberate?'1':'.45';
+  } else if(!aud){
+    w.innerHTML=`<div class="callout bad"><b>Audience is mandatory.</b> A token minted for another consumer must not authenticate here.</div>`;
+    go.disabled=true; go.style.opacity='.45';
+  } else { w.innerHTML=''; go.disabled=false; go.style.opacity='1'; }
+}
+function fedSubmit(){
+  closeModal();
+  toast('Bound after reauth. Audited: binding.created — issuer, subject, audience, lifetime recorded.');
+}
+
+/* K8s CR-condition detail (#19): the same condition in kubectl and UI voice */
+function openCond(said,tname,key){
+  const c=CONDS[key];
+  openModal(`<div class="mh"><h3><code style="font-size:13px">${tname}</code> — ${key}</h3>
+    <div class="sub">the condition reads the same in kubectl and in the UI</div></div>
+  <div class="mb">
+    <div class="callout ${c.sev==='warn'?'warn':'bad'}">${c.ui(said,tname)}
+      ${c.keys.length?`<span class="keyset">${c.keys.map(k=>`<code>${k}</code>`).join('')}</span>`:''}</div>
+    <div><div class="note faint" style="margin-bottom:6px">kubectl describe hikyosecret ${tname.split('/').pop()}</div>
+    <div class="yaml">${c.yaml(tname)}</div></div>
+    <div class="callout"><b>Next step:</b> ${c.fix}</div>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="closeModal()">Close</button></div>`);
+}
+
+/* ============ shell ============ */
+function render(){
+  const c=$('#content');
+  c.innerHTML=state.scenario==='restore'?renderRestore():renderA();
+}
+$('#scen').onchange=e=>{state.scenario=e.target.value;render()};
+$('#themebtn').onclick=()=>{
+  const b=document.documentElement;
+  b.dataset.theme=b.dataset.theme==='light'?'':'light';
+};
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/machine-access/3/index.html
+++ b/docs/site/public/prototypes/machine-access/3/index.html
@@ -1,0 +1,752 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo machine access (ticket #31)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #31, iteration 3.
+
+  Question: how do the workload-integration setup and service-account /
+  credential screens look and behave — against the locked machine-identity
+  (#17), Compose (#18) and Kubernetes (#19) ADRs, in the env-matrix-31
+  design language with the app-chrome reference chrome (15+16+18) and the
+  #21 ceremony vocabulary.
+
+  ITERATION 3 — journey moves BELOW (Alex, it-2): the row expansion
+  leads with credentials / federated bindings (left) and delivery
+  targets + actions (right); the five-step journey rail sits underneath,
+  full-width. Structure otherwise it-2: variant a's tabbed inventory.
+
+  Shared: scenario simulator (normal / expiring / post-restore — the last
+  swaps the surface into the #17 restore-reconciliation screen), display-once
+  mint ceremony, grant-mutation warning naming the newly-reachable plaintext
+  set, per-project machine-reveal opt-in warning, federation binding form
+  with the pull_request refusal, K8s CR-condition vocabulary reading the
+  same in kubectl and the UI.
+-->
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.71 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --warn:oklch(0.82 0.11 85);
+    --warn-soft:oklch(0.82 0.11 85/.14);
+    --ok:oklch(0.8 0.1 155);
+    --ok-soft:oklch(0.8 0.1 155/.14);
+    --stepup:oklch(0.78 0.09 250);          /* blue "confirm it's you" — #21/#29 */
+    --stepup-soft:oklch(0.78 0.09 250/.14);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --sheet-shadow:0 12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.46 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --warn:oklch(0.55 0.12 80);
+    --warn-soft:oklch(0.55 0.12 80/.12);
+    --ok:oklch(0.5 0.11 155);
+    --ok-soft:oklch(0.5 0.11 155/.12);
+    --stepup:oklch(0.48 0.1 255);
+    --stepup-soft:oklch(0.48 0.1 255/.12);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --sheet-shadow:0 12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{background:var(--bg);color:var(--tx);font-family:var(--sans);font-size:14px;
+    -webkit-font-smoothing:antialiased;height:100dvh;display:flex;flex-direction:column;
+    overflow:hidden;padding-bottom:env(safe-area-inset-bottom)}
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  code,.mono{font-family:var(--mono)}
+
+  /* ---------- app shell (app-chrome 15/18e, simplified) ---------- */
+  #app{display:grid;grid-template-columns:56px 218px 1fr;height:100dvh;overflow:hidden}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;padding:14px 0 12px;
+    border-right:1px solid var(--line);background:var(--bg2)}
+  .orgav{width:36px;height:36px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:11px;background:var(--bg3);outline:2px solid var(--accent);outline-offset:2px}
+  .raildiv{width:26px;border-top:1px solid var(--line);margin:4px 0}
+  .pav{width:36px;height:36px;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    font-weight:700;font-size:12px;color:var(--tx-dim);border:1px solid transparent}
+  .pav.act{background:var(--accent);color:var(--on-accent)}
+  #rail .spacer{flex:1}
+  #rail .me{width:36px;height:36px;border-radius:50%;background:var(--bg3);color:var(--tx);
+    font-weight:700;font-size:11px;display:flex;align-items:center;justify-content:center}
+
+  #side{display:flex;flex-direction:column;overflow-y:auto;border-right:1px solid var(--line);
+    background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--tx-faint);
+    padding:30px 16px 6px;font-weight:700}
+  #side .stitle:first-child{padding-top:16px}
+  /* sidebar treatment e (locked, app-chrome 18): sub-items on hairline left rule */
+  #side .srow{display:flex;align-items:center;gap:8px;text-align:left;font-size:13px;color:var(--tx-dim);
+    min-height:38px;padding:9px 16px 9px 13px;margin-left:19px;width:calc(100% - 19px);
+    border-left:1px solid oklch(from var(--line) l c h/.75)}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600;border-left-color:var(--accent)}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #hdr{display:flex;align-items:center;gap:14px;padding:12px 22px;border-bottom:1px solid var(--line);flex:none}
+  #hdr .crumb{font-size:14px;font-weight:600;display:flex;align-items:baseline;gap:8px;min-width:0}
+  #hdr .crumb .sep{color:var(--tx-faint);font-weight:400}
+  #hdr .right{margin-left:auto;display:flex;align-items:center;gap:10px}
+  .hsel{background:var(--bg2);border:1px solid var(--line);border-radius:4px;color:var(--tx);
+    font-size:12px;padding:6px 8px}
+  .hbtn{border:1px solid var(--line);border-radius:4px;padding:6px 10px;font-size:12px;color:var(--tx-dim)}
+  .hbtn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  #content{flex:1;overflow-y:auto;padding:22px 22px 96px}
+
+  /* ---------- shared bits ---------- */
+  .kind{font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;font-weight:600;border-radius:3px;
+    padding:2.5px 7px;white-space:nowrap;border:1px solid var(--line);color:var(--tx-dim)}
+  .kind.workload{color:var(--accent);border-color:oklch(from var(--accent) l c h/.5);background:var(--accent-soft)}
+  .kind.automation{color:var(--stepup);border-color:oklch(from var(--stepup) l c h/.5);background:var(--stepup-soft)}
+  .envchip{font-family:var(--mono);font-size:10.5px;border:1px solid var(--line);border-radius:3px;
+    padding:2px 7px;color:var(--tx-dim);white-space:nowrap}
+  .envchip.reveal{border-color:oklch(from var(--accent) l c h/.6);color:var(--accent)}
+  .envchip.reveal::after{content:" ◆";font-size:9px}
+  .badge{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2px 7px;white-space:nowrap}
+  .badge.ok{color:var(--ok);background:var(--ok-soft)}
+  .badge.warn{color:var(--warn);background:var(--warn-soft)}
+  .badge.bad{color:var(--bad);background:var(--bad-soft)}
+  .badge.dim{color:var(--tx-faint);border:1px solid var(--line)}
+  .badge.dead{color:var(--bad);border:1px solid oklch(from var(--bad) l c h/.5);text-decoration:line-through}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:7px 13px;font-size:12.5px;font-weight:500;color:var(--tx-dim)}
+  .btn:hover{color:var(--tx);border-color:var(--tx-faint)}
+  .btn.pri{background:var(--accent);color:var(--on-accent);border-color:transparent;font-weight:600}
+  .btn.pri:hover{filter:brightness(1.06)}
+  .btn.danger{color:var(--bad);border-color:oklch(from var(--bad) l c h/.5)}
+  .btn.stepup{background:var(--stepup);color:var(--bg);border-color:transparent;font-weight:600}
+  .btn.sm{padding:4px 9px;font-size:11.5px}
+  .note{font-size:12px;color:var(--tx-dim);line-height:1.55}
+  .note.faint{color:var(--tx-faint);font-size:11.5px}
+  .callout{border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:6px;
+    padding:12px 14px;font-size:12.5px;line-height:1.55;color:var(--tx-dim);background:var(--bg2)}
+  .callout.warn{border-left-color:var(--warn)}
+  .callout.bad{border-left-color:var(--bad)}
+  .callout.stepup{border-left-color:var(--stepup)}
+  .callout code{font-size:11.5px;color:var(--tx)}
+  .keyset{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+  .keyset code{border:1px solid var(--line);border-radius:3px;padding:2px 7px;font-size:11px;background:var(--bg3)}
+
+  /* condition chips (K8s CR vocabulary) */
+  .cond{font-family:var(--mono);font-size:10px;font-weight:600;border-radius:3px;padding:2.5px 8px;
+    white-space:nowrap;cursor:pointer;border:1px solid transparent}
+  .cond.ok{color:var(--ok);background:var(--ok-soft)}
+  .cond.bad{color:var(--bad);background:var(--bad-soft)}
+  .cond.warn{color:var(--warn);background:var(--warn-soft)}
+  .cond:hover{border-color:currentColor}
+
+  /* ---------- variant a: inventory ---------- */
+  .tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);margin-bottom:18px}
+  .tab{padding:9px 16px;font-size:13px;color:var(--tx-dim);border-bottom:2px solid transparent;margin-bottom:-1px}
+  .tab:hover{color:var(--tx)}
+  .tab.act{color:var(--tx);font-weight:600;border-bottom-color:var(--accent)}
+  .tab .cnt{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-left:6px}
+  table.inv{width:100%;border-collapse:collapse;font-size:13px}
+  table.inv th{text-align:left;font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:8px 10px;border-bottom:1px solid var(--line)}
+  table.inv td{padding:10px;border-bottom:1px solid oklch(from var(--line) l c h/.5);vertical-align:middle}
+  table.inv tr.sarow{cursor:pointer}
+  table.inv tr.sarow:hover td{background:var(--rowalt)}
+  table.inv tr.sub td{background:oklch(from var(--bg2) l c h/.6);font-size:12.5px;padding:14px 16px 16px 26px}
+  .subgrid{display:grid;grid-template-columns:minmax(300px,1fr) minmax(320px,1.2fr);gap:10px 34px}
+  .subh{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--tx-faint);font-weight:700;margin-bottom:6px}
+  @media (max-width:980px){.subgrid{grid-template-columns:1fr}}
+  .chev{display:inline-block;transition:transform .15s;color:var(--tx-faint);margin-right:8px;font-size:10px}
+  .open .chev{transform:rotate(90deg)}
+  .cell-envs{display:flex;flex-wrap:wrap;gap:5px}
+
+  /* ---------- journey rail (from it-1 variant b, now the row expansion) ---------- */
+  .steps{display:flex;flex-direction:column;gap:0;max-width:640px}
+  .step{display:flex;gap:12px;position:relative;padding:7px 0}
+  .step .dot{width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;
+    font-size:10px;font-weight:700;border:1.5px solid var(--line);color:var(--tx-faint);background:var(--bg);z-index:1;margin-top:1px}
+  .step.done .dot{background:var(--ok-soft);border-color:var(--ok);color:var(--ok)}
+  .step.fail .dot{background:var(--bad-soft);border-color:var(--bad);color:var(--bad)}
+  .step.next .dot{border-color:var(--accent);color:var(--accent)}
+  .step:not(:last-child)::before{content:'';position:absolute;left:8.5px;top:26px;bottom:-8px;width:1px;
+    background:oklch(from var(--line) l c h/.75)}
+  .step .stx{font-size:12.5px;color:var(--tx-dim);line-height:1.45;min-width:0}
+  .step.done .stx{color:var(--tx-faint)}
+  .step.fail .stx,.step.next .stx{color:var(--tx)}
+  .step .stx .who{font-family:var(--mono);font-size:10px;color:var(--tx-faint)}
+  .errblock{font-family:var(--mono);font-size:11px;line-height:1.6;background:var(--bg);
+    border:1px solid oklch(from var(--bad) l c h/.4);border-radius:4px;padding:10px 12px;margin-top:6px;
+    color:var(--tx-dim);white-space:pre-wrap;word-break:break-word}
+  .errblock b{color:var(--bad);font-weight:600}
+  .tgts{display:flex;flex-direction:column;gap:6px}
+  .tgt{display:flex;align-items:center;gap:8px;font-size:12px;flex-wrap:wrap}
+  .tgt code{font-size:11px;color:var(--tx-dim)}
+
+
+  /* credential rows (shared a-sub/c) */
+  .credrow{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:8px 0;
+    border-bottom:1px solid oklch(from var(--line) l c h/.4);font-size:12.5px}
+  .credrow:last-child{border-bottom:none}
+  .credrow code.pfx{font-size:11.5px;color:var(--tx)}
+  .credrow .meta{color:var(--tx-faint);font-size:11.5px}
+  .credrow .acts{margin-left:auto;display:flex;gap:6px}
+
+  /* binding rows */
+  .kv{display:grid;grid-template-columns:150px 1fr;gap:6px 14px;font-size:12.5px}
+  .kv dt{color:var(--tx-faint)}
+  .kv dd{color:var(--tx);font-family:var(--mono);font-size:12px;word-break:break-all}
+  .bindrow{border:1px solid var(--line);border-radius:6px;padding:12px 14px;margin-bottom:10px;background:var(--bg2)}
+  .bindrow .b1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .bindrow .kv{grid-template-columns:90px 1fr}
+
+  /* section headers on the surface */
+  .shead{display:flex;align-items:center;gap:12px;margin:0 0 14px;flex-wrap:wrap}
+  .shead h2{font-size:16px;font-weight:700}
+  .shead .right{margin-left:auto;display:flex;gap:8px}
+  .policy{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;
+    display:flex;align-items:flex-start;gap:14px;margin-bottom:18px;flex-wrap:wrap}
+  .policy .ptx{flex:1;min-width:240px}
+  .policy .ptx .t{font-weight:600;font-size:13px;margin-bottom:3px}
+  .toggle{width:40px;height:22px;border-radius:999px;border:1px solid var(--line);background:var(--bg3);
+    position:relative;flex:none;margin-top:2px}
+  .toggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
+    background:var(--tx-faint);transition:left .15s,background .15s}
+  .toggle.on{background:var(--accent-soft);border-color:var(--accent)}
+  .toggle.on::after{left:20px;background:var(--accent)}
+
+  /* ---------- restore reconciliation ---------- */
+  .recban{border:1px solid oklch(from var(--bad) l c h/.55);background:var(--bad-soft);border-radius:6px;
+    padding:14px 16px;margin-bottom:18px;font-size:13px;line-height:1.55}
+  .recban b{color:var(--bad)}
+  .recrow{border:1px solid var(--line);border-radius:6px;background:var(--bg2);padding:14px 16px;margin-bottom:12px}
+  .recrow .r1{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+  .recrow .r1 .nm{font-family:var(--mono);font-weight:600;font-size:13.5px}
+  .recrow ul{list-style:none;display:flex;flex-direction:column;gap:5px;font-size:12.5px;color:var(--tx-dim);margin:6px 0 10px}
+  .recrow li{display:flex;gap:8px;align-items:baseline;flex-wrap:wrap}
+  .recrow.done{border-color:oklch(from var(--ok) l c h/.5)}
+
+  /* ---------- modal ---------- */
+  #ovl{position:fixed;inset:0;background:oklch(0 0 0/.55);display:none;align-items:center;justify-content:center;
+    z-index:40;padding:18px}
+  #ovl.show{display:flex}
+  #modal{background:var(--bg);border:1px solid var(--line);border-radius:6px;box-shadow:var(--sheet-shadow);
+    width:min(560px,100%);max-height:88dvh;display:flex;flex-direction:column}
+  #modal .mh{padding:16px 20px 0}
+  #modal .mh h3{font-size:15px;font-weight:700}
+  #modal .mh .sub{font-size:12px;color:var(--tx-faint);margin-top:3px}
+  #modal .mb{padding:14px 20px;overflow-y:auto;display:flex;flex-direction:column;gap:12px}
+  #modal .mf{padding:12px 20px 16px;display:flex;gap:8px;justify-content:flex-end;border-top:1px solid var(--line)}
+  .tokbox{font-family:var(--mono);font-size:12.5px;background:var(--bg2);border:1px solid var(--accent);
+    border-radius:4px;padding:14px;word-break:break-all;line-height:1.6;color:var(--tx)}
+  .field{display:flex;flex-direction:column;gap:5px}
+  .field label{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--tx-faint);font-weight:700}
+  .field input,.field select{background:var(--bg2);border:1px solid var(--line);border-radius:4px;
+    color:var(--tx);padding:8px 10px;font-size:13px;width:100%}
+  .field input.mono{font-family:var(--mono);font-size:12px}
+  .chk{display:flex;gap:10px;align-items:flex-start;font-size:12.5px;color:var(--tx-dim);line-height:1.5;cursor:pointer}
+  .chk input{margin-top:2px;accent-color:var(--accent)}
+  .presets{display:flex;gap:6px;flex-wrap:wrap}
+  .preset{font-size:11.5px;border:1px solid var(--line);border-radius:3px;padding:4px 10px;color:var(--tx-dim)}
+  .preset:hover{border-color:var(--accent);color:var(--tx)}
+  .yaml{font-family:var(--mono);font-size:11px;line-height:1.65;background:var(--bg2);border:1px solid var(--line);
+    border-radius:4px;padding:12px 14px;white-space:pre-wrap;word-break:break-word;color:var(--tx-dim)}
+  .yaml .k{color:var(--accent)}
+  .yaml .bad{color:var(--bad)}
+
+  /* toast */
+  #toast{position:fixed;bottom:76px;left:50%;transform:translateX(-50%);background:var(--bg3);
+    border:1px solid var(--line);border-radius:6px;padding:10px 16px;font-size:12.5px;display:none;z-index:60;
+    box-shadow:var(--sheet-shadow)}
+  #toast.show{display:block}
+
+
+  @media (max-width:860px){
+    #app{grid-template-columns:56px 1fr}
+    #side{display:none}
+    .kv{grid-template-columns:120px 1fr}
+  }
+</style>
+</head>
+<body>
+<div id="app">
+  <nav id="rail" aria-label="Organizations and projects">
+    <div class="orgav" title="example.com">WI</div>
+    <div class="raildiv"></div>
+    <div class="pav act" title="example-app">DB</div>
+    <div class="pav" title="sample-catalog">PT</div>
+    <div class="spacer"></div>
+    <div class="me" title="Alex">MW</div>
+  </nav>
+  <nav id="side" aria-label="Project sections">
+    <div class="stitle">example-app</div>
+    <button class="srow">Environment matrix</button>
+    <button class="srow">Version history</button>
+    <button class="srow act">Machine access <span class="cnt" id="side-cnt">5</span></button>
+    <button class="srow">Project settings</button>
+    <div class="stitle">Organization</div>
+    <button class="srow">Members &amp; grants</button>
+    <button class="srow">Org settings</button>
+  </nav>
+  <div id="main">
+    <header id="hdr">
+      <div class="crumb"><span>example-app</span><span class="sep">/</span><span>Machine access</span></div>
+      <div class="right">
+        <label class="note faint" for="scen">scenario</label>
+        <select id="scen" class="hsel" aria-label="Scenario simulator">
+          <option value="normal">normal</option>
+          <option value="expiring">expiring credentials</option>
+          <option value="restore">post-restore</option>
+        </select>
+        <button class="hbtn" id="themebtn" aria-label="Toggle theme">◐</button>
+      </div>
+    </header>
+    <div id="content"></div>
+  </div>
+</div>
+
+<div id="ovl" role="dialog" aria-modal="true"><div id="modal"></div></div>
+<div id="toast" role="status"></div>
+
+<script>
+/* ============ demo data (in-memory only — PROTOTYPE) ============ */
+const ENV_SECRETS = { // secret keys per environment — the "newly reachable plaintext set"
+  production:['DATABASE_URL','SMTP_PASSWORD','S3_SECRET_KEY','SESSION_PEPPER'],
+  staging:['DATABASE_URL','S3_SECRET_KEY'],
+  development:['DATABASE_URL'],
+};
+const state = {
+  tab:'sa', scenario:'normal', openRows:{},
+  revealOptIn:true,          // per-project machine-reveal opt-in (#18)
+  reactivated:{},            // restore scenario
+  minted:{},                 // sa -> fresh cred minted post-restore
+};
+const SAS = [
+  {id:'api-workload', kind:'workload', created:'2026-07-02', read:['production'], reveal:['production'],
+   creds:[{pfx:'hik_1_wl_9fK2mQ', created:'2026-07-02', expiry:'2026-10-01', days:57, last:'2 min ago'}],
+   bindings:[], targets:[]},
+  {id:'staging-runner', kind:'workload', created:'2026-06-18', read:['staging'], reveal:['staging'],
+   creds:[{pfx:'hik_1_wl_x7Rq0d', created:'2026-06-18', expiry:'2026-08-19', days:14, last:'41 min ago'},
+          {pfx:'hik_1_wl_p2Vn8s', created:'2026-08-01', expiry:'2026-11-01', days:88, last:'never'}],
+   bindings:[], targets:[]},
+  {id:'worker-beta', kind:'workload', created:'2026-08-04', read:['staging'], reveal:[],
+   creds:[{pfx:'hik_1_wl_c4Ht2z', created:'2026-08-04', expiry:'2026-11-04', days:91, last:'6 min ago'}],
+   bindings:[], targets:[]},
+  {id:'k3s-cluster', kind:'workload', created:'2026-05-30', read:['production','staging'], reveal:['production'],
+   creds:[],
+   bindings:[{issuer:'https://kubernetes.default.svc.cluster.local',
+              subject:'system:serviceaccount:hikyo-system:hikyo-fetch',
+              audience:'hikyo.example.com/main', expiry:'2026-11-30', days:117}],
+   targets:[
+     {name:'apps/api-env', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'ok', reason:'Completed'}]},
+     {name:'apps/worker-env', ns:'apps', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'UndeliverableKeys'}]},
+     {name:'batch/report-env', ns:'batch', envK:'staging',
+      conds:[{t:'SyncRefused', s:'bad', reason:'LoaderControlAckRequired'}]},
+     {name:'apps/api-env (canary)', ns:'apps', envK:'production',
+      conds:[{t:'Synced', s:'ok', reason:'converged@rev41'},{t:'RolloutRequested', s:'warn', reason:'Stalled'}]},
+     {name:'legacy/import-env', ns:'legacy', envK:'staging',
+      conds:[{t:'NotReconciled', s:'bad', reason:'DesignationMissing'}]},
+   ]},
+  {id:'ci-export', kind:'automation', created:'2026-06-01', read:['production'], reveal:[], caps:['read','audit-read'],
+   creds:[{pfx:'hik_1_au_m3Wb5k', created:'2026-06-01', expiry:'2026-09-01', days:27, last:'3 h ago'}],
+   bindings:[{issuer:'https://token.actions.githubusercontent.com',
+              subject:'repo:example-user/example-app:ref:refs/heads/main',
+              audience:'hikyo.example.com/main', expiry:'2026-08-07', days:2}],
+   targets:[]},
+];
+const CONDS = { // CR-condition vocabulary (#19) — kubectl YAML + the same sentence as UI copy
+  'UndeliverableKeys':{sev:'bad', ui:(sa,t)=>`Nothing was synced: the resolved manifest contains secret keys this service account cannot reveal. Delivery is all-or-nothing — partial sync would surface as the application's own crash three layers away.`,
+    keys:['DATABASE_URL','S3_SECRET_KEY'],
+    fix:`Grant <code>reveal(staging)</code> to <code>k3s-cluster</code> — requires <code>manage-identities(example-app)</code> ∧ <code>reveal</code> over the whole post-state, plus reauthentication.`,
+    yaml:(t)=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">UndeliverableKeys</span>
+    message: >-
+      refusing to sync: manifest contains secret occurrences this
+      principal cannot reveal: DATABASE_URL, S3_SECRET_KEY.
+      delivery is all-or-nothing. required: machine-reveal opt-in
+      on project example-app + reveal(staging) on service account
+      k3s-cluster.`},
+  'LoaderControlAckRequired':{sev:'bad', ui:()=>`The mapping delivers <code>PATH</code>, a key on the loader-control baseline. The refusal is enforced at delivery, consumption-agnostic — even a volume-mount-only Secret needs the acknowledgement, because delivery time cannot know how a key is consumed.`,
+    keys:['PATH'],
+    fix:`Add the acknowledgement to the <code>HikyoSecret</code> listing exactly these keys. The acknowledged list is carried on the fetch and recorded in Hikyo's audit event (#24) — regardless of cluster audit posture.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">SyncRefused</span>
+    status: "True"
+    reason: <span class="bad">LoaderControlAckRequired</span>
+    message: >-
+      mapping delivers loader-control baseline key: PATH.
+      add spec.loaderControlAck listing exactly these keys.
+      the acknowledged list is carried on every fetch and
+      recorded in the server audit log.`},
+  'Stalled':{sev:'warn', ui:()=>`The Secret is delivered and current, but the workload controller has not completed the rollout — this Deployment is paused. Delivered-but-not-rolled is a visible state, never a silent success; the operator claims completion only from the workload controller's own status.`,
+    keys:[], fix:`Resume the Deployment (<code>kubectl rollout resume</code>), or accept that pods roll on the next controller-driven restart.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">RolloutRequested</span>
+    status: "False"
+    reason: <span class="bad">Stalled</span>
+    message: >-
+      secret delivered (converged@rev41) but deployment
+      apps/api-canary is paused; rollout has not completed.
+      completion is claimed only from the workload
+      controller's own status.`},
+  'DesignationMissing':{sev:'bad', ui:()=>`The referenced bootstrap Secret is not designated for Hikyo delivery use. Designation is an act by someone holding <b>write</b> on that Secret — a strictly greater right than reading it — and must name the <code>HikyoInstance</code> it may be presented to.`,
+    keys:[], fix:`Label the bootstrap Secret with the designation naming <code>HikyoInstance/main</code> (spelling per #25), applied by a principal with write on the Secret.`,
+    yaml:()=>`status:
+  conditions:
+  - type: <span class="k">NotReconciled</span>
+    status: "True"
+    reason: <span class="bad">DesignationMissing</span>
+    message: >-
+      referenced Secret legacy/hikyo-bootstrap is not
+      designated for hikyo delivery use, or its designation
+      does not name HikyoInstance/main. designate it with
+      write authority on the Secret.`},
+};
+
+/* ============ helpers ============ */
+const $=s=>document.querySelector(s);
+const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+function toast(msg){const t=$('#toast');t.textContent=msg;t.classList.add('show');clearTimeout(t._h);t._h=setTimeout(()=>t.classList.remove('show'),3200)}
+function expiryBadge(days,label){ // in-product-first expiry signal (#17)
+  const hot=state.scenario==='expiring';
+  const d=hot?Math.max(1,Math.round(days/7)):days;
+  if(d<=7) return `<span class="badge bad">expires in ${d}d</span>`;
+  if(d<=30) return `<span class="badge warn">expires in ${d}d</span>`;
+  return `<span class="badge dim">${label||'expires'} ${d}d</span>`;
+}
+function journey(sa){ // five-step journey state (#18)
+  const s=[];
+  s.push({t:`Service account minted <span class="who">kind: ${sa.kind} — immutable at creation</span>`, st:'done'});
+  s.push({t:`<code>read</code> granted — ${sa.read.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">delivers config + secret-presence only</span>`, st:sa.read.length?'done':'next'});
+  const missing=sa.read.filter(e=>!sa.reveal.includes(e));
+  const failing=missing.length&&sa.kind==='workload';
+  s.push({t:failing?`Delivery fails, naming what it could not deliver`:`First delivery succeeded`, st:failing?'fail':'done',
+    err:failing?(sa.targets.length?`HikyoSecret apps/worker-env — SyncRefused
+<b>reason:</b> UndeliverableKeys
+manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was synced.
+required: reveal(${missing[0]}) on ${sa.id}`
+:`$ hikyo run --project example-app --env ${missing[0]} -- node worker.js
+<b>refused:</b> manifest contains secret occurrences this principal
+cannot reveal: ${ENV_SECRETS[missing[0]].join(', ')}
+delivery is all-or-nothing; nothing was started.
+required: reveal(${missing[0]}) on ${sa.id}`):null});
+  s.push({t:`Project machine-reveal opt-in ${state.revealOptIn?'acknowledged':'<b>not acknowledged</b>'} <span class="who">a credential holding reveal is a standing decryption capability</span>`, st:state.revealOptIn?'done':(failing?'next':'done')});
+  s.push({t:missing.length?`Grant <code>reveal</code> on ${missing.map(e=>`<code>${e}</code>`).join(', ')} <span class="who">manage-identities ∧ reveal over the post-state + reauth</span>`:`<code>reveal</code> granted — full delivery`, st:missing.length?(state.revealOptIn?'next':''):'done'});
+  return s;
+}
+function credRow(sa,c){
+  return `<div class="credrow">
+    <code class="pfx">${c.pfx}…</code>
+    <span class="badge dim">bearer</span>
+    ${expiryBadge(c.days)}
+    <span class="meta">created ${c.created} · last used ${c.last}</span>
+    <span class="acts">
+      <button class="btn sm" onclick="openMint('${sa.id}',true)">Rotate</button>
+      <button class="btn sm danger" onclick="toast('Revoked — bites at the next fetch, never at expiry (#15). Undo…')">Revoke</button>
+    </span>
+  </div>`;
+}
+function bindRow(sa,b){
+  return `<div class="bindrow">
+    <div class="b1"><span class="badge dim">federated</span>${expiryBadge(b.days,'binding expires')}
+      <span class="note faint">byte-for-byte match — no wildcards, no case folding · renewal is a mint</span></div>
+    <dl class="kv">
+      <dt>issuer</dt><dd>${b.issuer}</dd>
+      <dt>subject</dt><dd>${b.subject}</dd>
+      <dt>audience</dt><dd>${b.audience}</dd>
+    </dl>
+  </div>`;
+}
+function condChips(sa,t){
+  return t.conds.map(c=>{
+    const key=CONDS[c.reason]?c.reason:null;
+    return `<span class="cond ${c.s}" ${key?`onclick="openCond('${sa.id}','${esc(t.name)}','${key}')"`:''} role="${key?'button':'status'}">${c.t}: ${c.reason}</span>`;
+  }).join(' ');
+}
+
+/* ============ variant a — inventory ============ */
+function renderA(){
+  const tabs=`<div class="tabs" role="tablist">
+    <button class="tab ${state.tab==='sa'?'act':''}" onclick="state.tab='sa';render()">Service accounts<span class="cnt">${SAS.length}</span></button>
+    <button class="tab ${state.tab==='fed'?'act':''}" onclick="state.tab='fed';render()">Federation<span class="cnt">${SAS.flatMap(s=>s.bindings).length}</span></button>
+    <button class="tab ${state.tab==='k8s'?'act':''}" onclick="state.tab='k8s';render()">Kubernetes targets<span class="cnt">${SAS.flatMap(s=>s.targets).length}</span></button>
+  </div>`;
+  if(state.tab==='sa'){
+    const rows=SAS.map(sa=>{
+      const open=state.openRows[sa.id];
+      const worst=Math.min(...sa.creds.map(c=>c.days),...sa.bindings.map(b=>b.days),999);
+      const miss=sa.read.filter(e=>!sa.reveal.includes(e));
+      const setup=sa.kind!=='workload'?'<span class="badge dim">n/a</span>':
+        miss.length?`<span class="badge bad">step ${state.revealOptIn?5:4} of 5</span>`:'<span class="badge ok">complete</span>';
+      let h=`<tr class="sarow ${open?'open':''}" onclick="state.openRows['${sa.id}']=!${!!open};render()">
+        <td><span class="chev">▶</span><code>${sa.id}</code></td>
+        <td><span class="kind ${sa.kind}">${sa.kind}</span></td>
+        <td><span class="cell-envs">${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join('')}</span></td>
+        <td>${sa.creds.length+sa.bindings.length} ${worst<999?expiryBadge(worst):''}</td>
+        <td class="mono" style="font-size:11.5px;color:var(--tx-faint)">${sa.creds[0]?.last??(sa.bindings.length?'via federation':'—')}</td>
+        <td>${setup}</td></tr>`;
+      if(open){
+        // it-3 (Alex): credentials/bindings/targets first, journey BELOW
+        const steps=sa.kind==='workload'?journey(sa):null;
+        const journeyBlock=steps?`<div class="subh" style="margin-top:16px">setup journey</div>
+          <div class="steps">${steps.map((s,i)=>`
+            <div class="step ${s.st}"><div class="dot">${s.st==='done'?'✓':s.st==='fail'?'✕':i+1}</div>
+            <div class="stx">${s.t}${s.err?`<div class="errblock">${s.err}</div>`:''}
+            ${s.st==='next'&&i===4?`<div style="margin-top:8px"><button class="btn sm pri" onclick="event.stopPropagation();openGrant('${sa.id}',true)">Grant reveal…</button></div>`:''}
+            ${s.st==='next'&&i===3?`<div style="margin-top:8px"><button class="btn sm pri" onclick="event.stopPropagation();openOptIn()">Review opt-in…</button></div>`:''}
+            </div></div>`).join('')}</div>`
+          :`<p class="note faint" style="margin-top:16px">Automation principal — runs off-box on a schedule or in CI. Capability allowlist: <code>${(sa.caps||['read']).join(', ')}</code>; never <code>manage-*</code>, never instance capabilities (#15). No setup journey: automation never delivers to a workload.</p>`;
+        h+=`<tr class="sub"><td colspan="6">
+          <div class="subgrid">
+            <div>
+              <div class="subh">credentials</div>
+              ${sa.creds.map(c=>credRow(sa,c)).join('')||'<div class="note faint" style="padding:4px 0 8px">No bearer credentials — authenticates by federation only.</div>'}
+              ${sa.bindings.length?`<div class="subh" style="margin-top:12px">federated bindings</div>${sa.bindings.map(b=>bindRow(sa,b)).join('')}`:''}
+            </div>
+            <div>
+              ${sa.targets.length?`<div class="subh">delivery targets</div><div class="tgts">${sa.targets.map(t=>`<div class="tgt"><code>${t.name}</code>${condChips(sa,t)}</div>`).join('')}</div>`:''}
+              <div style="display:flex;gap:8px;margin-top:${sa.targets.length?'14px':'0'};flex-wrap:wrap">
+                <button class="btn sm pri" onclick="event.stopPropagation();openMint('${sa.id}')">Mint credential</button>
+                <button class="btn sm" onclick="event.stopPropagation();openBinding('${sa.id}')">Add federated binding</button>
+                <button class="btn sm" onclick="event.stopPropagation();openGrant('${sa.id}')">Add environment grant…</button>
+              </div>
+            </div>
+          </div>
+          ${journeyBlock}
+        </td></tr>`;
+      }
+      return h;
+    }).join('');
+    return tabs+policyStrip()+`<table class="inv" aria-label="Service accounts">
+      <thead><tr><th>service account</th><th>kind</th><th>read scope <span style="text-transform:none;letter-spacing:0">(◆ = reveal)</span></th><th>credentials</th><th>last used</th><th>setup</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+      <p class="note faint" style="margin-top:12px">Credential list is metadata only — prefix, kind, scope, expiry, last-used. Values are write-only: displayed exactly once at mint, never retrievable, rotation never returns the prior value (#17).</p>`;
+  }
+  if(state.tab==='fed'){
+    const rows=SAS.flatMap(sa=>sa.bindings.map(b=>({sa,b})));
+    return tabs+`<div class="shead"><h2>Federated bindings</h2><div class="right"><button class="btn pri" onclick="openBinding('k3s-cluster')">New binding</button></div></div>
+      <p class="note" style="margin-bottom:14px">An external OIDC identity is bound to exactly one service account by a byte-exact <code>(issuer, subject)</code> pair — no wildcards, no JIT provisioning. An unbound identity is not a login. A binding is a standing permission to present tokens and expires on the same terms as a bearer credential; renewal is a mint.</p>
+      ${rows.map(({sa,b})=>`<div class="bindrow"><div class="b1"><code style="font-size:12px;font-weight:600">${sa.id}</code><span class="kind ${sa.kind}">${sa.kind}</span>${expiryBadge(b.days,'binding expires')}</div>
+        <dl class="kv"><dt>issuer</dt><dd>${b.issuer}</dd><dt>subject</dt><dd>${b.subject}</dd><dt>audience</dt><dd>${b.audience}</dd></dl></div>`).join('')}`;
+  }
+  const trows=SAS.flatMap(sa=>sa.targets.map(t=>({sa,t})));
+  return tabs+`<div class="shead"><h2>Kubernetes delivery targets</h2></div>
+    <p class="note" style="margin-bottom:14px">One <code>HikyoSecret</code> per managed Secret. Conditions read the same here and in <code>kubectl describe</code> — click one for both voices.</p>
+    <table class="inv" aria-label="Kubernetes targets"><thead><tr><th>hikyosecret</th><th>service account</th><th>environment</th><th>conditions</th></tr></thead>
+    <tbody>${trows.map(({sa,t})=>`<tr><td><code>${t.name}</code></td><td><code style="font-size:11.5px">${sa.id}</code></td>
+      <td><span class="envchip">${t.envK}</span></td><td style="display:flex;gap:5px;flex-wrap:wrap">${condChips(sa,t)}</td></tr>`).join('')}</tbody></table>`;
+}
+function policyStrip(){
+  return `<div class="policy">
+    <button class="toggle ${state.revealOptIn?'on':''}" role="switch" aria-checked="${state.revealOptIn}" aria-label="Machine reveal opt-in" onclick="openOptIn()"></button>
+    <div class="ptx"><div class="t">Machine secret delivery (per-project opt-in)</div>
+    <div class="note">${state.revealOptIn
+      ?'Acknowledged: workload credentials granted <code>reveal</code> are a standing decryption capability. Fresh service accounts still deliver config + secret-presence only until <code>reveal</code> is granted per account.'
+      :'Off: every workload delivery on this project is config + secret-presence only. <b>hikyo run on a fresh service account delivers no secrets</b> — this is step 4 of the setup journey.'}</div></div>
+  </div>`;
+}
+
+/* ============ restore reconciliation (#17) ============ */
+function renderRestore(){
+  const rows=SAS.map(sa=>{
+    const re=state.reactivated[sa.id];
+    return `<div class="recrow ${re?'done':''}">
+      <div class="r1"><span class="nm">${sa.id}</span><span class="kind ${sa.kind}">${sa.kind}</span>
+        ${re?'<span class="badge ok">re-activated</span>':'<span class="badge warn">inert</span>'}</div>
+      <ul>
+        <li><span class="note faint" style="width:90px">grants</span>${sa.read.map(e=>`<span class="envchip ${sa.reveal.includes(e)?'reveal':''}">${e}</span>`).join(' ')} <span class="note faint">${re?'restored':'inert until re-activation'}</span></li>
+        ${sa.creds.map(c=>`<li><span class="note faint" style="width:90px">bearer</span><code>${c.pfx}…</code><span class="badge dead">permanently dead</span><span class="note faint">values never survive restore — re-establish by minting fresh</span></li>`).join('')}
+        ${sa.bindings.map(b=>`<li><span class="note faint" style="width:90px">federated</span><code style="font-size:11px">${b.subject}</code><span class="badge warn">quarantined</span><span class="note faint">binding survives; quarantined until the clock-skew window passes (ops spec)</span></li>`).join('')}
+      </ul>
+      ${re?`${state.minted[sa.id]?'<span class="badge ok">fresh credential minted</span>':(sa.creds.length?`<button class="btn sm pri" onclick="openMint('${sa.id}')">Mint fresh credential</button>`:'<span class="note faint">federation-only — no mint needed</span>')}`
+          :`<button class="btn sm stepup" onclick="state.reactivated['${sa.id}']=true;render();toast('${sa.id} re-activated — identity, kind and grants restored. Audited.')">Re-activate ${sa.id}</button>`}
+    </div>`;
+  }).join('');
+  return `<div class="recban"><b>RECOVERY MODE — reconciliation commit open.</b>
+    This instance was restored from the 2026-08-04 02:00 backup. Restore is a fail-closed security event (#8):
+    every service account below is <b>inert</b> until you re-activate it, explicitly, per principal.
+    <b>There is no bulk-accept</b> — each re-activation is an individual, audited decision.
+    Bearer credential values never survive restore; federated bindings do, under quarantine.</div>${rows}`;
+}
+
+/* ============ modals ============ */
+const ovl=$('#ovl'), modal=$('#modal');
+function openModal(html){modal.innerHTML=html;ovl.classList.add('show');modal.querySelector('button')?.focus()}
+function closeModal(){ovl.classList.remove('show')}
+ovl.addEventListener('click',e=>{if(e.target===ovl)closeModal()});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal()});
+
+/* display-once mint ceremony (#17): reauth step-up -> token shown exactly once */
+function openMint(said,rotate){
+  const sa=SAS.find(s=>s.id===said);
+  const envs=sa.reveal.length?sa.reveal:sa.read;
+  openModal(`<div class="mh"><h3>${rotate?'Rotate':'Mint'} credential — ${sa.id}</h3>
+    <div class="sub">${sa.kind} · scope ${sa.read.join(', ')}</div></div>
+  <div class="mb">
+    <div class="callout stepup"><b>Confirm it's you.</b> ${rotate?'Rotation':'Minting'} delivers the token display-once <b>to you</b> — the formula covers every environment reachable in the resulting post-state${envs.length?` (${envs.map(e=>`<code>${e}</code>`).join(', ')})`:''}, not just added ones. A replacement credential is not a smaller act than a new one (#17 amendment).</div>
+    ${rotate?'<p class="note">The prior value is never returned. The old credential keeps working until you revoke it — rotation and revocation are separate, deliberate acts.</p>':''}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="showToken('${said}')">Use passkey</button></div>`);
+}
+function showToken(said){
+  const sa=SAS.find(s=>s.id===said);
+  const t=`hik_1_${sa.kind==='workload'?'wl':'au'}_${randB62(43)}k7Qx`;
+  openModal(`<div class="mh"><h3>Credential minted — shown exactly once</h3>
+    <div class="sub">${sa.id} · expires 2026-11-05 (instance default)</div></div>
+  <div class="mb">
+    <div class="tokbox" id="tokval">${t}</div>
+    <button class="btn" onclick="navigator.clipboard&&navigator.clipboard.writeText(document.getElementById('tokval').textContent);toast('Copied. The clipboard is now the only copy outside your target.')">Copy to clipboard</button>
+    <div class="callout warn"><b>This value is never retrievable again.</b> The list shows metadata only; rotation never returns this value. Store it in the consuming system now — if it is lost, revoke and mint a fresh one.</div>
+    <label class="chk"><input type="checkbox" id="stored"> I have stored this credential in its target system.</label>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="if(document.getElementById('stored').checked){state.minted['${said}']=true;closeModal();render();toast('Minted. Audited: credential.minted, actor alex, display-once delivery.')}else{toast('Confirm you stored it — there is no second look.')}">Done</button></div>`);
+}
+function randB62(n){const a='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';let s='';const r=crypto.getRandomValues(new Uint8Array(n));for(const b of r)s+=a[b%62];return s}
+
+/* grant-mutation warning (#17 amends #15): names the newly-reachable plaintext set */
+function openGrant(said,revealMode){
+  const sa=SAS.find(s=>s.id===said);
+  const addable=revealMode?sa.read.filter(e=>!sa.reveal.includes(e))
+                          :Object.keys(ENV_SECRETS).filter(e=>!sa.read.includes(e));
+  const env=addable[0]||'production';
+  const newKeys=ENV_SECRETS[env]||[];
+  const nCreds=sa.creds.length+sa.bindings.length;
+  openModal(`<div class="mh"><h3>${revealMode?'Grant reveal':'Add environment grant'} — ${sa.id}</h3>
+    <div class="sub">grants attach to the service account, never to a credential</div></div>
+  <div class="mb">
+    <div class="field"><label>${revealMode?'reveal on environment':'environment (read)'}</label>
+      <select id="genv">${addable.map(e=>`<option>${e}</option>`).join('')}</select></div>
+    <div class="callout warn"><b>This grant re-scopes every credential already in circulation.</b>
+      ${sa.id} has <b>${nCreds} live credential${nCreds===1?'':'s'}</b>${sa.bindings.length?' (including federated bindings)':''} — each one ${revealMode?'gains standing decryption of':'gains read (secret-presence) on'} <code>${env}</code> the moment this lands. Newly reachable plaintext set:
+      <span class="keyset">${newKeys.map(k=>`<code>${k}</code>`).join('')}</span></div>
+    <p class="note faint">Formula: <code>manage-identities(example-app)</code> ∧ <code>reveal(${env})</code> — over the newly reachable set for a grant mutation — plus reauthentication.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" onclick="closeModal();${revealMode?`SAS.find(s=>s.id==='${said}').reveal.push(document.getElementById('genv').value)`:`SAS.find(s=>s.id==='${said}').read.push(document.getElementById('genv').value)`};render();toast('Granted after reauth. Audited: grant.widened, newly-reachable set recorded. Undo…')">Use passkey &amp; grant</button></div>`);
+}
+
+/* per-project machine-reveal opt-in (#18) */
+function openOptIn(){
+  const on=state.revealOptIn;
+  const workloads=SAS.filter(s=>s.kind==='workload'&&s.reveal.length);
+  openModal(`<div class="mh"><h3>${on?'Withdraw':'Acknowledge'} machine secret delivery — example-app</h3>
+    <div class="sub">per-project operator decision, step 4 of the setup journey</div></div>
+  <div class="mb">
+    ${on?`<div class="callout bad"><b>Withdrawing stops secret plaintext to every workload credential on this project at its next fetch.</b>
+      Currently delivering secrets: ${workloads.map(w=>`<code>${w.id}</code>`).join(', ')||'none'}.
+      Their deliveries become all-or-nothing refusals naming the undeliverable keys — workloads consuming secrets will fail loudly at next restart.</div>`
+    :`<div class="callout warn"><b>A workload credential granted <code>reveal</code> is a standing decryption capability.</b>
+      Anyone holding such a credential file can read those secrets for as long as it lives — this acknowledgement is what makes that a decision rather than an accident.
+      Granting reveal per account still requires the post-state formula + reauth afterwards.</div>`}
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn ${on?'danger':'stepup'}" onclick="state.revealOptIn=!${on};closeModal();render();toast('${on?'Withdrawn — refusals begin at next fetch. Audited.':'Acknowledged after reauth. Audited: project.machine-reveal enabled.'}')">${on?'Withdraw opt-in':'Use passkey & acknowledge'}</button></div>`);
+}
+
+/* federation binding form (#17/#19): byte-exact, audience mandatory, pull_request refusal */
+function openBinding(said){
+  openModal(`<div class="mh"><h3>Add federated binding — ${said}</h3>
+    <div class="sub">byte-exact (issuer, subject) → exactly one service account · audience mandatory</div></div>
+  <div class="mb">
+    <div class="presets">
+      <button class="preset" onclick="fedPreset('k8s')">Kubernetes SA token</button>
+      <button class="preset" onclick="fedPreset('forgejo')">Forgejo Actions</button>
+      <button class="preset" onclick="fedPreset('gha')">GitHub Actions</button>
+    </div>
+    <div class="field"><label>issuer</label><input class="mono" id="fiss" placeholder="https://…" oninput="fedCheck()"></div>
+    <div class="field"><label>subject (matched byte-for-byte)</label><input class="mono" id="fsub" placeholder="system:serviceaccount:ns:name" oninput="fedCheck()"></div>
+    <div class="field"><label>audience</label><input class="mono" id="faud" value="hikyo.example.com/main" oninput="fedCheck()"></div>
+    <div class="field"><label>binding lifetime</label><select id="flt"><option>90 days (instance default)</option><option>180 days</option><option disabled>indefinite — requires allow_indefinite (off)</option></select></div>
+    <div id="fedwarn"></div>
+    <p class="note faint">No wildcards, no namespace patterns, no case folding — canonicalization merges distinct external identities. An unbound identity is not a login. Renewal is a mint; expiry warnings follow the in-product-first path.</p>
+  </div>
+  <div class="mf"><button class="btn" onclick="closeModal()">Cancel</button>
+    <button class="btn stepup" id="fedgo" onclick="fedSubmit()">Use passkey &amp; bind</button></div>`);
+}
+function fedPreset(k){
+  const iss=$('#fiss'),sub=$('#fsub');
+  if(k==='k8s'){iss.value='https://kubernetes.default.svc.cluster.local';sub.value='system:serviceaccount:hikyo-system:hikyo-fetch'}
+  if(k==='forgejo'){iss.value='https://git.example.com';sub.value='repo:example-org/example-app:ref:refs/heads/main'}
+  if(k==='gha'){iss.value='https://token.actions.githubusercontent.com';sub.value='repo:example-user/example-app:pull_request'}
+  fedCheck();
+}
+function fedCheck(){
+  const sub=$('#fsub').value, aud=$('#faud').value, w=$('#fedwarn'), go=$('#fedgo');
+  const pr=/:pull_request(_target)?\b/.test(sub);
+  const deliberate=$('#prbind')?.checked;
+  if(pr){
+    w.innerHTML=`<div class="callout bad"><b>Refused: subject binds <code>${sub.match(/pull_request(_target)?/)[0]}</code>.</b>
+      A pull-request workflow runs third-party code — binding it hands every PR author this service account's fetch authority.
+      Refused unless deliberately bound.</div>
+      <label class="chk" style="margin-top:8px"><input type="checkbox" id="prbind" onchange="fedCheck()"> I am deliberately binding a pull-request identity and accept that PR authors reach this account's scope.</label>`;
+    go.disabled=!deliberate; go.style.opacity=deliberate?'1':'.45';
+  } else if(!aud){
+    w.innerHTML=`<div class="callout bad"><b>Audience is mandatory.</b> A token minted for another consumer must not authenticate here.</div>`;
+    go.disabled=true; go.style.opacity='.45';
+  } else { w.innerHTML=''; go.disabled=false; go.style.opacity='1'; }
+}
+function fedSubmit(){
+  closeModal();
+  toast('Bound after reauth. Audited: binding.created — issuer, subject, audience, lifetime recorded.');
+}
+
+/* K8s CR-condition detail (#19): the same condition in kubectl and UI voice */
+function openCond(said,tname,key){
+  const c=CONDS[key];
+  openModal(`<div class="mh"><h3><code style="font-size:13px">${tname}</code> — ${key}</h3>
+    <div class="sub">the condition reads the same in kubectl and in the UI</div></div>
+  <div class="mb">
+    <div class="callout ${c.sev==='warn'?'warn':'bad'}">${c.ui(said,tname)}
+      ${c.keys.length?`<span class="keyset">${c.keys.map(k=>`<code>${k}</code>`).join('')}</span>`:''}</div>
+    <div><div class="note faint" style="margin-bottom:6px">kubectl describe hikyosecret ${tname.split('/').pop()}</div>
+    <div class="yaml">${c.yaml(tname)}</div></div>
+    <div class="callout"><b>Next step:</b> ${c.fix}</div>
+  </div>
+  <div class="mf"><button class="btn pri" onclick="closeModal()">Close</button></div>`);
+}
+
+/* ============ shell ============ */
+function render(){
+  const c=$('#content');
+  c.innerHTML=state.scenario==='restore'?renderRestore():renderA();
+}
+$('#scen').onchange=e=>{state.scenario=e.target.value;render()};
+$('#themebtn').onclick=()=>{
+  const b=document.documentElement;
+  b.dataset.theme=b.dataset.theme==='light'?'':'light';
+};
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/machine-access/index.html
+++ b/docs/site/public/prototypes/machine-access/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Workload integration &amp; machine identity — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,72px) clamp(18px,6vw,72px)}
+  .back{font-size:12px;color:var(--tx-dim);text-decoration:none;display:inline-block;margin-bottom:18px}
+  .back:hover{color:var(--tx)}
+  h1{font-size:clamp(20px,4vw,28px);font-weight:700}
+  h1 span{color:var(--accent)}
+  .q{font-size:13px;color:var(--tx-dim);margin:10px 0 30px;max-width:60ch;line-height:1.6}
+  ul{list-style:none;display:grid;gap:10px;max-width:680px}
+  li a{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:10px;background:var(--bg2)}
+  li a:hover{border-color:var(--accent)}
+  .num{font-family:var(--mono);font-size:11px;color:var(--accent)}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>workload integration <span>&amp;</span> machine identity</h1>
+  <p class="q">How do the workload-integration setup and service-account/credential screens look and behave — write-only credentials, display-once mint, grant-mutation warnings, federation bindings, restore reconciliation, the K8s CR-condition vocabulary? Wayfinder ticket #31, against the locked #17/#18/#19 ADRs.</p>
+  <ul>
+    <li><a href="3/">
+      <span class="num">3</span><span class="name">Journey below</span><span class="latest">LOCKED</span>
+      <span class="desc">Alex's it-2 verdict: the journey rail moves below. The expansion leads with credentials / federated bindings (left) and delivery targets + actions (right); the five-step setup journey sits underneath, full-width under its own section header.</span>
+    </a></li>
+    <li><a href="2/">
+      <span class="num">2</span><span class="name">Structure decided — a + journey on expansion</span>
+      <span class="desc">Alex's it-1 verdict baked in: the tabbed inventory (Service accounts / Federation / Kubernetes targets) is the surface; expanding a row shows the five-step journey rail — CLI voice for plain workloads, CR-condition voice for operator-fetched — beside credentials, federated bindings and delivery targets. Variant switcher removed; master-detail discarded. Ceremonies unchanged from it-1, not yet individually judged.</span>
+    </a></li>
+    <li><a href="1/">
+      <span class="num">1</span><span class="name">Baseline — three structural variants</span>
+      <span class="desc">a inventory (tabbed console, expandable credential rows) · b journey board (card per SA around the #18 five-step journey) · c master-detail (SA list + jump-index detail pane), switchable via ?variant= + floating bar. Shared: display-once mint ceremony, grant-mutation warning naming the newly-reachable plaintext set, reveal opt-in, federation form with the pull_request refusal, K8s condition modal (kubectl + UI voice), post-restore reconciliation scenario. Verdict: a wins, with b's journey as the row expansion.</span>
+    </a></li>
+  </ul>
+  <footer>every change is a new numbered iteration — published ones never mutate · <a href="/prototypes/">all prototypes</a></footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/reveal-edit/1/index.html
+++ b/docs/site/public/prototypes/reveal-edit/1/index.html
@@ -1,0 +1,1673 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo reveal &amp; multi-env editing (ticket #21)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #21, iteration 1.
+  Sibling of env-matrix/31 (frozen reference design, ticket #20). Same shell,
+  same matrix; this prototype resolves the reveal / masking / multi-env
+  editing interactions:
+  - Reauthentication ceremony (ADR #15 sliding window + ADR #16 possession
+    factor): purpose-bound modal, enumerated key set, passkey or TOTP.
+    Protected envs cap the window at 0 ⇒ passkey required per disclosure
+    (TOTP cannot honour a zero window — ADR #16).
+    Demo timings are compressed and labeled: window 90s (stands in for a
+    project-settings value like 15 min), re-mask 10s, clipboard clear 45s.
+  - Per-cell reveal with visible auto-remask countdown.
+  - Clipboard = disclosure (ADR #15 disclosure-by-proxy): copying a secret
+    is gated and audited exactly like reveal, incl. copy-without-display.
+  - Row edit: click a key name to edit it across every environment in one
+    motion (fill-all shortcut, per-env write-only replacement, live
+    per-field validation).
+  - Publish/copy confirms into protected envs are the same ceremony, never
+    a browser confirm().
+  - Per-key audit toasts make ADR #15's one-event-per-key rule feelable.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  #filterbar{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:8px 14px;font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    background:color-mix(in oklch,var(--bad) 8%,var(--bg2));
+    border-bottom:1px solid var(--line);border-left:3px solid var(--bad);
+  }
+  #filterbar button{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:999px;padding:4px 12px;min-height:28px;
+  }
+  #filterbar button:hover{border-color:var(--accent);color:var(--accent)}
+  #side .srow.hiddenby{opacity:.4;cursor:default}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- reauth ceremony (ticket #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:14px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:10px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:10px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+  /* reveal-window chip in the header */
+  #revwin{
+    display:none;align-items:center;gap:6px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    border:1px solid var(--accent);border-radius:999px;padding:5px 11px;
+  }
+  #revwin.on{display:inline-flex}
+  #revwin .wt{font-variant-numeric:tabular-nums}
+  /* auto-remask countdown on revealed values */
+  .remask{
+    display:inline-block;font-family:var(--mono);font-size:9.5px;color:var(--tx-faint);
+    font-variant-numeric:tabular-nums;flex:none;
+  }
+  .cellv .remask{margin-left:2px}
+  /* audit toasts */
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(430px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:8px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+  /* row editor (edit one key across envs in one motion) */
+  #sheet .rowgrid{display:grid;gap:10px;margin-top:14px}
+  #sheet .rohikyo{
+    display:grid;grid-template-columns:92px 1fr;gap:8px;align-items:start;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:10px;
+  }
+  #sheet .rohikyo.prot{border-color:oklch(from var(--bad) l c h/.5)}
+  #sheet .rohikyo .ename{
+    font-size:12px;font-weight:600;padding-top:10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .rohikyo .ename .pp{display:block;color:var(--bad);font-size:9px;letter-spacing:.06em;font-weight:600}
+  #sheet .rohikyo .ename .rq{display:block;color:var(--tx-faint);font-size:9.5px;font-weight:400}
+  #sheet .rohikyo .editor{width:100%;min-width:0;padding:9px 12px;font-size:12.5px}
+  #sheet .rohikyo .everr{grid-column:2;font-size:11px;color:var(--bad);font-family:var(--mono)}
+  #sheet .rohikyo .ecur{grid-column:2;display:flex;align-items:center;gap:8px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);flex-wrap:wrap}
+  #sheet .rohikyo .ecur button{font-size:11px;color:var(--tx-dim);border:1px solid var(--line);
+    border-radius:6px;padding:3px 9px;min-height:26px}
+  #sheet .rohikyo .ecur button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .fillall{
+    display:flex;gap:8px;margin-top:12px;align-items:center;flex-wrap:wrap;
+    padding:10px 12px;border:1px dashed var(--line);border-radius:10px;
+  }
+  #sheet .fillall .editor{flex:1;min-width:160px;padding:9px 12px;font-size:12.5px}
+  #sheet .fillall .lbl{font-size:12px;color:var(--tx-faint)}
+  /* clipboard button beside reveal */
+  .copybtn{white-space:nowrap}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+    #sheet .rohikyo{grid-template-columns:1fr}
+    #sheet .rohikyo .ename{padding-top:0}
+    #sheet .rohikyo .everr,#sheet .rohikyo .ecur{grid-column:1}
+    #revwin .wl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <span id="revwin" title="reveal window — disclosures in non-protected environments skip the prompt while it runs (ADR #15: the window gates the prompt, never the check)"><span class="wl">reveal window</span> <span class="wt"></span></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div id="filterbar" hidden></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+/* demo timings — compressed so the mechanics are feelable; the real values
+   are project settings (ADR #15) and ops-spec defaults */
+const WINDOW_MS=90_000;     /* sliding reveal window (stands in for e.g. 15 min) */
+const REMASK_MS=10_000;     /* revealed value auto-remasks */
+const CLIP_CLEAR_MS=45_000; /* clipboard cleared, best-effort */
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Map(),         // id → remask deadline (ms epoch)
+  reauthUntil:0,              // sliding reveal window (0 = no window)
+  reauth:null,                // {purpose,items:[{key,envId}],prot,waiting,then}
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {key,mode:'row',vals} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  const remask=k.secret&&!dim?`<span class="remask" data-remask="${k.name}:${e.id}"></span>`:'';
+  return`<span class="cellv ${dim?'dim':''}" ${open}><span class="tx">${v}</span>${remask}${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="edit ${esc(k.name)} across environments">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openRow('${k.name}')" onkeydown="if(event.key==='Enter')openRow('${k.name}')">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit · tap a <b>key name</b> to edit it across every environment<br>revealed values re-mask after ${REMASK_MS/1000}s · protected reveals need a passkey every time</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function renderFilterBar(){
+  const bar=document.getElementById('filterbar');
+  if(!S.filter){bar.hidden=true;return}
+  const n=KEYS.filter(keyHasProblem).length;
+  bar.hidden=false;
+  bar.innerHTML=`<span>⚠ filter active: <b style="color:var(--tx)">problems</b> — showing ${n} of ${KEYS.length} keys</span>
+    <button onclick="toggleProblemFilter()">✕ show all keys</button>`;
+}
+function render(){
+  renderFilterBar();renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  /* the filter survives navigation (Alex, iteration 31) — groups the filter
+     hides are rendered inert in the panel instead of silently dead */
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.reauthUntil=0;S.collapsed.clear();S.filter=null;cancelReauth();closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>{
+      const hid=S.filter==='problems'&&!g.p;
+      return`<button class="srow ${hid?'hiddenby':''}" ${hid?'disabled title="hidden by the problems filter"':`onclick="jumpGroup('${g.f}')"`}><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`}).join('')}
+    <button class="srow" style="color:var(--tx-faint)" onclick="openCreate(null)">+ group</button>
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()"
+      title="${S.filter==='problems'?'back to all keys':'show only keys with problems'}">⚠ problems${S.filter==='problems'?'<span style="margin-left:auto;font-size:11px">✕</span>':''}${totalProblems()?`<span class="pb" ${S.filter==='problems'?'style="margin-left:8px"':''}>${totalProblems()}</span>`:''}</button>
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no unpublished edits"'}>Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById(folder?'nk-name':'nk-folder')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function openRow(name){S.sheet={key:name,mode:'row',vals:{}};renderSheet(true)}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  if(mode==='row'){renderRowSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    /* a remask tick can re-render mid-edit — keep whatever was typed */
+    const prev=document.getElementById('editval');if(prev)init=prev.value;
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}" oninput="liveEdit(this)"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}" oninput="liveEdit(this)"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}')">${revealed?`hide <span class="remask" data-remask="${key}:${envId}"></span>`:'reveal value'}</button>`:'')
+      :'';
+    /* clipboard = disclosure for secrets (works from the masked state too) */
+    const copyBtn=c.value!==undefined&&(!k.secret||reveal)?
+      `<button class="btn copybtn" onclick="copyValue('${key}','${envId}')"
+        title="${k.secret?'copies without displaying — still a disclosure, audited per key':'copy value'}">copy</button>`:'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}${copyBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only. Copying is a disclosure too, so it stays gated with reveal.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+/* ============ disclosure ceremony (ticket #21; ADR #15 + #16) ============ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),5200);
+}
+/* ADR #15: one audit event per disclosed key — never "revealed 40 secrets" */
+const audit=(op,key,envId)=>toast(`audit · ${op} · <b>${esc(key)}</b> @ ${envById(envId).name}`,'audit');
+
+/* Gate a disclosure decision. items = the enumerated key set the decision
+   covers (ADR #16: protected unit = ONE decision over an enumerated set).
+   Protected env in the set ⇒ effective window 0 ⇒ passkey, no window granted.
+   Otherwise: a live window skips the PROMPT (never the permission check);
+   success grants/slides the window. */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;   /* sliding */
+    startTicker();then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();startTicker();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);               /* stand-in for the WebAuthn ceremony */
+}
+function totpInput(el){
+  if(el.value.replace(/\D/g,'').length>=6)reauthOK(); /* demo: any 6 digits */
+}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it. This is a <b>disclosure</b> re-auth; account-security changes use a different, clearly separate step-up.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=KEYS.find(x=>x.name===i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> A zero window can only be honoured by a passkey: a TOTP code stays valid for its whole step (ADR #16). No reveal window is granted; this decision covers only the keys above.`
+      :`Success opens a sliding <b>reveal window</b> (${WINDOW_MS/1000}s here — stands in for the project-settings value, e.g. 15 min). While it runs, non-protected disclosures skip this prompt. The permission check itself still runs on every disclosure — the window gates the prompt, never the check (ADR #15).`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ---- countdown ticker: remask deadlines + window chip ---- */
+let tick=null;
+function startTicker(){if(!tick)tick=setInterval(tickFn,250)}
+function tickFn(){
+  const now=Date.now();let expired=false;
+  for(const[id,exp]of S.revealed)if(now>=exp){S.revealed.delete(id);expired=true}
+  document.querySelectorAll('[data-remask]').forEach(el=>{
+    const exp=S.revealed.get(el.dataset.remask);
+    el.textContent=exp?'↺'+Math.ceil((exp-now)/1000)+'s':'';
+  });
+  const w=document.getElementById('revwin');
+  if(S.reauthUntil>now){w.classList.add('on');w.querySelector('.wt').textContent=Math.ceil((S.reauthUntil-now)/1000)+'s'}
+  else w.classList.remove('on');
+  if(expired)render();
+  if(!S.revealed.size&&S.reauthUntil<=now){clearInterval(tick);tick=null}
+}
+
+function doReveal(key,envId){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  disclose('reveal',[{key,envId}],()=>{
+    S.revealed.set(id,Date.now()+REMASK_MS);
+    audit('reveal',key,envId);
+    startTicker();render();
+  });
+}
+/* clipboard is a destination the actor controls ⇒ copying a secret is a
+   disclosure (ADR #15 disclosure-by-proxy), displayed or not */
+function copyValue(key,envId){
+  const k=KEYS.find(x=>x.name===key);
+  const v=k.values[envId];
+  if(v===undefined)return;
+  if(!k.secret){
+    navigator.clipboard?.writeText(v);
+    toast(`copied <b>${esc(key)}</b> @ ${envById(envId).name}`);
+    return;
+  }
+  disclose('copy',[{key,envId}],()=>{
+    navigator.clipboard?.writeText(v);
+    audit('copy',key,envId);
+    toast(`copied without display — cleared in ${CLIP_CLEAR_MS/1000}s if this tab stays focused (the OS may keep clipboard history)`);
+    setTimeout(async()=>{
+      try{if(document.hasFocus()&&await navigator.clipboard.readText()===v)
+        await navigator.clipboard.writeText('')}catch(e){}
+    },CLIP_CLEAR_MS);
+  });
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+/* live inline validation while typing (single-cell editor) */
+function liveEdit(el){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  const err=el.value?validateEdit(k,el.value):null;
+  const e=document.getElementById('editerr');
+  if(err){e.textContent='✕ '+err;e.hidden=false}else e.hidden=true;
+}
+/* ---------- row editor: one key across every environment in one motion ---------- */
+function renderRowSheet(){
+  const{key}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  /* remask ticks re-render — keep whatever was typed */
+  document.querySelectorAll('.rowval').forEach(i=>{S.sheet.vals[i.dataset.env]=i.value});
+  const fa=document.getElementById('fillall-val');if(fa)S.sheet.fillVal=fa.value;
+  const rows=readableEnvs().map(e=>{
+    const c=cellInfo(k,e.id);
+    const id=key+':'+e.id;
+    const revealed=S.revealed.has(id);
+    const reveal=canReveal(e.id);
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const typed=S.sheet.vals[e.id];
+    const init=typed!==undefined?typed:(!k.secret&&c.value!==undefined?c.value:'');
+    const err=init?validateEdit(k,init):null;
+    const ph=c.value===undefined?'not set — type to set'
+      :writeOnly?'write-only replacement — current stays hidden'
+      :k.secret?'replacement value':'';
+    let curline='';
+    if(k.secret&&c.value!==undefined)curline=`<div class="ecur">current:
+      ${revealed?esc(c.value)+` <span class="remask" data-remask="${id}"></span>`:MASK}
+      ${reveal?`<button onclick="doReveal('${key}','${e.id}')">${revealed?'hide':'reveal'}</button>
+        <button onclick="copyValue('${key}','${e.id}')" title="${'copies without displaying — a disclosure, audited'}">copy</button>`:''}</div>`;
+    return`<div class="rohikyo ${e.protected?'prot':''}">
+      <span class="ename">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}${isRequired(k,e.id)?'<span class="rq">required</span>':''}</span>
+      <input class="editor rowval" data-env="${e.id}" placeholder="${ph}" value="${esc(init)}"
+        oninput="rowLive(this)" onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveRow()">
+      ${curline}
+      <div class="everr" data-everr="${e.id}" ${err?'':'hidden'}>${err?'✕ '+esc(err):''}</div>
+    </div>`}).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'} · all environments</span></h2>
+    <div class="sub">edit this key everywhere in one motion — each changed field becomes a draft in its environment</div>
+    <div class="fillall"><span class="lbl">same value everywhere:</span>
+      <input class="editor" id="fillall-val" placeholder="type once…" value="${esc(S.sheet.fillVal||'')}"
+        onkeydown="if(event.key==='Enter')fillAll()">
+      <button class="btn" onclick="fillAll()">fill all</button></div>
+    <div class="rowgrid">${rows}</div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveRow()">save drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px">empty field = unchanged (clear a value from its cell) · ⌘↵ saves</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function rowLive(el){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  const err=el.value?validateEdit(k,el.value):null;
+  const e=document.querySelector(`[data-everr="${el.dataset.env}"]`);
+  if(err){e.textContent='✕ '+err;e.hidden=false}else e.hidden=true;
+}
+function fillAll(){
+  const v=document.getElementById('fillall-val').value;
+  document.querySelectorAll('.rowval').forEach(i=>{i.value=v;rowLive(i)});
+}
+function saveRow(){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  let n=0;
+  document.querySelectorAll('.rowval').forEach(i=>{
+    const env=i.dataset.env,v=i.value;
+    if(!v)return;                       /* empty = unchanged */
+    if(v===k.values[env])return;
+    const err=validateEdit(k,v);
+    k.values[env]=v;
+    if(err)k.invalid[env]=err;else delete k.invalid[env];
+    S.drafts.add(k.name+':'+env);n++;
+  });
+  closeSheet();render();
+  if(n)toast(`${n} draft${n>1?'s':''} saved on <b>${esc(k.name)}</b> — publish stays the gate`);
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const apply=()=>{
+    for(const t of targets){
+      k.values[t]=k.values[envId];
+      delete k.invalid[t];
+      S.drafts.add(key+':'+t);
+      if(k.secret)audit('copy-into',key,t);
+    }
+    S.sheet.mode='view';
+    render();
+  };
+  /* secret: the SOURCE disclosure is what's gated (ADR #15 disclosure-by-proxy);
+     protected targets join the enumerated set so the decision names the whole
+     blast radius and a protected member caps the window at 0 */
+  const items=k.secret
+    ?[{key,envId},...targets.map(t=>({key,envId:t}))]
+    :targets.filter(t=>envById(t).protected).map(t=>({key,envId:t}));
+  if(items.length)disclose('copy',items,apply);
+  else apply();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length){
+    /* enumerate exactly what the protected publish carries (ADR #16:
+       one decision over an enumerated set — never "publish production?") */
+    const items=[];
+    for(const env of prot)for(const d of S.drafts)
+      if(d.endsWith(':'+env))items.push({key:d.slice(0,d.lastIndexOf(':')),envId:env});
+    for(const d of S.drafts)if(d.endsWith(':schema'))
+      items.push({key:d.slice(0,-7)+' (schema change)',envId:prot[0]});
+    disclose('publish',items,()=>finishPublish(targets));
+    return;
+  }
+  finishPublish(targets);
+}
+function finishPublish(targets){
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key</h2>
+    <div class="vrow" style="margin-top:14px">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)" value="${esc(folder||'')}"
+        list="nk-groups" onkeydown="if(event.key==='Escape')closeSheet()">
+      <datalist id="nk-groups">${folders().map(f=>`<option value="${esc(f)}">`).join('')}</datalist>
+    </div>
+    <div class="sub">a new group name creates that group — declared into the environments you pick, no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  /* group field is always live — an unseen name creates that group */
+  const folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+  if(!folder)return err('group required, e.g. app');
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  if(last===-1)KEYS.push(k);          /* brand-new group → appears at the end */
+  else KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();S.reauthUntil=0;cancelReauth();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=()=>{if(S.reauth){cancelReauth();return}closeSheet()};
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){if(S.reauth){cancelReauth();return}closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/reveal-edit/6/index.html
+++ b/docs/site/public/prototypes/reveal-edit/6/index.html
@@ -1,0 +1,1927 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo reveal &amp; multi-env editing (ticket #21)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #21, iteration 6 "REVEAL APPROACHES".
+  Original (env-matrix 31) theming restored — iterations 2-5 were theming
+  variations, dropped by Alex's verdict: the open question is the SHAPE of
+  the reveal interaction, not its skin. Four structurally different reveal
+  approaches, switchable via ?reveal= and a floating bottom bar
+  (arrow keys cycle; publish/copy ceremonies stay modal in all modes):
+    ?reveal=modal    a — centered ceremony modal (iteration 1 baseline)
+    ?reveal=popover  b — inline ceremony popover anchored at the reveal
+                     button; the page never dims, the value reveals where
+                     your eyes already are
+    ?reveal=hold     c — hold-to-reveal: press-and-hold a masked cell,
+                     value shows only while held (release = instant
+                     remask; no timer); ceremony precedes the first hold
+    ?reveal=session  d — disclosure-session drawer: authenticate once
+                     into an explicit session (right drawer), revealed
+                     keys stay listed there with countdowns, one place
+                     to see everything open and end it all
+  Interaction set otherwise unchanged from iteration 1:
+  - Reauthentication ceremony (ADR #15 sliding window + ADR #16 possession
+    factor): purpose-bound modal, enumerated key set, passkey or TOTP.
+    Protected envs cap the window at 0 ⇒ passkey required per disclosure
+    (TOTP cannot honour a zero window — ADR #16).
+    Demo timings are compressed and labeled: window 90s (stands in for a
+    project-settings value like 15 min), re-mask 10s, clipboard clear 45s.
+  - Per-cell reveal with visible auto-remask countdown.
+  - Clipboard = disclosure (ADR #15 disclosure-by-proxy): copying a secret
+    is gated and audited exactly like reveal, incl. copy-without-display.
+  - Row edit: click a key name to edit it across every environment in one
+    motion (fill-all shortcut, per-env write-only replacement, live
+    per-field validation).
+  - Publish/copy confirms into protected envs are the same ceremony, never
+    a browser confirm().
+  - Per-key audit toasts make ADR #15's one-event-per-key rule feelable.
+  Design context: PRODUCT.md / DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    /* dark (default) */
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{
+    display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim);
+  }
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:6px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:6px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- env visibility popover ---------------- */
+  .envbtn{
+    display:inline-flex;align-items:center;gap:4px;margin-left:8px;
+    border:1px solid var(--line);border-radius:6px;padding:6px 10px;min-height:32px;
+    font-size:10px;letter-spacing:.08em;color:var(--tx-dim);text-transform:none;
+  }
+  .envbtn:hover{border-color:var(--accent);color:var(--accent)}
+  #envpop{
+    position:fixed;z-index:30;min-width:210px;
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px;
+  }
+  #envpop .et{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:8px 10px 4px;font-weight:700}
+  #envpop label{
+    display:flex;align-items:center;gap:9px;padding:9px 10px;border-radius:7px;
+    font-size:13px;color:var(--tx);cursor:pointer;min-height:40px;
+  }
+  #envpop label:hover{background:var(--bg3)}
+  #envpop label.off{color:var(--tx-faint)}
+  #envpop .p{font-size:10px;letter-spacing:.06em;color:var(--bad);font-weight:600;margin-left:auto}
+
+  /* ---------------- matrix ---------------- */
+  /* .wrap is THE scroll container (both axes) so thead, group rows and the
+     key column can all stick inside it */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  #filterbar{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:8px 14px;font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    background:color-mix(in oklch,var(--bad) 8%,var(--bg2));
+    border-bottom:1px solid var(--line);border-left:3px solid var(--bad);
+  }
+  #filterbar button{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:999px;padding:4px 12px;min-height:28px;
+  }
+  #filterbar button:hover{border-color:var(--accent);color:var(--accent)}
+  #side .srow.hiddenby{opacity:.4;cursor:default}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:12px 12px 10px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;
+    max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  td.key .req{color:var(--tx-faint);font-size:9.5px;margin-left:6px;font-family:var(--sans)}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:14px 16px;min-height:44px;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gprob{
+    font-size:10.5px;font-weight:600;letter-spacing:.02em;text-transform:none;
+    color:var(--bad);background:var(--bad-soft);border-radius:999px;padding:3px 9px;white-space:nowrap;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.grp button.addk{
+    font-size:11px;color:var(--tx-faint);border:1px dashed var(--line);border-radius:999px;
+    padding:4px 12px;letter-spacing:.02em;text-transform:none;font-weight:500;white-space:nowrap}
+  tr.grp button.addk:hover{color:var(--accent);border-color:var(--accent)}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+    transition:filter .12s,border-color .12s;
+  }
+  .pill:hover{filter:brightness(1.12)}
+  .pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .pill .tx{overflow:hidden;text-overflow:ellipsis}
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  /* editable-slot affordance: trailing pencil (decided iteration 22) */
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  .pill .d{color:var(--chg);font-weight:700;font-style:normal}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  #empty{max-width:400px;margin:10vh auto 0;text-align:center;padding:0 20px}
+  #empty h3{font-size:16px;font-weight:600;margin:16px 0 8px}
+  #empty p{font-size:13px;color:var(--tx-dim);line-height:1.6}
+  #empty .ecta{display:flex;gap:10px;justify-content:center;margin-top:18px;flex-wrap:wrap}
+
+  /* ---------------- legend popover ---------------- */
+  #legendpop{
+    position:fixed;z-index:30;width:min(340px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.4);padding:12px 14px;
+    font-size:12px;color:var(--tx-dim);
+  }
+  #legendpop .lt{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  #legendpop .lrow{display:flex;align-items:center;gap:10px;padding:5px 0}
+  #legendpop .lrow .pill{cursor:default;min-height:24px;padding:4px 10px;flex:none}
+  #legendpop .lrow .pill:hover{filter:none}
+  #legendpop .lfoot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line);line-height:1.6}
+
+  /* ---------------- bottom sheet ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:20;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  /* centered modal (decided iteration 28 — bottom sheet retired) */
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(560px,calc(100% - 32px));max-height:80vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:14px;z-index:21;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:8px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px}
+  #sheet .sub b{color:var(--tx)}
+  #sheet .vrow{
+    display:flex;align-items:center;gap:10px;margin:16px 0 0;flex-wrap:wrap;
+  }
+  #sheet .vrow .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;padding:11px 14px;flex:1;min-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .vrow .cur.err{color:var(--bad);border-color:var(--bad)}
+  #sheet .vrow .cur.dim{color:var(--tx-dim)}
+  #sheet .editor{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--accent);
+    color:var(--tx);border-radius:8px;padding:11px 14px;flex:1;min-width:180px;
+  }
+  #sheet .editor::placeholder{color:var(--tx-faint);font-style:italic}
+  #sheet textarea.editor{resize:vertical;line-height:1.55;width:100%}
+  #sheet .vrow .cur.json{white-space:pre-wrap;overflow:auto;max-height:200px;text-overflow:clip}
+  #sheet .editor:disabled{opacity:.45}
+  #sheet .brow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  #sheet .brow .fsel{min-height:34px;padding:6px 8px;font-size:12px}
+  .btn{border:1px solid var(--line);border-radius:8px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px}
+  #sheet .verr{font-size:12px;color:var(--bad);font-family:var(--mono);margin-top:10px}
+  #sheet .schemarow{
+    display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    margin-top:12px;padding:9px 12px;border:1px solid transparent;border-radius:8px;
+    font-size:12px;color:var(--tx-faint);min-height:40px;
+  }
+  #sheet .schemarow:hover{color:var(--tx-dim);border-color:var(--line)}
+  #sheet .schemarow .tri{font-size:9px;transition:transform .18s cubic-bezier(.25,1,.5,1)}
+  #sheet .schemarow.open .tri{transform:rotate(90deg)}
+  #sheet .copyrow{
+    display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+    font-size:12.5px;color:var(--tx-dim);
+  }
+  #sheet .copyrow label{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:12px}
+  #sheet .copyrow button.go{border:1px solid var(--accent);color:var(--accent);border-radius:6px;padding:7px 14px}
+
+  #sheet select.fsel{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:10px 12px;border-radius:8px;font-family:var(--mono);font-size:13px;min-height:44px}
+  #sheet .pubenv{
+    margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:8px;
+  }
+  #sheet .pubenv.blocked{border-color:var(--bad)}
+  #sheet .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  #sheet .pubenv .ph b{font-weight:600}
+  #sheet .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  #sheet .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  #sheet .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  #sheet .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+    display:flex;gap:10px;align-items:baseline}
+  #sheet .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+  #sheet .pubenv .blockmsg{margin-top:8px;font-size:12px;color:var(--bad);font-family:var(--mono)}
+
+  /* ---------------- app shell (iteration 8 variants) ---------------- */
+  #app{display:grid;grid-template-columns:1fr;height:100dvh;overflow:hidden}
+  body[data-v=a] #app{grid-template-columns:250px 1fr}
+  body[data-v=c] #app{grid-template-columns:56px 210px 1fr}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  body[data-v=b] #main{width:min(1240px,100%);justify-self:center;
+    border-left:1px solid var(--line);border-right:1px solid var(--line)}
+  #rail{display:none;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  body[data-v=c] #rail{display:flex}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:none;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  body[data-v=a] #side,body[data-v=c] #side{display:flex}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);
+    font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--bad);
+    background:var(--bad-soft);border-radius:999px;padding:2px 8px}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #jumpbar{display:none;gap:8px;align-items:center;overflow-x:auto;scrollbar-width:none;
+    padding:8px 16px;border-bottom:1px solid var(--line);flex:none;background:var(--bg)}
+  #jumpbar::-webkit-scrollbar{display:none}
+  body[data-v=b] #jumpbar{display:flex}
+  #jumpbar .jp{white-space:nowrap;border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;font-size:12px;color:var(--tx-dim);min-height:32px}
+  #jumpbar .jp:hover{border-color:var(--accent);color:var(--accent)}
+  #jumpbar .jp .pb{color:var(--bad);font-weight:600;margin-left:5px;font-size:10.5px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+  .projsel-wrap{display:none;padding:10px 16px 2px}
+  select.projsel{
+    width:100%;background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    border-radius:8px;padding:11px 12px;font:inherit;font-size:13.5px;min-height:44px}
+  @supports (appearance:base-select){
+    select.projsel,select.projsel::picker(select){appearance:base-select}
+    select.projsel::picker(select){
+      background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+      box-shadow:0 10px 34px oklch(0 0 0/.4);padding:6px}
+    select.projsel option{padding:10px;border-radius:7px;font-size:13px;color:var(--tx-dim)}
+    select.projsel option:hover{background:var(--bg3);color:var(--tx)}
+    select.projsel option:checked{color:var(--accent);font-weight:600}
+  }
+
+  /* ---------------- reauth ceremony (ticket #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:14px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:8px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:10px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:10px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+  /* reveal-window chip in the header */
+  #revwin{
+    display:none;align-items:center;gap:6px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    border:1px solid var(--accent);border-radius:999px;padding:5px 11px;
+  }
+  #revwin.on{display:inline-flex}
+  #revwin .wt{font-variant-numeric:tabular-nums}
+  /* auto-remask countdown on revealed values */
+  .remask{
+    display:inline-block;font-family:var(--mono);font-size:9.5px;color:var(--tx-faint);
+    font-variant-numeric:tabular-nums;flex:none;
+  }
+  .cellv .remask{margin-left:2px}
+  /* audit toasts */
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(430px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:8px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+  /* row editor (edit one key across envs in one motion) */
+  #sheet .rowgrid{display:grid;gap:10px;margin-top:14px}
+  #sheet .rohikyo{
+    display:grid;grid-template-columns:92px 1fr;gap:8px;align-items:start;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:10px;
+  }
+  #sheet .rohikyo.prot{border-color:oklch(from var(--bad) l c h/.5)}
+  #sheet .rohikyo .ename{
+    font-size:12px;font-weight:600;padding-top:10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .rohikyo .ename .pp{display:block;color:var(--bad);font-size:9px;letter-spacing:.06em;font-weight:600}
+  #sheet .rohikyo .ename .rq{display:block;color:var(--tx-faint);font-size:9.5px;font-weight:400}
+  #sheet .rohikyo .editor{width:100%;min-width:0;padding:9px 12px;font-size:12.5px}
+  #sheet .rohikyo .everr{grid-column:2;font-size:11px;color:var(--bad);font-family:var(--mono)}
+  #sheet .rohikyo .ecur{grid-column:2;display:flex;align-items:center;gap:8px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-faint);flex-wrap:wrap}
+  #sheet .rohikyo .ecur button{font-size:11px;color:var(--tx-dim);border:1px solid var(--line);
+    border-radius:6px;padding:3px 9px;min-height:26px}
+  #sheet .rohikyo .ecur button:hover{border-color:var(--accent);color:var(--accent)}
+  #sheet .fillall{
+    display:flex;gap:8px;margin-top:12px;align-items:center;flex-wrap:wrap;
+    padding:10px 12px;border:1px dashed var(--line);border-radius:10px;
+  }
+  #sheet .fillall .editor{flex:1;min-width:160px;padding:9px 12px;font-size:12.5px}
+  #sheet .fillall .lbl{font-size:12px;color:var(--tx-faint)}
+  /* clipboard button beside reveal */
+  .copybtn{white-space:nowrap}
+
+  /* ============ reveal approaches (iteration 6) ============ */
+  /* b — inline ceremony popover, anchored at the reveal affordance */
+  #rpop{
+    position:fixed;z-index:27;width:min(280px,calc(100vw - 24px));
+    background:var(--bg2);border:1px solid var(--line);border-radius:10px;
+    box-shadow:0 10px 34px oklch(0 0 0/.45);padding:12px 14px;
+  }
+  #rpop .rp-t{font-family:var(--mono);font-size:11px;color:var(--tx-dim);margin-bottom:8px}
+  #rpop .rp-t b{color:var(--tx)}
+  #rpop .factor{margin-top:0;min-height:46px;padding:10px 12px;font-size:12.5px}
+  #rpop .totprow{margin-top:8px}
+  #rpop .totprow input{font-size:14px;padding:8px}
+  #rpop .rp-x{position:absolute;top:6px;right:6px;width:26px;height:26px;color:var(--tx-faint);
+    display:flex;align-items:center;justify-content:center;border-radius:6px}
+  #rpop .rp-x:hover{color:var(--tx)}
+  #rpop .rp-note{font-size:10.5px;color:var(--tx-faint);margin-top:8px;line-height:1.5}
+  /* c — hold-to-reveal */
+  body[data-rmode=hold] .cellv.holdable{user-select:none;-webkit-user-select:none;touch-action:none}
+  body[data-rmode=hold] .cellv.holdable .tx{letter-spacing:.06em}
+  body[data-rmode=hold] .cellv.holding{background:var(--accent-soft);outline:1px solid var(--accent)}
+  .holdhint{font-size:9px;color:var(--tx-faint);font-family:var(--sans);white-space:nowrap}
+  /* d — disclosure-session drawer */
+  #drawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(320px,88vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;padding:16px;overflow-y:auto;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #drawer.open{transform:none}
+  #drawer h3{font-size:13px;font-weight:600;display:flex;align-items:center;gap:8px}
+  #drawer .d-x{margin-left:auto;width:28px;height:28px;color:var(--tx-faint);border-radius:6px;
+    display:flex;align-items:center;justify-content:center}
+  #drawer .d-x:hover{color:var(--tx)}
+  #drawer .d-state{font-family:var(--mono);font-size:11px;color:var(--tx-dim);margin-top:6px}
+  #drawer .d-state b{color:var(--accent)}
+  #drawer .d-list{margin-top:14px;display:grid;gap:8px}
+  #drawer .d-item{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+    font-family:var(--mono);font-size:11px;color:var(--tx);
+    background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:9px 11px;
+  }
+  #drawer .d-item .de{color:var(--tx-faint)}
+  #drawer .d-item button{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:6px;padding:3px 9px;min-height:24px}
+  #drawer .d-item button:hover{border-color:var(--accent);color:var(--accent)}
+  #drawer .d-empty{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:14px;line-height:1.6}
+  #drawer .d-end{margin-top:auto;padding-top:14px}
+  #drawer .factor{margin-top:10px}
+  #drawer .totprow{display:flex;margin-top:8px}
+  #drawer .totprow input{flex:1;font-family:var(--mono);font-size:14px;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);border-radius:8px;padding:9px;min-width:0}
+  /* floating reveal-approach switcher — prototype chrome, off-system on purpose */
+  #modebar{
+    position:fixed;bottom:calc(12px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:50;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.02 300);border:1px solid oklch(0.45 0.06 300);
+    border-radius:999px;padding:4px;box-shadow:0 8px 30px oklch(0 0 0/.55);
+    font-family:var(--mono);font-size:11px;color:oklch(0.92 0.02 300);
+  }
+  #modebar button{min-width:32px;min-height:32px;border-radius:999px;color:inherit;
+    display:flex;align-items:center;justify-content:center;font-size:13px}
+  #modebar button:hover{background:oklch(0.26 0.03 300)}
+  #modebar .sl{padding:0 10px;white-space:nowrap;min-width:200px;text-align:center}
+  #modebar .sl b{color:oklch(0.85 0.1 300);font-weight:500}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:10px 8px}
+    thead th.keyh{min-width:120px;max-width:140px}
+    td.key{max-width:140px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .pill{max-width:170px;font-size:11px}
+    .ctl .lbl{display:none}
+    body[data-v=a] #app,body[data-v=c] #app{grid-template-columns:1fr}
+    body[data-v=b] #main{border:none}
+    #rail{display:none!important}
+    body[data-v=a] #side,body[data-v=c] #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    body[data-v=a] #side.open,body[data-v=c] #side.open{transform:none}
+    body[data-v=a] #menubtn,body[data-v=c] #menubtn{display:inline-flex}
+    body[data-v=c] .projsel-wrap{display:block}
+    #sheet .rohikyo{grid-template-columns:1fr}
+    #sheet .rohikyo .ename{padding-top:0}
+    #sheet .rohikyo .everr,#sheet .rohikyo .ecur{grid-column:1}
+    #revwin .wl{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark" data-v="a">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span id="projname" style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <span id="revwin" title="reveal window — disclosures in non-protected environments skip the prompt while it runs (ADR #15: the window gates the prompt, never the check)"><span class="wl">reveal window</span> <span class="wt"></span></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — decides read/reveal permission" aria-label="acting as role">
+      <option value="admin">admin · reveal everywhere</option>
+      <option value="dev" selected>developer · reveal except prod</option>
+      <option value="viewer">viewer · no reveal</option>
+      <option value="external">external · production hidden</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="legendbtn" onclick="toggleLegendPop(event)" title="what the cells mean" aria-label="what the cells mean">?</button>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div id="jumpbar"></div>
+<div id="filterbar" hidden></div>
+<div class="wrap"><table id="matrix"></table>
+<div id="empty" hidden></div></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<div id="envpop" hidden></div>
+<div id="legendpop" hidden></div>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="key details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="rpop" hidden></div>
+<aside id="drawer" aria-label="disclosure session"></aside>
+<div id="toasts" aria-live="polite"></div>
+<div id="modebar" role="group" aria-label="reveal approach switcher">
+  <button onclick="cycleRmode(-1)" aria-label="previous approach">‹</button>
+  <span class="sl" id="modelabel"></span>
+  <button onclick="cycleRmode(1)" aria-label="next approach">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* NO INHERITANCE: environments are flat peers; every value explicit. */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+/* key: {folder,name,type,secret,required:'all'|'none'|[ids],
+         values:{env:'...'}, invalid:{env:msg}, changed:[envIds], draft?} */
+const K=(folder,name,type,secret,required,values,invalid,changed,desc)=>(
+  {folder,name,type,secret,required,values:values||{},invalid:invalid||{},changed:changed||[],desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+
+const KEYS=[
+  K('app','APP_NAME','string',false,'all',all('Hikyo Demo')),
+  K('app','APP_URL','url',false,'all',
+    {dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'},{},['prd']),
+  K('app','PORT','int',false,'all',all('8080')),
+  K('app','LOG_LEVEL','string',false,'all',{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,'none',{dev:'false',stg:'false',prd:'false',pre:'true'},{},['pre']),
+  K('app','FEATURE_FLAGS','json',false,'all',
+    {dev:'{"beta":true,"newNav":true}',stg:'{"beta":"yes","newNav":false}',prd:'{"beta":false,"newNav":false}',pre:'{"beta":true,"newNav":true}'},
+    {stg:'/beta: expected boolean, got string'},[],
+    'json key with an attached JSON Schema — flag names must map to booleans.'),
+  K('database','DATABASE_URL','url',true,'all',
+    {dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'},{},[],
+    'Preview points at staging’s database — an explicit copy now, not inheritance.'),
+  K('database','DB_POOL_SIZE','int',false,'all',{dev:'10',stg:'ten',prd:'40',pre:'10'},{stg:'must be a whole number — got "ten"'},[]),
+  K('database','DB_SSL_MODE','string',false,['prd'],{prd:'verify-full'}),
+  K('database','DB_MIGRATIONS_AUTO','bool',false,'all',{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('auth','SESSION_SECRET','string',true,'all',
+    {dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'},{},['stg']),
+  K('auth','OIDC_ISSUER','url',false,['stg','prd'],
+    {dev:'https://id.example.dev',stg:'https://id.example.dev',prd:'https://id.example.dev',pre:'localhost:8080'},{pre:'must be a full URL, e.g. https://id.example.dev'}),
+  K('auth','OIDC_CLIENT_ID','string',false,['stg','prd'],{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,['stg','prd'],{stg:'oidc-stg-secret'},{},[],
+    'Required in production and simply not there — the gap is honest now.'),
+  K('mail','SMTP_HOST','string',false,'none',{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PORT','int',false,'none',all('587')),
+  K('mail','SMTP_PASSWORD','string',true,'none',{stg:'stg-smtp-pass',prd:'prd-smtp-pass'},{},[],
+    'Not set in development or preview: no mail from those boxes.'),
+  K('integrations','FORGEJO_TOKEN','string',true,'none',{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','GCP_SERVICE_ACCOUNT','json',true,['prd'],
+    {dev:'{"type":"service_account","project_id":"ew-dev","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo","AKIAIOSFODNN7":"pasted-extra"}',
+     stg:'{"type":"service_account","project_id":"ew-stg","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}',
+     prd:'{"type":"service_account","project_id":"ew-prd","private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEdemo"}'},
+    {dev:'unexpected property — instance details redacted (secret)'},[],
+    'secret json: schema errors never echo the value or an instance-derived path (ADR #12).'),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,'all',
+    {dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'},{},['prd']),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,'all',
+    {dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'},{},[],
+    'Required in production and unset: publish is blocked.'),
+  K('observability','SENTRY_DSN','url',false,'none',{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','OTEL_ENDPOINT','url',false,'none',all('http://otel.internal:4317')),
+];
+/* JSON Schema attached inline on the key (schema ADR #12: rules live on the key,
+   pinned + profiled subset — demo checker below covers type/required/properties/
+   additionalProperties/enum) */
+KEYS.find(k=>k.name==='FEATURE_FLAGS').schema=
+  {type:'object',additionalProperties:{type:'boolean'}};
+KEYS.find(k=>k.name==='GCP_SERVICE_ACCOUNT').schema=
+  {type:'object',required:['type','project_id','private_key'],
+   properties:{type:{enum:['service_account']},project_id:{type:'string'},private_key:{type:'string'}},
+   additionalProperties:false};
+/* per-type constraints, also inline on the key (ADR #12: pattern anchored to
+   the whole value, integer min/max, url scheme allowlist) */
+KEYS.find(k=>k.name==='PORT').constraints={min:1,max:65535};
+KEYS.find(k=>k.name==='LOG_LEVEL').constraints={pattern:'debug|info|warn|error'};
+(function fill(){
+  let s=42; const rnd=()=>((s=(Math.imul(48271,s)>>>0)%2147483647)/2147483647);
+  const names={
+    app:['APP_TIMEZONE','APP_LOCALE','MAX_UPLOAD_MB','REQUEST_TIMEOUT_MS','CORS_ORIGINS','TRUSTED_PROXIES','SESSION_IDLE_MIN','SESSION_ABS_HOURS','RATE_LIMIT_RPS','MAINTENANCE_MODE'],
+    database:['DB_STATEMENT_TIMEOUT_MS','DB_IDLE_TIMEOUT_S','DB_MAX_LIFETIME_MIN','DB_LOG_QUERIES','DB_SCHEMA'],
+    auth:['PASSWORD_MIN_LENGTH','TOTP_ISSUER_LABEL','WEBAUTHN_RP_ID','RECOVERY_CODE_COUNT','INVITE_TTL_HOURS','JIT_PROVISIONING'],
+    mail:['SMTP_FROM','SMTP_STARTTLS','MAIL_REPLY_TO'],
+    integrations:['WEBHOOK_SIGNING_KEY','FORGEJO_BASE_URL','S3_BUCKET','S3_REGION','S3_ENDPOINT','GH_APP_ID'],
+    observability:['METRICS_ENABLED','TRACE_SAMPLE_RATE','LOG_FORMAT','AUDIT_EXPORT_PATH','HEALTHCHECK_PATH','PPROF_ENABLED','SLOW_QUERY_MS'],
+  };
+  const samples={int:['30','120','5','8','60'],bool:['true','false'],string:['on','off','eu-west-1','v1','main'],url:['http://svc.internal:9090']};
+  for(const folder in names) for(const n of names[folder]){
+    const r=rnd();
+    const type=/(_MS|_S|_MIN|_HOURS|_MB|_RPS|_COUNT|_ID$|RATE|LENGTH)/.test(n)?'int':/(ENABLED|MODE|STARTTLS|QUERIES|PROVISIONING)/.test(n)?'bool':/(URL|ENDPOINT|PATH)/.test(n)?'url':'string';
+    const secret=/(KEY|TOKEN|SECRET)/.test(n);
+    const val=type==='url'?samples.url[0]:samples[type][Math.floor(rnd()*samples[type].length)];
+    const k=K(folder,n,type,secret,'none',all(val));
+    if(r<0.2){const e=ENVS[Math.floor(rnd()*4)].id;k.values[e]=type==='int'?String(Math.floor(rnd()*90)+10):val;}
+    if(r>0.93)k.changed=[ENVS[Math.floor(rnd()*4)].id];
+    KEYS.push(k);
+  }
+})();
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* per-project key store: the demo project is seeded, others start empty */
+const PDATA={'hikyo-demo':KEYS.slice()};
+/* per-env published revision number (revision ADR #11: per-env monotonic) */
+const REV={dev:41,stg:38,prd:29,pre:12};
+
+/* ============================ state & permissions ============================ */
+const isRequired=(k,e)=>k.required==='all'||(Array.isArray(k.required)&&k.required.includes(e));
+/* demo timings — compressed so the mechanics are feelable; the real values
+   are project settings (ADR #15) and ops-spec defaults */
+const WINDOW_MS=90_000;     /* sliding reveal window (stands in for e.g. 15 min) */
+const REMASK_MS=10_000;     /* revealed value auto-remasks */
+const CLIP_CLEAR_MS=45_000; /* clipboard cleared, best-effort */
+const S={
+  theme:'dark',
+  role:'dev',
+  hiddenEnvs:new Set(),
+  collapsed:new Set(),
+  revealed:new Map(),         // id → remask deadline (ms epoch)
+  reauthUntil:0,              // sliding reveal window / session (0 = none)
+  reauth:null,                // {purpose,items:[{key,envId}],prot,waiting,then}
+  rmode:'modal',              // reveal approach: modal|popover|hold|session
+  rpop:null,rpopAt:0,         // inline ceremony popover state
+  holdGrant:null,holdGrantUntil:0,
+  drawerOpen:false,drawerWait:false,pendingReveal:null,
+  drafts:new Set(),
+  envpop:false,envpopX:0,envpopY:0,
+  filter:null,
+  legendpop:false,legendpopX:0,legendpopY:0,
+  sheet:null,                 // {key,envId,mode:'view'|'edit'|'copy'} | {key,mode:'row',vals} | {mode:'create',folder}
+};
+function cellInfo(k,envId){
+  const value=k.values[envId];
+  const state=value!==undefined?'set':'absent';
+  const required=isRequired(k,envId);
+  const invalid=k.invalid[envId];
+  const missing=required&&state==='absent';
+  const changed=k.changed.includes(envId)||S.drafts.has(k.name+':'+envId);
+  return{state,value,required,invalid,missing,changed};
+}
+/* simulated permission model; real one = ADR #15.
+   read=false ⇒ env nonexistent for this principal (unauthorized ≡ nonexistent). */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected},
+  viewer:{read:e=>true,reveal:e=>false},
+  external:{read:e=>!e.protected,reveal:e=>!e.protected},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+const visibleEnvs=()=>readableEnvs().filter(e=>!S.hiddenEnvs.has(e.id));
+function groupProblems(f){
+  let n=0;
+  for(const k of KEYS.filter(k=>k.folder===f))for(const e of readableEnvs()){
+    const c=cellInfo(k,e.id);if(c.invalid||c.missing)n++;
+  }
+  return n;
+}
+/* tiny JSON Schema checker (demo subset of the pinned 2020-12 profile).
+   Returns {path,msg,safe} — `safe` carries no instance-derived data, for
+   secret keys (ADR #12: schema-keyword locations only, no instance pointer). */
+function checkJson(sch,v,path){
+  const t=Array.isArray(v)?'array':v===null?'null':typeof v;
+  if(sch.type&&t!==sch.type)
+    return{path,msg:`expected ${sch.type}, got ${t}`,safe:`expected ${sch.type}`};
+  if(sch.enum&&!sch.enum.includes(v))
+    return{path,msg:`must be one of: ${sch.enum.join(', ')}`,safe:`must be one of: ${sch.enum.join(', ')}`};
+  if(t==='object'){
+    for(const r of sch.required||[])if(!(r in v))
+      return{path,msg:`missing required property "${r}"`,safe:`missing required property "${r}"`};
+    for(const p in v){
+      const ps=sch.properties?.[p];
+      let e=null;
+      if(ps)e=checkJson(ps,v[p],path+'/'+p);
+      else if(sch.additionalProperties===false)
+        e={path:path+'/'+p,msg:`unexpected property "${p}"`,safe:'unexpected property'};
+      else if(typeof sch.additionalProperties==='object')
+        e=checkJson(sch.additionalProperties,v[p],path+'/'+p);
+      if(e)return e;
+    }
+  }
+  return null;
+}
+function validateEdit(k,val){
+  if(k.type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number, e.g. 8080';
+  if(k.type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(k.type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL, e.g. https://example.dev';
+  const cn=k.constraints;
+  if(cn){
+    if(k.type==='string'){
+      /* pattern anchored to the whole value (ADR #12) */
+      if(cn.pattern&&!(new RegExp('^(?:'+cn.pattern+')$')).test(val))return`must match pattern ${cn.pattern}`;
+      if(cn.minLength!==undefined&&val.length<cn.minLength)return`too short — at least ${cn.minLength} characters`;
+      if(cn.maxLength!==undefined&&val.length>cn.maxLength)return`too long — at most ${cn.maxLength} characters`;
+    }
+    if(k.type==='int'){
+      const n=Number(val);
+      if(cn.min!==undefined&&n<cn.min)return`must be at least ${cn.min}`;
+      if(cn.max!==undefined&&n>cn.max)return`must be at most ${cn.max}`;
+    }
+    if(k.type==='url'&&cn.schemes?.length&&!cn.schemes.includes(val.split(':')[0].toLowerCase()))
+      return`URL scheme must be ${cn.schemes.join(' or ')}`;
+  }
+  if(k.type==='json'){
+    let v;
+    try{v=JSON.parse(val)}catch(e){return'not valid JSON — '+String(e.message)}
+    if(k.schema){
+      const er=checkJson(k.schema,v,'');
+      if(er)return k.secret
+        ?er.safe+' — instance details redacted (secret)'
+        :(er.path||'value')+': '+er.msg;
+    }
+  }
+  return null;
+}
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+function shownValue(k,envId,c){
+  if(c.value===undefined)return'';
+  if(!k.secret)return c.value;
+  return S.revealed.has(k.name+':'+envId)?c.value:MASK;
+}
+
+/* ============================ render ============================ */
+function renderEnvPop(){
+  const pop=document.getElementById('envpop');
+  if(!S.envpop){pop.hidden=true;return}
+  pop.hidden=false;
+  pop.style.left=Math.max(12,Math.min(S.envpopX,innerWidth-230))+'px';
+  pop.style.top=S.envpopY+'px';
+  pop.innerHTML=`<div class="et">environments</div>`+
+    readableEnvs().map(e=>{
+      const on=!S.hiddenEnvs.has(e.id);
+      return`<label class="${on?'':'off'}">
+        <input type="checkbox" ${on?'checked':''} onchange="toggleEnv('${e.id}')">
+        ${e.name}${e.protected?'<span class="p">PROT</span>':''}
+      </label>`;
+    }).join('');
+}
+function toggleEnvPop(ev){
+  ev.stopPropagation();
+  if(!S.envpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.envpopX=r.left;S.envpopY=r.bottom+6;
+  }
+  S.envpop=!S.envpop;renderEnvPop();
+}
+document.addEventListener('click',e=>{
+  if(S.envpop&&!e.target.closest('#envpop')){S.envpop=false;renderEnvPop()}
+  if(S.legendpop&&!e.target.closest('#legendpop')){S.legendpop=false;renderLegendPop()}
+  if(S.rpop&&Date.now()-S.rpopAt>200&&!e.target.closest('#rpop'))rpopClose();
+});
+function toggleEnv(id){
+  if(S.hiddenEnvs.has(id))S.hiddenEnvs.delete(id);
+  else if(visibleEnvs().length>1)S.hiddenEnvs.add(id);
+  render();
+}
+function toggleProblemFilter(){S.filter=S.filter?null:'problems';render()}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+function pillFor(k,e,c){
+  const d=c.changed?`<span class="d" title="changed since last publish">Δ</span>`:'';
+  const draft=S.drafts.has(k.name+':'+e.id)?`<span class="draftdot" title="unpublished local edit"></span>`:'';
+  const open=`onclick="openSheet('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openSheet('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  if(c.invalid){
+    let iv=shownValue(k,e.id,c);
+    if(k.type==='json'){iv=iv.replace(/\s+/g,' ');if(iv.length>42)iv=iv.slice(0,42)+'…'}
+    return`<span class="pill invalid" ${open}><span class="tx">✕ ${esc(iv)}</span>${d}${draft}</span><span class="viol">${esc(c.invalid)}</span>`;
+  }
+  if(c.missing)return`<span class="pill missing" ${open}><span class="tx">! required · unset</span></span>`;
+  if(c.state==='absent')return`<span class="cellv absent" ${open}><span class="tx">·</span></span>`;
+  let raw=shownValue(k,e.id,c);
+  if(k.type==='json'){raw=raw.replace(/\s+/g,' ');if(raw.length>42)raw=raw.slice(0,42)+'…'}
+  const v=esc(raw);
+  const dim=k.secret&&!S.revealed.has(k.name+':'+e.id);
+  const remask=k.secret&&!dim?`<span class="remask" data-remask="${k.name}:${e.id}"></span>`:'';
+  const holdable=dim&&S.rmode==='hold'&&canReveal(e.id)?' holdable':'';
+  return`<span class="cellv ${dim?'dim':''}${holdable}" data-hk="${esc(k.name)}" data-he="${e.id}" ${open}><span class="tx">${v}</span>${remask}${d}${draft}</span>`;
+}
+const EMPTY_ICON=`<svg width="44" height="44" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="7" fill="none" stroke="var(--line)"/><path d="M8 12h16M8 16h16M8 20h10" stroke="var(--accent)" stroke-width="2.4" stroke-linecap="round" opacity=".7"/></svg>`;
+function renderEmpty(kind){
+  const el=document.getElementById('empty');el.hidden=false;
+  document.getElementById('matrix').innerHTML='';
+  if(kind==='nokeys')el.innerHTML=`${EMPTY_ICON}
+    <h3>no keys in ${esc(PROJ)} yet</h3>
+    <p>declare a key once, give each environment its own value — the matrix shows the whole configuration surface at a glance.</p>
+    <div class="ecta">
+      <button class="btn primary" onclick="openCreate(null)">declare first key</button>
+      <button class="btn" onclick="alert('imports run through the CLI:\n\n  hikyo scaffold --from .env\n\nreview the generated definitions, apply, then import values (source-of-truth flow, ticket #13). Out of scope for this prototype.')">import from .env</button>
+    </div>`;
+  else el.innerHTML=`${EMPTY_ICON}
+    <h3>no problems</h3>
+    <p>every readable environment validates — nothing blocks publish.</p>
+    <div class="ecta"><button class="btn primary" onclick="toggleProblemFilter()">show all keys</button></div>`;
+}
+const keyHasProblem=k=>readableEnvs().some(e=>{const c=cellInfo(k,e.id);return c.invalid||c.missing});
+function totalProblems(){let n=0;for(const f of folders())n+=groupProblems(f);return n}
+function renderMatrix(){
+  if(KEYS.length===0){renderEmpty('nokeys');return}
+  if(S.filter==='problems'&&!KEYS.some(keyHasProblem)){renderEmpty('noproblems');return}
+  document.getElementById('empty').hidden=true;
+  const envs=visibleEnvs();
+  const head=`<thead><tr><th class="keyh">key
+    <button class="envbtn" onclick="toggleEnvPop(event)" aria-label="choose visible environments">envs ${envs.length}/${readableEnvs().length} ▾</button></th>${envs.map(e=>
+    `<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}</th>`).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f&&(S.filter!=='problems'||keyHasProblem(k)));
+    if(!ks.length)continue;
+    const closed=S.collapsed.has(f);
+    const probs=groupProblems(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>
+        ${probs?`<span class="gprob">${probs} problem${probs>1?'s':''}</span>`:''}
+        ${sum}
+        ${closed?'':`<span onclick="event.stopPropagation();openCreate('${f}')" class="addk" role="button">+ key</span>`}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="edit ${esc(k.name)} across environments">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openRow('${k.name}')" onkeydown="if(event.key==='Enter')openRow('${k.name}')">${esc(k.name)}</span><span class="req">${k.required==='all'?'req':Array.isArray(k.required)?'req·'+k.required.join(','):''}</span></td>`;
+      for(const e of envs)body+=`<td>${pillFor(k,e,cellInfo(k,e.id))}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function renderLegendPop(){
+  const pop=document.getElementById('legendpop');
+  if(!S.legendpop){pop.hidden=true;return}
+  pop.hidden=false;
+  /* clamp both edges — r.right-340 goes negative on narrow screens */
+  pop.style.left=Math.max(12,Math.min(S.legendpopX,innerWidth-352))+'px';
+  pop.style.top=S.legendpopY+'px';
+  pop.innerHTML=`<div class="lt">what the cells mean</div>
+    <div class="lrow"><span class="cellv" style="cursor:default">value</span> set in that environment — nothing inherits</div>
+    <div class="lrow"><span class="cellv dim" style="cursor:default">••••••••</span> secret value (🔒 marks the key) — tap to reveal, if permitted</div>
+    <div class="lrow"><span class="cellv absent" style="cursor:default">·</span> not set</div>
+    <div class="lrow"><span class="pill missing">! required · unset</span> blocks publish</div>
+    <div class="lrow"><span class="pill invalid">✕ value</span> schema violation</div>
+    <div class="lfoot">Δ changed since last publish · <span class="draftdot" style="display:inline-block"></span> unpublished draft<br>tap any cell to inspect or edit · tap a <b>key name</b> to edit it across every environment<br>revealed values re-mask after ${REMASK_MS/1000}s · protected reveals need a passkey every time</div>`;
+}
+function toggleLegendPop(ev){
+  ev.stopPropagation();
+  if(!S.legendpop){
+    const r=ev.currentTarget.getBoundingClientRect();
+    S.legendpopX=r.right-340;S.legendpopY=r.bottom+8;
+  }
+  S.legendpop=!S.legendpop;renderLegendPop();
+}
+function renderDrafts(){
+  const el=document.getElementById('drafts');
+  el.hidden=S.drafts.size===0;
+  el.textContent=`${S.drafts.size} unpublished edit${S.drafts.size>1?'s':''} · publish…`;
+}
+function renderFilterBar(){
+  const bar=document.getElementById('filterbar');
+  if(!S.filter){bar.hidden=true;return}
+  const n=KEYS.filter(keyHasProblem).length;
+  bar.hidden=false;
+  bar.innerHTML=`<span>⚠ filter active: <b style="color:var(--tx)">problems</b> — showing ${n} of ${KEYS.length} keys</span>
+    <button onclick="toggleProblemFilter()">✕ show all keys</button>`;
+}
+function render(){
+  renderFilterBar();renderMatrix();renderDrafts();renderShell();renderEnvPop();renderLegendPop();
+  renderDrawer();
+  syncGh();
+  if(S.sheet)renderSheet();
+}
+
+/* ============================ app shell (variants) ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+let PROJ=PROJECTS[0];
+const VAR='c'; /* shell settled: rail + panel */
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  /* the filter survives navigation (Alex, iteration 31) — groups the filter
+     hides are rendered inert in the panel instead of silently dead */
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function pickProject(p){
+  if(p===PROJ){setSide(false);return}
+  PDATA[PROJ]=KEYS.slice();
+  KEYS.length=0;KEYS.push(...(PDATA[p]||[]));
+  PROJ=p;
+  S.drafts.clear();S.revealed.clear();S.reauthUntil=0;S.collapsed.clear();S.filter=null;cancelReauth();closeSheet();
+  document.getElementById('projname').textContent=p.replace('hikyo-','');
+  render();
+  setSide(false);
+}
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function renderShell(){
+  const groups=folders().map(f=>{
+    const n=KEYS.filter(k=>k.folder===f).length;
+    const p=groupProblems(f);
+    return{f,n,p};
+  });
+  /* variant c: the rail owns project switching — the panel repeats none of it,
+     it navigates INSIDE the current project. variant a has no rail, so the
+     sidebar carries the projects list itself. */
+  const projectsBlock=VAR==='c'
+    ?`<div class="projsel-wrap"><select class="projsel" onchange="pickProject(this.value)" aria-label="project">
+        ${PROJECTS.map(p=>`<option ${p===PROJ?'selected':''}>${p}</option>`).join('')}
+      </select></div>
+      <div class="stitle" style="padding-top:14px">${esc(PROJ)}</div>`
+    :`<div class="stitle">projects</div>
+      ${PROJECTS.map(p=>`<button class="srow ${p===PROJ?'act':''}" onclick="pickProject('${p}')">${p}</button>`).join('')}`;
+  document.getElementById('side').innerHTML=`
+    ${projectsBlock}
+    <div class="stitle">groups</div>
+    ${groups.map(g=>{
+      const hid=S.filter==='problems'&&!g.p;
+      return`<button class="srow ${hid?'hiddenby':''}" ${hid?'disabled title="hidden by the problems filter"':`onclick="jumpGroup('${g.f}')"`}><span class="mono">${g.f}/</span>
+      ${g.p?`<span class="pb">${g.p}</span>`:`<span class="cnt">${g.n}</span>`}</button>`}).join('')}
+    <button class="srow" style="color:var(--tx-faint)" onclick="openCreate(null)">+ group</button>
+    <div class="stitle">views</div>
+    <button class="srow ${S.filter==='problems'?'act':''}" onclick="toggleProblemFilter()"
+      title="${S.filter==='problems'?'back to all keys':'show only keys with problems'}">⚠ problems${S.filter==='problems'?'<span style="margin-left:auto;font-size:11px">✕</span>':''}${totalProblems()?`<span class="pb" ${S.filter==='problems'?'style="margin-left:8px"':''}>${totalProblems()}</span>`:''}</button>
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no unpublished edits"'}>Δ drafts${S.drafts.size?`<span class="cnt">${S.drafts.size}</span>`:''}</button>
+    ${VAR==='c'?`<div class="stitle">project</div>
+    <button class="srow" onclick="alert('prototype: project settings (icon, access, metadata) — to be prototyped later')">⚙ settings</button>`:''}`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map(p=>`<button class="pav ${p===PROJ?'act':''}" title="${p}"
+      style="${p===PROJ?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      onclick="pickProject('${p}')">${monogram(p)}</button>`).join('');
+  document.getElementById('jumpbar').innerHTML=
+    groups.map(g=>`<button class="jp" onclick="jumpGroup('${g.f}')">${g.f}${g.p?`<span class="pb">${g.p}</span>`:''}</button>`).join('');
+}
+document.body.dataset.v=VAR;
+
+/* group headers stick right under the measured thead — fractional height,
+   re-measured after webfont load and on resize (a rounded offsetHeight left
+   a visible seam) */
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ bottom sheet ============================ */
+function openSheet(name,envId){S.sheet={key:name,envId,mode:'view'};renderSheet(true)}
+function openCreate(folder){S.sheet={mode:'create',folder};renderSheet(true);
+  setTimeout(()=>document.getElementById(folder?'nk-name':'nk-folder')?.focus(),60)}
+function openPublish(){S.sheet={mode:'publish'};renderSheet(true)}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function openRow(name){S.sheet={key:name,mode:'row',vals:{}};renderSheet(true)}
+function renderSheet(opening){
+  const{key,envId,mode}=S.sheet;
+  if(mode==='create'){renderCreateSheet();return}
+  if(mode==='publish'){renderPublishSheet();return}
+  if(mode==='row'){renderRowSheet();return}
+  const k=KEYS.find(x=>x.name===key);const env=envById(envId);
+  const c=cellInfo(k,envId);
+  const reveal=canReveal(envId);
+  const revealed=S.revealed.has(key+':'+envId);
+
+  let stateLine;
+  if(c.invalid)stateLine=`schema violation: <b>${esc(c.invalid)}</b>`;
+  else if(c.missing)stateLine=`<b>required here and unset</b> — publish is blocked`;
+  else if(c.state==='absent')stateLine=`not set in <b>${env.name}</b> — nothing is delivered`;
+  else stateLine=`set in <b>${env.name}</b>`;
+
+  let vrow='';
+  if(mode==='edit'){
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const isJson=k.type==='json';
+    let init=!k.secret&&c.value!==undefined?c.value:'';
+    if(isJson&&init){try{init=JSON.stringify(JSON.parse(init),null,2)}catch(e){}}
+    /* a remask tick can re-render mid-edit — keep whatever was typed */
+    const prev=document.getElementById('editval');if(prev)init=prev.value;
+    const ph=writeOnly?'write-only replacement — current value stays hidden'
+      :'new value ('+k.type+(isJson&&k.schema?' — validated against this key’s schema':'')+')';
+    const field=isJson
+      ?`<textarea class="editor" id="editval" rows="7" spellcheck="false" placeholder="${ph}" oninput="liveEdit(this)"
+          onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">${esc(init)}</textarea>`
+      :`<input class="editor" id="editval" type="text" placeholder="${ph}" value="${esc(init)}" oninput="liveEdit(this)"
+          onkeydown="if(event.key==='Enter')saveEdit();if(event.key==='Escape'){S.sheet.mode='view';renderSheet()}">`;
+    vrow=`<div class="vrow">${field}</div>
+    <div class="verr" id="editerr" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveEdit()">save to ${env.name}</button>
+      <button class="btn" onclick="S.sheet.mode='view';renderSheet()">cancel</button>
+    </div>`;
+  }else{
+    let cur;
+    if(c.value===undefined)cur=`<span class="cur dim">—</span>`;
+    else if(k.secret&&!revealed)cur=`<span class="cur dim">${MASK}</span>`;
+    else{
+      let pv=c.value;
+      if(k.type==='json'){try{pv=JSON.stringify(JSON.parse(pv),null,2)}catch(e){}}
+      cur=`<span class="cur ${k.type==='json'?'json':''} ${c.invalid?'err':''}">${esc(pv)}</span>`;
+    }
+    const revealBtn=k.secret&&c.value!==undefined?
+      (reveal?`<button class="btn" onclick="doReveal('${key}','${envId}',event)">${revealed?`hide <span class="remask" data-remask="${key}:${envId}"></span>`:'reveal value'}</button>`:'')
+      :'';
+    /* clipboard = disclosure for secrets (works from the masked state too) */
+    const copyBtn=c.value!==undefined&&(!k.secret||reveal)?
+      `<button class="btn copybtn" onclick="copyValue('${key}','${envId}')"
+        title="${k.secret?'copies without displaying — still a disclosure, audited per key':'copy value'}">copy</button>`:'';
+    /* copying a secret out of this env is a disclosure toward the targets —
+       gated on reveal of the SOURCE env (ADR #15 disclosure-by-proxy) */
+    const canCopy=c.value!==undefined&&(!k.secret||reveal);
+    const others=readableEnvs().filter(e=>e.id!==envId);
+    const copyrow=mode==='copy'?`<div class="copyrow">
+        copy this value to:
+        ${others.map(e=>`<label><input type="checkbox" class="cp-env" value="${e.id}"> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+        <button class="go" onclick="doCopy()">copy</button>
+        <button onclick="S.sheet.mode='view';renderSheet()" style="opacity:.6">cancel</button>
+      </div>`:'';
+    vrow=`<div class="vrow">${cur}${revealBtn}${copyBtn}</div>
+    ${k.secret&&c.value!==undefined&&!reveal?`<div class="noperm">no reveal here for your role — write-only replacement only. Copying is a disclosure too, so it stays gated with reveal.</div>`:''}
+    ${copyrow}
+    <div class="acts">
+      <button class="btn primary" onclick="S.sheet.mode='edit';renderSheet();setTimeout(()=>document.getElementById('editval').focus(),50)">${c.state==='set'?'edit value':'set value'}</button>
+      ${canCopy&&mode!=='copy'?`<button class="btn" onclick="S.sheet.mode='copy';renderSheet()">copy to…</button>`:''}
+      ${c.state==='set'?`<button class="btn danger" onclick="clearValue()">clear value</button>`:''}
+    </div>`;
+  }
+
+  const reqTxt=k.required==='all'?'all environments':k.required==='none'?'nowhere':k.required.join(', ');
+  const cn=k.constraints||{};
+  const cnSummary=[cn.pattern?'pattern':null,
+    cn.minLength!==undefined||cn.maxLength!==undefined?'length':null,
+    cn.min!==undefined||cn.max!==undefined?'range':null,
+    cn.schemes?'schemes':null,k.schema?'json schema':null].filter(Boolean).join(' · ');
+  const schemaLbl=`schema · ${cnSummary?cnSummary+' · ':''}required in ${esc(reqTxt)}`;
+  /* changing a value-dependent rule on a secret is a disclosure oracle (ADR #12):
+     publish outcomes leak the value bit by bit — requires reveal everywhere it's set */
+  const ruleGate=k.secret&&readableEnvs().some(e=>k.values[e.id]!==undefined&&!canReveal(e.id));
+  const dis=ruleGate?'disabled':'';
+  const cfield=(id,ph,v,w)=>`<input class="editor" id="${id}" placeholder="${ph}" value="${v??''}" style="min-width:0;flex:1 1 ${w||'160px'};padding:8px 10px;font-size:12px" ${dis}>`;
+  let cnFields='';
+  if(k.type==='string')cnFields=cfield('cn-pattern','pattern (anchored), e.g. debug|info',cn.pattern)
+    +cfield('cn-minlen','min length',cn.minLength,'70px')+cfield('cn-maxlen','max length',cn.maxLength,'70px');
+  if(k.type==='int')cnFields=cfield('cn-min','min',cn.min,'70px')+cfield('cn-max','max',cn.max,'70px');
+  if(k.type==='url')cnFields=cfield('cn-schemes','allowed schemes, e.g. https',cn.schemes?.join(', '));
+  let jsonBlock='';
+  if(k.type==='json'&&mode==='view'&&S.sheet.schemaOpen){
+    /* schema builder: primary UI; raw JSON Schema behind "advanced".
+       undefined = not imported yet · null = schema beyond the builder subset */
+    if(S.sheet.builder===undefined){
+      S.sheet.builder=builderFromSchema(k.schema);
+      if(S.sheet.builder===null)S.sheet.advOpen=true;
+    }
+    const b=S.sheet.builder;
+    const canInfer=c.value!==undefined&&(!k.secret||revealed);
+    const typeOpts=sel=>['any',...JTYPES].map(t=>`<option ${sel===t?'selected':''}>${t}</option>`).join('');
+    const rows=b?b.props.map((p,i)=>`<div class="brow">
+        <input class="editor" placeholder="property" value="${esc(p.name)}" style="min-width:0;flex:2;padding:7px 10px;font-size:12px"
+          onchange="S.sheet.builder.props[${i}].name=this.value" ${dis}>
+        <select class="fsel" onchange="S.sheet.builder.props[${i}].type=this.value" ${dis}>${typeOpts(p.type)}</select>
+        <label style="font-size:12px;color:var(--tx-dim);display:flex;gap:5px;align-items:center"><input type="checkbox" ${p.required?'checked':''}
+          onchange="S.sheet.builder.props[${i}].required=this.checked" ${dis}> required</label>
+        <button class="btn" style="min-height:34px;padding:4px 10px" onclick="S.sheet.builder.props.splice(${i},1);renderSheet()" aria-label="remove property" ${dis}>✕</button>
+      </div>`).join(''):'';
+    jsonBlock=`<div class="copyrow" style="flex-direction:column;align-items:stretch;gap:8px">
+      <div style="font-size:12px;color:var(--tx-faint)">value shape${b===null?' — <i>this schema uses features beyond the simple builder; edit it as JSON below</i>':''}</div>
+      ${rows}
+      ${b?`<div class="brow">
+        <button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="S.sheet.builder.props.push({name:'',type:'string',required:true});renderSheet()" ${dis}>+ property</button>
+        ${canInfer?`<button class="btn" style="min-height:34px;padding:6px 12px;font-size:12px" onclick="inferSchema()" ${dis}>infer from current value</button>`:''}
+      </div>
+      <div class="brow"><span style="font-size:12px;color:var(--tx-dim)">other properties:</span>
+        <select class="fsel" onchange="S.sheet.builder.extra=this.value" ${dis}>
+          <option value="any" ${b.extra==='any'?'selected':''}>allowed, any value</option>
+          <option value="none" ${b.extra==='none'?'selected':''}>not allowed</option>
+          ${JTYPES.map(t=>`<option value="${t}" ${b.extra===t?'selected':''}>allowed, must be ${t}</option>`).join('')}
+        </select></div>`:''}
+      <button class="schemarow ${S.sheet.advOpen?'open':''}" style="margin-top:0;padding:6px 2px" onclick="S.sheet.advOpen=!S.sheet.advOpen;renderSheet()"><span class="tri">▸</span>advanced — edit as JSON Schema</button>
+      ${S.sheet.advOpen?`<textarea class="editor" id="cn-jschema" rows="6" spellcheck="false"
+        placeholder='JSON Schema for values, e.g. {"type":"object"}' ${dis}>${k.schema?esc(JSON.stringify(k.schema,null,2)):''}</textarea>
+        <div style="font-size:11px;color:var(--tx-faint)">while advanced is open, apply saves this JSON — not the rows above.</div>`:''}
+      <div class="brow"><button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button></div>
+    </div>
+    <div class="verr" id="cn-err" hidden></div>`;
+  }
+  const schemaBlock=mode!=='view'?'':S.sheet.schemaOpen
+    ?`<button class="schemarow open" onclick="S.sheet.schemaOpen=false;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>
+      <div class="copyrow">required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="rq-env" value="${e.id}" ${isRequired(k,e.id)?'checked':''} onchange="setRequired('${k.name}')"> ${e.id}</label>`).join('')}
+      </div>
+      ${jsonBlock}
+      ${cnFields?`<div class="copyrow" style="align-items:stretch">constraints:
+        ${cnFields}
+        <button class="go" onclick="applyConstraints('${k.name}')" ${dis}>apply</button>
+      </div>
+      <div class="verr" id="cn-err" hidden></div>`:''}
+      ${ruleGate?`<div class="noperm">value rules on a secret only change with reveal everywhere it’s set — otherwise publish outcomes would leak the value (ADR #12).</div>`:''}
+      <div class="sub" style="margin-top:8px">rule changes are schema drafts — they ride the same publish and re-validate every environment.</div>`
+    :`<button class="schemarow" onclick="S.sheet.schemaOpen=true;renderSheet()"><span class="tri">▸</span>${schemaLbl}</button>`;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''} — ${stateLine}${c.changed?' · <b>Δ changed</b>':''}</div>
+    ${k.desc?`<div class="sub" style="font-style:italic">${esc(k.desc)}</div>`:''}
+    ${vrow}
+    ${schemaBlock}`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+/* ============ disclosure ceremony (ticket #21; ADR #15 + #16) ============ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),5200);
+}
+/* ADR #15: one audit event per disclosed key — never "revealed 40 secrets" */
+const audit=(op,key,envId)=>toast(`audit · ${op} · <b>${esc(key)}</b> @ ${envById(envId).name}`,'audit');
+
+/* Gate a disclosure decision. items = the enumerated key set the decision
+   covers (ADR #16: protected unit = ONE decision over an enumerated set).
+   Protected env in the set ⇒ effective window 0 ⇒ passkey, no window granted.
+   Otherwise: a live window skips the PROMPT (never the permission check);
+   success grants/slides the window. */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;   /* sliding */
+    startTicker();then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();startTicker();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);               /* stand-in for the WebAuthn ceremony */
+}
+function totpInput(el){
+  if(el.value.replace(/\D/g,'').length>=6)reauthOK(); /* demo: any 6 digits */
+}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it. This is a <b>disclosure</b> re-auth; account-security changes use a different, clearly separate step-up.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=KEYS.find(x=>x.name===i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> A zero window can only be honoured by a passkey: a TOTP code stays valid for its whole step (ADR #16). No reveal window is granted; this decision covers only the keys above.`
+      :`Success opens a sliding <b>reveal window</b> (${WINDOW_MS/1000}s here — stands in for the project-settings value, e.g. 15 min). While it runs, non-protected disclosures skip this prompt. The permission check itself still runs on every disclosure — the window gates the prompt, never the check (ADR #15).`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ---- countdown ticker: remask deadlines + window chip ---- */
+let tick=null;
+function startTicker(){if(!tick)tick=setInterval(tickFn,250)}
+function tickFn(){
+  const now=Date.now();let expired=false;
+  for(const[id,exp]of S.revealed)if(now>=exp){S.revealed.delete(id);expired=true}
+  document.querySelectorAll('[data-remask]').forEach(el=>{
+    const idr=el.dataset.remask;
+    const exp=idr==='__session'?S.reauthUntil:S.revealed.get(idr);
+    el.textContent=exp&&exp>now?'↺'+Math.ceil((exp-now)/1000)+'s':'';
+  });
+  const w=document.getElementById('revwin');
+  if(S.reauthUntil>now){w.classList.add('on');w.querySelector('.wt').textContent=Math.ceil((S.reauthUntil-now)/1000)+'s'}
+  else w.classList.remove('on');
+  if(expired)render();
+  if(!S.revealed.size&&S.reauthUntil<=now){clearInterval(tick);tick=null}
+}
+
+function doReveal(key,envId,ev){
+  const id=key+':'+envId;
+  if(S.revealed.has(id)){S.revealed.delete(id);render();return}
+  const prot=envById(envId).protected;
+  const finish=()=>{
+    S.revealed.set(id,Date.now()+REMASK_MS);
+    audit('reveal',key,envId);
+    startTicker();render();
+  };
+  if(S.rmode==='popover'&&!(Date.now()<S.reauthUntil&&!prot)){
+    rpopOpen([{key,envId}],ev,finish);return;
+  }
+  if(S.rmode==='session'&&!prot){
+    if(Date.now()<S.reauthUntil){
+      S.reauthUntil=Date.now()+WINDOW_MS;          /* sliding */
+      /* session entries live until the session ends — re-bind them all */
+      for(const[k2]of S.revealed)if(!envById(k2.slice(k2.lastIndexOf(':')+1)).protected)S.revealed.set(k2,S.reauthUntil);
+      S.revealed.set(id,S.reauthUntil);
+      audit('reveal',key,envId);
+      S.drawerOpen=true;startTicker();render();return;
+    }
+    S.pendingReveal={key,envId};S.drawerOpen=true;render();return;
+  }
+  if(S.rmode==='session'&&prot){
+    disclose('reveal',[{key,envId}],()=>{finish();S.drawerOpen=true;render()});return;
+  }
+  disclose('reveal',[{key,envId}],finish);  /* modal (and hold-mode sheet fallback) */
+}
+
+/* ---- b · inline ceremony popover ---- */
+function rpopOpen(items,ev,then){
+  S.rpop={items,then,prot:items.some(i=>envById(i.envId).protected),waiting:false};
+  S.rpopAt=Date.now();
+  renderRpop();
+  const el=document.getElementById('rpop');
+  const r=ev?.target?.closest('button,.cellv')?.getBoundingClientRect()||{left:innerWidth/2-140,bottom:innerHeight/2-80};
+  el.style.left=Math.max(12,Math.min(r.left,innerWidth-292))+'px';
+  el.style.top=Math.max(12,Math.min(r.bottom+8,innerHeight-el.offsetHeight-12))+'px';
+}
+function renderRpop(){
+  const p=S.rpop;const el=document.getElementById('rpop');
+  if(!p){el.hidden=true;return}
+  el.hidden=false;
+  const i0=p.items[0];
+  el.innerHTML=`<button class="rp-x" onclick="rpopClose()" aria-label="close">✕</button>
+    <div class="rp-t">reveal <b>${esc(i0.key)}</b> @ ${envById(i0.envId).name}${p.prot?' · <span style="color:var(--bad)">PROTECTED</span>':''}</div>
+    <button class="factor ${p.waiting?'waiting':''}" onclick="rpopPasskey()">
+      <span class="fi">🔑</span><span>${p.waiting?'waiting for your passkey…':'use your passkey'}</span></button>
+    ${p.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+      placeholder="or TOTP code" aria-label="TOTP code" oninput="if(this.value.replace(/\\D/g,'').length>=6)rpopOK()"></div>`}
+    <div class="rp-note">${p.prot?'protected — passkey each time, no reveal window':`grants the ${WINDOW_MS/1000}s reveal window`} · demo: any 6 digits</div>`;
+}
+function rpopPasskey(){const p=S.rpop;if(!p||p.waiting)return;p.waiting=true;renderRpop();setTimeout(rpopOK,900)}
+function rpopOK(){
+  const p=S.rpop;if(!p)return;
+  if(!p.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.rpop=null;renderRpop();startTicker();
+  p.then();
+}
+function rpopClose(){S.rpop=null;renderRpop()}
+
+/* ---- c · hold-to-reveal (grid cells; release = instant remask) ---- */
+let holdTimer=null,holdCell=null,holdSuppress=false;
+document.addEventListener('pointerdown',e=>{
+  if(S.rmode!=='hold')return;
+  const c=e.target.closest('.holdable');if(!c)return;
+  e.preventDefault();
+  holdTimer=setTimeout(()=>{
+    holdTimer=null;
+    const key=c.dataset.hk,env=c.dataset.he,id=key+':'+env;
+    if(!canReveal(env))return;
+    const prot=envById(env).protected;
+    const granted=S.holdGrant===id&&Date.now()<S.holdGrantUntil;
+    if((prot&&!granted)||(!prot&&Date.now()>=S.reauthUntil)){
+      disclose('reveal',[{key,envId:env}],()=>{
+        if(prot){S.holdGrant=id;S.holdGrantUntil=Date.now()+10000;
+          toast('approved — hold the cell again to view (10s)')}
+        startTicker();
+      });
+      return;
+    }
+    if(!prot)S.reauthUntil=Date.now()+WINDOW_MS;else S.holdGrant=null;
+    holdCell=c;holdSuppress=true;
+    c.classList.add('holding');
+    c.querySelector('.tx').textContent=KEYS.find(x=>x.name===key).values[env];
+    audit('reveal',key,env);startTicker();
+  },260);
+});
+function endHold(){
+  if(holdTimer){clearTimeout(holdTimer);holdTimer=null}
+  if(holdCell){holdCell=null;render()}     /* re-render restores the mask */
+}
+document.addEventListener('pointerup',endHold);
+document.addEventListener('pointercancel',endHold);
+document.addEventListener('click',e=>{
+  if(holdSuppress){holdSuppress=false;e.stopPropagation();e.preventDefault()}
+},true);
+
+/* ---- d · disclosure-session drawer ---- */
+function closeDrawer(){S.drawerOpen=false;S.pendingReveal=null;render()}
+function drawerPasskey(){if(S.drawerWait)return;S.drawerWait=true;render();setTimeout(drawerAuthOK,900)}
+function drawerAuthOK(){
+  S.drawerWait=false;
+  S.reauthUntil=Date.now()+WINDOW_MS;
+  const p=S.pendingReveal;S.pendingReveal=null;
+  if(p){S.revealed.set(p.key+':'+p.envId,S.reauthUntil);audit('reveal',p.key,p.envId)}
+  startTicker();render();
+}
+function endSession(){
+  S.reauthUntil=0;
+  for(const[id]of S.revealed)if(!envById(id.slice(id.lastIndexOf(':')+1)).protected)S.revealed.delete(id);
+  render();toast('disclosure session ended — values re-masked');
+}
+function renderDrawer(){
+  const el=document.getElementById('drawer');
+  const open=S.rmode==='session'&&S.drawerOpen;
+  el.classList.toggle('open',!!open);
+  if(!open)return;
+  const live=S.reauthUntil>Date.now();
+  const items=[...S.revealed.keys()].map(id=>{
+    const i=id.lastIndexOf(':');const key=id.slice(0,i),env=id.slice(i+1);
+    return`<div class="d-item">🔒 ${esc(key)} <span class="de">@ ${envById(env).name}</span>
+      <span class="remask" data-remask="${id}"></span>
+      <button onclick="S.revealed.delete('${id}');render()">hide</button></div>`;
+  }).join('');
+  el.innerHTML=`<h3>disclosure session<button class="d-x" onclick="closeDrawer()" aria-label="close">✕</button></h3>
+    ${live
+      ?`<div class="d-state">authenticated · <b><span class="remask" data-remask="__session"></span></b> sliding — every reveal extends it</div>
+        ${items?`<div class="d-list">${items}</div>`
+          :`<div class="d-empty">nothing revealed yet — tap a masked value anywhere; everything you open is listed here until you end the session.</div>`}
+        <div class="d-end"><button class="btn danger" style="width:100%" onclick="endSession()">end session — re-mask everything</button></div>`
+      :`<div class="d-state">not authenticated</div>
+        <button class="factor ${S.drawerWait?'waiting':''}" onclick="drawerPasskey()">
+          <span class="fi">🔑</span><span>${S.drawerWait?'waiting for your passkey…':'start a disclosure session'}</span></button>
+        <div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+          placeholder="or TOTP code" aria-label="TOTP code" oninput="if(this.value.replace(/\\D/g,'').length>=6)drawerAuthOK()"></div>
+        ${S.pendingReveal?`<div class="d-state">then reveals ${esc(S.pendingReveal.key)} @ ${envById(S.pendingReveal.envId).name}</div>`:''}
+        <div class="rp-note" style="margin-top:10px">one authentication, an explicit ${WINDOW_MS/1000}s session; protected values still take their own passkey ceremony · demo: any 6 digits</div>`}`;
+}
+/* clipboard is a destination the actor controls ⇒ copying a secret is a
+   disclosure (ADR #15 disclosure-by-proxy), displayed or not */
+function copyValue(key,envId){
+  const k=KEYS.find(x=>x.name===key);
+  const v=k.values[envId];
+  if(v===undefined)return;
+  if(!k.secret){
+    navigator.clipboard?.writeText(v);
+    toast(`copied <b>${esc(key)}</b> @ ${envById(envId).name}`);
+    return;
+  }
+  disclose('copy',[{key,envId}],()=>{
+    navigator.clipboard?.writeText(v);
+    audit('copy',key,envId);
+    toast(`copied without display — cleared in ${CLIP_CLEAR_MS/1000}s if this tab stays focused (the OS may keep clipboard history)`);
+    setTimeout(async()=>{
+      try{if(document.hasFocus()&&await navigator.clipboard.readText()===v)
+        await navigator.clipboard.writeText('')}catch(e){}
+    },CLIP_CLEAR_MS);
+  });
+}
+function saveEdit(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const val=document.getElementById('editval').value;
+  if(!val){S.sheet.mode='view';renderSheet();return}
+  const err=validateEdit(k,val);
+  if(err){const e=document.getElementById('editerr');e.textContent='✕ '+err+' — saved as a draft; publish stays blocked until fixed';e.hidden=false}
+  k.values[envId]=val;
+  delete k.invalid[envId];
+  if(err)k.invalid[envId]=err;
+  S.drafts.add(key+':'+envId);
+  S.sheet.mode='view';
+  render();
+}
+/* live inline validation while typing (single-cell editor) */
+function liveEdit(el){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  const err=el.value?validateEdit(k,el.value):null;
+  const e=document.getElementById('editerr');
+  if(err){e.textContent='✕ '+err;e.hidden=false}else e.hidden=true;
+}
+/* ---------- row editor: one key across every environment in one motion ---------- */
+function renderRowSheet(){
+  const{key}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  /* remask ticks re-render — keep whatever was typed */
+  document.querySelectorAll('.rowval').forEach(i=>{S.sheet.vals[i.dataset.env]=i.value});
+  const fa=document.getElementById('fillall-val');if(fa)S.sheet.fillVal=fa.value;
+  const rows=readableEnvs().map(e=>{
+    const c=cellInfo(k,e.id);
+    const id=key+':'+e.id;
+    const revealed=S.revealed.has(id);
+    const reveal=canReveal(e.id);
+    const writeOnly=k.secret&&!reveal&&c.value!==undefined;
+    const typed=S.sheet.vals[e.id];
+    const init=typed!==undefined?typed:(!k.secret&&c.value!==undefined?c.value:'');
+    const err=init?validateEdit(k,init):null;
+    const ph=c.value===undefined?'not set — type to set'
+      :writeOnly?'write-only replacement — current stays hidden'
+      :k.secret?'replacement value':'';
+    let curline='';
+    if(k.secret&&c.value!==undefined)curline=`<div class="ecur">current:
+      ${revealed?esc(c.value)+` <span class="remask" data-remask="${id}"></span>`:MASK}
+      ${reveal?`<button onclick="doReveal('${key}','${e.id}',event)">${revealed?'hide':'reveal'}</button>
+        <button onclick="copyValue('${key}','${e.id}')" title="${'copies without displaying — a disclosure, audited'}">copy</button>`:''}</div>`;
+    return`<div class="rohikyo ${e.protected?'prot':''}">
+      <span class="ename">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}${isRequired(k,e.id)?'<span class="rq">required</span>':''}</span>
+      <input class="editor rowval" data-env="${e.id}" placeholder="${ph}" value="${esc(init)}"
+        oninput="rowLive(this)" onkeydown="if(event.key==='Enter'&&(event.metaKey||event.ctrlKey))saveRow()">
+      ${curline}
+      <div class="everr" data-everr="${e.id}" ${err?'':'hidden'}>${err?'✕ '+esc(err):''}</div>
+    </div>`}).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(k.name)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'} · all environments</span></h2>
+    <div class="sub">edit this key everywhere in one motion — each changed field becomes a draft in its environment</div>
+    <div class="fillall"><span class="lbl">same value everywhere:</span>
+      <input class="editor" id="fillall-val" placeholder="type once…" value="${esc(S.sheet.fillVal||'')}"
+        onkeydown="if(event.key==='Enter')fillAll()">
+      <button class="btn" onclick="fillAll()">fill all</button></div>
+    <div class="rowgrid">${rows}</div>
+    <div class="acts">
+      <button class="btn primary" onclick="saveRow()">save drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px">empty field = unchanged (clear a value from its cell) · ⌘↵ saves</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function rowLive(el){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  const err=el.value?validateEdit(k,el.value):null;
+  const e=document.querySelector(`[data-everr="${el.dataset.env}"]`);
+  if(err){e.textContent='✕ '+err;e.hidden=false}else e.hidden=true;
+}
+function fillAll(){
+  const v=document.getElementById('fillall-val').value;
+  document.querySelectorAll('.rowval').forEach(i=>{i.value=v;rowLive(i)});
+}
+function saveRow(){
+  const k=KEYS.find(x=>x.name===S.sheet.key);
+  let n=0;
+  document.querySelectorAll('.rowval').forEach(i=>{
+    const env=i.dataset.env,v=i.value;
+    if(!v)return;                       /* empty = unchanged */
+    if(v===k.values[env])return;
+    const err=validateEdit(k,v);
+    k.values[env]=v;
+    if(err)k.invalid[env]=err;else delete k.invalid[env];
+    S.drafts.add(k.name+':'+env);n++;
+  });
+  closeSheet();render();
+  if(n)toast(`${n} draft${n>1?'s':''} saved on <b>${esc(k.name)}</b> — publish stays the gate`);
+}
+function clearValue(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  delete k.values[envId];delete k.invalid[envId];
+  S.drafts.add(key+':'+envId);
+  render();
+}
+function doCopy(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const targets=[...document.querySelectorAll('.cp-env:checked')].map(i=>i.value);
+  if(!targets.length){S.sheet.mode='view';renderSheet();return}
+  const apply=()=>{
+    for(const t of targets){
+      k.values[t]=k.values[envId];
+      delete k.invalid[t];
+      S.drafts.add(key+':'+t);
+      if(k.secret)audit('copy-into',key,t);
+    }
+    S.sheet.mode='view';
+    render();
+  };
+  /* secret: the SOURCE disclosure is what's gated (ADR #15 disclosure-by-proxy);
+     protected targets join the enumerated set so the decision names the whole
+     blast radius and a protected member caps the window at 0 */
+  const items=k.secret
+    ?[{key,envId},...targets.map(t=>({key,envId:t}))]
+    :targets.filter(t=>envById(t).protected).map(t=>({key,envId:t}));
+  if(items.length)disclose('copy',items,apply);
+  else apply();
+}
+/* ---------------- publish (review → confirm; revision ADR #11) ---------------- */
+function envBlocked(envId){
+  return KEYS.some(k=>{const c=cellInfo(k,envId);return c.invalid||c.missing});
+}
+function renderPublishSheet(){
+  const valueDrafts=[...S.drafts].filter(d=>!d.endsWith(':schema'));
+  const schemaDrafts=[...S.drafts].filter(d=>d.endsWith(':schema')).map(d=>d.slice(0,-7));
+  const byEnv={};
+  for(const d of valueDrafts){const i=d.lastIndexOf(':');const key=d.slice(0,i),env=d.slice(i+1);
+    (byEnv[env]??=[]).push(key)}
+  const envs=readableEnvs().filter(e=>byEnv[e.id]?.length||schemaDrafts.length);
+  const secs=envs.map(e=>{
+    const blocked=envBlocked(e.id);
+    const items=(byEnv[e.id]||[]).map(key=>{
+      const k=KEYS.find(x=>x.name===key);const c=cellInfo(k,e.id);
+      const v=c.value===undefined?'(cleared)':k.secret?MASK:c.value;
+      return`<li>${k.secret?'🔒 ':''}${esc(key)}<span class="nv">${esc(v)}</span></li>`;
+    }).join('');
+    return`<div class="pubenv ${blocked?'blocked':''}">
+      <label class="ph">
+        <input type="checkbox" class="pb-env" value="${e.id}" ${blocked?'disabled':'checked'}>
+        <b>${e.name}</b>${e.protected?'<span class="pp">PROTECTED — confirms before publish</span>':''}
+        <span class="rev">r${REV[e.id]} → r${REV[e.id]+1}</span>
+      </label>
+      <ul>${items}${schemaDrafts.map(n=>`<li>schema: ${esc(n)} required-in changed</li>`).join('')}</ul>
+      ${blocked?`<div class="blockmsg">✕ this environment has violations or missing required keys — publish blocked until fixed</div>`:''}
+    </div>`;
+  }).join('');
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish</h2>
+    <div class="sub">each environment publishes as its own atomic revision — untick any you want to hold back</div>
+    ${secs||'<div class="sub" style="margin-top:14px">nothing to publish</div>'}
+    <div class="acts">
+      ${secs?`<button class="btn primary" onclick="doPublish()">publish selected</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="sub" style="margin-top:12px">invalid environments cannot publish — delivery only sees valid revisions.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function doPublish(){
+  const targets=[...document.querySelectorAll('.pb-env:checked')].map(i=>i.value);
+  if(!targets.length)return;
+  const prot=targets.filter(id=>envById(id).protected);
+  if(prot.length){
+    /* enumerate exactly what the protected publish carries (ADR #16:
+       one decision over an enumerated set — never "publish production?") */
+    const items=[];
+    for(const env of prot)for(const d of S.drafts)
+      if(d.endsWith(':'+env))items.push({key:d.slice(0,d.lastIndexOf(':')),envId:env});
+    for(const d of S.drafts)if(d.endsWith(':schema'))
+      items.push({key:d.slice(0,-7)+' (schema change)',envId:prot[0]});
+    disclose('publish',items,()=>finishPublish(targets));
+    return;
+  }
+  finishPublish(targets);
+}
+function finishPublish(targets){
+  for(const env of targets){
+    REV[env]++;
+    for(const d of[...S.drafts]){
+      if(d.endsWith(':'+env)){
+        S.drafts.delete(d);
+        const k=KEYS.find(x=>x.name===d.slice(0,d.lastIndexOf(':')));
+        if(k&&!k.changed.includes(env))k.changed.push(env);
+      }
+    }
+  }
+  for(const d of[...S.drafts])if(d.endsWith(':schema'))S.drafts.delete(d);
+  closeSheet();render();
+}
+/* ---------------- required-in (schema ADR #12 presence per env) ---------------- */
+function setRequired(name){
+  const k=KEYS.find(x=>x.name===name);
+  const ids=[...document.querySelectorAll('.rq-env:checked')].map(i=>i.value);
+  k.required=ids.length===ENVS.length?'all':ids.length?ids:'none';
+  S.drafts.add(name+':schema');
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+/* ------- schema builder: two-way map between a JSON Schema subset and rows.
+   Subset: {type:'object', required, properties:{n:{type}|{}}, additionalProperties:false|{type}}.
+   Anything richer → null → the raw editor takes over. ------- */
+const JTYPES=['string','number','boolean','object','array'];
+function builderFromSchema(sch){
+  if(!sch)return{props:[],extra:'any'};
+  const allowed=['type','required','properties','additionalProperties'];
+  if(sch.type!=='object'||Object.keys(sch).some(x=>!allowed.includes(x)))return null;
+  const props=[];
+  for(const n in sch.properties||{}){
+    const p=sch.properties[n],pk=Object.keys(p);
+    if(pk.length>1||(pk.length===1&&pk[0]!=='type'))return null;
+    if(p.type!==undefined&&!JTYPES.includes(p.type))return null;
+    props.push({name:n,type:p.type||'any',required:(sch.required||[]).includes(n)});
+  }
+  for(const r of sch.required||[])if(!props.some(p=>p.name===r))props.push({name:r,type:'any',required:true});
+  let extra='any';
+  const ap=sch.additionalProperties;
+  if(ap===false)extra='none';
+  else if(ap!==undefined&&ap!==true){
+    const ak=Object.keys(ap);
+    if(ak.length===1&&ak[0]==='type'&&JTYPES.includes(ap.type))extra=ap.type;else return null;
+  }
+  return{props,extra};
+}
+function schemaFromBuilder(b){
+  const sch={type:'object'};
+  const req=[...new Set(b.props.filter(p=>p.required&&p.name).map(p=>p.name))];
+  if(req.length)sch.required=req;
+  const props={};
+  for(const p of b.props)if(p.name)props[p.name]=p.type==='any'?{}:{type:p.type};
+  if(Object.keys(props).length)sch.properties=props;
+  if(b.extra==='none')sch.additionalProperties=false;
+  else if(b.extra!=='any')sch.additionalProperties={type:b.extra};
+  /* nothing declared → no schema at all */
+  if(!sch.required&&!sch.properties&&sch.additionalProperties===undefined)return null;
+  return sch;
+}
+function inferSchema(){
+  const{key,envId}=S.sheet;
+  const k=KEYS.find(x=>x.name===key);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  let j;
+  try{j=JSON.parse(k.values[envId])}catch(e){return err('current value is not valid JSON — fix the value first')}
+  if(!j||typeof j!=='object'||Array.isArray(j))
+    return err('the builder describes objects — this value is '+(Array.isArray(j)?'an array':typeof j)+'; use advanced');
+  const t=x=>Array.isArray(x)?'array':x===null?'any':typeof x;
+  S.sheet.builder={props:Object.keys(j).map(n=>({name:n,type:JTYPES.includes(t(j[n]))?t(j[n]):'any',required:true})),extra:'none'};
+  S.sheet.advOpen=false;
+  renderSheet();
+}
+/* re-check every stored value against the key's current rules */
+function revalidate(k){
+  for(const e of ENVS){
+    const v=k.values[e.id];
+    if(v===undefined){delete k.invalid[e.id];continue}
+    const er=validateEdit(k,v);
+    if(er)k.invalid[e.id]=er;else delete k.invalid[e.id];
+  }
+}
+function applyConstraints(name){
+  const k=KEYS.find(x=>x.name===name);
+  const err=m=>{const e=document.getElementById('cn-err');e.textContent='✕ '+m;e.hidden=false};
+  const num=id=>{const v=document.getElementById(id)?.value.trim();
+    if(v===undefined||v==='')return undefined;
+    if(!/^-?\d+$/.test(v))return NaN;
+    return Number(v)};
+  const cn={};
+  if(k.type==='string'){
+    const p=document.getElementById('cn-pattern').value.trim();
+    if(p){try{new RegExp('^(?:'+p+')$')}catch(e){return err('pattern does not compile: '+e.message)}cn.pattern=p}
+    cn.minLength=num('cn-minlen');cn.maxLength=num('cn-maxlen');
+    if(Number.isNaN(cn.minLength)||Number.isNaN(cn.maxLength))return err('lengths must be whole numbers');
+    if(cn.minLength!==undefined&&cn.maxLength!==undefined&&cn.minLength>cn.maxLength)return err('min length exceeds max length');
+  }
+  if(k.type==='int'){
+    cn.min=num('cn-min');cn.max=num('cn-max');
+    if(Number.isNaN(cn.min)||Number.isNaN(cn.max))return err('bounds must be whole numbers');
+    if(cn.min!==undefined&&cn.max!==undefined&&cn.min>cn.max)return err('min exceeds max');
+  }
+  if(k.type==='url'){
+    const s=document.getElementById('cn-schemes').value.trim();
+    if(s)cn.schemes=s.split(',').map(x=>x.trim().toLowerCase()).filter(Boolean);
+  }
+  if(k.type==='json'){
+    if(S.sheet?.advOpen){
+      const t=document.getElementById('cn-jschema').value.trim();
+      if(t){try{k.schema=JSON.parse(t)}catch(e){return err('schema is not valid JSON — '+String(e.message))}}
+      else delete k.schema;
+      S.sheet.builder=undefined;    /* re-import rows from the new schema */
+    }else if(S.sheet?.builder){
+      const sch=schemaFromBuilder(S.sheet.builder);
+      if(sch)k.schema=sch;else delete k.schema;
+    }
+  }
+  for(const key in cn)if(cn[key]===undefined)delete cn[key];
+  if(Object.keys(cn).length)k.constraints=cn;else delete k.constraints;
+  S.drafts.add(name+':schema');
+  revalidate(k);
+  if(S.sheet)S.sheet.schemaOpen=true;
+  render();
+}
+function renderCreateSheet(){
+  const{folder}=S.sheet;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>new key</h2>
+    <div class="vrow" style="margin-top:14px">
+      <input class="editor" id="nk-folder" type="text" placeholder="group (e.g. app)" value="${esc(folder||'')}"
+        list="nk-groups" onkeydown="if(event.key==='Escape')closeSheet()">
+      <datalist id="nk-groups">${folders().map(f=>`<option value="${esc(f)}">`).join('')}</datalist>
+    </div>
+    <div class="sub">a new group name creates that group — declared into the environments you pick, no inheritance, each gets its own copy</div>
+    <div class="vrow">
+      <input class="editor" id="nk-name" type="text" placeholder="KEY_NAME"
+        onkeydown="if(event.key==='Enter')addKey();if(event.key==='Escape')closeSheet()">
+    </div>
+    <div class="vrow">
+      <select id="nk-type" class="fsel"
+        onchange="const j=this.value==='json';const v=document.getElementById('nk-val');v.rows=j?5:1;v.placeholder=j?'first value (json — multiline)':'first value (optional)';document.getElementById('nk-schemarow').hidden=!j"><option>string</option><option>int</option><option>bool</option><option>url</option><option>json</option></select>
+      <label style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--tx-dim)"><input type="checkbox" id="nk-sec"> 🔒 secret</label>
+    </div>
+    <div class="vrow">
+      <textarea class="editor" id="nk-val" rows="1" placeholder="first value (optional)"
+        onkeydown="if(event.key==='Enter'&&(this.rows===1||event.metaKey||event.ctrlKey)){event.preventDefault();addKey()}if(event.key==='Escape')closeSheet()"></textarea>
+    </div>
+    <div class="sub" id="nk-schemarow" hidden style="margin-top:8px">value shape (which properties, which types) is declared after — open the key and use the schema section; it can infer the shape from this first value.</div>
+    <div class="copyrow">
+      set that value in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-env" value="${e.id}" ${e.protected?'':'checked'}> ${e.id}${e.protected?' ⚠':''}</label>`).join('')}
+    </div>
+    <div class="copyrow">
+      required in:
+      ${readableEnvs().map(e=>`<label><input type="checkbox" class="nk-req" value="${e.id}"> ${e.id}</label>`).join('')}
+    </div>
+    <div class="verr" id="nk-err" hidden></div>
+    <div class="acts">
+      <button class="btn primary" onclick="addKey()">declare</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>
+    <div class="sub" style="margin-top:12px"><b>secret</b> is permanent: values hidden and reveal-gated everywhere.</div>`;
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function addKey(){
+  const err=m=>{const e=document.getElementById('nk-err');e.textContent='✕ '+m;e.hidden=false};
+  /* group field is always live — an unseen name creates that group */
+  const folder=(document.getElementById('nk-folder')?.value||'').trim().toLowerCase().replace(/[^a-z0-9_-]/g,'');
+  if(!folder)return err('group required, e.g. app');
+  const raw=document.getElementById('nk-name').value.trim();
+  if(!raw)return err('key name required');
+  const name=raw.toUpperCase().replace(/[^A-Z0-9_]/g,'_');
+  if(KEYS.some(k=>k.name===name))return err(name+' already exists');
+  const type=document.getElementById('nk-type').value;
+  const val=document.getElementById('nk-val').value;
+  const envs=[...document.querySelectorAll('.nk-env:checked')].map(i=>i.value);
+  if(val){
+    const v=validateEdit({type},val);
+    if(v)return err(v);
+    if(!envs.length)return err('pick at least one environment for the value');
+  }
+  const req=[...document.querySelectorAll('.nk-req:checked')].map(i=>i.value);
+  const k=K(folder,name,type,document.getElementById('nk-sec').checked,
+    req.length===ENVS.length?'all':req.length?req:'none',{});
+  k.draft=true;
+  if(val)for(const e of envs){k.values[e]=val;S.drafts.add(k.name+':'+e)}
+  const last=KEYS.map(x=>x.folder).lastIndexOf(folder);
+  if(last===-1)KEYS.push(k);          /* brand-new group → appears at the end */
+  else KEYS.splice(last+1,0,k);
+  closeSheet();render();
+}
+
+/* ============================ chrome ============================ */
+document.getElementById('role').onchange=e=>{
+  S.role=e.target.value;S.revealed.clear();S.reauthUntil=0;cancelReauth();closeSheet();
+  if(visibleEnvs().length===0)S.hiddenEnvs.clear();
+  render();
+};
+document.getElementById('themebtn').onclick=()=>{
+  S.theme=S.theme==='dark'?'light':'dark';
+  document.body.dataset.theme=S.theme;
+};
+document.getElementById('scrim').onclick=()=>{if(S.reauth){cancelReauth();return}closeSheet()};
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){if(S.reauth){cancelReauth();return}closeSheet();setSide(false)}});
+if(matchMedia('(prefers-color-scheme: light)').matches){S.theme='light';document.body.dataset.theme='light'}
+
+/* ---------- reveal-approach switcher (iteration 6) ---------- */
+const RMODES=[
+  ['modal','a · ceremony modal'],
+  ['popover','b · inline popover'],
+  ['hold','c · hold-to-reveal'],
+  ['session','d · session drawer'],
+];
+let rmodeIdx=Math.max(0,RMODES.findIndex(m=>m[0]===new URL(location).searchParams.get('reveal')));
+function applyRmode(){
+  S.rmode=RMODES[rmodeIdx][0];
+  document.body.dataset.rmode=S.rmode;
+  /* switching approaches resets disclosure state — no window leaks across modes */
+  S.revealed.clear();S.reauthUntil=0;S.holdGrant=null;
+  S.rpop=null;S.pendingReveal=null;S.drawerWait=false;
+  S.drawerOpen=S.rmode==='session';
+  cancelReauth();renderRpop();
+  const u=new URL(location);u.searchParams.set('reveal',S.rmode);
+  history.replaceState(null,'',u);
+  document.getElementById('modelabel').innerHTML=
+    `${rmodeIdx+1}/${RMODES.length} <b>${RMODES[rmodeIdx][1]}</b>`;
+  render();
+}
+function cycleRmode(d){rmodeIdx=(rmodeIdx+d+RMODES.length)%RMODES.length;applyRmode()}
+document.addEventListener('keydown',e=>{
+  if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
+  if(e.target.closest('input,textarea,select,[contenteditable]'))return;
+  cycleRmode(e.key==='ArrowRight'?1:-1);
+});
+applyRmode();
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/reveal-edit/index.html
+++ b/docs/site/public/prototypes/reveal-edit/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Reveal &amp; multi-env editing — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--on-accent:oklch(0.2 0.02 220);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,64px) clamp(18px,6vw,64px)}
+  .back{font-size:12.5px;color:var(--tx-faint);text-decoration:none}
+  .back:hover{color:var(--accent)}
+  h1{font-size:clamp(22px,4vw,30px);font-weight:700;letter-spacing:-0.01em;margin:10px 0 4px}
+  h1 span{color:var(--accent)}
+  .q{font-size:13.5px;color:var(--tx-dim);max-width:60ch;line-height:1.6;margin-bottom:32px}
+  ul{list-style:none;display:grid;gap:10px;max-width:760px}
+  li a{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;text-decoration:none;color:inherit;
+    padding:16px 18px;border:1px solid var(--line);border-radius:10px;background:var(--bg2);transition:border-color .15s}
+  li a:hover{border-color:var(--accent)}
+  li a:hover .name{color:var(--accent)}
+  .num{font-family:var(--mono);font-size:13px;color:var(--tx-faint);min-width:22px}
+  .name{font-size:15.5px;font-weight:600}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:var(--on-accent);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{flex-basis:100%;font-size:12.5px;color:var(--tx-dim);line-height:1.5;margin-top:2px}
+  footer{margin-top:34px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+  footer a{color:var(--tx-dim)}
+</style>
+</head>
+<body>
+  <a class="back" href="../">‹ all prototypes</a>
+  <h1>reveal &amp; multi-env editing <span>/</span> iterations</h1>
+  <p class="q">How do reveal, masking, clipboard, and editing-across-environments actually behave? Sibling of the frozen env-matrix reference (iteration 31, ticket #20). Wayfinder ticket #21.</p>
+  <ul>
+    <li><a href="6/">
+      <span class="num">6</span><span class="name">Reveal approaches — four structural shapes</span><span class="latest">LATEST</span>
+      <span class="desc">Original theming. Four structurally different reveal interactions, switchable via bottom bar / ← → / <code>?reveal=</code>: <b>a</b> ceremony modal (baseline) · <b>b</b> inline popover anchored at the reveal button · <b>c</b> hold-to-reveal (value visible only while pressed, release = instant remask) · <b>d</b> disclosure-session drawer (authenticate once, every open value listed with countdowns, one end-session kill switch). Iterations 2-5 (theming-only variations) dropped by verdict.</span>
+    </a></li>
+    <li><a href="1/">
+      <span class="num">1</span><span class="name">Ceremony, window, clipboard, row edit</span>
+      <span class="desc">Reauth ceremony modal (passkey / TOTP, purpose-bound, enumerated key set); sliding reveal window with header countdown, protected envs capped at 0 ⇒ passkey per disclosure; auto-remask countdown on revealed cells; clipboard as an audited disclosure incl. copy-without-display; key-name click → edit across every environment in one motion (fill-all, write-only replacement, live validation); publish/copy-to-protected run the same ceremony. Demo timings compressed: window 90s, remask 10s, clipboard clear 45s.</span>
+    </a></li>
+  </ul>
+  <footer>every change is a new numbered iteration — published ones never mutate · <a href="../env-matrix/31/">env-matrix reference (frozen)</a></footer>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/1/index.html
+++ b/docs/site/public/prototypes/revision-history/1/index.html
@@ -1,0 +1,1277 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 1 "HISTORY DRAWER".
+  Question: how do per-environment revision history, diffs, pins, and
+  rollback actually look and behave?
+
+  Shell: env-matrix 31 design language, ceremony modal from reveal-edit
+  (ticket #21 verdict). FLAT MODEL — no inheritance (env-matrix verdict;
+  amendment ADR outstanding), so restore has no mask machinery: staged
+  actions are set / clear / untouched.
+
+  Revision-ADR (#11) bindings made feelable:
+  - Per-env monotonic revision timeline: rev number, actor, age, changed
+    keys, pinned schema rev. Lineage is permanent; payloads are GC'd.
+  - Secret-safe diffs: without reveal-history a secret shows WRITE-PRESENCE
+    only (edited/added/removed) — comparison status (changed/unchanged) is
+    itself a guessing oracle, so it appears only WITH reveal-history.
+    Historical plaintext = per-key ceremony, gated on reveal-history,
+    audited per key. `reveal` and `reveal-history` are independent grants —
+    the auditor role here holds history WITHOUT current reveal.
+  - Restore = new revision through the normal publish pipeline: preview
+    stages per-key set/clear against the published state, re-validates
+    against the CURRENT schema (tightened rules block loud, naming keys),
+    restoring a secret occurrence needs reveal-history, staged changes land
+    as ordinary drafts, publish runs the #21 ceremony for protected envs.
+  - Payload-collected revisions: lineage visible, diff-by-value and restore
+    fail loud naming the retention policy. Demo retention: last 6 + pinned.
+  - Pins: durable authorized quota-bounded resources with owner + expiry.
+    Pin to a NON-CURRENT revision needs reveal-history (disclosure by
+    proxy). A pin holding a payload past the retention window is surfaced
+    as the reason, with release. Pin to a revision failing the current
+    schema needs an explicit recorded override.
+  - Others' pending drafts: quiet markers in matrix + timeline header.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  /* env-header rev badge — THE entry point into history */
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  /* another user's pending change — deliberately quieter than your own */
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+  .pill.missing{background:var(--bad-soft);border-color:var(--bad);color:var(--bad);font-weight:500}
+  .pill.invalid{border:1.5px solid var(--bad);color:var(--bad)}
+  td .viol{display:block;font-size:10px;color:var(--bad);margin-top:3px;font-family:var(--mono)}
+
+  /* ---------------- app shell (rail + panel, settled) ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- history drawer ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  #hdrawer .dh .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  #hdrawer .dh .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  #hdrawer .dh .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  #hdrawer .dh .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  #hdrawer .dh .pendline b{color:var(--chg)}
+  #hdrawer .dh .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  #hdrawer .dh .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 24px}
+  #hdrawer .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  #hdrawer .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  /* pins */
+  .pinrow{
+    margin:0 14px 8px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500}
+  .pinrow .pw{color:var(--tx-dim)}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px}
+  .pinrow .warn{flex-basis:100%;font-size:10.5px;color:var(--bad);line-height:1.5}
+  .pinrow .drift{flex-basis:100%;font-size:10.5px;color:var(--chg);line-height:1.5}
+  .pinrow button{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow button:hover{border-color:var(--bad);color:var(--bad)}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  /* timeline */
+  .tl{list-style:none;margin:4px 0 0;position:relative}
+  .tl::before{content:'';position:absolute;left:29px;top:8px;bottom:8px;width:1px;background:var(--line)}
+  .tl li{position:relative;padding:10px 18px 10px 48px}
+  .tl li .dot{
+    position:absolute;left:24px;top:16px;width:11px;height:11px;border-radius:50%;
+    background:var(--bg2);border:2px solid var(--tx-faint);
+  }
+  .tl li.cur .dot{border-color:var(--accent);background:var(--accent)}
+  .tl li.gc .dot{border-style:dashed;opacity:.6}
+  .tl li .rrow{display:flex;align-items:baseline;gap:8px;flex-wrap:wrap}
+  .tl li .rnum{font-family:var(--mono);font-size:13px;font-weight:500;color:var(--tx)}
+  .tl li.cur .rnum{color:var(--accent)}
+  .tl li .who{font-size:11.5px;color:var(--tx-dim)}
+  .tl li .age{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-left:auto}
+  .tl li .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .tl li .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tl li .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tl li .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .tl li .keys{
+    font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-top:4px;line-height:1.6;
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  .tl li .keys .sk{color:var(--tx-dim)}
+  .tl li .prov{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-top:2px}
+  .tl li .racts{display:flex;gap:6px;margin-top:7px;flex-wrap:wrap}
+  .tl li .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .tl li .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .tl li .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .tl li .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .tl li .gcnote{font-size:10.5px;color:var(--tx-faint);margin-top:5px;font-style:italic}
+  .tl li .showmore{margin:2px 0 0;font-size:11px;color:var(--tx-faint);font-family:var(--mono)}
+  .tl li .showmore:hover{color:var(--accent)}
+
+  /* ---------------- centered modal (shared: sheet / diff / restore / publish) ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  /* diff rows */
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dk .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  /* restore preview rows */
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .stg.keep{color:var(--tx-faint);border:1px solid var(--line)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+
+  /* publish env blocks */
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape from #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  /* toasts */
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer{width:100vw}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+/* current int/pattern constraints — the CURRENT schema revision (s14).
+   DB_POOL_SIZE tightened to int at s12: older revisions hold 'ten'. */
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+/* ---- revision history per env ----
+   Lineage is PERMANENT (rev, actor, when, changed keys, pinned schema rev).
+   Payloads are GC'd: retained = last RETAIN_N revisions + pinned (ADR #11).
+   changes: [{key, kind:'edited'|'added'|'removed', old, new}] — old/new are
+   demo plaintext; the UI decides what a principal may see. */
+const RETAIN_N=6;
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+/* ---- snapshots: walk back from current values applying inverse changes.
+   snapshot(env, rev) → Map(key → value|undefined). Flat model: presence
+   states are set / unset only. */
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+/* ---- pins: durable, owned, quota-bounded, expiring (ADR #11) ---- */
+const PIN_QUOTA=5;
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+/* payload retained iff current, within last RETAIN_N, or pinned */
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<RETAIN_N||pinnedRevs(envId).has(rev));
+}
+
+/* others' pending drafts — quiet markers (ADR #11: visible before publish) */
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const S={
+  role:'dev',
+  collapsed:new Set(),
+  drafts:new Map(),          // 'key:env' → {key,envId,action:'set'|'clear',value,fromRev}
+  reauthUntil:0,
+  reauth:null,               // {purpose,items,prot,waiting,then}
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev)}
+  sheet:null,                // {mode:'cell'|'diff'|'restore'|'publish'|'pin', ...}
+  revealedHist:new Set(),    // 'env:rev:key' — historical plaintext shown this render
+};
+/* reveal (current) and reveal-history are INDEPENDENT grants (ADR #11/#15) */
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  /* recently-changed signal: last published revision touched this key */
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="projsel-wrap"></div>
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history drawer ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,expanded:new Set()};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  /* per-key history: same drawer, filtered — entry from the key name */
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){S.drawer=null;renderDrawer();render()}
+function drawerTab(envId){S.drawer.envId=envId;S.drawer.expanded=new Set();renderDrawer();render()}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function toggleExpand(rev){
+  if(S.drawer.expanded.has(rev))S.drawer.expanded.delete(rev);else S.drawer.expanded.add(rev);
+  renderDrawer();
+}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');return}
+  const env=envById(d.envId);
+  const hist=HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+  const pins=pinsFor(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  const canH=canHistory(d.envId);
+  el.innerHTML=`
+    <div class="dh">
+      <h3>↺ revision history
+        <span class="cur">current r${curRev(d.envId)}</span>
+        ${env.protected?'<span class="pp">PROTECTED</span>':''}
+        <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+      <div class="envtabs">${readableEnvs().map(e=>
+        `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+      ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+      ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+    </div>
+    <div class="dbody">
+      <div class="dsec">pins <span class="q">${pins.length}/${PIN_QUOTA} quota</span></div>
+      ${pins.length?pins.map(p=>{
+        const gcSoon=!HIST[d.envId].slice(0,RETAIN_N).some(r=>r.rev===p.rev)&&p.rev!==curRev(d.envId);
+        const entry=revEntry(d.envId,p.rev);
+        const drift=entry&&entry.schemaRev!=='s14'&&p.rev===27;
+        return`<div class="pinrow">
+        <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+        <span class="pe">by ${p.by} · expires ${p.expDays}d</span>
+        <button onclick="releasePin(${p.id})">release</button>
+        ${gcSoon?`<span class="warn">⚠ this pin is the only thing holding r${p.rev}'s payload past the retention window (last ${RETAIN_N} + pins) — release it and the payload is collected.</span>`:''}
+        ${drift?`<span class="drift">Δ drift: pinned under schema s13; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).</span>`:''}
+      </div>`}).join(''):`<div class="pinnote">no pins — workloads follow latest. A pin is a durable authorized resource with an owner, quota and expiry, never a fetch parameter (ADR #11).</div>`}
+      <div class="dsec">timeline <span class="q">lineage permanent · payloads last ${RETAIN_N} + pinned</span></div>
+      <ul class="tl">
+      ${hist.map((r,i)=>{
+        const isCur=r.rev===curRev(d.envId);
+        const retained=payloadRetained(d.envId,r.rev);
+        const pinnedHere=pins.filter(p=>p.rev===r.rev);
+        const expanded=S.drawer.expanded.has(r.rev);
+        const secretCount=r.changes.filter(c=>keyByName(c.key)?.secret).length;
+        const keysline=r.changes.map(c=>{
+          const sk=keyByName(c.key)?.secret;
+          return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+        return`<li class="${isCur?'cur':''} ${retained?'':'gc'}">
+          <span class="dot"></span>
+          <div class="rrow">
+            <span class="rnum">r${r.rev}</span>
+            <span class="who">${esc(r.actor)}</span>
+            ${isCur?'<span class="tag curt">current</span>':''}
+            ${pinnedHere.map(p=>`<span class="tag pint" title="pinned by ${esc(p.workload)}">⚲ pinned</span>`).join('')}
+            ${retained?'':'<span class="tag gct" title="payload garbage-collected by retention policy — lineage remains">payload collected</span>'}
+            <span class="age">${ago(r.at)}</span>
+          </div>
+          <div class="keys">${r.changes.length} key${r.changes.length>1?'s':''}: ${keysline}</div>
+          <div class="prov">schema ${r.schemaRev} pinned at publish${secretCount?` · ${secretCount} secret write${secretCount>1?'s':''}`:''}</div>
+          <div class="racts">
+            ${i<hist.length-1||HIST[d.envId].length>hist.length
+              ?`<button onclick="openDiff('${d.envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable; lineage (which keys changed) is above"'}>diff vs previous</button>`:''}
+            ${isCur?'':`<button onclick="openDiff('${d.envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+            ${isCur?'':`<button onclick="tryRestore('${d.envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable — fails loud, nothing reconstructed (ADR #11)"'}>restore…</button>`}
+            <button onclick="tryPin('${d.envId}',${r.rev})">pin…</button>
+            ${retained?'':`<button onclick="gcExplain(${r.rev})">why unavailable?</button>`}
+          </div>
+        </li>`}).join('')}
+      </ul>
+      ${canH?'':`<div class="pinnote" style="margin-top:14px">your role holds no <b>reveal-history</b> here: secret rows in diffs show write-presence only, and restores that re-deliver an earlier secret are refused (ADR #11/#15).</div>`}
+    </div>`;
+  el.classList.add('open');
+}
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (keep last ${RETAIN_N} revisions + pinned). Lineage is permanent; the values are gone — not restorable, not diffable by value, not revealable. No replay-from-metadata path exists (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})`);
+  toast(`pin on r${p.rev} released — ${payloadRetained(p.envId,p.rev)?'payload still inside the retention window':'payload now eligible for collection'}`);
+  renderDrawer();render();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  if(pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA} for this project) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  const isCur=rev===curRev(envId);
+  /* pinning a NON-CURRENT revision routes historical content to a workload:
+     disclosure by proxy ⇒ reveal-history (permission ADR #15 amendment) */
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (disclosure by proxy, ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false};
+  renderSheet();
+}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin it anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    PINS.push({id:nextPinId++,envId,rev,workload:'api-server (k8s)',by:'you',expDays:30});
+    audit('pin created',`r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+    toast(`⚲ pinned r${rev} — payload retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.new!==undefined&&to!==curRev(envId)?'':r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    /* SECRET: without reveal-history → WRITE-PRESENCE only. With it →
+       changed/unchanged comparison + per-key plaintext ceremony. */
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span></div>
+        <div class="wp">write-presence only: someone wrote to this entry. Whether the plaintext differs is not shown — comparison status is a guessing oracle without <b>reveal-history</b> (ADR #11).</div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'||cmp==='added'||cmp==='removed'?cmp==='changed'?'changed':cmp:'unchanged'}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 secret rows: ${canH
+      ?`comparison (<b>changed/unchanged</b>) is visible because this role holds <b>reveal-history</b>. Plaintext stays a separate per-key ceremony, audited with the revision read.`
+      :`<b>write-presence only</b> for this role. A principal who can stage a guessed value and read “unchanged” recovers a low-entropy secret bit by bit — that oracle is why comparison status sits behind <b>reveal-history</b> (ADR #11).`}
+      Collected revisions are absent from the pickers: no value diff survives GC.</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  /* flat model: presence is set/unset — staged actions are set / clear.
+     (The inheritance ADR's mask rules died with inheritance; the amendment
+     ADR will restate restore for the flat model.) */
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now){continue}
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div class="dk" style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span class="lock" style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'stage set':'stage clear'}</span>
+      </div>
+      ${p.action==='set'
+        ?`<div class="why">${p.secret?(canH?'re-delivers the r'+rev+' plaintext (masked here; ceremony at publish)':'re-delivers an earlier secret value'):'→ '+esc(p.value)}${p.now===undefined?' · currently unset':''}</div>`
+        :`<div class="why">r${rev} had no value here — the current value ${p.secret?'(secret)':esc(p.now)} is cleared. Flat model: no mask machinery, clear IS the inverse.</div>`}
+      ${permBlock?`<div class="verr">needs reveal-history: restoring an earlier secret is a historical disclosure toward every consumer (ADR #11/#12) — your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved explicitly: ${esc(fixes[p.key])} (staged instead of the historical value)</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="sub">Restore is <b>a new revision through the normal publish pipeline</b> — never a rewrite. This preview stages per-key changes reproducing r${rev}'s outcome; they land in your working state as ordinary drafts, and publish runs the full ceremony (ADR #11).</div>
+    <div class="dgrid" style="margin-top:14px">
+      ${plan.length?plan.map(rowHtml).join(''):`<div class="pinnote" style="margin:8px 0">current state already matches r${rev} — nothing to stage, no churn.</div>`}
+    </div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">✕ <b>not restorable as-is</b>: ${unresolved.map(esc).join(', ')} fail${unresolved.length===1?'s':''} the current schema (restores re-validate against the CURRENT revision, not the one pinned in r${rev}). Resolve explicitly above, or cancel.</div>`:''}
+    ${blockedPerm?`<div class="oraclenote" style="color:var(--bad)">✕ <b>refused</b>: this restore re-delivers earlier secret values and your role holds no <b>reveal-history</b> on ${env.name}. Nothing was staged — the refusal names its keys above, never silently splits.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  /* per-key restore: stage this single earlier value */
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish (restore rides the normal pipeline) ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Publish is per-environment authorized immediately before commit; a restore publish is an ordinary publish — same preview, same protected ceremony, no privileged path (ADR #11).</div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv ${env.protected?'blocked':''}">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet (minimal — history is the subject) ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  const env=envById(envId);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ pin <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}</h2>
+    <div class="sub">A pin is a <b>durable authorized resource</b> — owner, quota (${pinsFor(envId).length}/${PIN_QUOTA} used), expiry — never a fetch parameter, so GC can see every reference (ADR #11). The pinned payload is retained while the pin lives.</div>
+    <div class="cur dim">workload: api-server (k8s) · expiry: 30d (demo default → ops spec #32)</div>
+    ${isCur?'':`<div class="noperm">non-current revision: this routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure, recorded per key set.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced to operators as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="confirmPin()">create pin</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+/* open production history on load — the prototype's subject, immediately visible */
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/2/index.html
+++ b/docs/site/public/prototypes/revision-history/2/index.html
@@ -1,0 +1,1604 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 2 "HISTORY APPROACHES".
+  Alex's iteration-1 verdict: information too dense. Iteration 2 answers with
+  FOUR structurally different presentations of the same history — switchable
+  via ?view= and a floating bottom bar (arrow keys cycle). Interaction shape
+  varies, never the skin (design language stays env-matrix 31):
+    ?view=collapse  a — collapsed timeline: one line per revision in the
+                    drawer, click a row to expand keys/provenance/actions
+                    (current revision starts expanded)
+    ?view=panes     b — list + detail: wider drawer split into a slim rev
+                    list (left) and a detail pane (right) for the selected
+                    revision — per-row buttons disappear entirely
+    ?view=story     c — activity story: history as plain-language sentences
+                    ("alex rotated SESSION_SECRET · 2d ago"), grouped cards,
+                    actions revealed only on an opened card
+    ?view=page      d — full-page history: the matrix steps aside; a roomy
+                    table with one revision per row and a detail band on the
+                    selected row (answers iteration 1's drawer-vs-page open
+                    question head-on)
+  Every ADR #11 binding from iteration 1 is preserved in all four views:
+  lineage permanent / payloads last 6 + pinned (collected revs fail loud),
+  secret diffs = write-presence without reveal-history vs comparison +
+  per-key ceremony with it, restore = normal publish pipeline (flat-model
+  set/clear, current-schema re-validation, reveal-history refusal for
+  secret restores, #21 ceremony for protected), pins = durable owned
+  quota-bounded expiring resources (non-current pin ⇒ ceremony; schema-fail
+  pin ⇒ recorded override; retention-holding pin flagged with release).
+  Long ADR prose is demoted to (?) tooltips everywhere.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  body.histpage .wrap{display:none}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- shared history bits ---------------- */
+  .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  .pinrow{
+    margin:0 14px 8px;padding:9px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500;white-space:nowrap}
+  .pinrow .pw{color:var(--tx-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px;white-space:nowrap}
+  .wbadge{
+    font-size:9.5px;letter-spacing:.04em;font-weight:600;border-radius:999px;
+    padding:2px 8px;cursor:help;white-space:nowrap;border:none;
+  }
+  .wbadge.warn{color:var(--bad);background:var(--bad-soft)}
+  .wbadge.drift{color:var(--chg);background:var(--chg-soft)}
+  .pinrow .rel{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow .rel:hover{border-color:var(--bad);color:var(--bad)}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  .hint{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:15px;height:15px;border-radius:999px;border:1px solid var(--line);
+    font-size:9.5px;color:var(--tx-faint);cursor:help;flex:none;vertical-align:-2px;
+  }
+  .hint:hover{border-color:var(--accent);color:var(--accent)}
+  .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px;white-space:nowrap}
+  .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .racts{display:flex;gap:6px;flex-wrap:wrap}
+  .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+
+  /* ---------------- history drawer (views a/b/c) ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  body[data-hview=panes] #hdrawer{width:min(640px,96vw)}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  .pendline b{color:var(--chg)}
+  .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 70px}
+
+  /* view a — collapsed timeline */
+  .tl{list-style:none;margin:4px 0 0;position:relative}
+  .tl::before{content:'';position:absolute;left:29px;top:8px;bottom:8px;width:1px;background:var(--line)}
+  .tl li{position:relative;padding:2px 14px 2px 44px}
+  .tl li .dot{
+    position:absolute;left:24px;top:16px;width:11px;height:11px;border-radius:50%;
+    background:var(--bg2);border:2px solid var(--tx-faint);z-index:1;
+  }
+  .tl li.cur .dot{border-color:var(--accent);background:var(--accent)}
+  .tl li.gc .dot{border-style:dashed;opacity:.6}
+  .tl li .rowbtn{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 8px;border-radius:6px;min-height:38px}
+  .tl li .rowbtn:hover{background:var(--bg3)}
+  .tl li.exp .rowbtn{background:var(--bg3);border-radius:6px 6px 0 0}
+  .tl li .chev{font-size:9px;color:var(--tx-faint);display:inline-block;
+    transition:transform .18s cubic-bezier(.25,1,.5,1);flex:none}
+  .tl li.exp .chev{transform:rotate(90deg)}
+  .tl li .rnum{font-family:var(--mono);font-size:13px;font-weight:500;color:var(--tx)}
+  .tl li.cur .rnum{color:var(--accent)}
+  .tl li .who{font-size:11.5px;color:var(--tx-dim)}
+  .tl li .nk{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  .tl li .age{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);margin-left:auto}
+  .tl li .detail{background:var(--bg3);border-radius:0 0 6px 6px;padding:4px 10px 12px}
+  .keysline{font-family:var(--mono);font-size:10.5px;color:var(--tx-faint);line-height:1.7;
+    padding:4px 0 2px}
+  .keysline .sk{color:var(--tx-dim)}
+  .provline{font-family:var(--mono);font-size:10px;color:var(--tx-faint);padding-bottom:8px}
+  .gcnote{font-size:10.5px;color:var(--tx-faint);padding:2px 0 8px;font-style:italic}
+
+  /* view b — list + detail panes */
+  .panes{display:grid;grid-template-columns:170px 1fr;height:100%}
+  .panes .plist{border-right:1px solid var(--line);overflow-y:auto;padding:8px 0 70px}
+  .panes .plist button{
+    display:flex;align-items:center;gap:7px;width:100%;text-align:left;
+    padding:9px 12px;min-height:40px;border-left:2px solid transparent;
+  }
+  .panes .plist button:hover{background:var(--bg3)}
+  .panes .plist button.sel{background:var(--bg3);border-left-color:var(--accent)}
+  .panes .plist .rnum{font-family:var(--mono);font-size:12.5px;font-weight:500;color:var(--tx)}
+  .panes .plist button.cur .rnum{color:var(--accent)}
+  .panes .plist .age{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-left:auto}
+  .panes .plist .pdot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none}
+  .panes .plist .gdot{width:6px;height:6px;border-radius:50%;border:1px dashed var(--tx-faint);flex:none;opacity:.7}
+  .panes .pdetail{overflow-y:auto;padding:14px 16px 70px}
+  .pdetail .ph2{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .pdetail .ph2 .rnum{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--tx)}
+  .pdetail .meta{font-size:12px;color:var(--tx-dim);margin-top:6px;line-height:1.6}
+  .pdetail .meta b{color:var(--tx)}
+  .pdetail .chgrid{display:grid;gap:6px;margin-top:12px}
+  .pdetail .chrow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:8px 11px;font-family:var(--mono);font-size:11.5px;
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pdetail .chrow .lock{color:var(--bad);font-size:10px}
+  .pdetail .chrow .name{color:var(--tx);font-weight:500}
+  .pdetail .racts{margin-top:14px}
+  .pdetail .racts button{padding:8px 14px;min-height:36px;font-size:11.5px}
+
+  /* view c — activity story */
+  .story{padding:10px 14px 70px;display:grid;gap:8px}
+  .scard{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:11px 13px;text-align:left;width:100%;
+  }
+  .scard:hover{border-color:var(--accent)}
+  .scard.open{border-color:var(--accent)}
+  .scard .sline{font-size:13px;color:var(--tx);line-height:1.55}
+  .scard .sline b{font-weight:600}
+  .scard .sline .mono{font-family:var(--mono);font-size:12px}
+  .scard .smeta{display:flex;align-items:center;gap:8px;margin-top:5px;flex-wrap:wrap;
+    font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  .scard .sacts{margin-top:10px}
+  .sday{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    font-weight:700;padding:8px 4px 0}
+
+  /* view d — full-page history */
+  #histpage{display:none;flex:1;overflow-y:auto;padding-bottom:80px}
+  body.histpage #histpage{display:block}
+  #histpage .hph{
+    display:flex;align-items:center;gap:12px;flex-wrap:wrap;
+    padding:16px 22px 12px;border-bottom:1px solid var(--line);
+    position:sticky;top:0;background:var(--bg);z-index:3;
+  }
+  #histpage .hph h2{font-size:16px;font-weight:600;display:flex;align-items:center;gap:8px}
+  #histpage .hph .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #histpage .hph .back{
+    font-size:12px;color:var(--tx-dim);border:1px solid var(--line);border-radius:4px;
+    padding:7px 13px;min-height:34px}
+  #histpage .hph .back:hover{border-color:var(--accent);color:var(--accent)}
+  #histpage .pinstrip{display:flex;gap:8px;flex-wrap:wrap;padding:12px 22px 4px;align-items:center}
+  #histpage .pinstrip .pinrow{margin:0;flex:none;max-width:420px}
+  #histpage .htable{width:100%;max-width:1080px;margin:6px 0 0;border-collapse:collapse}
+  #histpage .htable th{
+    text-align:left;font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;padding:12px 14px;border-bottom:1px solid var(--line)}
+  #histpage .htable th:first-child,#histpage .htable td:first-child{padding-left:22px}
+  #histpage .htable td{padding:13px 14px;border-bottom:1px solid oklch(from var(--line) l c h/.45);
+    font-size:13px;vertical-align:top}
+  #histpage .htable tr.hrow{cursor:pointer}
+  #histpage .htable tr.hrow:hover td{background:var(--bg2)}
+  #histpage .htable tr.hrow.sel td{background:var(--bg2)}
+  #histpage .htable .rnum{font-family:var(--mono);font-size:14px;font-weight:500;color:var(--tx);white-space:nowrap}
+  #histpage .htable tr.cur .rnum{color:var(--accent)}
+  #histpage .htable .who{color:var(--tx);font-size:13px}
+  #histpage .htable .when{font-family:var(--mono);font-size:11px;color:var(--tx-faint);white-space:nowrap}
+  #histpage .htable .what{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);line-height:1.7}
+  #histpage .htable .what .sk{color:var(--tx)}
+  #histpage .htable tr.gc td{opacity:.65}
+  #histpage .detailband td{background:var(--bg2);padding:4px 14px 16px}
+  #histpage .detailband .provline{padding:6px 0 10px}
+
+  /* ---------------- centered modal ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+  .sumline{
+    display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .sumline .schip{border:1px solid var(--line);border-radius:999px;padding:3px 10px}
+  .sumline .schip.bad{border-color:var(--bad);color:var(--bad)}
+
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape, #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  #toasts{
+    position:fixed;left:14px;bottom:calc(60px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* floating view switcher — prototype chrome, off-system on purpose */
+  #modebar{
+    position:fixed;bottom:calc(12px + env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);
+    z-index:50;display:flex;align-items:center;gap:2px;
+    background:oklch(0.14 0.02 300);border:1px solid oklch(0.45 0.06 300);
+    border-radius:999px;padding:4px;box-shadow:0 8px 30px oklch(0 0 0/.55);
+    font-family:var(--mono);font-size:11px;color:oklch(0.92 0.02 300);
+  }
+  #modebar button{min-width:32px;min-height:32px;border-radius:999px;color:inherit;
+    display:flex;align-items:center;justify-content:center;font-size:13px}
+  #modebar button:hover{background:oklch(0.26 0.03 300)}
+  #modebar .sl{padding:0 10px;white-space:nowrap;min-width:220px;text-align:center}
+  #modebar .sl b{color:oklch(0.85 0.1 300);font-weight:500}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer,body[data-hview=panes] #hdrawer{width:100vw}
+    .panes{grid-template-columns:120px 1fr}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+    #modebar .sl{min-width:150px}
+  }
+</style>
+</head>
+<body data-theme="dark" data-hview="collapse">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+<div id="histpage"></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+<div id="modebar" role="group" aria-label="history view switcher">
+  <button onclick="cycleView(-1)" aria-label="previous view">‹</button>
+  <span class="sl" id="modelabel"></span>
+  <button onclick="cycleView(1)" aria-label="next view">›</button>
+</div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+const RETAIN_N=6;
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+const PIN_QUOTA=5;
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<RETAIN_N||pinnedRevs(envId).has(rev));
+}
+
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const HVIEWS=[
+  {id:'collapse',label:'collapsed timeline'},
+  {id:'panes',label:'list + detail panes'},
+  {id:'story',label:'activity story'},
+  {id:'page',label:'full-page history'},
+];
+const S={
+  role:'dev',
+  hview:new URLSearchParams(location.search).get('view')||'collapse',
+  collapsed:new Set(),
+  drafts:new Map(),
+  reauthUntil:0,
+  reauth:null,
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev), sel:rev, openCard:rev}
+  sheet:null,
+  revealedHist:new Set(),
+};
+if(!HVIEWS.some(v=>v.id===S.hview))S.hview='collapse';
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ---- (?) tooltip copy: the ADR reasoning lives here, not in the flow ---- */
+const TIP={
+  retention:`Lineage (who published what, when) is permanent. The VALUES of old revisions are garbage-collected: kept for the last ${RETAIN_N} revisions plus anything pinned (demo values — ops spec #32 owns the real ones). A collected revision cannot be diffed by value, restored, or revealed — no replay-from-metadata path exists (ADR #11).`,
+  writePresence:`Without reveal-history, secret rows show only that someone WROTE to the entry — never whether the plaintext differs. Comparison status is a guessing oracle: stage a guessed value, read "unchanged", recover a low-entropy secret bit by bit (ADR #11).`,
+  pin:`A pin is a durable authorized resource — owner, per-project quota, expiry — never a fetch parameter, so GC can see every reference. The pinned payload is retained while the pin lives (ADR #11).`,
+  restore:`Restore never rewrites history: it stages per-key changes reproducing the old outcome, they land as ordinary drafts, and publish runs the full pipeline — impact preview, per-env authorization, protected ceremony, validation against the CURRENT schema (ADR #11).`,
+};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  closePage();
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history — shared builders ============================ */
+function rowActions(envId,r,opts){
+  const hist=HIST[envId];
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const idx=hist.findIndex(x=>x.rev===r.rev);
+  const big=opts?.big?'style="padding:8px 14px;min-height:36px;font-size:11.5px"':'';
+  return`<div class="racts">
+    ${idx<hist.length-1?`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs previous</button>`:''}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();tryRestore('${envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable (ADR #11)"'}>restore…</button>`}
+    <button ${big} onclick="event.stopPropagation();tryPin('${envId}',${r.rev})">pin…</button>
+    ${retained?'':`<button ${big} onclick="event.stopPropagation();gcExplain(${r.rev})">why unavailable?</button>`}
+  </div>`;
+}
+function keysLine(r){
+  return r.changes.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+}
+function revTags(envId,r){
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const pinnedHere=pinsFor(envId).filter(p=>p.rev===r.rev);
+  return`${isCur?'<span class="tag curt">current</span>':''}
+    ${pinnedHere.length?`<span class="tag pint" title="pinned by ${esc(pinnedHere.map(p=>p.workload).join(', '))}">⚲</span>`:''}
+    ${retained?'':'<span class="tag gct" title="'+esc(TIP.retention)+'">collected</span>'}`;
+}
+function pinsHtml(envId,inline){
+  const pins=pinsFor(envId);
+  if(!pins.length)return inline?'':`<div class="pinnote">no pins — workloads follow latest. <span class="hint" title="${esc(TIP.pin)}">?</span></div>`;
+  return pins.map(p=>{
+    const holdsPastWindow=!HIST[envId].slice(0,RETAIN_N).some(r=>r.rev===p.rev)&&p.rev!==curRev(envId);
+    const entry=revEntry(envId,p.rev);
+    const drift=entry&&entry.schemaRev!=='s14';
+    return`<div class="pinrow">
+      <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+      <span class="pe">${p.expDays}d left</span>
+      ${holdsPastWindow?`<span class="wbadge warn" title="This pin alone holds r${p.rev}'s payload past the retention window (last ${RETAIN_N} + pins). Release it and the payload is collected.">⚠ holds payload</span>`:''}
+      ${drift?`<span class="wbadge drift" title="Pinned under schema ${entry.schemaRev}; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).">Δ drift</span>`:''}
+      <button class="rel" onclick="releasePin(${p.id})">release</button>
+    </div>`}).join('');
+}
+function drawerHead(d){
+  const env=envById(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  return`<div class="dh">
+    <h3>↺ revision history
+      <span class="cur">current r${curRev(d.envId)}</span>
+      ${env.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+    <div class="envtabs">${readableEnvs().map(e=>
+      `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+  </div>`;
+}
+function histList(d){
+  return HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+}
+function permFootnote(envId){
+  return canHistory(envId)?'':`<div class="pinnote" style="margin-top:14px">no <b>reveal-history</b> for this role: secret diffs show write-presence only, secret restores refused. <span class="hint" title="${esc(TIP.writePresence)}">?</span></div>`;
+}
+
+/* ============================ history — view a: collapsed timeline ============================ */
+function renderCollapse(d){
+  const hist=histList(d);
+  return`${drawerHead(d)}
+    <div class="dbody">
+      <div class="dsec">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin)}">?</span></span></div>
+      ${pinsHtml(d.envId)}
+      <div class="dsec">timeline <span class="q">payloads: last ${RETAIN_N} + pinned <span class="hint" title="${esc(TIP.retention)}">?</span></span></div>
+      <ul class="tl">
+      ${hist.map(r=>{
+        const isCur=r.rev===curRev(d.envId);
+        const retained=payloadRetained(d.envId,r.rev);
+        const expanded=S.drawer.expanded.has(r.rev);
+        return`<li class="${isCur?'cur':''} ${retained?'':'gc'} ${expanded?'exp':''}">
+          <span class="dot"></span>
+          <button class="rowbtn" onclick="toggleExpand(${r.rev})" aria-expanded="${expanded}">
+            <span class="chev">▶</span>
+            <span class="rnum">r${r.rev}</span>
+            <span class="who">${esc(r.actor)}</span>
+            <span class="nk">${r.changes.length} key${r.changes.length>1?'s':''}</span>
+            ${revTags(d.envId,r)}
+            <span class="age">${ago(r.at)}</span>
+          </button>
+          ${expanded?`<div class="detail">
+            <div class="keysline">${keysLine(r)}</div>
+            <div class="provline">schema ${r.schemaRev} pinned at publish</div>
+            ${rowActions(d.envId,r)}
+          </div>`:''}
+        </li>`}).join('')}
+      </ul>
+      ${permFootnote(d.envId)}
+    </div>`;
+}
+function toggleExpand(rev){
+  if(S.drawer.expanded.has(rev))S.drawer.expanded.delete(rev);else S.drawer.expanded.add(rev);
+  renderDrawer();
+}
+
+/* ============================ history — view b: list + detail panes ============================ */
+function renderPanes(d){
+  const hist=histList(d);
+  if(!hist.some(r=>r.rev===d.sel))d.sel=hist[0]?.rev;
+  const sel=hist.find(r=>r.rev===d.sel);
+  const retained=sel&&payloadRetained(d.envId,sel.rev);
+  return`${drawerHead(d)}
+    <div class="panes">
+      <div class="plist">
+        ${hist.map(r=>{
+          const isCur=r.rev===curRev(d.envId);
+          const rt=payloadRetained(d.envId,r.rev);
+          const pinned=pinnedRevs(d.envId).has(r.rev);
+          return`<button class="${r.rev===d.sel?'sel':''} ${isCur?'cur':''}" onclick="selRev(${r.rev})">
+            <span class="rnum">r${r.rev}</span>
+            ${pinned?'<span class="pdot" title="pinned"></span>':''}
+            ${rt?'':'<span class="gdot" title="payload collected"></span>'}
+            <span class="age">${ago(r.at)}</span>
+          </button>`}).join('')}
+      </div>
+      <div class="pdetail">
+        ${sel?`
+        <div class="ph2"><span class="rnum">r${sel.rev}</span>${revTags(d.envId,sel)}</div>
+        <div class="meta">published by <b>${esc(sel.actor)}</b> · ${ago(sel.at)} · schema ${sel.schemaRev} pinned</div>
+        ${retained?'':`<div class="meta" style="color:var(--tx-faint);font-style:italic">payload collected by retention (last ${RETAIN_N} + pinned) — lineage below is permanent; value diff, restore and reveal are gone. <span class="hint" title="${esc(TIP.retention)}">?</span></div>`}
+        <div class="chgrid">
+          ${sel.changes.map(c=>{
+            const sk=keyByName(c.key)?.secret;
+            return`<div class="chrow">${sk?'<span class="lock">🔒</span>':''}<span class="name">${esc(c.key)}</span>
+              <span class="kindtag ${c.kind}">${c.kind}</span>
+              ${sk?`<span style="color:var(--tx-faint);font-size:10px">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span>`:''}
+            </div>`}).join('')}
+        </div>
+        <div class="racts">${rowActions(d.envId,sel,{big:true})}</div>
+        <div class="dsec" style="padding:22px 0 6px">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin)}">?</span></span></div>
+        <div style="margin:0 -14px">${pinsHtml(d.envId)}</div>
+        ${permFootnote(d.envId)}`:'<div class="meta">no revisions</div>'}
+      </div>
+    </div>`;
+}
+function selRev(rev){S.drawer.sel=rev;renderDrawer()}
+
+/* ============================ history — view c: activity story ============================ */
+function storySentence(envId,r){
+  const parts=[];
+  const edited=r.changes.filter(c=>c.kind==='edited');
+  const added=r.changes.filter(c=>c.kind==='added');
+  const removed=r.changes.filter(c=>c.kind==='removed');
+  const nameList=cs=>cs.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="mono">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+  const secretEdited=edited.filter(c=>keyByName(c.key)?.secret);
+  const plainEdited=edited.filter(c=>!keyByName(c.key)?.secret);
+  if(secretEdited.length)parts.push(`rotated ${nameList(secretEdited)}`);
+  if(plainEdited.length)parts.push(`changed ${nameList(plainEdited)}`);
+  if(added.length)parts.push(`added ${nameList(added)}`);
+  if(removed.length)parts.push(`removed ${nameList(removed)}`);
+  return`<b>${esc(r.actor)}</b> ${parts.join(', ')}`;
+}
+function dayBucket(t){
+  const d=(NOW-t)/864e5;
+  if(d<1)return'today';
+  if(d<2)return'yesterday';
+  if(d<7)return'this week';
+  if(d<31)return'this month';
+  return'older';
+}
+function renderStory(d){
+  const hist=histList(d);
+  let lastBucket=null;
+  return`${drawerHead(d)}
+    <div class="dbody">
+      ${pinsFor(d.envId).length?`<div class="dsec">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA}</span></div>${pinsHtml(d.envId)}`:''}
+      <div class="story">
+      ${hist.map(r=>{
+        const bucket=dayBucket(r.at);
+        const dayHdr=bucket!==lastBucket?`<div class="sday">${bucket}</div>`:'';
+        lastBucket=bucket;
+        const open=S.drawer.openCard===r.rev;
+        const retained=payloadRetained(d.envId,r.rev);
+        return`${dayHdr}<button class="scard ${open?'open':''}" onclick="openCard(${r.rev})" aria-expanded="${open}">
+          <div class="sline">${storySentence(d.envId,r)}</div>
+          <div class="smeta">r${r.rev} ${revTags(d.envId,r)} <span style="margin-left:auto">${ago(r.at)}</span></div>
+          ${open?`<div class="sacts" onclick="event.stopPropagation()">
+            <div class="provline">schema ${r.schemaRev} pinned at publish${retained?'':` · payload collected <span class="hint" title="${esc(TIP.retention)}">?</span>`}</div>
+            ${rowActions(d.envId,r)}
+          </div>`:''}
+        </button>`}).join('')}
+      </div>
+      ${permFootnote(d.envId)}
+    </div>`;
+}
+function openCard(rev){
+  S.drawer.openCard=S.drawer.openCard===rev?null:rev;
+  renderDrawer();
+}
+
+/* ============================ history — view d: full-page ============================ */
+function renderPage(d){
+  const env=envById(d.envId);
+  const hist=histList(d);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  document.getElementById('histpage').innerHTML=`
+    <div class="hph">
+      <button class="back" onclick="closeDrawer()">← matrix</button>
+      <h2>↺ ${env.name} history ${env.protected?'<span class="pp">PROTECTED</span>':''}</h2>
+      <span style="font-family:var(--mono);font-size:11px;color:var(--tx-faint)">current r${curRev(d.envId)} · payloads: last ${RETAIN_N} + pinned <span class="hint" title="${esc(TIP.retention)}">?</span></span>
+      <span style="flex:1"></span>
+      <div class="envtabs" style="margin-top:0">${readableEnvs().map(e=>
+        `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    </div>
+    ${d.keyFilter?`<div style="padding:10px 22px 0"><div class="keyfilter" style="margin-top:0;max-width:360px">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()">✕</button></div></div>`:''}
+    ${myPend||othPend.length?`<div class="pendline" style="padding:10px 22px 0">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    <div class="pinstrip">${pinsHtml(d.envId,true)||''}</div>
+    <table class="htable">
+      <thead><tr><th style="width:90px">rev</th><th style="width:140px">published by</th><th style="width:110px">when</th><th>changed</th></tr></thead>
+      <tbody>
+      ${hist.map(r=>{
+        const isCur=r.rev===curRev(d.envId);
+        const retained=payloadRetained(d.envId,r.rev);
+        const sel=d.sel===r.rev;
+        return`<tr class="hrow ${isCur?'cur':''} ${retained?'':'gc'} ${sel?'sel':''}" onclick="selPageRev(${r.rev})">
+          <td><span class="rnum">r${r.rev}</span></td>
+          <td><span class="who">${esc(r.actor)}</span></td>
+          <td><span class="when">${ago(r.at)}</span></td>
+          <td><span class="what">${keysLine(r)}</span> ${revTags(d.envId,r)}</td>
+        </tr>
+        ${sel?`<tr class="detailband"><td colspan="4">
+          <div class="provline">schema ${r.schemaRev} pinned at publish${retained?'':` · payload collected — value diff, restore and reveal are gone <span class="hint" title="${esc(TIP.retention)}">?</span>`}</div>
+          ${rowActions(d.envId,r,{big:true})}
+        </td></tr>`:''}`}).join('')}
+      </tbody>
+    </table>
+    ${permFootnote(d.envId)?`<div style="padding:0 22px">${permFootnote(d.envId)}</div>`:''}`;
+}
+function selPageRev(rev){
+  S.drawer.sel=S.drawer.sel===rev?null:rev;
+  renderPage(S.drawer);
+}
+function closePage(){
+  document.body.classList.remove('histpage');
+}
+
+/* ============================ history — dispatch ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,expanded:new Set([curRev(envId)]),sel:curRev(envId),openCard:null};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){
+  S.drawer=null;
+  closePage();
+  renderDrawer();render();
+}
+function drawerTab(envId){
+  S.drawer.envId=envId;
+  S.drawer.expanded=new Set([curRev(envId)]);
+  S.drawer.sel=curRev(envId);
+  S.drawer.openCard=null;
+  renderDrawer();render();
+}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');closePage();return}
+  if(S.hview==='page'){
+    el.classList.remove('open');
+    document.body.classList.add('histpage');
+    renderPage(d);
+    return;
+  }
+  closePage();
+  el.innerHTML=({collapse:renderCollapse,panes:renderPanes,story:renderStory})[S.hview](d);
+  el.classList.add('open');
+}
+
+/* ---- view switcher ---- */
+function setView(id){
+  S.hview=id;
+  document.body.dataset.hview=id;
+  const u=new URL(location);u.searchParams.set('view',id);history.replaceState(null,'',u);
+  const i=HVIEWS.findIndex(v=>v.id===id);
+  document.getElementById('modelabel').innerHTML=`<b>${String.fromCharCode(97+i)}</b> — ${HVIEWS[i].label}`;
+  renderDrawer();
+}
+function cycleView(dir){
+  const i=HVIEWS.findIndex(v=>v.id===S.hview);
+  setView(HVIEWS[(i+dir+HVIEWS.length)%HVIEWS.length].id);
+}
+document.addEventListener('keydown',e=>{
+  if(e.target.closest('input,textarea,select,[contenteditable]'))return;
+  if(e.key==='ArrowLeft')cycleView(-1);
+  if(e.key==='ArrowRight')cycleView(1);
+});
+
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (last ${RETAIN_N} + pinned). Lineage is permanent; the values are gone — not restorable, not diffable, not revealable (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})`);
+  toast(`pin on r${p.rev} released — ${payloadRetained(p.envId,p.rev)?'payload still inside the retention window':'payload now eligible for collection'}`);
+  renderDrawer();render();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  if(pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA}) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  const isCur=rev===curRev(envId);
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false};
+  renderSheet();
+}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    PINS.push({id:nextPinId++,envId,rev,workload:'api-server (k8s)',by:'you',expDays:30});
+    audit('pin created',`r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+    toast(`⚲ pinned r${rev} — payload retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span>
+        <span style="color:var(--tx-faint);font-size:10px;margin-left:auto">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span></div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'?'changed':cmp==='unchanged'?'unchanged':cmp}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 ${canH
+      ?`comparison shown (this role holds <b>reveal-history</b>); plaintext is a separate per-key ceremony, audited.`
+      :`write-presence only for this role <span class="hint" title="${esc(TIP.writePresence)}">?</span>`}</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now)continue;
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const nSet=plan.filter(p=>p.action==='set').length;
+  const nClear=plan.filter(p=>p.action==='clear').length;
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'set':'clear'}</span>
+        ${p.action==='set'&&!p.secret?`<span style="color:var(--tx-faint);font-size:10.5px">→ ${esc(p.value)}</span>`:''}
+      </div>
+      ${permBlock?`<div class="verr">needs reveal-history — restoring an earlier secret is a historical disclosure (ADR #11); your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved: ${esc(fixes[p.key])} staged instead of the historical value</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}
+      <span class="hint" title="${esc(TIP.restore)}">?</span></h2>
+    <div class="sub">Stages drafts reproducing r${rev} — publish runs the normal pipeline, history is never rewritten.</div>
+    <div class="sumline">
+      ${nSet?`<span class="schip">${nSet} set</span>`:''}
+      ${nClear?`<span class="schip">${nClear} clear</span>`:''}
+      ${unresolved.length?`<span class="schip bad">${unresolved.length} schema-blocked</span>`:''}
+      ${blockedPerm?`<span class="schip bad">needs reveal-history</span>`:''}
+      ${!plan.length?`<span class="schip">already matches — nothing to stage</span>`:''}
+    </div>
+    <div class="dgrid" style="margin-top:12px">${plan.map(rowHtml).join('')}</div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">restores re-validate against the <b>current</b> schema, not r${rev}'s — resolve the blocked keys explicitly, or cancel.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Per-environment authorization at commit; protected environments run the ceremony. Same pipeline as any publish. <span class="hint" title="${esc(TIP.restore)}">?</span></div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  const env=envById(envId);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ pin <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}
+      <span class="hint" title="${esc(TIP.pin)}">?</span></h2>
+    <div class="sub">Quota ${pinsFor(envId).length}/${PIN_QUOTA} · the pinned payload is retained while the pin lives.</div>
+    <div class="cur dim">workload: api-server (k8s) · expiry: 30d (demo default → ops spec #32)</div>
+    ${isCur?'':`<div class="noperm">non-current revision: routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="confirmPin()">create pin</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+setView(S.hview);
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/3/index.html
+++ b/docs/site/public/prototypes/revision-history/3/index.html
@@ -1,0 +1,1366 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 3 "PANES + PIN CLARITY".
+  Alex's iteration-2 verdict: view b (list + detail panes) wins — it is now
+  the single history surface (switcher removed; a/c/d retired with it-2).
+  Second ask: make PINNING understandable to users — what a pin does and how
+  it affects the values a workload receives. Pin clarity is visible text,
+  not tooltip-only:
+  - pins section carries a one-line plain-language definition
+  - each pin row states the gap: "receives r27 — 2 behind latest"
+  - a pinned revision's detail pane says who is receiving it instead of
+    latest
+  - the pin-create sheet leads with "what this does": keeps exactly rN's
+    values across restarts, new publishes stop reaching the workload,
+    payload exempt from retention, expiry -> resumes latest on next fetch
+    (loudly); plus a vs-latest change summary under the disclosure rules
+    (config plaintext, secrets write-presence/comparison per role)
+  Every ADR #11 binding from iterations 1-2 is preserved:
+  lineage permanent / payloads last 6 + pinned (collected revs fail loud),
+  secret diffs = write-presence without reveal-history vs comparison +
+  per-key ceremony with it, restore = normal publish pipeline (flat-model
+  set/clear, current-schema re-validation, reveal-history refusal for
+  secret restores, #21 ceremony for protected), pins = durable owned
+  quota-bounded expiring resources (non-current pin ⇒ ceremony; schema-fail
+  pin ⇒ recorded override; retention-holding pin flagged with release).
+  Long ADR prose is demoted to (?) tooltips everywhere.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- shared history bits ---------------- */
+  .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  .pinrow{
+    margin:0 14px 8px;padding:9px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500;white-space:nowrap}
+  .pinrow .pw{color:var(--tx-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px;white-space:nowrap}
+  .wbadge{
+    font-size:9.5px;letter-spacing:.04em;font-weight:600;border-radius:999px;
+    padding:2px 8px;cursor:help;white-space:nowrap;border:none;
+  }
+  .wbadge.warn{color:var(--bad);background:var(--bad-soft)}
+  .wbadge.drift{color:var(--chg);background:var(--chg-soft)}
+  .pinrow .rel{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow .rel:hover{border-color:var(--bad);color:var(--bad)}
+  /* the plain-language gap line — visible, never tooltip-only (Alex, it-2) */
+  .pinrow .pingap{flex-basis:100%;font-family:var(--sans);font-size:11px;
+    color:var(--tx-dim);line-height:1.5}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  /* pin sheet "what this does" block */
+  .pinwhat{margin-top:14px;padding:12px 14px;background:var(--bg);
+    border:1px solid var(--line);border-radius:6px}
+  .pinwhat .pwt{font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  .pinwhat ul{list-style:none;display:grid;gap:7px}
+  .pinwhat li{font-size:12.5px;color:var(--tx-dim);line-height:1.55;
+    display:flex;gap:9px;align-items:baseline}
+  .pinwhat li::before{content:'·';color:var(--accent);font-weight:700;flex:none}
+  .pinwhat li b{color:var(--tx)}
+  .pinwhat .mono{font-family:var(--mono);font-size:11.5px}
+  .hint{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:15px;height:15px;border-radius:999px;border:1px solid var(--line);
+    font-size:9.5px;color:var(--tx-faint);cursor:help;flex:none;vertical-align:-2px;
+  }
+  .hint:hover{border-color:var(--accent);color:var(--accent)}
+  .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px;white-space:nowrap}
+  .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .racts{display:flex;gap:6px;flex-wrap:wrap}
+  .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+
+  /* ---------------- history drawer (views a/b/c) ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  #hdrawer{width:min(640px,96vw)}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  .pendline b{color:var(--chg)}
+  .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 70px}
+
+  /* view b — list + detail panes */
+  .panes{display:grid;grid-template-columns:170px 1fr;height:100%}
+  .panes .plist{border-right:1px solid var(--line);overflow-y:auto;padding:8px 0 70px}
+  .panes .plist button{
+    display:flex;align-items:center;gap:7px;width:100%;text-align:left;
+    padding:9px 12px;min-height:40px;border-left:2px solid transparent;
+  }
+  .panes .plist button:hover{background:var(--bg3)}
+  .panes .plist button.sel{background:var(--bg3);border-left-color:var(--accent)}
+  .panes .plist .rnum{font-family:var(--mono);font-size:12.5px;font-weight:500;color:var(--tx)}
+  .panes .plist button.cur .rnum{color:var(--accent)}
+  .panes .plist .age{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-left:auto}
+  .panes .plist .pdot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none}
+  .panes .plist .gdot{width:6px;height:6px;border-radius:50%;border:1px dashed var(--tx-faint);flex:none;opacity:.7}
+  .panes .pdetail{overflow-y:auto;padding:14px 16px 70px}
+  .pdetail .ph2{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .pdetail .ph2 .rnum{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--tx)}
+  .pdetail .meta{font-size:12px;color:var(--tx-dim);margin-top:6px;line-height:1.6}
+  .pdetail .meta b{color:var(--tx)}
+  .pdetail .chgrid{display:grid;gap:6px;margin-top:12px}
+  .pdetail .chrow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:8px 11px;font-family:var(--mono);font-size:11.5px;
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pdetail .chrow .lock{color:var(--bad);font-size:10px}
+  .pdetail .chrow .name{color:var(--tx);font-weight:500}
+  .pdetail .racts{margin-top:14px}
+  .pdetail .racts button{padding:8px 14px;min-height:36px;font-size:11.5px}
+
+  /* ---------------- centered modal ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+  .sumline{
+    display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .sumline .schip{border:1px solid var(--line);border-radius:999px;padding:3px 10px}
+  .sumline .schip.bad{border-color:var(--bad);color:var(--bad)}
+
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape, #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer{width:100vw}
+    .panes{grid-template-columns:120px 1fr}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+const RETAIN_N=6;
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+const PIN_QUOTA=5;
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<RETAIN_N||pinnedRevs(envId).has(rev));
+}
+
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const S={
+  role:'dev',
+  collapsed:new Set(),
+  drafts:new Map(),
+  reauthUntil:0,
+  reauth:null,
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev), sel:rev, openCard:rev}
+  sheet:null,
+  revealedHist:new Set(),
+};
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ---- (?) tooltip copy: the ADR reasoning lives here, not in the flow ---- */
+const TIP={
+  retention:`Lineage (who published what, when) is permanent. The VALUES of old revisions are garbage-collected: kept for the last ${RETAIN_N} revisions plus anything pinned (demo values — ops spec #32 owns the real ones). A collected revision cannot be diffed by value, restored, or revealed — no replay-from-metadata path exists (ADR #11).`,
+  writePresence:`Without reveal-history, secret rows show only that someone WROTE to the entry — never whether the plaintext differs. Comparison status is a guessing oracle: stage a guessed value, read "unchanged", recover a low-entropy secret bit by bit (ADR #11).`,
+  pin:`Pinning freezes what one workload receives: it keeps getting exactly the pinned revision's values instead of latest, until the pin is released or expires. Under the hood a pin is a durable authorized resource — owner, per-project quota, expiry — never a fetch parameter, so retention can see every reference and keeps the pinned values alive (ADR #11).`,
+  restore:`Restore never rewrites history: it stages per-key changes reproducing the old outcome, they land as ordinary drafts, and publish runs the full pipeline — impact preview, per-env authorization, protected ceremony, validation against the CURRENT schema (ADR #11).`,
+};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history — shared builders ============================ */
+function rowActions(envId,r,opts){
+  const hist=HIST[envId];
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const idx=hist.findIndex(x=>x.rev===r.rev);
+  const big=opts?.big?'style="padding:8px 14px;min-height:36px;font-size:11.5px"':'';
+  return`<div class="racts">
+    ${idx<hist.length-1?`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs previous</button>`:''}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();tryRestore('${envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable (ADR #11)"'}>restore…</button>`}
+    <button ${big} onclick="event.stopPropagation();tryPin('${envId}',${r.rev})">pin…</button>
+    ${retained?'':`<button ${big} onclick="event.stopPropagation();gcExplain(${r.rev})">why unavailable?</button>`}
+  </div>`;
+}
+function keysLine(r){
+  return r.changes.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+}
+function revTags(envId,r){
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const pinnedHere=pinsFor(envId).filter(p=>p.rev===r.rev);
+  return`${isCur?'<span class="tag curt">current</span>':''}
+    ${pinnedHere.length?`<span class="tag pint" title="pinned by ${esc(pinnedHere.map(p=>p.workload).join(', '))}">⚲</span>`:''}
+    ${retained?'':'<span class="tag gct" title="'+esc(TIP.retention)+'">collected</span>'}`;
+}
+function pinsHtml(envId){
+  const pins=pinsFor(envId);
+  if(!pins.length)return`<div class="pinnote">no pins — every workload here follows latest (r${curRev(envId)}). <span class="hint" title="${esc(TIP.pin)}">?</span></div>`;
+  return pins.map(p=>{
+    const behind=HIST[envId].findIndex(r=>r.rev===p.rev);
+    const holdsPastWindow=behind>=RETAIN_N;
+    const entry=revEntry(envId,p.rev);
+    const drift=entry&&entry.schemaRev!=='s14';
+    return`<div class="pinrow">
+      <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+      <span class="pe">${p.expDays}d left</span>
+      ${holdsPastWindow?`<span class="wbadge warn" title="This pin alone holds r${p.rev}'s values past the retention window (last ${RETAIN_N} + pins). Release it and they are collected.">⚠ holds payload</span>`:''}
+      ${drift?`<span class="wbadge drift" title="Pinned under schema ${entry.schemaRev}; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).">Δ drift</span>`:''}
+      <button class="rel" onclick="releasePin(${p.id})">release</button>
+      <span class="pingap">${behind
+        ?`${esc(p.workload)} still runs on r${p.rev}'s values — ${behind} publish${behind>1?'es':''} behind latest (r${curRev(envId)}). New publishes don't reach it.`
+        :`pinned at latest — no gap yet, but the next publish will not reach ${esc(p.workload)}.`}</span>
+    </div>`}).join('');
+}
+function drawerHead(d){
+  const env=envById(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  return`<div class="dh">
+    <h3>↺ revision history
+      <span class="cur">current r${curRev(d.envId)}</span>
+      ${env.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+    <div class="envtabs">${readableEnvs().map(e=>
+      `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+  </div>`;
+}
+function histList(d){
+  return HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+}
+function permFootnote(envId){
+  return canHistory(envId)?'':`<div class="pinnote" style="margin-top:14px">no <b>reveal-history</b> for this role: secret diffs show write-presence only, secret restores refused. <span class="hint" title="${esc(TIP.writePresence)}">?</span></div>`;
+}
+
+/* ============================ history — view b: list + detail panes ============================ */
+function renderPanes(d){
+  const hist=histList(d);
+  if(!hist.some(r=>r.rev===d.sel))d.sel=hist[0]?.rev;
+  const sel=hist.find(r=>r.rev===d.sel);
+  const retained=sel&&payloadRetained(d.envId,sel.rev);
+  return`${drawerHead(d)}
+    <div class="panes">
+      <div class="plist">
+        ${hist.map(r=>{
+          const isCur=r.rev===curRev(d.envId);
+          const rt=payloadRetained(d.envId,r.rev);
+          const pinned=pinnedRevs(d.envId).has(r.rev);
+          return`<button class="${r.rev===d.sel?'sel':''} ${isCur?'cur':''}" onclick="selRev(${r.rev})">
+            <span class="rnum">r${r.rev}</span>
+            ${pinned?'<span class="pdot" title="pinned"></span>':''}
+            ${rt?'':'<span class="gdot" title="payload collected"></span>'}
+            <span class="age">${ago(r.at)}</span>
+          </button>`}).join('')}
+      </div>
+      <div class="pdetail">
+        ${sel?`
+        <div class="ph2"><span class="rnum">r${sel.rev}</span>${revTags(d.envId,sel)}</div>
+        <div class="meta">published by <b>${esc(sel.actor)}</b> · ${ago(sel.at)} · schema ${sel.schemaRev} pinned</div>
+        ${pinsFor(d.envId).filter(p=>p.rev===sel.rev).map(p=>`<div class="meta" style="color:var(--accent)">⚲ ${esc(p.workload)} receives <b>this revision's values</b>${sel.rev===curRev(d.envId)?'':` instead of latest (r${curRev(d.envId)})`} — until the pin is released or expires (${p.expDays}d)</div>`).join('')}
+        ${retained?'':`<div class="meta" style="color:var(--tx-faint);font-style:italic">payload collected by retention (last ${RETAIN_N} + pinned) — lineage below is permanent; value diff, restore and reveal are gone. <span class="hint" title="${esc(TIP.retention)}">?</span></div>`}
+        <div class="chgrid">
+          ${sel.changes.map(c=>{
+            const sk=keyByName(c.key)?.secret;
+            return`<div class="chrow">${sk?'<span class="lock">🔒</span>':''}<span class="name">${esc(c.key)}</span>
+              <span class="kindtag ${c.kind}">${c.kind}</span>
+              ${sk?`<span style="color:var(--tx-faint);font-size:10px">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span>`:''}
+            </div>`}).join('')}
+        </div>
+        <div class="racts">${rowActions(d.envId,sel,{big:true})}</div>
+        <div class="dsec" style="padding:22px 0 6px">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin)}">?</span></span></div>
+        <div class="pinnote" style="margin:0 0 8px">a pinned workload stops following latest — it keeps receiving exactly the pinned revision's values, restarts included, until the pin is released or expires.</div>
+        <div style="margin:0 -14px">${pinsHtml(d.envId)}</div>
+        ${permFootnote(d.envId)}`:'<div class="meta">no revisions</div>'}
+      </div>
+    </div>`;
+}
+function selRev(rev){S.drawer.sel=rev;renderDrawer()}
+
+/* ============================ history — dispatch ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,sel:curRev(envId)};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){
+  S.drawer=null;
+  renderDrawer();render();
+}
+function drawerTab(envId){
+  S.drawer.envId=envId;
+  S.drawer.sel=curRev(envId);
+  renderDrawer();render();
+}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');return}
+  el.innerHTML=renderPanes(d);
+  el.classList.add('open');
+}
+
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (last ${RETAIN_N} + pinned). Lineage is permanent; the values are gone — not restorable, not diffable, not revealable (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})`);
+  toast(`pin on r${p.rev} released — ${payloadRetained(p.envId,p.rev)?'payload still inside the retention window':'payload now eligible for collection'}`);
+  renderDrawer();render();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  if(pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA}) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  const isCur=rev===curRev(envId);
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false};
+  renderSheet();
+}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    PINS.push({id:nextPinId++,envId,rev,workload:'api-server (k8s)',by:'you',expDays:30});
+    audit('pin created',`r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+    toast(`⚲ pinned r${rev} — payload retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span>
+        <span style="color:var(--tx-faint);font-size:10px;margin-left:auto">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span></div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'?'changed':cmp==='unchanged'?'unchanged':cmp}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 ${canH
+      ?`comparison shown (this role holds <b>reveal-history</b>); plaintext is a separate per-key ceremony, audited.`
+      :`write-presence only for this role <span class="hint" title="${esc(TIP.writePresence)}">?</span>`}</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now)continue;
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const nSet=plan.filter(p=>p.action==='set').length;
+  const nClear=plan.filter(p=>p.action==='clear').length;
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'set':'clear'}</span>
+        ${p.action==='set'&&!p.secret?`<span style="color:var(--tx-faint);font-size:10.5px">→ ${esc(p.value)}</span>`:''}
+      </div>
+      ${permBlock?`<div class="verr">needs reveal-history — restoring an earlier secret is a historical disclosure (ADR #11); your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved: ${esc(fixes[p.key])} staged instead of the historical value</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}
+      <span class="hint" title="${esc(TIP.restore)}">?</span></h2>
+    <div class="sub">Stages drafts reproducing r${rev} — publish runs the normal pipeline, history is never rewritten.</div>
+    <div class="sumline">
+      ${nSet?`<span class="schip">${nSet} set</span>`:''}
+      ${nClear?`<span class="schip">${nClear} clear</span>`:''}
+      ${unresolved.length?`<span class="schip bad">${unresolved.length} schema-blocked</span>`:''}
+      ${blockedPerm?`<span class="schip bad">needs reveal-history</span>`:''}
+      ${!plan.length?`<span class="schip">already matches — nothing to stage</span>`:''}
+    </div>
+    <div class="dgrid" style="margin-top:12px">${plan.map(rowHtml).join('')}</div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">restores re-validate against the <b>current</b> schema, not r${rev}'s — resolve the blocked keys explicitly, or cancel.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Per-environment authorization at commit; protected environments run the ceremony. Same pipeline as any publish. <span class="hint" title="${esc(TIP.restore)}">?</span></div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  /* vs-latest summary — phrased from the workload's point of view.
+     Disclosure rules unchanged: config plaintext; secret comparison only
+     with reveal-history (a non-current pin already required it), values
+     always masked here. */
+  let gapBlock='';
+  if(!isCur){
+    const rows=diffRows(envId,rev,curRev(envId));
+    const rowLine=r=>{
+      if(r.kind==='added')return`<li><b class="mono">${esc(r.key)}</b> — the workload will <b>not</b> have this key (added after r${rev})</li>`;
+      if(r.kind==='removed')return`<li><b class="mono">${esc(r.key)}</b> — the workload keeps this key (removed after r${rev})</li>`;
+      if(r.secret)return`<li>🔒 <b class="mono">${esc(r.key)}</b> — ${canH?(r.old!==r.new?'stays at an <b>older value</b> than latest':'same value as latest'):'written to since (write-presence only)'}</li>`;
+      return`<li><b class="mono">${esc(r.key)}</b> — stays at <b>${esc(r.old)}</b> (latest: ${esc(r.new)})</li>`;
+    };
+    gapBlock=`<div class="pinwhat">
+      <div class="pwt">compared to latest (r${curRev(envId)}) — ${rows.length} difference${rows.length!==1?'s':''}</div>
+      <ul>${rows.length?rows.map(rowLine).join(''):'<li>identical delivered content — the pin only freezes it going forward.</li>'}</ul>
+    </div>`;
+  }
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ pin <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}
+      <span class="hint" title="${esc(TIP.pin)}">?</span></h2>
+    <div class="sub">Quota ${pinsFor(envId).length}/${PIN_QUOTA} · workload: api-server (k8s) · expiry: 30d (demo default → ops spec #32)</div>
+    <div class="pinwhat">
+      <div class="pwt">what pinning does</div>
+      <ul>
+        <li><b>api-server keeps receiving exactly r${rev}'s values</b> — across restarts and redeploys — instead of following latest.</li>
+        <li>new publishes to ${env.name} <b>stop reaching this workload</b> while the pin lives; everyone else still gets latest.</li>
+        <li>r${rev}'s values are <b>kept from retention clean-up</b> as long as the pin exists.</li>
+        <li>on release or expiry (30d) the workload <b>resumes latest on its next fetch</b> — surfaced loudly, never silent.</li>
+      </ul>
+    </div>
+    ${gapBlock}
+    ${isCur?'':`<div class="noperm">non-current revision: this routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="confirmPin()">create pin</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/4/index.html
+++ b/docs/site/public/prototypes/revision-history/4/index.html
@@ -1,0 +1,1439 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 4 "PIN = WORKLOAD BINDING".
+  Alex's iteration-3 findings:
+  1. "holds payload" is jargon. Replaced by plain consequence language:
+     badge -> "sole keeper", the gap sentence says "r21 is past normal
+     retention — its values survive only because of this pin", and
+     RELEASING such a pin now asks for confirmation spelling out that the
+     values are permanently collected (no diff, no restore, no reveal).
+  2. The same revision could be pinned twice — senseless for one workload.
+     The pin model is now explicitly a WORKLOAD BINDING: a workload has at
+     most ONE pin per environment. The pin sheet gains a workload picker;
+     choosing a workload that is already pinned turns the sheet into a
+     MOVE ("api-server currently runs r27 — this moves it to r25") and
+     replaces the old pin atomically. Two DIFFERENT workloads pinning the
+     same revision remains legal and reads as separate rows.
+  Iteration-3 surface otherwise unchanged: list + detail panes (it-2
+  verdict), visible plain-language pin clarity everywhere.
+  Every ADR #11 binding from iterations 1-3 is preserved:
+  lineage permanent / payloads last 6 + pinned (collected revs fail loud),
+  secret diffs = write-presence without reveal-history vs comparison +
+  per-key ceremony with it, restore = normal publish pipeline (flat-model
+  set/clear, current-schema re-validation, reveal-history refusal for
+  secret restores, #21 ceremony for protected), pins = durable owned
+  quota-bounded expiring resources (non-current pin ⇒ ceremony; schema-fail
+  pin ⇒ recorded override; retention-holding pin flagged with release).
+  Long ADR prose is demoted to (?) tooltips everywhere.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- shared history bits ---------------- */
+  .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  .pinrow{
+    margin:0 14px 8px;padding:9px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500;white-space:nowrap}
+  .pinrow .pw{color:var(--tx-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px;white-space:nowrap}
+  .wbadge{
+    font-size:9.5px;letter-spacing:.04em;font-weight:600;border-radius:999px;
+    padding:2px 8px;cursor:help;white-space:nowrap;border:none;
+  }
+  .wbadge.warn{color:var(--bad);background:var(--bad-soft)}
+  .wbadge.drift{color:var(--chg);background:var(--chg-soft)}
+  .pinrow .rel{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow .rel:hover{border-color:var(--bad);color:var(--bad)}
+  /* the plain-language gap line — visible, never tooltip-only (Alex, it-2) */
+  .pinrow .pingap{flex-basis:100%;font-family:var(--sans);font-size:11px;
+    color:var(--tx-dim);line-height:1.5}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  /* pin sheet "what this does" block */
+  .pinwhat{margin-top:14px;padding:12px 14px;background:var(--bg);
+    border:1px solid var(--line);border-radius:6px}
+  .pinwhat .pwt{font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  .pinwhat ul{list-style:none;display:grid;gap:7px}
+  .pinwhat li{font-size:12.5px;color:var(--tx-dim);line-height:1.55;
+    display:flex;gap:9px;align-items:baseline}
+  .pinwhat li::before{content:'·';color:var(--accent);font-weight:700;flex:none}
+  .pinwhat li b{color:var(--tx)}
+  .pinwhat .mono{font-family:var(--mono);font-size:11.5px}
+  .hint{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:15px;height:15px;border-radius:999px;border:1px solid var(--line);
+    font-size:9.5px;color:var(--tx-faint);cursor:help;flex:none;vertical-align:-2px;
+  }
+  .hint:hover{border-color:var(--accent);color:var(--accent)}
+  .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px;white-space:nowrap}
+  .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .racts{display:flex;gap:6px;flex-wrap:wrap}
+  .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+
+  /* ---------------- history drawer (views a/b/c) ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  #hdrawer{width:min(640px,96vw)}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  .pendline b{color:var(--chg)}
+  .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 70px}
+
+  /* view b — list + detail panes */
+  .panes{display:grid;grid-template-columns:170px 1fr;height:100%}
+  .panes .plist{border-right:1px solid var(--line);overflow-y:auto;padding:8px 0 70px}
+  .panes .plist button{
+    display:flex;align-items:center;gap:7px;width:100%;text-align:left;
+    padding:9px 12px;min-height:40px;border-left:2px solid transparent;
+  }
+  .panes .plist button:hover{background:var(--bg3)}
+  .panes .plist button.sel{background:var(--bg3);border-left-color:var(--accent)}
+  .panes .plist .rnum{font-family:var(--mono);font-size:12.5px;font-weight:500;color:var(--tx)}
+  .panes .plist button.cur .rnum{color:var(--accent)}
+  .panes .plist .age{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-left:auto}
+  .panes .plist .pdot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none}
+  .panes .plist .gdot{width:6px;height:6px;border-radius:50%;border:1px dashed var(--tx-faint);flex:none;opacity:.7}
+  .panes .pdetail{overflow-y:auto;padding:14px 16px 70px}
+  .pdetail .ph2{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .pdetail .ph2 .rnum{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--tx)}
+  .pdetail .meta{font-size:12px;color:var(--tx-dim);margin-top:6px;line-height:1.6}
+  .pdetail .meta b{color:var(--tx)}
+  .pdetail .chgrid{display:grid;gap:6px;margin-top:12px}
+  .pdetail .chrow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:8px 11px;font-family:var(--mono);font-size:11.5px;
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pdetail .chrow .lock{color:var(--bad);font-size:10px}
+  .pdetail .chrow .name{color:var(--tx);font-weight:500}
+  .pdetail .racts{margin-top:14px}
+  .pdetail .racts button{padding:8px 14px;min-height:36px;font-size:11.5px}
+
+  /* ---------------- centered modal ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+  .sumline{
+    display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .sumline .schip{border:1px solid var(--line);border-radius:999px;padding:3px 10px}
+  .sumline .schip.bad{border-color:var(--bad);color:var(--bad)}
+
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape, #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer{width:100vw}
+    .panes{grid-template-columns:120px 1fr}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+const RETAIN_N=6;
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+const PIN_QUOTA=5;
+/* a pin is a WORKLOAD BINDING: at most one pin per (workload, environment).
+   Re-pinning a bound workload is a MOVE, never a second pin. Different
+   workloads pinning the same revision is legal (separate rows). */
+const WORKLOADS=['api-server (k8s)','billing-batch (compose)','cron-reports (compose)'];
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinOf=(envId,workload)=>PINS.find(p=>p.envId===envId&&p.workload===workload);
+/* sole keeper: this pin alone keeps its revision's values past retention */
+const isSoleKeeper=p=>{
+  const idx=HIST[p.envId].findIndex(r=>r.rev===p.rev);
+  return idx>=RETAIN_N&&!PINS.some(o=>o.id!==p.id&&o.envId===p.envId&&o.rev===p.rev);
+};
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<RETAIN_N||pinnedRevs(envId).has(rev));
+}
+
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const S={
+  role:'dev',
+  collapsed:new Set(),
+  drafts:new Map(),
+  reauthUntil:0,
+  reauth:null,
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev), sel:rev, openCard:rev}
+  sheet:null,
+  revealedHist:new Set(),
+};
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ---- (?) tooltip copy: the ADR reasoning lives here, not in the flow ---- */
+const TIP={
+  retention:`Lineage (who published what, when) is permanent. The VALUES of old revisions are garbage-collected: kept for the last ${RETAIN_N} revisions plus anything pinned (demo values — ops spec #32 owns the real ones). A collected revision cannot be diffed by value, restored, or revealed — no replay-from-metadata path exists (ADR #11).`,
+  writePresence:`Without reveal-history, secret rows show only that someone WROTE to the entry — never whether the plaintext differs. Comparison status is a guessing oracle: stage a guessed value, read "unchanged", recover a low-entropy secret bit by bit (ADR #11).`,
+  pin:`Pinning freezes what one workload receives: it keeps getting exactly the pinned revision's values instead of latest, until the pin is released or expires. One pin per workload per environment — re-pinning moves the binding, it never stacks. Under the hood a pin is a durable authorized resource — owner, per-project quota, expiry — never a fetch parameter, so retention can see every reference and keeps the pinned values alive (ADR #11).`,
+  restore:`Restore never rewrites history: it stages per-key changes reproducing the old outcome, they land as ordinary drafts, and publish runs the full pipeline — impact preview, per-env authorization, protected ceremony, validation against the CURRENT schema (ADR #11).`,
+};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history — shared builders ============================ */
+function rowActions(envId,r,opts){
+  const hist=HIST[envId];
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const idx=hist.findIndex(x=>x.rev===r.rev);
+  const big=opts?.big?'style="padding:8px 14px;min-height:36px;font-size:11.5px"':'';
+  return`<div class="racts">
+    ${idx<hist.length-1?`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs previous</button>`:''}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();tryRestore('${envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable (ADR #11)"'}>restore…</button>`}
+    <button ${big} onclick="event.stopPropagation();tryPin('${envId}',${r.rev})">pin…</button>
+    ${retained?'':`<button ${big} onclick="event.stopPropagation();gcExplain(${r.rev})">why unavailable?</button>`}
+  </div>`;
+}
+function keysLine(r){
+  return r.changes.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+}
+function revTags(envId,r){
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const pinnedHere=pinsFor(envId).filter(p=>p.rev===r.rev);
+  return`${isCur?'<span class="tag curt">current</span>':''}
+    ${pinnedHere.length?`<span class="tag pint" title="pinned by ${esc(pinnedHere.map(p=>p.workload).join(', '))}">⚲</span>`:''}
+    ${retained?'':'<span class="tag gct" title="'+esc(TIP.retention)+'">collected</span>'}`;
+}
+function pinsHtml(envId){
+  const pins=pinsFor(envId);
+  if(!pins.length)return`<div class="pinnote">no pins — every workload here follows latest (r${curRev(envId)}). <span class="hint" title="${esc(TIP.pin)}">?</span></div>`;
+  return pins.map(p=>{
+    const behind=HIST[envId].findIndex(r=>r.rev===p.rev);
+    const sole=isSoleKeeper(p);
+    const entry=revEntry(envId,p.rev);
+    const drift=entry&&entry.schemaRev!=='s14';
+    return`<div class="pinrow">
+      <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+      <span class="pe">${p.expDays}d left</span>
+      ${sole?`<span class="wbadge warn" title="r${p.rev} is past normal retention (last ${RETAIN_N} revisions). Its old values still exist ONLY because of this pin — releasing it deletes them permanently: no diff, no restore, no reveal.">⚠ sole keeper</span>`:''}
+      ${drift?`<span class="wbadge drift" title="Pinned under schema ${entry.schemaRev}; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).">Δ drift</span>`:''}
+      <button class="rel" onclick="releasePin(${p.id})">release</button>
+      <span class="pingap">${behind
+        ?`${esc(p.workload)} still runs on r${p.rev}'s values — ${behind} publish${behind>1?'es':''} behind latest (r${curRev(envId)}). New publishes don't reach it.`
+        :`pinned at latest — no gap yet, but the next publish will not reach ${esc(p.workload)}.`}${sole
+        ?` r${p.rev} is past normal retention: its values survive only because of this pin.`:''}</span>
+    </div>`}).join('');
+}
+function drawerHead(d){
+  const env=envById(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  return`<div class="dh">
+    <h3>↺ revision history
+      <span class="cur">current r${curRev(d.envId)}</span>
+      ${env.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+    <div class="envtabs">${readableEnvs().map(e=>
+      `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+  </div>`;
+}
+function histList(d){
+  return HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+}
+function permFootnote(envId){
+  return canHistory(envId)?'':`<div class="pinnote" style="margin-top:14px">no <b>reveal-history</b> for this role: secret diffs show write-presence only, secret restores refused. <span class="hint" title="${esc(TIP.writePresence)}">?</span></div>`;
+}
+
+/* ============================ history — view b: list + detail panes ============================ */
+function renderPanes(d){
+  const hist=histList(d);
+  if(!hist.some(r=>r.rev===d.sel))d.sel=hist[0]?.rev;
+  const sel=hist.find(r=>r.rev===d.sel);
+  const retained=sel&&payloadRetained(d.envId,sel.rev);
+  return`${drawerHead(d)}
+    <div class="panes">
+      <div class="plist">
+        ${hist.map(r=>{
+          const isCur=r.rev===curRev(d.envId);
+          const rt=payloadRetained(d.envId,r.rev);
+          const pinned=pinnedRevs(d.envId).has(r.rev);
+          return`<button class="${r.rev===d.sel?'sel':''} ${isCur?'cur':''}" onclick="selRev(${r.rev})">
+            <span class="rnum">r${r.rev}</span>
+            ${pinned?'<span class="pdot" title="pinned"></span>':''}
+            ${rt?'':'<span class="gdot" title="payload collected"></span>'}
+            <span class="age">${ago(r.at)}</span>
+          </button>`}).join('')}
+      </div>
+      <div class="pdetail">
+        ${sel?`
+        <div class="ph2"><span class="rnum">r${sel.rev}</span>${revTags(d.envId,sel)}</div>
+        <div class="meta">published by <b>${esc(sel.actor)}</b> · ${ago(sel.at)} · schema ${sel.schemaRev} pinned</div>
+        ${pinsFor(d.envId).filter(p=>p.rev===sel.rev).map(p=>`<div class="meta" style="color:var(--accent)">⚲ ${esc(p.workload)} receives <b>this revision's values</b>${sel.rev===curRev(d.envId)?'':` instead of latest (r${curRev(d.envId)})`} — until the pin is released or expires (${p.expDays}d)</div>`).join('')}
+        ${retained?'':`<div class="meta" style="color:var(--tx-faint);font-style:italic">payload collected by retention (last ${RETAIN_N} + pinned) — lineage below is permanent; value diff, restore and reveal are gone. <span class="hint" title="${esc(TIP.retention)}">?</span></div>`}
+        <div class="chgrid">
+          ${sel.changes.map(c=>{
+            const sk=keyByName(c.key)?.secret;
+            return`<div class="chrow">${sk?'<span class="lock">🔒</span>':''}<span class="name">${esc(c.key)}</span>
+              <span class="kindtag ${c.kind}">${c.kind}</span>
+              ${sk?`<span style="color:var(--tx-faint);font-size:10px">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span>`:''}
+            </div>`}).join('')}
+        </div>
+        <div class="racts">${rowActions(d.envId,sel,{big:true})}</div>
+        <div class="dsec" style="padding:22px 0 6px">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin)}">?</span></span></div>
+        <div class="pinnote" style="margin:0 0 8px">a pinned workload stops following latest — it keeps receiving exactly the pinned revision's values, restarts included, until the pin is released or expires.</div>
+        <div style="margin:0 -14px">${pinsHtml(d.envId)}</div>
+        ${permFootnote(d.envId)}`:'<div class="meta">no revisions</div>'}
+      </div>
+    </div>`;
+}
+function selRev(rev){S.drawer.sel=rev;renderDrawer()}
+
+/* ============================ history — dispatch ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,sel:curRev(envId)};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){
+  S.drawer=null;
+  renderDrawer();render();
+}
+function drawerTab(envId){
+  S.drawer.envId=envId;
+  S.drawer.sel=curRev(envId);
+  renderDrawer();render();
+}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');return}
+  el.innerHTML=renderPanes(d);
+  el.classList.add('open');
+}
+
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (last ${RETAIN_N} + pinned). Lineage is permanent; the values are gone — not restorable, not diffable, not revealable (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  /* releasing a sole-keeper pin permanently deletes its revision's values —
+     that deserves a confirm spelling out the consequence, not a silent zap */
+  if(isSoleKeeper(p)){S.sheet={mode:'release',pinId:id};renderSheet();return}
+  doRelease(id);
+}
+function doRelease(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  const gone=!payloadRetained(p.envId,p.rev);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})${gone?' · values collected':''}`);
+  toast(gone
+    ?`pin released — <b>r${p.rev}'s old values are gone</b> (past retention, no other pin kept them). ${esc(p.workload)} resumes latest on its next fetch.`
+    :`pin released — ${esc(p.workload)} resumes latest (r${curRev(p.envId)}) on its next fetch. r${p.rev}'s values stay inside the retention window.`);
+  closeSheet();renderDrawer();render();
+}
+function renderReleaseSheet(){
+  const p=PINS.find(x=>x.id===S.sheet.pinId);
+  const env=envById(p.envId);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>release pin <span style="color:var(--accent)">r${p.rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}</h2>
+    <div class="pinwhat" style="border-color:var(--bad)">
+      <div class="pwt" style="color:var(--bad)">this permanently deletes r${p.rev}'s values</div>
+      <ul>
+        <li>r${p.rev} is past normal retention (last ${RETAIN_N} revisions) — <b>this pin is the only thing keeping its values</b>.</li>
+        <li>after release they are <b>collected</b>: no diff by value, no restore, no reveal. The timeline entry (who changed what, when) stays.</li>
+        <li>${esc(p.workload)} resumes <b>latest (r${curRev(p.envId)})</b> on its next fetch.</li>
+      </ul>
+    </div>
+    <div class="acts">
+      <button class="btn danger" onclick="doRelease(${p.id})">release — delete r${p.rev}'s values</button>
+      <button class="btn" onclick="closeSheet()">keep the pin</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  const isCur=rev===curRev(envId);
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  /* default to the first workload not yet pinned in this env, else first */
+  const wl=WORKLOADS.find(w=>!pinOf(envId,w))||WORKLOADS[0];
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false,workload:wl};
+  renderSheet();
+}
+function setPinWorkload(w){S.sheet.workload=w;renderSheet()}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const existing=pinOf(envId,workload);
+  if(existing&&existing.rev===rev){
+    toast(`${esc(workload)} is already pinned to r${rev} — nothing to do. One pin per workload; pinning again would change nothing (a workload fetches exactly one revision).`,'err');
+    return;
+  }
+  if(!existing&&pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA}) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    if(existing){
+      /* MOVE: one pin per (workload, env) — replace atomically, never a second pin */
+      const from=existing.rev;
+      existing.rev=rev;existing.by='you';existing.expDays=30;
+      audit('pin moved',`${esc(workload)} r${from} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ moved ${esc(workload)} from r${from} to r${rev} — it fetches r${rev}'s values from its next fetch on.${payloadRetained(envId,from)?'':` r${from}'s values were kept only by this pin and are now collected.`}`);
+    }else{
+      PINS.push({id:nextPinId++,envId,rev,workload,by:'you',expDays:30});
+      audit('pin created',`${esc(workload)} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ pinned ${esc(workload)} to r${rev} — values retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    }
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span>
+        <span style="color:var(--tx-faint);font-size:10px;margin-left:auto">write-presence <span class="hint" title="${esc(TIP.writePresence)}">?</span></span></div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'?'changed':cmp==='unchanged'?'unchanged':cmp}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 ${canH
+      ?`comparison shown (this role holds <b>reveal-history</b>); plaintext is a separate per-key ceremony, audited.`
+      :`write-presence only for this role <span class="hint" title="${esc(TIP.writePresence)}">?</span>`}</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now)continue;
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const nSet=plan.filter(p=>p.action==='set').length;
+  const nClear=plan.filter(p=>p.action==='clear').length;
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'set':'clear'}</span>
+        ${p.action==='set'&&!p.secret?`<span style="color:var(--tx-faint);font-size:10.5px">→ ${esc(p.value)}</span>`:''}
+      </div>
+      ${permBlock?`<div class="verr">needs reveal-history — restoring an earlier secret is a historical disclosure (ADR #11); your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved: ${esc(fixes[p.key])} staged instead of the historical value</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}
+      <span class="hint" title="${esc(TIP.restore)}">?</span></h2>
+    <div class="sub">Stages drafts reproducing r${rev} — publish runs the normal pipeline, history is never rewritten.</div>
+    <div class="sumline">
+      ${nSet?`<span class="schip">${nSet} set</span>`:''}
+      ${nClear?`<span class="schip">${nClear} clear</span>`:''}
+      ${unresolved.length?`<span class="schip bad">${unresolved.length} schema-blocked</span>`:''}
+      ${blockedPerm?`<span class="schip bad">needs reveal-history</span>`:''}
+      ${!plan.length?`<span class="schip">already matches — nothing to stage</span>`:''}
+    </div>
+    <div class="dgrid" style="margin-top:12px">${plan.map(rowHtml).join('')}</div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">restores re-validate against the <b>current</b> schema, not r${rev}'s — resolve the blocked keys explicitly, or cancel.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Per-environment authorization at commit; protected environments run the ceremony. Same pipeline as any publish. <span class="hint" title="${esc(TIP.restore)}">?</span></div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const existing=pinOf(envId,workload);
+  const isMove=existing&&existing.rev!==rev;
+  const isNoop=existing&&existing.rev===rev;
+  /* vs-latest summary — phrased from the workload's point of view.
+     Disclosure rules unchanged: config plaintext; secret comparison only
+     with reveal-history (a non-current pin already required it), values
+     always masked here. */
+  let gapBlock='';
+  if(!isCur){
+    const rows=diffRows(envId,rev,curRev(envId));
+    const rowLine=r=>{
+      if(r.kind==='added')return`<li><b class="mono">${esc(r.key)}</b> — the workload will <b>not</b> have this key (added after r${rev})</li>`;
+      if(r.kind==='removed')return`<li><b class="mono">${esc(r.key)}</b> — the workload keeps this key (removed after r${rev})</li>`;
+      if(r.secret)return`<li>🔒 <b class="mono">${esc(r.key)}</b> — ${canH?(r.old!==r.new?'stays at an <b>older value</b> than latest':'same value as latest'):'written to since (write-presence only)'}</li>`;
+      return`<li><b class="mono">${esc(r.key)}</b> — stays at <b>${esc(r.old)}</b> (latest: ${esc(r.new)})</li>`;
+    };
+    gapBlock=`<div class="pinwhat">
+      <div class="pwt">compared to latest (r${curRev(envId)}) — ${rows.length} difference${rows.length!==1?'s':''}</div>
+      <ul>${rows.length?rows.map(rowLine).join(''):'<li>identical delivered content — the pin only freezes it going forward.</li>'}</ul>
+    </div>`;
+  }
+  const wlShort=esc(workload.split(' ')[0]);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ ${isMove?'move pin to':'pin'} <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}
+      <span class="hint" title="${esc(TIP.pin)}">?</span></h2>
+    <div class="sub" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:8px">
+      workload:
+      <select onchange="setPinWorkload(this.value)" aria-label="workload to pin"
+        style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:7px 10px;border-radius:4px;font-size:12.5px">
+        ${WORKLOADS.map(w=>{
+          const p=pinOf(envId,w);
+          return`<option value="${esc(w)}" ${w===workload?'selected':''}>${esc(w)}${p?` — pinned to r${p.rev}`:' — follows latest'}</option>`}).join('')}
+      </select>
+      <span style="color:var(--tx-faint)">quota ${pinsFor(envId).length}/${PIN_QUOTA} · expiry 30d</span>
+    </div>
+    ${isMove?`<div class="noperm" style="color:var(--chg)">⚲ ${esc(workload)} is currently pinned to <b>r${existing.rev}</b> — one pin per workload, so this <b>moves</b> it to r${rev} (the r${existing.rev} pin is replaced${isSoleKeeper(existing)?`, and r${existing.rev}'s values, kept only by that pin, are collected`:''}).</div>`:''}
+    ${isNoop?`<div class="noperm" style="color:var(--bad)">already pinned to r${rev} — a workload fetches exactly one revision, so pinning it again changes nothing.</div>`:''}
+    <div class="pinwhat">
+      <div class="pwt">what pinning does</div>
+      <ul>
+        <li><b>${wlShort} keeps receiving exactly r${rev}'s values</b> — across restarts and redeploys — instead of following latest.</li>
+        <li>new publishes to ${env.name} <b>stop reaching this workload</b> while the pin lives; everyone else still gets latest.</li>
+        <li>r${rev}'s values are <b>kept from retention clean-up</b> as long as the pin exists.</li>
+        <li>on release or expiry (30d) the workload <b>resumes latest on its next fetch</b> — surfaced loudly, never silent.</li>
+      </ul>
+    </div>
+    ${gapBlock}
+    ${isCur?'':`<div class="noperm">non-current revision: this routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" ${isNoop?'disabled':''} onclick="confirmPin()">${isMove?`move pin to r${rev}`:'create pin'}</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet,release:renderReleaseSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/5/index.html
+++ b/docs/site/public/prototypes/revision-history/5/index.html
@@ -1,0 +1,1575 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 5 "RETENTION INHERITANCE".
+  Alex's iteration-4→5 ask: revision retention becomes configurable per org
+  AND per project — new projects inherit the org default; a project that
+  overrides DETACHES (later org changes no longer touch it); a project
+  still inheriting follows org changes; a project value may never exceed
+  the org value (refused at set time; an org lowering clamps existing
+  overrides loudly, shown as "capped by org"). Feelable via the ⚙ retention
+  sheet from the drawer head: org stepper + per-project state list +
+  this-project inherit/custom radio; applying re-renders the timeline so
+  "collected" tags move live. Retention changes are audited (#24 registry:
+  retention-policy change). Spec note: #15 already places #11's payload
+  policy under project-settings at project scope; the org default +
+  inherit-until-modified + org cap is NEW — recorded in NOTES.md for the
+  UI spec / #32 / #27.
+  Carried from iteration 4 "PIN = WORKLOAD BINDING":
+  1. "holds payload" is jargon. Replaced by plain consequence language:
+     badge -> "sole keeper", the gap sentence says "r21 is past normal
+     retention — its values survive only because of this pin", and
+     RELEASING such a pin now asks for confirmation spelling out that the
+     values are permanently collected (no diff, no restore, no reveal).
+  2. The same revision could be pinned twice — senseless for one workload.
+     The pin model is now explicitly a WORKLOAD BINDING: a workload has at
+     most ONE pin per environment. The pin sheet gains a workload picker;
+     choosing a workload that is already pinned turns the sheet into a
+     MOVE ("api-server currently runs r27 — this moves it to r25") and
+     replaces the old pin atomically. Two DIFFERENT workloads pinning the
+     same revision remains legal and reads as separate rows.
+  Iteration-3 surface otherwise unchanged: list + detail panes (it-2
+  verdict), visible plain-language pin clarity everywhere.
+  Every ADR #11 binding from iterations 1-3 is preserved:
+  lineage permanent / payloads last 6 + pinned (collected revs fail loud),
+  secret diffs = write-presence without reveal-history vs comparison +
+  per-key ceremony with it, restore = normal publish pipeline (flat-model
+  set/clear, current-schema re-validation, reveal-history refusal for
+  secret restores, #21 ceremony for protected), pins = durable owned
+  quota-bounded expiring resources (non-current pin ⇒ ceremony; schema-fail
+  pin ⇒ recorded override; retention-holding pin flagged with release).
+  Long ADR prose is demoted to (?) tooltips everywhere.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- shared history bits ---------------- */
+  .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  .pinrow{
+    margin:0 14px 8px;padding:9px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500;white-space:nowrap}
+  .pinrow .pw{color:var(--tx-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px;white-space:nowrap}
+  .wbadge{
+    font-size:9.5px;letter-spacing:.04em;font-weight:600;border-radius:999px;
+    padding:2px 8px;cursor:help;white-space:nowrap;border:none;
+  }
+  .wbadge.warn{color:var(--bad);background:var(--bad-soft)}
+  .wbadge.drift{color:var(--chg);background:var(--chg-soft)}
+  .pinrow .rel{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow .rel:hover{border-color:var(--bad);color:var(--bad)}
+  /* the plain-language gap line — visible, never tooltip-only (Alex, it-2) */
+  .pinrow .pingap{flex-basis:100%;font-family:var(--sans);font-size:11px;
+    color:var(--tx-dim);line-height:1.5}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  /* pin sheet "what this does" block */
+  .pinwhat{margin-top:14px;padding:12px 14px;background:var(--bg);
+    border:1px solid var(--line);border-radius:6px}
+  .pinwhat .pwt{font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  .pinwhat ul{list-style:none;display:grid;gap:7px}
+  .pinwhat li{font-size:12.5px;color:var(--tx-dim);line-height:1.55;
+    display:flex;gap:9px;align-items:baseline}
+  .pinwhat li::before{content:'·';color:var(--accent);font-weight:700;flex:none}
+  .pinwhat li b{color:var(--tx)}
+  .pinwhat .mono{font-family:var(--mono);font-size:11.5px}
+  .hint{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:15px;height:15px;border-radius:999px;border:1px solid var(--line);
+    font-size:9.5px;color:var(--tx-faint);cursor:help;flex:none;vertical-align:-2px;
+  }
+  .hint:hover{border-color:var(--accent);color:var(--accent)}
+  .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px;white-space:nowrap}
+  .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .racts{display:flex;gap:6px;flex-wrap:wrap}
+  .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+
+  /* ---------------- history drawer (views a/b/c) ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  #hdrawer{width:min(640px,96vw)}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  .pendline b{color:var(--chg)}
+  /* retention line in the drawer head — the ⚙ entry into the retention sheet */
+  .retline{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .retline b{color:var(--tx)}
+  .retbtn{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);
+    border-radius:3px;padding:3px 9px;min-height:24px}
+  .retbtn:hover{border-color:var(--accent);color:var(--accent)}
+  /* retention sheet */
+  .retrow{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    font-size:12.5px;color:var(--tx-dim);margin-top:8px}
+  .retrow b{color:var(--tx)}
+  .retrow input[type=number]{
+    width:64px;font-family:var(--mono);font-size:13px;text-align:center;
+    background:var(--bg2);border:1px solid var(--accent);color:var(--tx);
+    border-radius:4px;padding:7px 6px}
+  .retrow input[type=number]:disabled{opacity:.45;border-color:var(--line)}
+  .retrow .rerr{flex-basis:100%;font-size:11px;color:var(--bad);font-family:var(--mono)}
+  .plist2{display:grid;gap:5px;margin-top:8px}
+  .plist2 .pj{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11.5px;
+    color:var(--tx-dim);padding:7px 11px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .plist2 .pj .pn{color:var(--tx)}
+  .plist2 .pj .st{margin-left:auto;font-size:10.5px}
+  .plist2 .pj .st.inh{color:var(--tx-faint)}
+  .plist2 .pj .st.cus{color:var(--chg)}
+  .plist2 .pj .st.cap{color:var(--bad)}
+  .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 70px}
+
+  /* view b — list + detail panes */
+  .panes{display:grid;grid-template-columns:170px 1fr;height:100%}
+  .panes .plist{border-right:1px solid var(--line);overflow-y:auto;padding:8px 0 70px}
+  .panes .plist button{
+    display:flex;align-items:center;gap:7px;width:100%;text-align:left;
+    padding:9px 12px;min-height:40px;border-left:2px solid transparent;
+  }
+  .panes .plist button:hover{background:var(--bg3)}
+  .panes .plist button.sel{background:var(--bg3);border-left-color:var(--accent)}
+  .panes .plist .rnum{font-family:var(--mono);font-size:12.5px;font-weight:500;color:var(--tx)}
+  .panes .plist button.cur .rnum{color:var(--accent)}
+  .panes .plist .age{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-left:auto}
+  .panes .plist .pdot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none}
+  .panes .plist .gdot{width:6px;height:6px;border-radius:50%;border:1px dashed var(--tx-faint);flex:none;opacity:.7}
+  .panes .pdetail{overflow-y:auto;padding:14px 16px 70px}
+  .pdetail .ph2{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .pdetail .ph2 .rnum{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--tx)}
+  .pdetail .meta{font-size:12px;color:var(--tx-dim);margin-top:6px;line-height:1.6}
+  .pdetail .meta b{color:var(--tx)}
+  .pdetail .chgrid{display:grid;gap:6px;margin-top:12px}
+  .pdetail .chrow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:8px 11px;font-family:var(--mono);font-size:11.5px;
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pdetail .chrow .lock{color:var(--bad);font-size:10px}
+  .pdetail .chrow .name{color:var(--tx);font-weight:500}
+  .pdetail .racts{margin-top:14px}
+  .pdetail .racts button{padding:8px 14px;min-height:36px;font-size:11.5px}
+
+  /* ---------------- centered modal ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+  .sumline{
+    display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .sumline .schip{border:1px solid var(--line);border-radius:999px;padding:3px 10px}
+  .sumline .schip.bad{border-color:var(--bad);color:var(--bad)}
+
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape, #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer{width:100vw}
+    .panes{grid-template-columns:120px 1fr}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+/* retention: org default + per-project override (Alex, iteration 5):
+   new projects inherit the org value; a modified project detaches (later
+   org changes no longer touch it); an inherited project follows org
+   changes; a project value may never EXCEED the org value — refused at
+   set time, and an org lowering clamps existing overrides loudly. */
+let ORG_RETENTION=6;
+const PROJ_RETENTION={
+  'hikyo-demo':{mode:'inherit'},
+  'sample-kanban':{mode:'custom',n:4},
+  'sample-catalog':{mode:'inherit'},
+  'sample-tracker':{mode:'custom',n:10}, /* set while org was 12; org lowered since ⇒ capped */
+};
+const effRetention=p=>{
+  const r=PROJ_RETENTION[p];
+  return r.mode==='inherit'?ORG_RETENTION:Math.min(r.n,ORG_RETENTION);
+};
+/* the matrix project — everything in this prototype keys off it */
+const retainN=()=>effRetention('hikyo-demo');
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+const PIN_QUOTA=5;
+/* a pin is a WORKLOAD BINDING: at most one pin per (workload, environment).
+   Re-pinning a bound workload is a MOVE, never a second pin. Different
+   workloads pinning the same revision is legal (separate rows). */
+const WORKLOADS=['api-server (k8s)','billing-batch (compose)','cron-reports (compose)'];
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinOf=(envId,workload)=>PINS.find(p=>p.envId===envId&&p.workload===workload);
+/* sole keeper: this pin alone keeps its revision's values past retention */
+const isSoleKeeper=p=>{
+  const idx=HIST[p.envId].findIndex(r=>r.rev===p.rev);
+  return idx>=retainN()&&!PINS.some(o=>o.id!==p.id&&o.envId===p.envId&&o.rev===p.rev);
+};
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<retainN()||pinnedRevs(envId).has(rev));
+}
+
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const S={
+  role:'dev',
+  collapsed:new Set(),
+  drafts:new Map(),
+  reauthUntil:0,
+  reauth:null,
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev), sel:rev, openCard:rev}
+  sheet:null,
+  revealedHist:new Set(),
+};
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ---- (?) tooltip copy: the ADR reasoning lives here, not in the flow ---- */
+const TIP={
+  retention:()=>`Lineage (who published what, when) is permanent. The VALUES of old revisions are garbage-collected: kept for the last ${retainN()} revisions plus anything pinned (demo values — ops spec #32 owns the real ones). A collected revision cannot be diffed by value, restored, or revealed — no replay-from-metadata path exists (ADR #11).`,
+  writePresence:()=>`Without reveal-history, secret rows show only that someone WROTE to the entry — never whether the plaintext differs. Comparison status is a guessing oracle: stage a guessed value, read "unchanged", recover a low-entropy secret bit by bit (ADR #11).`,
+  pin:()=>`Pinning freezes what one workload receives: it keeps getting exactly the pinned revision's values instead of latest, until the pin is released or expires. One pin per workload per environment — re-pinning moves the binding, it never stacks. Under the hood a pin is a durable authorized resource — owner, per-project quota, expiry — never a fetch parameter, so retention can see every reference and keeps the pinned values alive (ADR #11).`,
+  restore:()=>`Restore never rewrites history: it stages per-key changes reproducing the old outcome, they land as ordinary drafts, and publish runs the full pipeline — impact preview, per-env authorization, protected ceremony, validation against the CURRENT schema (ADR #11).`,
+};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history — shared builders ============================ */
+function rowActions(envId,r,opts){
+  const hist=HIST[envId];
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const idx=hist.findIndex(x=>x.rev===r.rev);
+  const big=opts?.big?'style="padding:8px 14px;min-height:36px;font-size:11.5px"':'';
+  return`<div class="racts">
+    ${idx<hist.length-1?`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs previous</button>`:''}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();tryRestore('${envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable (ADR #11)"'}>restore…</button>`}
+    <button ${big} onclick="event.stopPropagation();tryPin('${envId}',${r.rev})">pin…</button>
+    ${retained?'':`<button ${big} onclick="event.stopPropagation();gcExplain(${r.rev})">why unavailable?</button>`}
+  </div>`;
+}
+function keysLine(r){
+  return r.changes.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+}
+function revTags(envId,r){
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const pinnedHere=pinsFor(envId).filter(p=>p.rev===r.rev);
+  return`${isCur?'<span class="tag curt">current</span>':''}
+    ${pinnedHere.length?`<span class="tag pint" title="pinned by ${esc(pinnedHere.map(p=>p.workload).join(', '))}">⚲</span>`:''}
+    ${retained?'':'<span class="tag gct" title="'+esc(TIP.retention())+'">collected</span>'}`;
+}
+function pinsHtml(envId){
+  const pins=pinsFor(envId);
+  if(!pins.length)return`<div class="pinnote">no pins — every workload here follows latest (r${curRev(envId)}). <span class="hint" title="${esc(TIP.pin())}">?</span></div>`;
+  return pins.map(p=>{
+    const behind=HIST[envId].findIndex(r=>r.rev===p.rev);
+    const sole=isSoleKeeper(p);
+    const entry=revEntry(envId,p.rev);
+    const drift=entry&&entry.schemaRev!=='s14';
+    return`<div class="pinrow">
+      <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+      <span class="pe">${p.expDays}d left</span>
+      ${sole?`<span class="wbadge warn" title="r${p.rev} is past normal retention (last ${retainN()} revisions). Its old values still exist ONLY because of this pin — releasing it deletes them permanently: no diff, no restore, no reveal.">⚠ sole keeper</span>`:''}
+      ${drift?`<span class="wbadge drift" title="Pinned under schema ${entry.schemaRev}; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).">Δ drift</span>`:''}
+      <button class="rel" onclick="releasePin(${p.id})">release</button>
+      <span class="pingap">${behind
+        ?`${esc(p.workload)} still runs on r${p.rev}'s values — ${behind} publish${behind>1?'es':''} behind latest (r${curRev(envId)}). New publishes don't reach it.`
+        :`pinned at latest — no gap yet, but the next publish will not reach ${esc(p.workload)}.`}${sole
+        ?` r${p.rev} is past normal retention: its values survive only because of this pin.`:''}</span>
+    </div>`}).join('');
+}
+function drawerHead(d){
+  const env=envById(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  return`<div class="dh">
+    <h3>↺ revision history
+      <span class="cur">current r${curRev(d.envId)}</span>
+      ${env.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+    <div class="envtabs">${readableEnvs().map(e=>
+      `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    <div class="retline">values kept: last <b>${retainN()}</b> revisions + pinned
+      ${PROJ_RETENTION['hikyo-demo'].mode==='inherit'?`<span class="wbadge" style="color:var(--tx-faint);border:1px solid var(--line)" title="this project has no retention of its own — it follows the org default and moves when the org value moves">inherits org</span>`:`<span class="wbadge" style="color:var(--chg);border:1px solid var(--chg)" title="this project overrode the org default — org changes no longer touch it">custom</span>`}
+      <button class="retbtn" onclick="openRetention()" title="revision retention — org default and project override">⚙ retention</button>
+      <span class="hint" title="${esc(TIP.retention())}">?</span></div>
+    ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+  </div>`;
+}
+function histList(d){
+  return HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+}
+function permFootnote(envId){
+  return canHistory(envId)?'':`<div class="pinnote" style="margin-top:14px">no <b>reveal-history</b> for this role: secret diffs show write-presence only, secret restores refused. <span class="hint" title="${esc(TIP.writePresence())}">?</span></div>`;
+}
+
+/* ============================ history — view b: list + detail panes ============================ */
+function renderPanes(d){
+  const hist=histList(d);
+  if(!hist.some(r=>r.rev===d.sel))d.sel=hist[0]?.rev;
+  const sel=hist.find(r=>r.rev===d.sel);
+  const retained=sel&&payloadRetained(d.envId,sel.rev);
+  return`${drawerHead(d)}
+    <div class="panes">
+      <div class="plist">
+        ${hist.map(r=>{
+          const isCur=r.rev===curRev(d.envId);
+          const rt=payloadRetained(d.envId,r.rev);
+          const pinned=pinnedRevs(d.envId).has(r.rev);
+          return`<button class="${r.rev===d.sel?'sel':''} ${isCur?'cur':''}" onclick="selRev(${r.rev})">
+            <span class="rnum">r${r.rev}</span>
+            ${pinned?'<span class="pdot" title="pinned"></span>':''}
+            ${rt?'':'<span class="gdot" title="payload collected"></span>'}
+            <span class="age">${ago(r.at)}</span>
+          </button>`}).join('')}
+      </div>
+      <div class="pdetail">
+        ${sel?`
+        <div class="ph2"><span class="rnum">r${sel.rev}</span>${revTags(d.envId,sel)}</div>
+        <div class="meta">published by <b>${esc(sel.actor)}</b> · ${ago(sel.at)} · schema ${sel.schemaRev} pinned</div>
+        ${pinsFor(d.envId).filter(p=>p.rev===sel.rev).map(p=>`<div class="meta" style="color:var(--accent)">⚲ ${esc(p.workload)} receives <b>this revision's values</b>${sel.rev===curRev(d.envId)?'':` instead of latest (r${curRev(d.envId)})`} — until the pin is released or expires (${p.expDays}d)</div>`).join('')}
+        ${retained?'':`<div class="meta" style="color:var(--tx-faint);font-style:italic">payload collected by retention (last ${retainN()} + pinned) — lineage below is permanent; value diff, restore and reveal are gone. <span class="hint" title="${esc(TIP.retention())}">?</span></div>`}
+        <div class="chgrid">
+          ${sel.changes.map(c=>{
+            const sk=keyByName(c.key)?.secret;
+            return`<div class="chrow">${sk?'<span class="lock">🔒</span>':''}<span class="name">${esc(c.key)}</span>
+              <span class="kindtag ${c.kind}">${c.kind}</span>
+              ${sk?`<span style="color:var(--tx-faint);font-size:10px">write-presence <span class="hint" title="${esc(TIP.writePresence())}">?</span></span>`:''}
+            </div>`}).join('')}
+        </div>
+        <div class="racts">${rowActions(d.envId,sel,{big:true})}</div>
+        <div class="dsec" style="padding:22px 0 6px">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin())}">?</span></span></div>
+        <div class="pinnote" style="margin:0 0 8px">a pinned workload stops following latest — it keeps receiving exactly the pinned revision's values, restarts included, until the pin is released or expires.</div>
+        <div style="margin:0 -14px">${pinsHtml(d.envId)}</div>
+        ${permFootnote(d.envId)}`:'<div class="meta">no revisions</div>'}
+      </div>
+    </div>`;
+}
+function selRev(rev){S.drawer.sel=rev;renderDrawer()}
+
+/* ============================ history — dispatch ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,sel:curRev(envId)};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){
+  S.drawer=null;
+  renderDrawer();render();
+}
+function drawerTab(envId){
+  S.drawer.envId=envId;
+  S.drawer.sel=curRev(envId);
+  renderDrawer();render();
+}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');return}
+  el.innerHTML=renderPanes(d);
+  el.classList.add('open');
+}
+
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (last ${retainN()} + pinned). Lineage is permanent; the values are gone — not restorable, not diffable, not revealable (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  /* releasing a sole-keeper pin permanently deletes its revision's values —
+     that deserves a confirm spelling out the consequence, not a silent zap */
+  if(isSoleKeeper(p)){S.sheet={mode:'release',pinId:id};renderSheet();return}
+  doRelease(id);
+}
+function doRelease(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  const gone=!payloadRetained(p.envId,p.rev);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})${gone?' · values collected':''}`);
+  toast(gone
+    ?`pin released — <b>r${p.rev}'s old values are gone</b> (past retention, no other pin kept them). ${esc(p.workload)} resumes latest on its next fetch.`
+    :`pin released — ${esc(p.workload)} resumes latest (r${curRev(p.envId)}) on its next fetch. r${p.rev}'s values stay inside the retention window.`);
+  closeSheet();renderDrawer();render();
+}
+function renderReleaseSheet(){
+  const p=PINS.find(x=>x.id===S.sheet.pinId);
+  const env=envById(p.envId);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>release pin <span style="color:var(--accent)">r${p.rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}</h2>
+    <div class="pinwhat" style="border-color:var(--bad)">
+      <div class="pwt" style="color:var(--bad)">this permanently deletes r${p.rev}'s values</div>
+      <ul>
+        <li>r${p.rev} is past normal retention (last ${retainN()} revisions) — <b>this pin is the only thing keeping its values</b>.</li>
+        <li>after release they are <b>collected</b>: no diff by value, no restore, no reveal. The timeline entry (who changed what, when) stays.</li>
+        <li>${esc(p.workload)} resumes <b>latest (r${curRev(p.envId)})</b> on its next fetch.</li>
+      </ul>
+    </div>
+    <div class="acts">
+      <button class="btn danger" onclick="doRelease(${p.id})">release — delete r${p.rev}'s values</button>
+      <button class="btn" onclick="closeSheet()">keep the pin</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  const isCur=rev===curRev(envId);
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  /* default to the first workload not yet pinned in this env, else first */
+  const wl=WORKLOADS.find(w=>!pinOf(envId,w))||WORKLOADS[0];
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false,workload:wl};
+  renderSheet();
+}
+function setPinWorkload(w){S.sheet.workload=w;renderSheet()}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const existing=pinOf(envId,workload);
+  if(existing&&existing.rev===rev){
+    toast(`${esc(workload)} is already pinned to r${rev} — nothing to do. One pin per workload; pinning again would change nothing (a workload fetches exactly one revision).`,'err');
+    return;
+  }
+  if(!existing&&pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA}) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    if(existing){
+      /* MOVE: one pin per (workload, env) — replace atomically, never a second pin */
+      const from=existing.rev;
+      existing.rev=rev;existing.by='you';existing.expDays=30;
+      audit('pin moved',`${esc(workload)} r${from} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ moved ${esc(workload)} from r${from} to r${rev} — it fetches r${rev}'s values from its next fetch on.${payloadRetained(envId,from)?'':` r${from}'s values were kept only by this pin and are now collected.`}`);
+    }else{
+      PINS.push({id:nextPinId++,envId,rev,workload,by:'you',expDays:30});
+      audit('pin created',`${esc(workload)} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ pinned ${esc(workload)} to r${rev} — values retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    }
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span>
+        <span style="color:var(--tx-faint);font-size:10px;margin-left:auto">write-presence <span class="hint" title="${esc(TIP.writePresence())}">?</span></span></div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'?'changed':cmp==='unchanged'?'unchanged':cmp}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 ${canH
+      ?`comparison shown (this role holds <b>reveal-history</b>); plaintext is a separate per-key ceremony, audited.`
+      :`write-presence only for this role <span class="hint" title="${esc(TIP.writePresence())}">?</span>`}</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now)continue;
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const nSet=plan.filter(p=>p.action==='set').length;
+  const nClear=plan.filter(p=>p.action==='clear').length;
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'set':'clear'}</span>
+        ${p.action==='set'&&!p.secret?`<span style="color:var(--tx-faint);font-size:10.5px">→ ${esc(p.value)}</span>`:''}
+      </div>
+      ${permBlock?`<div class="verr">needs reveal-history — restoring an earlier secret is a historical disclosure (ADR #11); your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved: ${esc(fixes[p.key])} staged instead of the historical value</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}
+      <span class="hint" title="${esc(TIP.restore())}">?</span></h2>
+    <div class="sub">Stages drafts reproducing r${rev} — publish runs the normal pipeline, history is never rewritten.</div>
+    <div class="sumline">
+      ${nSet?`<span class="schip">${nSet} set</span>`:''}
+      ${nClear?`<span class="schip">${nClear} clear</span>`:''}
+      ${unresolved.length?`<span class="schip bad">${unresolved.length} schema-blocked</span>`:''}
+      ${blockedPerm?`<span class="schip bad">needs reveal-history</span>`:''}
+      ${!plan.length?`<span class="schip">already matches — nothing to stage</span>`:''}
+    </div>
+    <div class="dgrid" style="margin-top:12px">${plan.map(rowHtml).join('')}</div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">restores re-validate against the <b>current</b> schema, not r${rev}'s — resolve the blocked keys explicitly, or cancel.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Per-environment authorization at commit; protected environments run the ceremony. Same pipeline as any publish. <span class="hint" title="${esc(TIP.restore())}">?</span></div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const existing=pinOf(envId,workload);
+  const isMove=existing&&existing.rev!==rev;
+  const isNoop=existing&&existing.rev===rev;
+  /* vs-latest summary — phrased from the workload's point of view.
+     Disclosure rules unchanged: config plaintext; secret comparison only
+     with reveal-history (a non-current pin already required it), values
+     always masked here. */
+  let gapBlock='';
+  if(!isCur){
+    const rows=diffRows(envId,rev,curRev(envId));
+    const rowLine=r=>{
+      if(r.kind==='added')return`<li><b class="mono">${esc(r.key)}</b> — the workload will <b>not</b> have this key (added after r${rev})</li>`;
+      if(r.kind==='removed')return`<li><b class="mono">${esc(r.key)}</b> — the workload keeps this key (removed after r${rev})</li>`;
+      if(r.secret)return`<li>🔒 <b class="mono">${esc(r.key)}</b> — ${canH?(r.old!==r.new?'stays at an <b>older value</b> than latest':'same value as latest'):'written to since (write-presence only)'}</li>`;
+      return`<li><b class="mono">${esc(r.key)}</b> — stays at <b>${esc(r.old)}</b> (latest: ${esc(r.new)})</li>`;
+    };
+    gapBlock=`<div class="pinwhat">
+      <div class="pwt">compared to latest (r${curRev(envId)}) — ${rows.length} difference${rows.length!==1?'s':''}</div>
+      <ul>${rows.length?rows.map(rowLine).join(''):'<li>identical delivered content — the pin only freezes it going forward.</li>'}</ul>
+    </div>`;
+  }
+  const wlShort=esc(workload.split(' ')[0]);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ ${isMove?'move pin to':'pin'} <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}
+      <span class="hint" title="${esc(TIP.pin())}">?</span></h2>
+    <div class="sub" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:8px">
+      workload:
+      <select onchange="setPinWorkload(this.value)" aria-label="workload to pin"
+        style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:7px 10px;border-radius:4px;font-size:12.5px">
+        ${WORKLOADS.map(w=>{
+          const p=pinOf(envId,w);
+          return`<option value="${esc(w)}" ${w===workload?'selected':''}>${esc(w)}${p?` — pinned to r${p.rev}`:' — follows latest'}</option>`}).join('')}
+      </select>
+      <span style="color:var(--tx-faint)">quota ${pinsFor(envId).length}/${PIN_QUOTA} · expiry 30d</span>
+    </div>
+    ${isMove?`<div class="noperm" style="color:var(--chg)">⚲ ${esc(workload)} is currently pinned to <b>r${existing.rev}</b> — one pin per workload, so this <b>moves</b> it to r${rev} (the r${existing.rev} pin is replaced${isSoleKeeper(existing)?`, and r${existing.rev}'s values, kept only by that pin, are collected`:''}).</div>`:''}
+    ${isNoop?`<div class="noperm" style="color:var(--bad)">already pinned to r${rev} — a workload fetches exactly one revision, so pinning it again changes nothing.</div>`:''}
+    <div class="pinwhat">
+      <div class="pwt">what pinning does</div>
+      <ul>
+        <li><b>${wlShort} keeps receiving exactly r${rev}'s values</b> — across restarts and redeploys — instead of following latest.</li>
+        <li>new publishes to ${env.name} <b>stop reaching this workload</b> while the pin lives; everyone else still gets latest.</li>
+        <li>r${rev}'s values are <b>kept from retention clean-up</b> as long as the pin exists.</li>
+        <li>on release or expiry (30d) the workload <b>resumes latest on its next fetch</b> — surfaced loudly, never silent.</li>
+      </ul>
+    </div>
+    ${gapBlock}
+    ${isCur?'':`<div class="noperm">non-current revision: this routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" ${isNoop?'disabled':''} onclick="confirmPin()">${isMove?`move pin to r${rev}`:'create pin'}</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ retention sheet ============================ */
+function openRetention(){
+  const p=PROJ_RETENTION['hikyo-demo'];
+  S.sheet={mode:'retention',org:ORG_RETENTION,pmode:p.mode,pn:p.mode==='custom'?p.n:ORG_RETENTION};
+  renderSheet();
+}
+function renderRetentionSheet(){
+  const{org,pmode,pn}=S.sheet;
+  const isAdmin=S.role==='admin';
+  const dis=isAdmin?'':'disabled';
+  const overCap=pmode==='custom'&&pn>org;
+  const projState=(name)=>{
+    const r=PROJ_RETENTION[name];
+    /* preview against the STAGED org value so the propagation is visible */
+    if(r.mode==='inherit')return`<span class="st inh">inherits → ${org}</span>`;
+    if(r.n>org)return`<span class="st cap">custom ${r.n} — capped to ${org} by org ⚠</span>`;
+    return`<span class="st cus">custom ${r.n}</span>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>revision retention <span style="color:var(--tx-faint)">·</span> how long old values live
+      <span class="hint" title="${esc(TIP.retention())}">?</span></h2>
+    <div class="sub">Per environment, the last <b>N</b> revisions keep their values (pinned ones always do). Older values are collected — history (who changed what, when) stays forever. Changes are audited; collection runs by policy, never instantly.</div>
+
+    <div class="pinwhat">
+      <div class="pwt">org default — acme</div>
+      <div class="retrow">
+        keep last <input type="number" min="1" max="99" value="${org}" ${dis}
+          oninput="S.sheet.org=Math.max(1,+this.value||1);renderSheet()"> revisions
+        <span style="font-size:11px;color:var(--tx-faint)">new projects start here; projects still inheriting follow this value when it changes</span>
+      </div>
+      <div class="plist2">
+        ${Object.keys(PROJ_RETENTION).map(name=>`<div class="pj"><span class="pn">${esc(name)}</span>${projState(name)}</div>`).join('')}
+      </div>
+      <div style="font-size:11px;color:var(--tx-faint);margin-top:8px;line-height:1.55">a project that has overridden keeps its own value — lowering the org default does not rewrite it, but does <b style="color:var(--tx-dim)">cap</b> it (a project may never keep more than the org allows).</div>
+    </div>
+
+    <div class="pinwhat">
+      <div class="pwt">this project — hikyo-demo</div>
+      <div class="retrow">
+        <label style="display:flex;gap:7px;align-items:center"><input type="radio" name="rmode" ${pmode==='inherit'?'checked':''} ${dis}
+          onchange="S.sheet.pmode='inherit';renderSheet()"> inherit org default (currently ${org})</label>
+      </div>
+      <div class="retrow">
+        <label style="display:flex;gap:7px;align-items:center"><input type="radio" name="rmode" ${pmode==='custom'?'checked':''} ${dis}
+          onchange="S.sheet.pmode='custom';renderSheet()"> custom:</label>
+        keep last <input type="number" min="1" max="99" value="${pn}" ${pmode==='custom'&&isAdmin?'':'disabled'}
+          oninput="S.sheet.pn=Math.max(1,+this.value||1);renderSheet()"> revisions
+        <span style="font-size:11px;color:var(--tx-faint)">≤ org (${org}) · overriding detaches this project from later org changes</span>
+        ${overCap?`<span class="rerr">✕ cannot exceed the org retention (${org}) — a project may never keep more history than the org allows</span>`:''}
+      </div>
+    </div>
+    ${isAdmin?'':`<div class="noperm">read-only for your role — the org default needs org admin; project retention rides <b>project-settings</b> (ADR #15).</div>`}
+    <div class="acts">
+      <button class="btn primary" ${isAdmin&&!overCap?'':'disabled'} onclick="applyRetention()">apply</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function applyRetention(){
+  const{org,pmode,pn}=S.sheet;
+  const before=retainN();
+  const orgChanged=org!==ORG_RETENTION;
+  ORG_RETENTION=org;
+  const p=PROJ_RETENTION['hikyo-demo'];
+  const projChanged=pmode!==p.mode||(pmode==='custom'&&pn!==p.n);
+  PROJ_RETENTION['hikyo-demo']=pmode==='inherit'?{mode:'inherit'}:{mode:'custom',n:pn};
+  if(orgChanged)audit('retention-policy changed',`org default → keep last ${org} (projects still inheriting follow; overrides keep their value, capped at ${org})`);
+  if(projChanged)audit('retention-policy changed',`hikyo-demo → ${pmode==='inherit'?`inherit org (${org})`:`custom ${pn}`}${pmode==='custom'?' · detached from org changes':''}`);
+  const after=retainN();
+  if(after!==before)toast(after<before
+    ?`retention tightened ${before} → ${after}: revisions past the new window lose their values as collection runs (pinned ones stay). Timeline updated.`
+    :`retention widened ${before} → ${after}: nothing comes back — values already collected are gone (ADR #11); the wider window applies from now on.`);
+  closeSheet();renderDrawer();render();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet,release:renderReleaseSheet,retention:renderRetentionSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/6/index.html
+++ b/docs/site/public/prototypes/revision-history/6/index.html
@@ -1,0 +1,1487 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>PROTOTYPE — Hikyo version history &amp; rollback (ticket #30)</title>
+<!--
+  THROWAWAY PROTOTYPE — wayfinder ticket #30, iteration 6 "RETENTION MOVES OUT".
+  Alex's iteration-5 verdict: retention SETTINGS belong in the settings
+  surfaces (app-chrome #29), not in the history drawer. The editing sheet
+  moved to prototype/app-chrome/16/ (project settings › Policy + org
+  settings › Policy). The drawer keeps a READ-ONLY line: effective window,
+  inherits-org/custom badge, and a pointer to project settings.
+  Retention semantics carried unchanged from iteration 5:
+  Alex's iteration-4→5 ask: revision retention becomes configurable per org
+  AND per project — new projects inherit the org default; a project that
+  overrides DETACHES (later org changes no longer touch it); a project
+  still inheriting follows org changes; a project value may never exceed
+  the org value (refused at set time; an org lowering clamps existing
+  overrides loudly, shown as "capped by org"). Feelable via the ⚙ retention
+  sheet from the drawer head: org stepper + per-project state list +
+  this-project inherit/custom radio; applying re-renders the timeline so
+  "collected" tags move live. Retention changes are audited (#24 registry:
+  retention-policy change). Spec note: #15 already places #11's payload
+  policy under project-settings at project scope; the org default +
+  inherit-until-modified + org cap is NEW — recorded in NOTES.md for the
+  UI spec / #32 / #27.
+  Carried from iteration 4 "PIN = WORKLOAD BINDING":
+  1. "holds payload" is jargon. Replaced by plain consequence language:
+     badge -> "sole keeper", the gap sentence says "r21 is past normal
+     retention — its values survive only because of this pin", and
+     RELEASING such a pin now asks for confirmation spelling out that the
+     values are permanently collected (no diff, no restore, no reveal).
+  2. The same revision could be pinned twice — senseless for one workload.
+     The pin model is now explicitly a WORKLOAD BINDING: a workload has at
+     most ONE pin per environment. The pin sheet gains a workload picker;
+     choosing a workload that is already pinned turns the sheet into a
+     MOVE ("api-server currently runs r27 — this moves it to r25") and
+     replaces the old pin atomically. Two DIFFERENT workloads pinning the
+     same revision remains legal and reads as separate rows.
+  Iteration-3 surface otherwise unchanged: list + detail panes (it-2
+  verdict), visible plain-language pin clarity everywhere.
+  Every ADR #11 binding from iterations 1-3 is preserved:
+  lineage permanent / payloads last 6 + pinned (collected revs fail loud),
+  secret diffs = write-presence without reveal-history vs comparison +
+  per-key ceremony with it, restore = normal publish pipeline (flat-model
+  set/clear, current-schema re-validation, reveal-history refusal for
+  secret restores, #21 ceremony for protected), pins = durable owned
+  quota-bounded expiring resources (non-current pin ⇒ ceremony; schema-fail
+  pin ⇒ recorded override; retention-holding pin flagged with release).
+  Long ADR prose is demoted to (?) tooltips everywhere.
+  Demo timings compressed and labeled. Design context: PRODUCT.md /
+  DESIGN.md at repo root.
+-->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231d2b33'/%3E%3Cpath d='M8 12h16M8 16h16M8 20h10' stroke='%237fd0cd' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E">
+<style>
+  :root{
+    --mono:ui-monospace,monospace;
+    --sans:system-ui,sans-serif;
+    --bg:oklch(0.19 0.012 220);
+    --bg2:oklch(0.225 0.014 220);
+    --bg3:oklch(0.27 0.016 220);
+    --line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);
+    --tx-dim:oklch(0.76 0.01 210);
+    --tx-faint:oklch(0.60 0.012 215);
+    --accent:oklch(0.82 0.09 195);
+    --on-accent:oklch(0.2 0.02 220);
+    --accent-soft:oklch(0.82 0.09 195/.14);
+    --bad:oklch(0.74 0.13 25);
+    --bad-soft:oklch(0.74 0.13 25/.14);
+    --chg:oklch(0.8 0.06 250);
+    --chg-soft:oklch(0.8 0.06 250/.14);
+    --ok:oklch(0.8 0.1 150);
+    --rowalt:oklch(0.93 0.008 200/.045);
+    --rowalt-solid:oklch(0.218 0.013 220);
+    --sheet-shadow:0 -12px 40px oklch(0 0 0/.5);
+  }
+  [data-theme=light]{
+    --bg:oklch(0.965 0.008 200);
+    --bg2:oklch(0.935 0.01 200);
+    --bg3:oklch(0.895 0.012 200);
+    --line:oklch(0.82 0.014 210);
+    --tx:oklch(0.25 0.03 225);
+    --tx-dim:oklch(0.4 0.025 220);
+    --tx-faint:oklch(0.52 0.02 218);
+    --accent:oklch(0.45 0.085 210);
+    --on-accent:oklch(0.97 0.008 200);
+    --accent-soft:oklch(0.45 0.085 210/.1);
+    --bad:oklch(0.48 0.14 30);
+    --bad-soft:oklch(0.48 0.14 30/.1);
+    --chg:oklch(0.45 0.08 255);
+    --chg-soft:oklch(0.45 0.08 255/.12);
+    --ok:oklch(0.5 0.12 150);
+    --rowalt:oklch(0.25 0.03 225/.07);
+    --rowalt-solid:oklch(0.943 0.009 200);
+    --sheet-shadow:0 -12px 40px oklch(0.3 0.02 220/.25);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{background:var(--bg)}
+  body{
+    background:var(--bg);color:var(--tx);font-family:var(--sans);
+    font-size:14px;-webkit-font-smoothing:antialiased;
+    height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+    padding-bottom:env(safe-area-inset-bottom);
+  }
+  button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}
+  input,select{font:inherit}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+  :is(button,select,input):focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* ---------------- header ---------------- */
+  header{
+    display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    padding:12px 16px;border-bottom:1px solid var(--line);
+    background:var(--bg);flex:none;
+  }
+  header .crumb{font-weight:600;font-size:15px;letter-spacing:.01em}
+  header .crumb span{color:var(--accent)}
+  header .grow{flex:1}
+  header .ctl{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--tx-dim)}
+  header select{
+    background:var(--bg2);border:1px solid var(--line);color:var(--tx);
+    padding:7px 10px;border-radius:4px;font-size:13px;
+  }
+  header .iconbtn{
+    border:1px solid var(--line);border-radius:4px;padding:7px 0;font-size:13px;color:var(--tx-dim);
+    min-height:36px;min-width:38px;display:inline-flex;align-items:center;justify-content:center;
+  }
+  header .iconbtn:hover{border-color:var(--accent);color:var(--accent)}
+  header .drafts{
+    font-size:12.5px;color:var(--chg);border:1px solid var(--chg);border-radius:999px;padding:6px 12px;
+    font-weight:600;
+  }
+  header .drafts:hover{background:var(--chg);color:var(--bg)}
+
+  /* ---------------- matrix ---------------- */
+  .wrap{flex:1;overflow:auto;overscroll-behavior:contain}
+  table{border-collapse:separate;border-spacing:0;min-width:100%}
+  thead th{
+    position:sticky;top:0;z-index:4;background:var(--bg);text-align:left;
+    padding:10px 12px 8px;border-bottom:1px solid var(--line);
+    font-size:12px;font-weight:600;
+  }
+  thead th.keyh{
+    position:sticky;left:0;z-index:5;background:var(--bg);
+    font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--tx-faint);
+    min-width:150px;max-width:200px;
+  }
+  thead th .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;margin-left:5px;vertical-align:2px}
+  thead th .revbtn{
+    display:inline-flex;align-items:center;gap:5px;margin-left:8px;
+    font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 8px;vertical-align:1px;
+  }
+  thead th .revbtn:hover{border-color:var(--accent);color:var(--accent)}
+  thead th .revbtn .pinned{color:var(--accent)}
+  tbody td{padding:5px 12px;border-bottom:1px solid oklch(from var(--line) l c h/.45)}
+  td.key{
+    position:sticky;left:0;background:var(--bg);z-index:2;
+    font-family:var(--mono);font-size:12px;white-space:nowrap;max-width:200px;
+  }
+  td.key .kn{display:inline-block;vertical-align:bottom;overflow:hidden;text-overflow:ellipsis;max-width:calc(100% - 34px);cursor:pointer}
+  td.key .kn:hover{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
+  td.key .lock{color:var(--bad);margin-right:5px}
+  tr.grp td{
+    position:sticky;top:calc(var(--gh,55px) - 1px);z-index:3;
+    background:var(--bg);padding:0;
+    border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  }
+  tr.grp button.gbtn{
+    display:flex;align-items:center;gap:10px;text-align:left;
+    position:sticky;left:0;max-width:100vw;
+    padding:13px 16px;min-height:42px;width:100%;
+    font-size:12px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  }
+  tr.grp .tri{transition:transform .18s cubic-bezier(.25,1,.5,1);font-size:10px;color:var(--tx-faint)}
+  tr.grp.closed .tri{transform:rotate(-90deg)}
+  tr.grp .gsum{
+    font-family:var(--mono);font-size:11px;font-weight:400;letter-spacing:0;text-transform:none;
+    color:var(--tx-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;min-width:0;
+  }
+  tr.grp .gcnt{font-weight:400;letter-spacing:0;color:var(--tx-faint);font-size:11px;text-transform:none}
+  tr.alt td{background:var(--rowalt)}
+  tr.alt td.key{background:var(--rowalt-solid)}
+
+  .cellv{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 10px;min-height:30px;border-radius:8px;cursor:pointer;
+  }
+  .cellv .tx{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-bottom:2px}
+  .cellv:hover{background:oklch(from var(--tx) l c h/.07)}
+  .cellv::after{content:'✎';font-size:10px;color:var(--tx-faint);margin-left:2px}
+  .cellv:hover::after{color:var(--accent)}
+  .cellv:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .cellv.dim{color:var(--tx-dim)}
+  .cellv.absent{color:var(--tx-faint)}
+  .cellv.absent .tx{min-width:20px;text-align:center}
+  .cellv .d{color:var(--chg);font-weight:700}
+  .cellv .draftdot{width:6px;height:6px;border-radius:50%;background:var(--chg);flex:none}
+  .cellv .odot{width:5px;height:5px;border-radius:50%;border:1px solid var(--chg);flex:none;opacity:.7}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;max-width:240px;
+    font-family:var(--mono);font-size:11.5px;line-height:1;
+    padding:7px 12px;border-radius:999px;white-space:nowrap;overflow:hidden;
+    min-height:30px;cursor:pointer;border:1px solid transparent;
+  }
+
+  /* ---------------- app shell ---------------- */
+  #app{display:grid;grid-template-columns:56px 210px 1fr;height:100dvh;overflow:hidden}
+  #main{display:flex;flex-direction:column;overflow:hidden;min-width:0}
+  #rail{display:flex;flex-direction:column;align-items:center;gap:8px;
+    padding:14px 0;border-right:1px solid var(--line);background:var(--bg2)}
+  #rail .pav{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;
+    justify-content:center;font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--tx-dim);
+    border:1px solid transparent}
+  #rail .pav:hover{border-color:var(--line);color:var(--tx)}
+  #rail .pav.act{background:var(--accent);color:var(--on-accent)}
+  #side{display:flex;flex-direction:column;overflow-y:auto;
+    border-right:1px solid var(--line);background:var(--bg2);padding:6px 0 20px}
+  #side .stitle{font-size:10px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 16px 6px;font-weight:700}
+  #side .srow{display:flex;align-items:center;gap:8px;width:100%;text-align:left;
+    padding:9px 16px;font-size:13px;color:var(--tx-dim);min-height:38px}
+  #side .srow:hover{color:var(--tx);background:var(--bg3)}
+  #side .srow.act{color:var(--tx);background:var(--accent-soft);font-weight:600}
+  #side .srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--tx-faint)}
+  #side .srow .mono{font-family:var(--mono);font-size:12px}
+  #side .srow .pb{margin-left:auto;font-size:10px;font-weight:600;color:var(--chg);
+    background:var(--chg-soft);border-radius:999px;padding:2px 8px}
+  #menubtn{display:none}
+  #sidescrim{position:fixed;inset:0;z-index:24;background:oklch(0 0 0/.35);display:none}
+  body.sideopen #sidescrim{display:block}
+
+  /* ---------------- shared history bits ---------------- */
+  .dsec{font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--tx-faint);padding:16px 18px 6px;font-weight:700;display:flex;align-items:baseline;gap:8px}
+  .dsec .q{letter-spacing:0;text-transform:none;font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:auto}
+  .pinrow{
+    margin:0 14px 8px;padding:9px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:6px;font-family:var(--mono);font-size:11px;color:var(--tx);
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pinrow .pr{color:var(--accent);font-weight:500;white-space:nowrap}
+  .pinrow .pw{color:var(--tx-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pinrow .pe{color:var(--tx-faint);font-size:10.5px;white-space:nowrap}
+  .wbadge{
+    font-size:9.5px;letter-spacing:.04em;font-weight:600;border-radius:999px;
+    padding:2px 8px;cursor:help;white-space:nowrap;border:none;
+  }
+  .wbadge.warn{color:var(--bad);background:var(--bad-soft)}
+  .wbadge.drift{color:var(--chg);background:var(--chg-soft)}
+  .pinrow .rel{margin-left:auto;font-size:10.5px;color:var(--tx-dim);
+    border:1px solid var(--line);border-radius:3px;padding:3px 9px;min-height:24px}
+  .pinrow .rel:hover{border-color:var(--bad);color:var(--bad)}
+  /* the plain-language gap line — visible, never tooltip-only (Alex, it-2) */
+  .pinrow .pingap{flex-basis:100%;font-family:var(--sans);font-size:11px;
+    color:var(--tx-dim);line-height:1.5}
+  .pinnote{margin:0 18px;font-size:11px;color:var(--tx-faint);line-height:1.55}
+  /* pin sheet "what this does" block */
+  .pinwhat{margin-top:14px;padding:12px 14px;background:var(--bg);
+    border:1px solid var(--line);border-radius:6px}
+  .pinwhat .pwt{font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--tx-faint);font-weight:700;margin-bottom:8px}
+  .pinwhat ul{list-style:none;display:grid;gap:7px}
+  .pinwhat li{font-size:12.5px;color:var(--tx-dim);line-height:1.55;
+    display:flex;gap:9px;align-items:baseline}
+  .pinwhat li::before{content:'·';color:var(--accent);font-weight:700;flex:none}
+  .pinwhat li b{color:var(--tx)}
+  .pinwhat .mono{font-family:var(--mono);font-size:11.5px}
+  .hint{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:15px;height:15px;border-radius:999px;border:1px solid var(--line);
+    font-size:9.5px;color:var(--tx-faint);cursor:help;flex:none;vertical-align:-2px;
+  }
+  .hint:hover{border-color:var(--accent);color:var(--accent)}
+  .tag{font-size:9.5px;letter-spacing:.06em;font-weight:600;border-radius:999px;padding:2px 8px;white-space:nowrap}
+  .tag.curt{color:var(--on-accent);background:var(--accent)}
+  .tag.pint{color:var(--accent);border:1px solid var(--accent)}
+  .tag.gct{color:var(--tx-faint);border:1px solid var(--line)}
+  .racts{display:flex;gap:6px;flex-wrap:wrap}
+  .racts button{
+    font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:26px;font-family:var(--mono)}
+  .racts button:hover{border-color:var(--accent);color:var(--accent)}
+  .racts button:disabled{opacity:.4;cursor:not-allowed}
+  .racts button:disabled:hover{border-color:var(--line);color:var(--tx-dim)}
+  .kindtag{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .kindtag.added{color:var(--ok);border:1px solid var(--ok)}
+  .kindtag.removed{color:var(--bad);border:1px solid var(--bad)}
+  .kindtag.edited{color:var(--chg);border:1px solid var(--chg)}
+  .kindtag.changed{color:var(--chg);background:var(--chg-soft)}
+  .kindtag.unchanged{color:var(--tx-faint);border:1px solid var(--line)}
+
+  /* ---------------- history drawer (views a/b/c) ---------------- */
+  #hdrawer{
+    position:fixed;top:0;right:0;bottom:0;width:min(440px,94vw);z-index:23;
+    background:var(--bg2);border-left:1px solid var(--line);
+    transform:translateX(105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+    display:flex;flex-direction:column;
+    box-shadow:-12px 0 40px oklch(0 0 0/.35);
+  }
+  #hdrawer.open{transform:none}
+  #hdrawer{width:min(640px,96vw)}
+  #hdrawer .dh{padding:16px 18px 12px;border-bottom:1px solid var(--line);flex:none}
+  #hdrawer .dh h3{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #hdrawer .dh h3 .pp{color:var(--bad);font-size:9.5px;letter-spacing:.08em;font-weight:600}
+  #hdrawer .dh h3 .cur{font-family:var(--mono);font-size:11px;color:var(--tx-faint);font-weight:400}
+  #hdrawer .dh .d-x{margin-left:auto;width:30px;height:30px;color:var(--tx-faint);border-radius:4px;
+    display:flex;align-items:center;justify-content:center;font-size:15px}
+  #hdrawer .dh .d-x:hover{color:var(--tx)}
+  .envtabs{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+  .envtabs button{
+    font-size:11.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:4px 10px;min-height:28px}
+  .envtabs button.act{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
+  .pendline{font-size:11.5px;color:var(--tx-dim);margin-top:10px;font-family:var(--mono)}
+  .pendline b{color:var(--chg)}
+  /* retention line in the drawer head — read-only; editing lives in the
+     settings surfaces (app-chrome/16), per Alex's it-5 verdict */
+  .retline{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .retline b{color:var(--tx)}
+  .retbtn{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);
+    border-radius:3px;padding:3px 9px;min-height:24px}
+  .retbtn:hover{border-color:var(--accent);color:var(--accent)}
+  .keyfilter{
+    display:flex;align-items:center;gap:8px;margin-top:10px;
+    font-family:var(--mono);font-size:11px;color:var(--accent);
+    background:var(--accent-soft);border-radius:3px;padding:5px 10px}
+  .keyfilter button{color:inherit;font-size:12px;margin-left:auto}
+  #hdrawer .dbody{flex:1;overflow-y:auto;padding:0 0 70px}
+
+  /* view b — list + detail panes */
+  .panes{display:grid;grid-template-columns:170px 1fr;height:100%}
+  .panes .plist{border-right:1px solid var(--line);overflow-y:auto;padding:8px 0 70px}
+  .panes .plist button{
+    display:flex;align-items:center;gap:7px;width:100%;text-align:left;
+    padding:9px 12px;min-height:40px;border-left:2px solid transparent;
+  }
+  .panes .plist button:hover{background:var(--bg3)}
+  .panes .plist button.sel{background:var(--bg3);border-left-color:var(--accent)}
+  .panes .plist .rnum{font-family:var(--mono);font-size:12.5px;font-weight:500;color:var(--tx)}
+  .panes .plist button.cur .rnum{color:var(--accent)}
+  .panes .plist .age{font-family:var(--mono);font-size:10px;color:var(--tx-faint);margin-left:auto}
+  .panes .plist .pdot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none}
+  .panes .plist .gdot{width:6px;height:6px;border-radius:50%;border:1px dashed var(--tx-faint);flex:none;opacity:.7}
+  .panes .pdetail{overflow-y:auto;padding:14px 16px 70px}
+  .pdetail .ph2{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .pdetail .ph2 .rnum{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--tx)}
+  .pdetail .meta{font-size:12px;color:var(--tx-dim);margin-top:6px;line-height:1.6}
+  .pdetail .meta b{color:var(--tx)}
+  .pdetail .chgrid{display:grid;gap:6px;margin-top:12px}
+  .pdetail .chrow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:8px 11px;font-family:var(--mono);font-size:11.5px;
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+  }
+  .pdetail .chrow .lock{color:var(--bad);font-size:10px}
+  .pdetail .chrow .name{color:var(--tx);font-weight:500}
+  .pdetail .racts{margin-top:14px}
+  .pdetail .racts button{padding:8px 14px;min-height:36px;font-size:11.5px}
+
+  /* ---------------- centered modal ---------------- */
+  #scrim{
+    position:fixed;inset:0;background:oklch(0 0 0/.45);z-index:25;
+    opacity:0;pointer-events:none;transition:opacity .18s;
+  }
+  #scrim.open{opacity:1;pointer-events:auto}
+  #sheet{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(640px,calc(100% - 32px));max-height:84vh;overflow-y:auto;
+    background:var(--bg2);border:1px solid var(--line);
+    border-radius:6px;z-index:26;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:18px 20px 24px;visibility:hidden;
+  }
+  #sheet.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #sheet .sheetclose{
+    display:flex;align-items:center;justify-content:center;
+    position:absolute;top:10px;right:10px;width:34px;height:34px;
+    border:1px solid transparent;border-radius:4px;color:var(--tx-faint);font-size:15px;
+  }
+  #sheet .sheetclose:hover{color:var(--tx);border-color:var(--line)}
+  #sheet h2{font-family:var(--mono);font-size:14px;font-weight:500;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  #sheet h2 .lock{color:var(--bad)}
+  #sheet .sub{font-size:12px;color:var(--tx-dim);margin-top:4px;line-height:1.55}
+  #sheet .sub b{color:var(--tx)}
+  .btn{border:1px solid var(--line);border-radius:4px;padding:11px 16px;font-size:13px;color:var(--tx-dim);min-height:44px}
+  .btn:hover{border-color:var(--accent);color:var(--accent)}
+  .btn.primary{background:var(--accent);color:var(--on-accent);border-color:var(--accent);font-weight:600}
+  .btn.primary:hover{filter:brightness(1.08);color:var(--on-accent)}
+  .btn.danger{color:var(--bad)}
+  .btn.danger:hover{border-color:var(--bad)}
+  .btn:disabled{opacity:.45;cursor:not-allowed}
+  #sheet .acts{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  #sheet .noperm{font-size:12px;color:var(--tx-faint);font-style:italic;margin-top:10px;line-height:1.55}
+  #sheet .cur{
+    font-family:var(--mono);font-size:13px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;padding:11px 14px;margin-top:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  #sheet .cur.dim{color:var(--tx-dim)}
+
+  .diffhead{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:12px;
+    font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);
+  }
+  .diffhead select{
+    background:var(--bg);border:1px solid var(--line);color:var(--tx);
+    padding:6px 8px;border-radius:4px;font-family:var(--mono);font-size:12px}
+  .dgrid{display:grid;gap:6px;margin-top:12px}
+  .drow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .drow .dk{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .drow .dk .lock{color:var(--bad);font-size:10px}
+  .drow .dk .name{color:var(--tx);font-weight:500}
+  .drow .dv{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:7px;
+    font-size:11px;color:var(--tx-dim)}
+  .drow .dv .old{text-decoration:line-through;text-decoration-color:oklch(from var(--bad) l c h/.6);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .new{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .drow .dv .arr{color:var(--tx-faint)}
+  .drow .wp{font-size:10.5px;color:var(--tx-faint);margin-top:6px;line-height:1.5}
+  .drow .dacts{display:flex;gap:6px;margin-top:7px}
+  .drow .dacts button{font-size:10.5px;color:var(--tx-dim);border:1px solid var(--line);border-radius:3px;
+    padding:3px 10px;min-height:24px}
+  .drow .dacts button:hover{border-color:var(--accent);color:var(--accent)}
+  .oraclenote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.6}
+  .oraclenote b{color:var(--tx-dim)}
+
+  .rprow{
+    background:var(--bg);border:1px solid var(--line);border-radius:6px;
+    padding:9px 12px;font-family:var(--mono);font-size:11.5px;
+  }
+  .rprow.blocked{border-color:var(--bad)}
+  .rprow.needsperm{border-color:oklch(from var(--bad) l c h/.5)}
+  .rprow .stg{font-size:9.5px;letter-spacing:.05em;font-weight:600;border-radius:999px;padding:2px 8px}
+  .stg.set{color:var(--accent);border:1px solid var(--accent)}
+  .stg.clear{color:var(--bad);border:1px solid var(--bad)}
+  .rprow .why{font-size:10.5px;color:var(--tx-faint);margin-top:5px;line-height:1.5}
+  .rprow .verr{font-size:10.5px;color:var(--bad);margin-top:5px;line-height:1.5}
+  .rprow input.fixval{
+    font-family:var(--mono);font-size:12px;background:var(--bg2);border:1px solid var(--accent);
+    color:var(--tx);border-radius:4px;padding:7px 10px;margin-top:6px;width:100%}
+  .sumline{
+    display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px;
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim)}
+  .sumline .schip{border:1px solid var(--line);border-radius:999px;padding:3px 10px}
+  .sumline .schip.bad{border-color:var(--bad);color:var(--bad)}
+
+  .pubenv{margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--line);border-radius:6px}
+  .pubenv .ph{display:flex;align-items:center;gap:8px;font-size:13px;flex-wrap:wrap}
+  .pubenv .ph b{font-weight:600}
+  .pubenv .ph .rev{font-family:var(--mono);font-size:11px;color:var(--tx-faint)}
+  .pubenv .ph .pp{color:var(--bad);font-size:10px;letter-spacing:.06em;font-weight:600}
+  .pubenv ul{list-style:none;margin-top:8px;display:grid;gap:4px}
+  .pubenv li{font-family:var(--mono);font-size:11.5px;color:var(--tx-dim);display:flex;gap:10px;align-items:baseline}
+  .pubenv li .nv{color:var(--tx);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:50%}
+
+  /* ---------------- reauth ceremony (frozen shape, #21) ---------------- */
+  #reauth{
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-46%) scale(.97);opacity:0;
+    width:min(420px,calc(100% - 32px));visibility:hidden;
+    background:var(--bg2);border:1px solid var(--accent);
+    border-radius:6px;z-index:28;box-shadow:var(--sheet-shadow);
+    transition:transform .22s cubic-bezier(.25,1,.5,1),opacity .18s;
+    padding:20px 22px 22px;
+  }
+  #reauth.open{transform:translate(-50%,-50%) scale(1);opacity:1;visibility:visible}
+  #reauth .rpurpose{
+    display:inline-flex;align-items:center;gap:7px;
+    font-family:var(--mono);font-size:11px;letter-spacing:.06em;
+    color:var(--accent);background:var(--accent-soft);
+    border-radius:999px;padding:4px 11px;margin-bottom:10px;
+  }
+  #reauth .rpurpose.prot{color:var(--bad);background:var(--bad-soft)}
+  #reauth h3{font-size:15px;font-weight:600;margin-bottom:4px}
+  #reauth .rsub{font-size:12.5px;color:var(--tx-dim);line-height:1.55}
+  #reauth .rkeys{
+    margin:12px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--line);
+    border-radius:4px;font-family:var(--mono);font-size:11.5px;color:var(--tx);
+    display:grid;gap:4px;max-height:130px;overflow-y:auto;
+  }
+  #reauth .rkeys .re{color:var(--tx-faint)}
+  #reauth .factor{
+    display:flex;align-items:center;gap:10px;width:100%;text-align:left;
+    margin-top:10px;padding:13px 14px;border:1px solid var(--line);border-radius:6px;
+    font-size:13.5px;color:var(--tx);min-height:52px;
+  }
+  #reauth .factor:hover{border-color:var(--accent)}
+  #reauth .factor .fi{font-size:19px;flex:none}
+  #reauth .factor .fh{font-size:11.5px;color:var(--tx-faint);display:block;margin-top:1px}
+  #reauth .factor.waiting{border-color:var(--accent);animation:pkpulse 1.1s ease-in-out infinite}
+  @keyframes pkpulse{50%{background:var(--accent-soft)}}
+  #reauth .totprow{display:flex;gap:8px;margin-top:10px}
+  #reauth .totprow input{
+    font-family:var(--mono);font-size:16px;letter-spacing:.35em;text-align:center;
+    background:var(--bg);border:1px solid var(--accent);color:var(--tx);
+    border-radius:6px;padding:11px 8px;width:100%;min-width:0;
+  }
+  #reauth .rnote{font-size:11px;color:var(--tx-faint);margin-top:12px;line-height:1.55}
+  #reauth .rnote b{color:var(--tx-dim)}
+  #reauth .rcancel{margin-top:12px;width:100%}
+
+  #toasts{
+    position:fixed;left:14px;bottom:calc(14px + env(safe-area-inset-bottom));z-index:40;
+    display:flex;flex-direction:column-reverse;gap:6px;pointer-events:none;max-width:min(460px,calc(100vw - 28px));
+  }
+  #toasts .toast{
+    font-family:var(--mono);font-size:11px;color:var(--tx-dim);
+    background:var(--bg2);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:6px;padding:8px 12px;box-shadow:0 6px 20px oklch(0 0 0/.35);
+    animation:tin .18s cubic-bezier(.25,1,.5,1);
+    overflow:hidden;text-overflow:ellipsis;white-space:normal;line-height:1.5;
+  }
+  #toasts .toast.audit{border-left-color:var(--bad)}
+  #toasts .toast.err{border-left-color:var(--bad);color:var(--bad)}
+  #toasts .toast b{color:var(--tx)}
+  @keyframes tin{from{opacity:0;transform:translateY(6px)}}
+
+  /* ---------------- mobile ---------------- */
+  @media (max-width:700px){
+    header{padding:10px 12px;gap:8px}
+    header .crumb{font-size:14px}
+    thead th{padding:8px 8px}
+    thead th.keyh{min-width:110px;max-width:130px}
+    td.key{max-width:130px;font-size:11px}
+    tbody td{padding:4px 8px}
+    .ctl .lbl{display:none}
+    #app{grid-template-columns:1fr}
+    #rail{display:none!important}
+    #side{
+      position:fixed;top:0;bottom:0;left:0;width:min(300px,80vw);z-index:25;
+      transform:translateX(-105%);transition:transform .2s cubic-bezier(.25,1,.5,1);
+      box-shadow:12px 0 40px oklch(0 0 0/.4);
+    }
+    #side.open{transform:none}
+    #menubtn{display:inline-flex}
+    #hdrawer{width:100vw}
+    .panes{grid-template-columns:120px 1fr}
+    .drow .dv{grid-template-columns:1fr;gap:2px}
+    .drow .dv .arr{display:none}
+  }
+</style>
+</head>
+<body data-theme="dark">
+<div id="app">
+<div id="rail"></div>
+<aside id="side"></aside>
+<div id="main">
+<header>
+  <button class="iconbtn" id="menubtn" onclick="setSide(!document.getElementById('side').classList.contains('open'))" title="menu" aria-label="open navigation">☰</button>
+  <span class="crumb">hikyo <span>/</span> acme <span>/</span> <span style="color:var(--tx)">demo</span></span>
+  <span class="grow"></span>
+  <button class="drafts" id="drafts" hidden onclick="openPublish()" title="review and publish"></button>
+  <span class="ctl"><span class="lbl">acting as</span>
+    <select id="role" title="simulated principal — reveal and reveal-history are independent grants (ADR #11/#15)" aria-label="acting as role">
+      <option value="admin">admin · reveal + history</option>
+      <option value="dev" selected>developer · reveal, NO history</option>
+      <option value="auditor">auditor · history, NO reveal</option>
+      <option value="viewer">viewer · neither</option>
+    </select>
+  </span>
+  <button class="iconbtn" id="themebtn" title="switch light / dark" aria-label="switch light or dark theme">◐</button>
+</header>
+
+<div class="wrap"><table id="matrix"></table></div>
+</div><!-- /main -->
+</div><!-- /app -->
+
+<div id="sidescrim" onclick="setSide(false)"></div>
+<aside id="hdrawer" aria-label="revision history"></aside>
+<div id="scrim"></div>
+<div id="sheet" role="dialog" aria-modal="true" aria-label="details"></div>
+<div id="reauth" role="dialog" aria-modal="true" aria-label="re-authentication"></div>
+<div id="toasts" aria-live="polite"></div>
+
+<script>
+/* ============================ domain data ============================ */
+/* FLAT MODEL — no inheritance; every value explicit (env-matrix verdict). */
+const ENVS=[
+  {id:'dev',name:'development'},
+  {id:'stg',name:'staging'},
+  {id:'prd',name:'production',protected:true},
+  {id:'pre',name:'preview'},
+];
+const envById=id=>ENVS.find(e=>e.id===id);
+
+const K=(folder,name,type,secret,values,desc)=>({folder,name,type,secret,values:values||{},desc});
+const all=v=>({dev:v,stg:v,prd:v,pre:v});
+const KEYS=[
+  K('app','APP_NAME','string',false,all('Hikyo Demo')),
+  K('app','APP_URL','url',false,{dev:'http://localhost:8080',stg:'https://stg.hikyo.dev',prd:'https://hikyo.dev',pre:'https://pr-{n}.preview.hikyo.dev'}),
+  K('app','PORT','int',false,all('8080')),
+  K('app','LOG_LEVEL','string',false,{dev:'debug',stg:'info',prd:'info',pre:'info'}),
+  K('app','FEATURE_MATRIX_V2','bool',false,{dev:'true',stg:'true',prd:'false',pre:'true'}),
+  K('database','DATABASE_URL','url',true,{dev:'postgres://hikyo:hikyo@localhost:5432/hikyo',stg:'postgres://hikyo@db.stg:5432/hikyo',prd:'postgres://hikyo@db.prd:5432/hikyo',pre:'postgres://hikyo@db.stg:5432/hikyo'}),
+  K('database','DB_POOL_SIZE','int',false,{dev:'10',stg:'25',prd:'40',pre:'10'}),
+  K('database','DB_SSL_MODE','string',false,{prd:'verify-full'}),
+  K('auth','SESSION_SECRET','string',true,{dev:'dev-only-not-secret',stg:'s3cr3t-stg-9f2e',prd:'s3cr3t-prd-77aa',pre:'s3cr3t-stg-9f2e'}),
+  K('auth','OIDC_CLIENT_ID','string',false,{stg:'ew-stg',prd:'ew-prd'}),
+  K('auth','OIDC_CLIENT_SECRET','string',true,{stg:'oidc-stg-secret',prd:'oidc-prd-secret'}),
+  K('mail','SMTP_HOST','string',false,{dev:'mail.internal',stg:'mail.internal',prd:'smtp.eu.mailer.dev',pre:'mail.internal'}),
+  K('mail','SMTP_PASSWORD','string',true,{stg:'stg-smtp-pass',prd:'prd-smtp-pass'}),
+  K('integrations','FORGEJO_TOKEN','string',true,{prd:'hik_1_at_x9k2m4'}),
+  K('integrations','S3_ACCESS_KEY_ID','string',true,{dev:'AKIADEFAULT0000',stg:'AKIADEFAULT0000',prd:'AKIAPRODONLY9999',pre:'AKIADEFAULT0000'}),
+  K('integrations','S3_SECRET_ACCESS_KEY','string',true,{dev:'wJalrXUtnFEMI/DEMO',stg:'wJalrXUtnFEMI/DEMO',prd:'wJalrXUtnFEMI/DEMO',pre:'wJalrXUtnFEMI/DEMO'}),
+  K('observability','SENTRY_DSN','url',false,{stg:'https://s1@sentry.io/11',prd:'https://s2@sentry.io/12'}),
+  K('observability','TRACE_SAMPLE_RATE','string',false,{dev:'1.0',stg:'0.5',prd:'0.1',pre:'1.0'}),
+];
+const keyByName=n=>KEYS.find(k=>k.name===n);
+const folders=()=>[...new Set(KEYS.map(k=>k.folder))];
+const CONSTRAINTS={PORT:{type:'int'},DB_POOL_SIZE:{type:'int'},TRACE_SAMPLE_RATE:{pattern:'0(\\.\\d+)?|1(\\.0+)?'}};
+function validateCurrent(key,val){
+  const c=CONSTRAINTS[key];const k=keyByName(key);
+  const type=c?.type||k.type;
+  if(type==='int'&&!/^-?\d+$/.test(val))return'must be a whole number (schema tightened in s12 — this historical value no longer validates)';
+  if(type==='bool'&&!/^(true|false)$/.test(val))return'must be true or false';
+  if(type==='url'&&!/^[a-z][a-z0-9+.-]*:\/\//i.test(val))return'must be a full URL';
+  if(c?.pattern&&!(new RegExp('^(?:'+c.pattern+')$')).test(val))return`must match pattern ${c.pattern}`;
+  return null;
+}
+
+/* retention: org default + per-project override (Alex, iteration 5):
+   new projects inherit the org value; a modified project detaches (later
+   org changes no longer touch it); an inherited project follows org
+   changes; a project value may never EXCEED the org value — refused at
+   set time, and an org lowering clamps existing overrides loudly. */
+let ORG_RETENTION=6;
+const PROJ_RETENTION={
+  'hikyo-demo':{mode:'inherit'},
+  'sample-kanban':{mode:'custom',n:4},
+  'sample-catalog':{mode:'inherit'},
+  'sample-tracker':{mode:'custom',n:10}, /* set while org was 12; org lowered since ⇒ capped */
+};
+const effRetention=p=>{
+  const r=PROJ_RETENTION[p];
+  return r.mode==='inherit'?ORG_RETENTION:Math.min(r.n,ORG_RETENTION);
+};
+/* the matrix project — everything in this prototype keys off it */
+const retainN=()=>effRetention('hikyo-demo');
+const NOW=Date.now();
+const h=(rev,actor,daysAgo,schemaRev,changes)=>({rev,actor,at:NOW-daysAgo*864e5,schemaRev,changes});
+const HIST={
+  prd:[
+    h(29,'alex',0.2,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'true',new:'false'},{key:'TRACE_SAMPLE_RATE',kind:'edited',old:'0.5',new:'0.1'}]),
+    h(28,'sam',2,'s14',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-old66',new:'s3cr3t-prd-77aa'}]),
+    h(27,'alex',5,'s13',[{key:'SMTP_HOST',kind:'edited',old:'mail.internal',new:'smtp.eu.mailer.dev'},{key:'SMTP_PASSWORD',kind:'edited',old:'prd-smtp-old',new:'prd-smtp-pass'}]),
+    h(26,'ci-deploy',9,'s13',[{key:'S3_ACCESS_KEY_ID',kind:'edited',old:'AKIAPRODOLD8888',new:'AKIAPRODONLY9999'},{key:'S3_SECRET_ACCESS_KEY',kind:'edited',old:'oldSecretKeyMaterial',new:'wJalrXUtnFEMI/DEMO'}]),
+    h(25,'sam',14,'s12',[{key:'DB_POOL_SIZE',kind:'edited',old:'ten',new:'40'},{key:'DB_SSL_MODE',kind:'added',old:undefined,new:'verify-full'}]),
+    h(24,'alex',20,'s11',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-prd-old',new:'oidc-prd-secret'}]),
+    h(23,'alex',26,'s11',[{key:'FORGEJO_TOKEN',kind:'added',old:undefined,new:'hik_1_at_x9k2m4'}]),
+    h(22,'sam',33,'s10',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s2@sentry.io/12'},{key:'LOG_LEVEL',kind:'edited',old:'warn',new:'info'}]),
+    h(21,'alex',41,'s10',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo@db-old.prd:5432/hikyo',new:'postgres://hikyo@db.prd:5432/hikyo'}]),
+    h(20,'alex',50,'s9',[{key:'TRACE_SAMPLE_RATE',kind:'added',old:undefined,new:'0.5'}]),
+    h(19,'sam',58,'s9',[{key:'APP_URL',kind:'edited',old:'https://old.hikyo.dev',new:'https://hikyo.dev'}]),
+    h(18,'alex',66,'s8',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-prd-ancient',new:'s3cr3t-prd-old66'}]),
+  ],
+  stg:[
+    h(38,'sam',1,'s14',[{key:'OIDC_CLIENT_SECRET',kind:'edited',old:'oidc-stg-old',new:'oidc-stg-secret'}]),
+    h(37,'alex',3,'s14',[{key:'DB_POOL_SIZE',kind:'edited',old:'10',new:'25'}]),
+    h(36,'alex',8,'s13',[{key:'SMTP_PASSWORD',kind:'edited',old:'stg-smtp-old',new:'stg-smtp-pass'}]),
+    h(35,'ci-deploy',15,'s12',[{key:'SESSION_SECRET',kind:'edited',old:'s3cr3t-stg-old11',new:'s3cr3t-stg-9f2e'}]),
+    h(34,'sam',24,'s11',[{key:'SENTRY_DSN',kind:'added',old:undefined,new:'https://s1@sentry.io/11'}]),
+  ],
+  dev:[
+    h(41,'alex',0.5,'s14',[{key:'LOG_LEVEL',kind:'edited',old:'info',new:'debug'}]),
+    h(40,'alex',4,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(39,'sam',11,'s13',[{key:'DATABASE_URL',kind:'edited',old:'postgres://hikyo:hikyo@127.0.0.1:5432/hikyo',new:'postgres://hikyo:hikyo@localhost:5432/hikyo'}]),
+  ],
+  pre:[
+    h(12,'alex',6,'s14',[{key:'FEATURE_MATRIX_V2',kind:'edited',old:'false',new:'true'}]),
+    h(11,'sam',18,'s12',[{key:'DATABASE_URL',kind:'added',old:undefined,new:'postgres://hikyo@db.stg:5432/hikyo'}]),
+  ],
+};
+const curRev=envId=>HIST[envId][0].rev;
+
+function snapshot(envId,rev){
+  const m=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  for(const rv of HIST[envId]){
+    if(rv.rev<=rev)break;
+    for(const c of rv.changes){
+      if(c.kind==='added')m.set(c.key,undefined);
+      else m.set(c.key,c.old);
+    }
+  }
+  return m;
+}
+const revEntry=(envId,rev)=>HIST[envId].find(r=>r.rev===rev);
+
+const PIN_QUOTA=5;
+/* a pin is a WORKLOAD BINDING: at most one pin per (workload, environment).
+   Re-pinning a bound workload is a MOVE, never a second pin. Different
+   workloads pinning the same revision is legal (separate rows). */
+const WORKLOADS=['api-server (k8s)','billing-batch (compose)','cron-reports (compose)'];
+let PINS=[
+  {id:1,envId:'prd',rev:27,workload:'api-server (k8s)',by:'alex',expDays:14},
+  {id:2,envId:'prd',rev:21,workload:'billing-batch (compose)',by:'sam',expDays:9},
+];
+let nextPinId=3;
+const pinsFor=envId=>PINS.filter(p=>p.envId===envId);
+const pinOf=(envId,workload)=>PINS.find(p=>p.envId===envId&&p.workload===workload);
+/* sole keeper: this pin alone keeps its revision's values past retention */
+const isSoleKeeper=p=>{
+  const idx=HIST[p.envId].findIndex(r=>r.rev===p.rev);
+  return idx>=retainN()&&!PINS.some(o=>o.id!==p.id&&o.envId===p.envId&&o.rev===p.rev);
+};
+const pinnedRevs=envId=>new Set(pinsFor(envId).map(p=>p.rev));
+function payloadRetained(envId,rev){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  return idx>-1&&(idx<retainN()||pinnedRevs(envId).has(rev));
+}
+
+const OTHERS_PENDING=[{key:'SESSION_SECRET',envId:'stg',who:'sam'},{key:'DB_POOL_SIZE',envId:'stg',who:'sam'}];
+
+/* ============================ state & permissions ============================ */
+const WINDOW_MS=90_000;
+const S={
+  role:'dev',
+  collapsed:new Set(),
+  drafts:new Map(),
+  reauthUntil:0,
+  reauth:null,
+  drawer:null,               // {envId, keyFilter?, expanded:Set(rev), sel:rev, openCard:rev}
+  sheet:null,
+  revealedHist:new Set(),
+};
+const ROLES={
+  admin:{read:e=>true,reveal:e=>true,history:e=>true},
+  dev:{read:e=>true,reveal:e=>!e.protected,history:e=>false},
+  auditor:{read:e=>true,reveal:e=>false,history:e=>true},
+  viewer:{read:e=>true,reveal:e=>false,history:e=>false},
+};
+const role=()=>ROLES[S.role];
+const canReveal=envId=>role().reveal(envById(envId));
+const canHistory=envId=>role().history(envById(envId));
+const readableEnvs=()=>ENVS.filter(e=>role().read(e));
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const MASK='••••••••';
+const ago=t=>{const d=(NOW-t)/864e5;return d<1?Math.round(d*24)+'h ago':Math.round(d)+'d ago'};
+
+/* ---- (?) tooltip copy: the ADR reasoning lives here, not in the flow ---- */
+const TIP={
+  retention:()=>`Lineage (who published what, when) is permanent. The VALUES of old revisions are garbage-collected: kept for the last ${retainN()} revisions plus anything pinned (demo values — ops spec #32 owns the real ones). A collected revision cannot be diffed by value, restored, or revealed — no replay-from-metadata path exists (ADR #11).`,
+  writePresence:()=>`Without reveal-history, secret rows show only that someone WROTE to the entry — never whether the plaintext differs. Comparison status is a guessing oracle: stage a guessed value, read "unchanged", recover a low-entropy secret bit by bit (ADR #11).`,
+  pin:()=>`Pinning freezes what one workload receives: it keeps getting exactly the pinned revision's values instead of latest, until the pin is released or expires. One pin per workload per environment — re-pinning moves the binding, it never stacks. Under the hood a pin is a durable authorized resource — owner, per-project quota, expiry — never a fetch parameter, so retention can see every reference and keeps the pinned values alive (ADR #11).`,
+  restore:()=>`Restore never rewrites history: it stages per-key changes reproducing the old outcome, they land as ordinary drafts, and publish runs the full pipeline — impact preview, per-env authorization, protected ceremony, validation against the CURRENT schema (ADR #11).`,
+};
+
+/* ============================ toasts & audit ============================ */
+function toast(html,cls){
+  const t=document.createElement('div');
+  t.className='toast '+(cls||'');t.innerHTML=html;
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(()=>t.remove(),6200);
+}
+const audit=(op,detail)=>toast(`audit · ${op} · ${detail}`,'audit');
+
+/* ============================ ceremony (frozen shape, #21) ============================ */
+function disclose(purpose,items,then){
+  const prot=items.some(i=>envById(i.envId).protected);
+  if(!prot&&Date.now()<S.reauthUntil){
+    S.reauthUntil=Date.now()+WINDOW_MS;
+    then();return;
+  }
+  S.reauth={purpose,items,prot,waiting:false,then};
+  renderReauth();
+}
+function cancelReauth(){S.reauth=null;renderReauth()}
+function reauthOK(){
+  const r=S.reauth;if(!r)return;
+  if(!r.prot)S.reauthUntil=Date.now()+WINDOW_MS;
+  S.reauth=null;renderReauth();
+  r.then();
+}
+function passkeyTap(){
+  const r=S.reauth;if(!r||r.waiting)return;
+  r.waiting=true;renderReauth();
+  setTimeout(reauthOK,900);
+}
+function totpInput(el){if(el.value.replace(/\D/g,'').length>=6)reauthOK()}
+function renderReauth(){
+  const el=document.getElementById('reauth');
+  const r=S.reauth;
+  if(!r){el.classList.remove('open');
+    if(!S.sheet)document.getElementById('scrim').classList.remove('open');
+    return}
+  const envNames=[...new Set(r.items.map(i=>envById(i.envId).name))].join(', ');
+  el.innerHTML=`
+    <span class="rpurpose ${r.prot?'prot':''}">${r.purpose} · ${esc(envNames)}${r.prot?' · PROTECTED':''}</span>
+    <h3>re-authenticate to ${r.purpose}</h3>
+    <div class="rsub">One decision over exactly the keys below — nothing else rides on it.</div>
+    <div class="rkeys">${r.items.map(i=>{
+      const k=keyByName(i.key);
+      return`<span>${k?.secret?'🔒 ':''}${esc(i.key)} <span class="re">@ ${envById(i.envId).name}${i.rev?' · rev '+i.rev:''}</span></span>`}).join('')}</div>
+    <button class="factor ${r.waiting?'waiting':''}" onclick="passkeyTap()">
+      <span class="fi">🔑</span>
+      <span>${r.waiting?'waiting for your passkey…':'use your passkey'}
+      <span class="fh">${r.waiting?'touch your authenticator (prototype: resolves by itself)':'tap, then touch your authenticator'}</span></span>
+    </button>
+    ${r.prot?'':`<div class="totprow"><input inputmode="numeric" autocomplete="one-time-code" maxlength="6"
+        placeholder="or TOTP code" aria-label="TOTP code" oninput="totpInput(this)"></div>`}
+    <div class="rnote">${r.prot
+      ?`<b>protected environment — window capped at 0.</b> Passkey per disclosure, no window granted (ADR #15/#16).`
+      :`Success opens a sliding reveal window (${WINDOW_MS/1000}s here). The permission check itself still runs on every disclosure.`}
+      <br>demo: TOTP accepts any 6 digits.</div>
+    <button class="btn rcancel" onclick="cancelReauth()">cancel</button>`;
+  el.classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+
+/* ============================ matrix render ============================ */
+function cellHtml(k,e){
+  const v=k.values[e.id];
+  const draft=S.drafts.get(k.name+':'+e.id);
+  const other=OTHERS_PENDING.find(o=>o.key===k.name&&o.envId===e.id);
+  const open=`onclick="openCell('${k.name}','${e.id}')" onkeydown="if(event.key==='Enter')openCell('${k.name}','${e.id}')" tabindex="0" role="button"`;
+  const dd=draft?`<span class="draftdot" title="your staged restore — unpublished"></span>`:'';
+  const od=other?`<span class="odot" title="${other.who} has a pending change here (quiet marker — ADR #11)"></span>`:'';
+  const lastRev=HIST[e.id][0];
+  const recent=lastRev.changes.some(c=>c.key===k.name);
+  const showCompare=!k.secret||canReveal(e.id);
+  const d=recent?`<span class="d" title="changed in rev ${lastRev.rev}${showCompare?'':' — write-presence only (no reveal here)'} — open history">Δ</span>`:'';
+  if(v===undefined&&!draft)return`<span class="cellv absent" ${open}><span class="tx">·</span>${od}</span>`;
+  let shown;
+  if(draft)shown=draft.action==='clear'?'· (will clear)':(k.secret?MASK:draft.value);
+  else shown=k.secret?MASK:v;
+  return`<span class="cellv ${k.secret?'dim':''}" ${open}><span class="tx">${esc(shown)}</span>${d}${dd}${od}</span>`;
+}
+function renderMatrix(){
+  const envs=readableEnvs();
+  const head=`<thead><tr><th class="keyh">key</th>${envs.map(e=>{
+    const pn=pinsFor(e.id).length;
+    return`<th style="min-width:190px">${e.name}${e.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="revbtn" onclick="openDrawer('${e.id}')" title="revision history of ${e.name}">
+        rev ${curRev(e.id)}${pn?` <span class="pinned">⚲${pn}</span>`:''} ·
+        history</button></th>`}).join('')}</tr></thead>`;
+  let body='';
+  for(const f of folders()){
+    let ri=0;
+    const ks=KEYS.filter(k=>k.folder===f);
+    const closed=S.collapsed.has(f);
+    const sum=closed?`<span class="gsum">${ks.map(k=>k.name).join(', ')}</span>`:'';
+    body+=`<tr class="grp ${closed?'closed':''}"><td colspan="${envs.length+1}">
+      <button class="gbtn" id="grp-${f}" onclick="toggleGroup('${f}')" aria-expanded="${!closed}">
+        <span class="tri">▾</span>${f}<span class="gcnt">${ks.length}</span>${sum}
+      </button></td></tr>`;
+    if(closed)continue;
+    for(const k of ks){
+      body+=`<tr class="${(ri++%2)?'alt':''}"><td class="key" title="${esc(k.name)}">${k.secret?'<span class="lock" title="secret">🔒</span>':''}<span class="kn" role="button" tabindex="0" onclick="openKeyHistory('${k.name}')" onkeydown="if(event.key==='Enter')openKeyHistory('${k.name}')" title="history of ${esc(k.name)}">${esc(k.name)}</span></td>`;
+      for(const e of envs)body+=`<td>${cellHtml(k,e)}</td>`;
+      body+='</tr>';
+    }
+  }
+  document.getElementById('matrix').innerHTML=head+`<tbody>${body}</tbody>`;
+}
+function toggleGroup(f){
+  if(S.collapsed.has(f))S.collapsed.delete(f);else S.collapsed.add(f);
+  render();
+}
+
+/* ============================ shell ============================ */
+const PROJECTS=['hikyo-demo','sample-kanban','sample-catalog','sample-tracker'];
+const monogram=p=>p.split(/[-_]/).map(w=>w[0]).join('').slice(0,2).toUpperCase();
+const projHue=p=>(PROJECTS.indexOf(p)*137.5)%360;
+function setSide(open){
+  document.getElementById('side').classList.toggle('open',open);
+  document.body.classList.toggle('sideopen',open);
+}
+function jumpGroup(f){
+  S.collapsed.delete(f);render();
+  document.getElementById('grp-'+f)?.scrollIntoView({behavior:'smooth',block:'start'});
+  setSide(false);
+}
+function renderShell(){
+  document.getElementById('side').innerHTML=`
+    <div class="stitle" style="padding-top:14px">hikyo-demo</div>
+    <div class="stitle">groups</div>
+    ${folders().map(f=>`<button class="srow" onclick="jumpGroup('${f}')"><span class="mono">${f}/</span>
+      <span class="cnt">${KEYS.filter(k=>k.folder===f).length}</span></button>`).join('')}
+    <div class="stitle">views</div>
+    ${readableEnvs().map(e=>`<button class="srow ${S.drawer?.envId===e.id?'act':''}" onclick="openDrawer('${e.id}')">↺ ${e.name} history<span class="cnt">r${curRev(e.id)}</span></button>`).join('')}
+    <button class="srow" ${S.drafts.size?'onclick="openPublish()"':'disabled style="opacity:.45;cursor:default" title="no staged changes"'}>Δ staged restore${S.drafts.size?`<span class="pb">${S.drafts.size}</span>`:''}</button>`;
+  document.getElementById('rail').innerHTML=
+    PROJECTS.map((p,i)=>`<button class="pav ${i===0?'act':''}" title="${p}"
+      style="${i===0?'':`background:oklch(0.32 0.04 ${projHue(p)});color:oklch(0.85 0.05 ${projHue(p)})`}"
+      ${i===0?'':`onclick="toast('prototype: only hikyo-demo is populated')"`}>${monogram(p)}</button>`).join('');
+  const dr=document.getElementById('drafts');
+  dr.hidden=S.drafts.size===0;
+  dr.textContent=`${S.drafts.size} staged restore${S.drafts.size>1?'s':''} · review & publish…`;
+}
+function syncGh(){
+  const th=document.querySelector('#matrix thead');
+  if(th)document.getElementById('matrix').style.setProperty('--gh',th.getBoundingClientRect().height+'px');
+}
+document.fonts?.ready.then(syncGh);
+addEventListener('resize',syncGh);
+
+/* ============================ history — shared builders ============================ */
+function rowActions(envId,r,opts){
+  const hist=HIST[envId];
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const idx=hist.findIndex(x=>x.rev===r.rev);
+  const big=opts?.big?'style="padding:8px 14px;min-height:36px;font-size:11.5px"':'';
+  return`<div class="racts">
+    ${idx<hist.length-1?`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'prev')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs previous</button>`:''}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();openDiff('${envId}',${r.rev},'cur')" ${retained?'':'disabled title="payload collected — value diff unavailable"'}>diff vs current</button>`}
+    ${isCur?'':`<button ${big} onclick="event.stopPropagation();tryRestore('${envId}',${r.rev})" ${retained?'':'disabled title="a collected revision is not restorable (ADR #11)"'}>restore…</button>`}
+    <button ${big} onclick="event.stopPropagation();tryPin('${envId}',${r.rev})">pin…</button>
+    ${retained?'':`<button ${big} onclick="event.stopPropagation();gcExplain(${r.rev})">why unavailable?</button>`}
+  </div>`;
+}
+function keysLine(r){
+  return r.changes.map(c=>{
+    const sk=keyByName(c.key)?.secret;
+    return`<span class="${sk?'sk':''}">${sk?'🔒':''}${esc(c.key)}</span>`}).join(', ');
+}
+function revTags(envId,r){
+  const isCur=r.rev===curRev(envId);
+  const retained=payloadRetained(envId,r.rev);
+  const pinnedHere=pinsFor(envId).filter(p=>p.rev===r.rev);
+  return`${isCur?'<span class="tag curt">current</span>':''}
+    ${pinnedHere.length?`<span class="tag pint" title="pinned by ${esc(pinnedHere.map(p=>p.workload).join(', '))}">⚲</span>`:''}
+    ${retained?'':'<span class="tag gct" title="'+esc(TIP.retention())+'">collected</span>'}`;
+}
+function pinsHtml(envId){
+  const pins=pinsFor(envId);
+  if(!pins.length)return`<div class="pinnote">no pins — every workload here follows latest (r${curRev(envId)}). <span class="hint" title="${esc(TIP.pin())}">?</span></div>`;
+  return pins.map(p=>{
+    const behind=HIST[envId].findIndex(r=>r.rev===p.rev);
+    const sole=isSoleKeeper(p);
+    const entry=revEntry(envId,p.rev);
+    const drift=entry&&entry.schemaRev!=='s14';
+    return`<div class="pinrow">
+      <span class="pr">⚲ r${p.rev}</span><span class="pw">${esc(p.workload)}</span>
+      <span class="pe">${p.expDays}d left</span>
+      ${sole?`<span class="wbadge warn" title="r${p.rev} is past normal retention (last ${retainN()} revisions). Its old values still exist ONLY because of this pin — releasing it deletes them permanently: no diff, no restore, no reveal.">⚠ sole keeper</span>`:''}
+      ${drift?`<span class="wbadge drift" title="Pinned under schema ${entry.schemaRev}; the current schema is s14. Delivered verbatim — reproducibility is the point of the pin (ADR #11).">Δ drift</span>`:''}
+      <button class="rel" onclick="releasePin(${p.id})">release</button>
+      <span class="pingap">${behind
+        ?`${esc(p.workload)} still runs on r${p.rev}'s values — ${behind} publish${behind>1?'es':''} behind latest (r${curRev(envId)}). New publishes don't reach it.`
+        :`pinned at latest — no gap yet, but the next publish will not reach ${esc(p.workload)}.`}${sole
+        ?` r${p.rev} is past normal retention: its values survive only because of this pin.`:''}</span>
+    </div>`}).join('');
+}
+function drawerHead(d){
+  const env=envById(d.envId);
+  const myPend=[...S.drafts.values()].filter(x=>x.envId===d.envId).length;
+  const othPend=OTHERS_PENDING.filter(o=>o.envId===d.envId);
+  return`<div class="dh">
+    <h3>↺ revision history
+      <span class="cur">current r${curRev(d.envId)}</span>
+      ${env.protected?'<span class="pp">PROTECTED</span>':''}
+      <button class="d-x" onclick="closeDrawer()" aria-label="close history">✕</button></h3>
+    <div class="envtabs">${readableEnvs().map(e=>
+      `<button class="${e.id===d.envId?'act':''}" onclick="drawerTab('${e.id}')">${e.name}</button>`).join('')}</div>
+    ${myPend||othPend.length?`<div class="pendline">${myPend?`<b>${myPend} staged by you</b> (unpublished)`:''}${myPend&&othPend.length?' · ':''}${othPend.length?`${othPend.length} pending by ${[...new Set(othPend.map(o=>o.who))].join(', ')}`:''}</div>`:''}
+    <div class="retline">values kept: last <b>${retainN()}</b> revisions + pinned
+      ${PROJ_RETENTION['hikyo-demo'].mode==='inherit'?`<span class="wbadge" style="color:var(--tx-faint);border:1px solid var(--line)" title="this project has no retention of its own — it follows the org default and moves when the org value moves">inherits org</span>`:`<span class="wbadge" style="color:var(--chg);border:1px solid var(--chg)" title="this project overrode the org default — org changes no longer touch it">custom</span>`}
+      <button class="retbtn" onclick="toast('retention is a settings concern: project settings › Policy › Revision retention (org default in org settings › Policy) — prototyped in app-chrome iteration 16')" title="change it in project settings › Policy (app-chrome/16)">→ project settings</button>
+      <span class="hint" title="${esc(TIP.retention())}">?</span></div>
+    ${d.keyFilter?`<div class="keyfilter">filtering: ${esc(d.keyFilter)} <button onclick="clearKeyFilter()" aria-label="clear key filter">✕</button></div>`:''}
+  </div>`;
+}
+function histList(d){
+  return HIST[d.envId].filter(r=>!d.keyFilter||r.changes.some(c=>c.key===d.keyFilter));
+}
+function permFootnote(envId){
+  return canHistory(envId)?'':`<div class="pinnote" style="margin-top:14px">no <b>reveal-history</b> for this role: secret diffs show write-presence only, secret restores refused. <span class="hint" title="${esc(TIP.writePresence())}">?</span></div>`;
+}
+
+/* ============================ history — view b: list + detail panes ============================ */
+function renderPanes(d){
+  const hist=histList(d);
+  if(!hist.some(r=>r.rev===d.sel))d.sel=hist[0]?.rev;
+  const sel=hist.find(r=>r.rev===d.sel);
+  const retained=sel&&payloadRetained(d.envId,sel.rev);
+  return`${drawerHead(d)}
+    <div class="panes">
+      <div class="plist">
+        ${hist.map(r=>{
+          const isCur=r.rev===curRev(d.envId);
+          const rt=payloadRetained(d.envId,r.rev);
+          const pinned=pinnedRevs(d.envId).has(r.rev);
+          return`<button class="${r.rev===d.sel?'sel':''} ${isCur?'cur':''}" onclick="selRev(${r.rev})">
+            <span class="rnum">r${r.rev}</span>
+            ${pinned?'<span class="pdot" title="pinned"></span>':''}
+            ${rt?'':'<span class="gdot" title="payload collected"></span>'}
+            <span class="age">${ago(r.at)}</span>
+          </button>`}).join('')}
+      </div>
+      <div class="pdetail">
+        ${sel?`
+        <div class="ph2"><span class="rnum">r${sel.rev}</span>${revTags(d.envId,sel)}</div>
+        <div class="meta">published by <b>${esc(sel.actor)}</b> · ${ago(sel.at)} · schema ${sel.schemaRev} pinned</div>
+        ${pinsFor(d.envId).filter(p=>p.rev===sel.rev).map(p=>`<div class="meta" style="color:var(--accent)">⚲ ${esc(p.workload)} receives <b>this revision's values</b>${sel.rev===curRev(d.envId)?'':` instead of latest (r${curRev(d.envId)})`} — until the pin is released or expires (${p.expDays}d)</div>`).join('')}
+        ${retained?'':`<div class="meta" style="color:var(--tx-faint);font-style:italic">payload collected by retention (last ${retainN()} + pinned) — lineage below is permanent; value diff, restore and reveal are gone. <span class="hint" title="${esc(TIP.retention())}">?</span></div>`}
+        <div class="chgrid">
+          ${sel.changes.map(c=>{
+            const sk=keyByName(c.key)?.secret;
+            return`<div class="chrow">${sk?'<span class="lock">🔒</span>':''}<span class="name">${esc(c.key)}</span>
+              <span class="kindtag ${c.kind}">${c.kind}</span>
+              ${sk?`<span style="color:var(--tx-faint);font-size:10px">write-presence <span class="hint" title="${esc(TIP.writePresence())}">?</span></span>`:''}
+            </div>`}).join('')}
+        </div>
+        <div class="racts">${rowActions(d.envId,sel,{big:true})}</div>
+        <div class="dsec" style="padding:22px 0 6px">pins <span class="q">${pinsFor(d.envId).length}/${PIN_QUOTA} <span class="hint" title="${esc(TIP.pin())}">?</span></span></div>
+        <div class="pinnote" style="margin:0 0 8px">a pinned workload stops following latest — it keeps receiving exactly the pinned revision's values, restarts included, until the pin is released or expires.</div>
+        <div style="margin:0 -14px">${pinsHtml(d.envId)}</div>
+        ${permFootnote(d.envId)}`:'<div class="meta">no revisions</div>'}
+      </div>
+    </div>`;
+}
+function selRev(rev){S.drawer.sel=rev;renderDrawer()}
+
+/* ============================ history — dispatch ============================ */
+function openDrawer(envId,keyFilter){
+  S.drawer={envId,keyFilter:keyFilter||null,sel:curRev(envId)};
+  renderDrawer();render();
+}
+function openKeyHistory(key){
+  openDrawer(S.drawer?.envId||'prd',key);
+}
+function closeDrawer(){
+  S.drawer=null;
+  renderDrawer();render();
+}
+function drawerTab(envId){
+  S.drawer.envId=envId;
+  S.drawer.sel=curRev(envId);
+  renderDrawer();render();
+}
+function clearKeyFilter(){S.drawer.keyFilter=null;renderDrawer()}
+function renderDrawer(){
+  const el=document.getElementById('hdrawer');
+  const d=S.drawer;
+  if(!d){el.classList.remove('open');return}
+  el.innerHTML=renderPanes(d);
+  el.classList.add('open');
+}
+
+function gcExplain(rev){
+  toast(`<b>r${rev}</b>: payload collected by retention policy (last ${retainN()} + pinned). Lineage is permanent; the values are gone — not restorable, not diffable, not revealable (ADR #11).`,'err');
+}
+function releasePin(id){
+  const p=PINS.find(x=>x.id===id);
+  /* releasing a sole-keeper pin permanently deletes its revision's values —
+     that deserves a confirm spelling out the consequence, not a silent zap */
+  if(isSoleKeeper(p)){S.sheet={mode:'release',pinId:id};renderSheet();return}
+  doRelease(id);
+}
+function doRelease(id){
+  const p=PINS.find(x=>x.id===id);
+  PINS=PINS.filter(x=>x.id!==id);
+  const gone=!payloadRetained(p.envId,p.rev);
+  audit('pin released',`r${p.rev} @ ${envById(p.envId).name} (${esc(p.workload)})${gone?' · values collected':''}`);
+  toast(gone
+    ?`pin released — <b>r${p.rev}'s old values are gone</b> (past retention, no other pin kept them). ${esc(p.workload)} resumes latest on its next fetch.`
+    :`pin released — ${esc(p.workload)} resumes latest (r${curRev(p.envId)}) on its next fetch. r${p.rev}'s values stay inside the retention window.`);
+  closeSheet();renderDrawer();render();
+}
+function renderReleaseSheet(){
+  const p=PINS.find(x=>x.id===S.sheet.pinId);
+  const env=envById(p.envId);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>release pin <span style="color:var(--accent)">r${p.rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}</h2>
+    <div class="pinwhat" style="border-color:var(--bad)">
+      <div class="pwt" style="color:var(--bad)">this permanently deletes r${p.rev}'s values</div>
+      <ul>
+        <li>r${p.rev} is past normal retention (last ${retainN()} revisions) — <b>this pin is the only thing keeping its values</b>.</li>
+        <li>after release they are <b>collected</b>: no diff by value, no restore, no reveal. The timeline entry (who changed what, when) stays.</li>
+        <li>${esc(p.workload)} resumes <b>latest (r${curRev(p.envId)})</b> on its next fetch.</li>
+      </ul>
+    </div>
+    <div class="acts">
+      <button class="btn danger" onclick="doRelease(${p.id})">release — delete r${p.rev}'s values</button>
+      <button class="btn" onclick="closeSheet()">keep the pin</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ pin create ============================ */
+function tryPin(envId,rev){
+  const isCur=rev===curRev(envId);
+  if(!isCur&&!canHistory(envId)){
+    toast(`<b>refused</b>: pinning a non-current revision needs <b>reveal-history</b> on ${envById(envId).name} — it routes historical content to a workload (ADR #15).`,'err');
+    return;
+  }
+  const snap=snapshot(envId,rev);
+  const schemaFail=[...snap.entries()].filter(([k,v])=>v!==undefined&&validateCurrent(k,v));
+  /* default to the first workload not yet pinned in this env, else first */
+  const wl=WORKLOADS.find(w=>!pinOf(envId,w))||WORKLOADS[0];
+  S.sheet={mode:'pin',envId,rev,isCur,schemaFail:schemaFail.map(([k])=>k),override:false,workload:wl};
+  renderSheet();
+}
+function setPinWorkload(w){S.sheet.workload=w;renderSheet()}
+function confirmPin(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const existing=pinOf(envId,workload);
+  if(existing&&existing.rev===rev){
+    toast(`${esc(workload)} is already pinned to r${rev} — nothing to do. One pin per workload; pinning again would change nothing (a workload fetches exactly one revision).`,'err');
+    return;
+  }
+  if(!existing&&pinsFor(envId).length>=PIN_QUOTA){
+    toast(`<b>pin quota reached</b> (${PIN_QUOTA}/${PIN_QUOTA}) — release a pin first. Quotas keep pins from defeating retention (ADR #11).`,'err');
+    return;
+  }
+  if(schemaFail.length&&!override){
+    toast(`<b>refused</b>: r${rev} fails the current schema (${schemaFail.join(', ')}) — tick the override to pin anyway, recorded as such (ADR #11).`,'err');
+    return;
+  }
+  const go=()=>{
+    if(existing){
+      /* MOVE: one pin per (workload, env) — replace atomically, never a second pin */
+      const from=existing.rev;
+      existing.rev=rev;existing.by='you';existing.expDays=30;
+      audit('pin moved',`${esc(workload)} r${from} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ moved ${esc(workload)} from r${from} to r${rev} — it fetches r${rev}'s values from its next fetch on.${payloadRetained(envId,from)?'':` r${from}'s values were kept only by this pin and are now collected.`}`);
+    }else{
+      PINS.push({id:nextPinId++,envId,rev,workload,by:'you',expDays:30});
+      audit('pin created',`${esc(workload)} → r${rev} @ ${envById(envId).name}${schemaFail.length?' · schema override RECORDED':''}`);
+      toast(`⚲ pinned ${esc(workload)} to r${rev} — values retained while the pin lives; expiry 30d (demo default → ops spec #32)`);
+    }
+    closeSheet();renderDrawer();render();
+  };
+  if(isCur)go();
+  else disclose('pin historical revision',[{key:'(delivery manifest of r'+rev+')',envId,rev}],go);
+}
+
+/* ============================ diff ============================ */
+function openDiff(envId,rev,mode){
+  const hist=HIST[envId];
+  const idx=hist.findIndex(r=>r.rev===rev);
+  const from=mode==='prev'?(hist[idx+1]?.rev??rev-1):rev;
+  const to=mode==='prev'?rev:curRev(envId);
+  S.sheet={mode:'diff',envId,from,to};
+  S.revealedHist.clear();
+  renderSheet();
+}
+function diffRows(envId,from,to){
+  const a=snapshot(envId,from),b=snapshot(envId,to);
+  const rows=[];
+  for(const k of KEYS){
+    const va=a.get(k.name),vb=b.get(k.name);
+    if(va===undefined&&vb===undefined)continue;
+    let kind=null;
+    if(va===undefined&&vb!==undefined)kind='added';
+    else if(va!==undefined&&vb===undefined)kind='removed';
+    else if(va!==vb)kind='edited';
+    if(kind)rows.push({key:k.name,secret:k.secret,kind,old:va,new:vb});
+  }
+  return rows;
+}
+function setDiffFrom(v){S.sheet.from=+v;S.revealedHist.clear();renderSheet()}
+function setDiffTo(v){S.sheet.to=+v;S.revealedHist.clear();renderSheet()}
+function renderDiffSheet(){
+  const{envId,from,to}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const rows=diffRows(envId,from,to);
+  const revOpts=sel=>HIST[envId].filter(r=>payloadRetained(envId,r.rev)).map(r=>
+    `<option value="${r.rev}" ${r.rev===sel?'selected':''}>r${r.rev}${r.rev===curRev(envId)?' (current)':''}</option>`).join('');
+  const rowHtml=r=>{
+    const id=envId+':'+from+'→'+to+':'+r.key;
+    if(!r.secret){
+      return`<div class="drow"><div class="dk"><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind}</span></div>
+        <div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>
+        ${r.old!==undefined&&r.kind==='edited'?`<div class="dacts"><button onclick="restoreOne('${envId}',${from},'${r.key}')" title="stage this single value as a pending change">restore this value</button></div>`:''}</div>`;
+    }
+    if(!canH){
+      return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${r.kind}">${r.kind==='edited'?'edited':r.kind}</span>
+        <span style="color:var(--tx-faint);font-size:10px;margin-left:auto">write-presence <span class="hint" title="${esc(TIP.writePresence())}">?</span></span></div></div>`;
+    }
+    const cmp=r.kind==='edited'?(r.old!==r.new?'changed':'unchanged'):r.kind;
+    const revealed=S.revealedHist.has(id);
+    return`<div class="drow"><div class="dk"><span class="lock">🔒</span><span class="name">${esc(r.key)}</span><span class="kindtag ${cmp==='changed'?'changed':cmp==='unchanged'?'unchanged':cmp}">${cmp}</span></div>
+      ${revealed
+        ?`<div class="dv"><span class="old">${r.old===undefined?'—':esc(r.old)}</span><span class="arr">→</span><span class="new">${r.new===undefined?'—':esc(r.new)}</span></div>`
+        :`<div class="dv"><span class="old">${r.old===undefined?'—':MASK}</span><span class="arr">→</span><span class="new" style="color:var(--tx-dim)">${r.new===undefined?'—':MASK}</span></div>`}
+      <div class="dacts">
+        ${revealed?'':`<button onclick="revealHist('${envId}',${from},${to},'${r.key}')" title="separate per-key disclosure — reauth immediately before rendering, audited with the revision read">reveal both sides</button>`}
+        ${r.kind==='edited'?`<button onclick="restoreOne('${envId}',${from},'${r.key}')">restore this value</button>`:''}
+      </div></div>`;
+  };
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>diff <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}</h2>
+    <div class="diffhead">
+      <select onchange="setDiffFrom(this.value)" aria-label="from revision">${revOpts(from)}</select>
+      <span>→</span>
+      <select onchange="setDiffTo(this.value)" aria-label="to revision">${revOpts(to)}</select>
+      <span style="margin-left:auto">${rows.length} difference${rows.length!==1?'s':''}</span>
+    </div>
+    <div class="dgrid">${rows.length?rows.map(rowHtml).join(''):'<div class="pinnote" style="margin:8px 0">no differences — identical delivered content.</div>'}</div>
+    <div class="oraclenote">🔒 ${canH
+      ?`comparison shown (this role holds <b>reveal-history</b>); plaintext is a separate per-key ceremony, audited.`
+      :`write-presence only for this role <span class="hint" title="${esc(TIP.writePresence())}">?</span>`}</div>`;
+  openModal();
+}
+function revealHist(envId,from,to,key){
+  const items=[{key,envId,rev:from+'→'+to}];
+  disclose('reveal history',items,()=>{
+    S.revealedHist.add(envId+':'+from+'→'+to+':'+key);
+    audit('historical reveal',`<b>${esc(key)}</b> @ ${envById(envId).name} · revs ${from}→${to} recorded`);
+    renderSheet();
+  });
+}
+
+/* ============================ restore ============================ */
+function tryRestore(envId,rev){
+  const snap=snapshot(envId,rev);
+  const cur=new Map(KEYS.map(k=>[k.name,k.values[envId]]));
+  const plan=[];
+  for(const k of KEYS){
+    const then=snap.get(k.name),now=cur.get(k.name);
+    if(then===undefined&&now===undefined)continue;
+    if(then===now)continue;
+    if(then===undefined)plan.push({key:k.name,secret:k.secret,action:'clear',value:undefined,now});
+    else plan.push({key:k.name,secret:k.secret,action:'set',value:then,now});
+  }
+  const withVal=plan.filter(p=>p.action==='set');
+  const secretRestores=withVal.filter(p=>p.secret);
+  const canH=canHistory(envId);
+  const schemaErrs={};
+  for(const p of withVal){
+    const err=validateCurrent(p.key,p.value);
+    if(err)schemaErrs[p.key]=err;
+  }
+  S.sheet={mode:'restore',envId,rev,plan,schemaErrs,fixes:{},blockedPerm:secretRestores.length&&!canH};
+  renderSheet();
+}
+function renderRestoreSheet(){
+  const{envId,rev,plan,schemaErrs,fixes,blockedPerm}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const unresolved=Object.keys(schemaErrs).filter(k=>!fixes[k]||validateCurrent(k,fixes[k]));
+  const nSet=plan.filter(p=>p.action==='set').length;
+  const nClear=plan.filter(p=>p.action==='clear').length;
+  const rowHtml=p=>{
+    const err=p.action==='set'?schemaErrs[p.key]:null;
+    const fixed=err&&fixes[p.key]&&!validateCurrent(p.key,fixes[p.key]);
+    const permBlock=p.secret&&p.action==='set'&&!canH;
+    return`<div class="rprow ${err&&!fixed?'blocked':''} ${permBlock?'needsperm':''}">
+      <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
+        ${p.secret?'<span style="color:var(--bad);font-size:10px">🔒</span>':''}
+        <span style="color:var(--tx);font-weight:500">${esc(p.key)}</span>
+        <span class="stg ${p.action==='set'?'set':'clear'}">${p.action==='set'?'set':'clear'}</span>
+        ${p.action==='set'&&!p.secret?`<span style="color:var(--tx-faint);font-size:10.5px">→ ${esc(p.value)}</span>`:''}
+      </div>
+      ${permBlock?`<div class="verr">needs reveal-history — restoring an earlier secret is a historical disclosure (ADR #11); your role cannot stage this.</div>`:''}
+      ${err&&!fixed?`<div class="verr">✕ blocked by CURRENT schema: ${esc(err)}</div>
+        <input class="fixval" placeholder="resolve explicitly — enter a value that passes the current schema" value="${esc(fixes[p.key]||'')}"
+          oninput="S.sheet.fixes['${p.key}']=this.value" onchange="renderSheet()">`:''}
+      ${fixed?`<div class="why" style="color:var(--ok)">✓ resolved: ${esc(fixes[p.key])} staged instead of the historical value</div>`:''}
+    </div>`;
+  };
+  const stageable=!blockedPerm&&unresolved.length===0&&plan.length>0;
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>restore <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}${env.protected?' <span class="lock">PROTECTED</span>':''}
+      <span class="hint" title="${esc(TIP.restore())}">?</span></h2>
+    <div class="sub">Stages drafts reproducing r${rev} — publish runs the normal pipeline, history is never rewritten.</div>
+    <div class="sumline">
+      ${nSet?`<span class="schip">${nSet} set</span>`:''}
+      ${nClear?`<span class="schip">${nClear} clear</span>`:''}
+      ${unresolved.length?`<span class="schip bad">${unresolved.length} schema-blocked</span>`:''}
+      ${blockedPerm?`<span class="schip bad">needs reveal-history</span>`:''}
+      ${!plan.length?`<span class="schip">already matches — nothing to stage</span>`:''}
+    </div>
+    <div class="dgrid" style="margin-top:12px">${plan.map(rowHtml).join('')}</div>
+    ${unresolved.length?`<div class="oraclenote" style="color:var(--bad)">restores re-validate against the <b>current</b> schema, not r${rev}'s — resolve the blocked keys explicitly, or cancel.</div>`:''}
+    <div class="acts">
+      <button class="btn primary" ${stageable?'':'disabled'} onclick="stageRestore()">stage ${plan.length} change${plan.length!==1?'s':''} as drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function stageRestore(){
+  const{envId,rev,plan,schemaErrs,fixes}=S.sheet;
+  for(const p of plan){
+    const value=p.action==='set'?(schemaErrs[p.key]?fixes[p.key]:p.value):undefined;
+    S.drafts.set(p.key+':'+envId,{key:p.key,envId,action:p.action,value,fromRev:rev});
+  }
+  audit('restore staged',`r${rev} @ ${envById(envId).name} · ${plan.length} pending change${plan.length>1?'s':''} (unpublished)`);
+  toast(`staged ${plan.length} change${plan.length>1?'s':''} from r${rev} — nothing published yet. Review via the drafts pill.`);
+  closeSheet();render();renderDrawer();
+}
+function restoreOne(envId,rev,key){
+  if(keyByName(key).secret&&!canHistory(envId)){
+    toast(`<b>refused</b>: restoring 🔒 ${esc(key)}'s earlier value needs <b>reveal-history</b> on ${envById(envId).name} (ADR #11).`,'err');
+    return;
+  }
+  const v=snapshot(envId,rev).get(key);
+  const err=v!==undefined&&validateCurrent(key,v);
+  if(err){toast(`<b>not restorable as-is</b>: ${esc(key)} @ r${rev} fails the current schema — ${esc(err)}. Use the full restore preview to resolve explicitly.`,'err');return}
+  S.drafts.set(key+':'+envId,{key,envId,action:v===undefined?'clear':'set',value:v,fromRev:rev});
+  audit('restore staged',`<b>${esc(key)}</b> ← r${rev} @ ${envById(envId).name} (pending)`);
+  closeSheet();render();renderDrawer();
+}
+
+/* ============================ publish ============================ */
+function openPublish(){S.sheet={mode:'publish'};renderSheet()}
+function renderPublishSheet(){
+  const byEnv={};
+  for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+  const envs=Object.keys(byEnv);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>review &amp; publish staged restore</h2>
+    <div class="sub">Per-environment authorization at commit; protected environments run the ceremony. Same pipeline as any publish. <span class="hint" title="${esc(TIP.restore())}">?</span></div>
+    ${envs.map(id=>{
+      const env=envById(id);
+      return`<div class="pubenv">
+      <div class="ph"><b>${env.name}</b><span class="rev">r${curRev(id)} → r${curRev(id)+1}</span>${env.protected?'<span class="pp">PROTECTED · ceremony required</span>':''}</div>
+      <ul>${byEnv[id].map(d=>{
+        const k=keyByName(d.key);
+        return`<li>${k.secret?'🔒 ':''}${esc(d.key)} <span class="nv">${d.action==='clear'?'(clear)':k.secret?MASK:esc(d.value)}</span> <span style="color:var(--tx-faint)">← r${d.fromRev}</span></li>`}).join('')}</ul>
+      </div>`}).join('')}
+    <div class="acts">
+      <button class="btn primary" onclick="doPublish()">publish ${S.drafts.size} change${S.drafts.size>1?'s':''}</button>
+      <button class="btn danger" onclick="S.drafts.clear();closeSheet();render()">discard drafts</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+function doPublish(){
+  const items=[...S.drafts.values()].map(d=>({key:d.key,envId:d.envId}));
+  const protEnvs=[...new Set(items.filter(i=>envById(i.envId).protected).map(i=>i.envId))];
+  const go=()=>{
+    const byEnv={};
+    for(const d of S.drafts.values())(byEnv[d.envId]??=[]).push(d);
+    for(const id in byEnv){
+      const newRev=curRev(id)+1;
+      HIST[id].unshift({rev:newRev,actor:'you',at:Date.now(),schemaRev:'s14',
+        changes:byEnv[id].map(d=>{
+          const oldV=keyByName(d.key).values[id];
+          if(d.action==='clear'){delete keyByName(d.key).values[id];return{key:d.key,kind:'removed',old:oldV,new:undefined}}
+          const kind=oldV===undefined?'added':'edited';
+          keyByName(d.key).values[id]=d.value;
+          return{key:d.key,kind,old:oldV,new:d.value}})});
+      audit('publish',`${envById(id).name} → r${newRev} · restore of r${byEnv[id][0].fromRev} · per-env auth checked at commit`);
+    }
+    S.drafts.clear();
+    closeSheet();render();renderDrawer();
+    toast(`published — history advanced. <b>Rollback created a NEW revision</b>; nothing was rewritten.`);
+  };
+  if(protEnvs.length)disclose('publish into protected',items.filter(i=>envById(i.envId).protected),go);
+  else go();
+}
+
+/* ============================ cell sheet ============================ */
+function openCell(key,envId){S.sheet={mode:'cell',key,envId};renderSheet()}
+function renderCellSheet(){
+  const{key,envId}=S.sheet;
+  const k=keyByName(key);const env=envById(envId);
+  const v=k.values[envId];
+  const draft=S.drafts.get(key+':'+envId);
+  const lastTouched=HIST[envId].find(r=>r.changes.some(c=>c.key===key));
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>${k.secret?'<span class="lock">🔒</span>':''}${esc(key)}
+      <span style="font-family:var(--sans);font-size:11px;color:var(--tx-faint);font-weight:400">${k.folder}/ · ${k.type} · ${k.secret?'secret':'config'}</span></h2>
+    <div class="sub">${env.name}${env.protected?' · <b>protected</b>':''}${lastTouched?` — last changed in <b>r${lastTouched.rev}</b> by ${esc(lastTouched.actor)}, ${ago(lastTouched.at)}`:''}</div>
+    <div class="cur ${v===undefined?'dim':''}">${draft?`(draft ← r${draft.fromRev}) `:''}${v===undefined?'— not set':k.secret?MASK:esc(v)}</div>
+    ${draft?`<div class="noperm">you have a staged restore on this entry (unpublished).</div>`:''}
+    <div class="acts">
+      <button class="btn primary" onclick="closeSheet();openDrawer('${envId}','${key}')">↺ history of this key</button>
+      ${draft?`<button class="btn danger" onclick="S.drafts.delete('${key}:${envId}');closeSheet();render();renderDrawer()">discard draft</button>`:''}
+      <button class="btn" onclick="closeSheet()">close</button>
+    </div>
+    <div class="noperm">value editing lives in the reveal-edit prototype (#21) — this one owns history.</div>`;
+  openModal();
+}
+
+/* ============================ pin sheet ============================ */
+function renderPinSheet(){
+  const{envId,rev,isCur,schemaFail,override,workload}=S.sheet;
+  const env=envById(envId);
+  const canH=canHistory(envId);
+  const existing=pinOf(envId,workload);
+  const isMove=existing&&existing.rev!==rev;
+  const isNoop=existing&&existing.rev===rev;
+  /* vs-latest summary — phrased from the workload's point of view.
+     Disclosure rules unchanged: config plaintext; secret comparison only
+     with reveal-history (a non-current pin already required it), values
+     always masked here. */
+  let gapBlock='';
+  if(!isCur){
+    const rows=diffRows(envId,rev,curRev(envId));
+    const rowLine=r=>{
+      if(r.kind==='added')return`<li><b class="mono">${esc(r.key)}</b> — the workload will <b>not</b> have this key (added after r${rev})</li>`;
+      if(r.kind==='removed')return`<li><b class="mono">${esc(r.key)}</b> — the workload keeps this key (removed after r${rev})</li>`;
+      if(r.secret)return`<li>🔒 <b class="mono">${esc(r.key)}</b> — ${canH?(r.old!==r.new?'stays at an <b>older value</b> than latest':'same value as latest'):'written to since (write-presence only)'}</li>`;
+      return`<li><b class="mono">${esc(r.key)}</b> — stays at <b>${esc(r.old)}</b> (latest: ${esc(r.new)})</li>`;
+    };
+    gapBlock=`<div class="pinwhat">
+      <div class="pwt">compared to latest (r${curRev(envId)}) — ${rows.length} difference${rows.length!==1?'s':''}</div>
+      <ul>${rows.length?rows.map(rowLine).join(''):'<li>identical delivered content — the pin only freezes it going forward.</li>'}</ul>
+    </div>`;
+  }
+  const wlShort=esc(workload.split(' ')[0]);
+  document.getElementById('sheet').innerHTML=`
+    <button class="sheetclose" onclick="closeSheet()" aria-label="close">✕</button>
+    <h2>⚲ ${isMove?'move pin to':'pin'} <span style="color:var(--accent)">r${rev}</span> <span style="color:var(--tx-faint)">·</span> ${env.name}
+      <span class="hint" title="${esc(TIP.pin())}">?</span></h2>
+    <div class="sub" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:8px">
+      workload:
+      <select onchange="setPinWorkload(this.value)" aria-label="workload to pin"
+        style="background:var(--bg);border:1px solid var(--line);color:var(--tx);padding:7px 10px;border-radius:4px;font-size:12.5px">
+        ${WORKLOADS.map(w=>{
+          const p=pinOf(envId,w);
+          return`<option value="${esc(w)}" ${w===workload?'selected':''}>${esc(w)}${p?` — pinned to r${p.rev}`:' — follows latest'}</option>`}).join('')}
+      </select>
+      <span style="color:var(--tx-faint)">quota ${pinsFor(envId).length}/${PIN_QUOTA} · expiry 30d</span>
+    </div>
+    ${isMove?`<div class="noperm" style="color:var(--chg)">⚲ ${esc(workload)} is currently pinned to <b>r${existing.rev}</b> — one pin per workload, so this <b>moves</b> it to r${rev} (the r${existing.rev} pin is replaced${isSoleKeeper(existing)?`, and r${existing.rev}'s values, kept only by that pin, are collected`:''}).</div>`:''}
+    ${isNoop?`<div class="noperm" style="color:var(--bad)">already pinned to r${rev} — a workload fetches exactly one revision, so pinning it again changes nothing.</div>`:''}
+    <div class="pinwhat">
+      <div class="pwt">what pinning does</div>
+      <ul>
+        <li><b>${wlShort} keeps receiving exactly r${rev}'s values</b> — across restarts and redeploys — instead of following latest.</li>
+        <li>new publishes to ${env.name} <b>stop reaching this workload</b> while the pin lives; everyone else still gets latest.</li>
+        <li>r${rev}'s values are <b>kept from retention clean-up</b> as long as the pin exists.</li>
+        <li>on release or expiry (30d) the workload <b>resumes latest on its next fetch</b> — surfaced loudly, never silent.</li>
+      </ul>
+    </div>
+    ${gapBlock}
+    ${isCur?'':`<div class="noperm">non-current revision: this routes <b>historical</b> content to a workload — the ceremony below is a reveal-history disclosure.</div>`}
+    ${schemaFail.length?`<div class="oraclenote" style="color:var(--bad)">⚠ r${rev} fails the <b>current</b> schema: ${schemaFail.map(esc).join(', ')}. Pinned delivery is verbatim — an explicit override is required and <b>recorded</b>; the pin is then surfaced as drift.</div>
+      <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:12.5px;color:var(--tx-dim)">
+        <input type="checkbox" ${override?'checked':''} onchange="S.sheet.override=this.checked"> pin despite current-schema failure (recorded as an explicit override)
+      </label>`:''}
+    <div class="acts">
+      <button class="btn primary" ${isNoop?'disabled':''} onclick="confirmPin()">${isMove?`move pin to r${rev}`:'create pin'}</button>
+      <button class="btn" onclick="closeSheet()">cancel</button>
+    </div>`;
+  openModal();
+}
+
+/* ============================ modal plumbing ============================ */
+function openModal(){
+  document.getElementById('sheet').classList.add('open');
+  document.getElementById('scrim').classList.add('open');
+}
+function closeSheet(){
+  S.sheet=null;
+  document.getElementById('sheet').classList.remove('open');
+  document.getElementById('scrim').classList.remove('open');
+}
+function renderSheet(){
+  if(!S.sheet)return;
+  ({cell:renderCellSheet,diff:renderDiffSheet,restore:renderRestoreSheet,publish:renderPublishSheet,pin:renderPinSheet,release:renderReleaseSheet})[S.sheet.mode]();
+}
+document.getElementById('scrim').addEventListener('click',()=>{
+  if(S.reauth)cancelReauth();else closeSheet();
+});
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){
+    if(S.reauth)cancelReauth();
+    else if(S.sheet)closeSheet();
+    else if(S.drawer)closeDrawer();
+  }
+});
+
+/* ============================ wiring ============================ */
+document.getElementById('role').addEventListener('change',e=>{
+  S.role=e.target.value;
+  S.revealedHist.clear();
+  render();renderDrawer();
+  if(S.sheet)renderSheet();
+});
+document.getElementById('themebtn').addEventListener('click',()=>{
+  document.body.dataset.theme=document.body.dataset.theme==='dark'?'light':'dark';
+});
+function render(){renderMatrix();renderShell();syncGh()}
+render();
+openDrawer('prd');
+</script>
+</body>
+</html>

--- a/docs/site/public/prototypes/revision-history/index.html
+++ b/docs/site/public/prototypes/revision-history/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Version history &amp; rollback — iterations</title>
+<style>
+  :root{
+    --bg:oklch(0.19 0.012 220);--bg2:oklch(0.225 0.014 220);--line:oklch(0.34 0.016 220);
+    --tx:oklch(0.93 0.008 200);--tx-dim:oklch(0.76 0.01 210);--tx-faint:oklch(0.6 0.012 215);
+    --accent:oklch(0.82 0.09 195);--mono:ui-monospace,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--tx);font-family:system-ui,sans-serif;
+    min-height:100vh;padding:clamp(24px,6vw,72px) clamp(18px,6vw,72px)}
+  h1{font-size:clamp(20px,4vw,28px);font-weight:700}
+  h1 span{color:var(--accent)}
+  .lede{font-size:13px;color:var(--tx-dim);margin:10px 0 30px;max-width:58ch;line-height:1.6}
+  ul{list-style:none;display:grid;gap:10px;max-width:680px}
+  li a{display:block;text-decoration:none;color:inherit;padding:16px 18px;
+    border:1px solid var(--line);border-radius:10px;background:var(--bg2)}
+  li a:hover{border-color:var(--accent)}
+  .name{font-size:15px;font-weight:600;display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
+  .name .n{font-family:var(--mono);font-size:11px;color:var(--accent)}
+  .latest{font-family:var(--mono);font-size:10px;letter-spacing:.08em;color:oklch(0.2 0.02 220);
+    background:var(--accent);border-radius:999px;padding:2px 9px}
+  .desc{font-size:12.5px;color:var(--tx-dim);margin-top:5px;line-height:1.55}
+  footer{margin-top:36px;font-family:var(--mono);font-size:11px;color:var(--tx-faint);line-height:1.8}
+</style>
+</head>
+<body>
+  <h1>version history <span>&amp;</span> rollback</h1>
+  <p class="lede">Wayfinder ticket #30 — per-env revision timeline, secret-safe diffs (write-presence vs reveal-history), pins as durable resources, least-blast restore through the normal publish pipeline. Every change is a new numbered iteration; published ones never mutate.</p>
+  <ul>
+    <li><a href="6/">
+      <div class="name"><span class="n">6</span>Retention moves out<span class="latest">LOCKED</span></div>
+      <div class="desc">Alex's it-5 verdict: retention settings belong in the settings surfaces, not the history drawer. Editing moved to app-chrome iteration 16 (project settings › Policy + org settings › Policy); the drawer keeps a read-only line — effective window, inherits-org/custom badge, "→ project settings" pointer. Semantics unchanged.</div>
+    </a></li>
+    <li><a href="5/">
+      <div class="name"><span class="n">5</span>Retention inheritance</div>
+      <div class="desc">Revision retention per org + per project: new projects inherit the org default, an override detaches (org changes no longer touch it), inheriting projects follow, and a project may never exceed the org value — refused at set time, capped loudly when the org lowers. ⚙ retention sheet from the drawer head; timeline "collected" tags move live on apply; changes audited.</div>
+    </a></li>
+    <li><a href="4/">
+      <div class="name"><span class="n">4</span>Pin = workload binding</div>
+      <div class="desc">It-3 findings fixed: "holds payload" jargon → "sole keeper" with plain consequence text, and releasing such a pin now confirms with "this permanently deletes rN's values". Pin model made explicit: one pin per (workload, environment) — the sheet gains a workload picker, re-pinning a bound workload becomes a move (r27 → r25), pinning the same rev twice is a refused no-op.</div>
+    </a></li>
+    <li><a href="3/">
+      <div class="name"><span class="n">3</span>Panes + pin clarity</div>
+      <div class="desc">Verdict on it-2: view b (list + detail panes) wins — now the single surface, switcher retired. Pinning explained in visible plain language: pins-section definition line, per-pin gap sentence ("still runs on r27's values — 2 publishes behind latest"), pinned-rev callout in the detail pane, and a pin-create sheet leading with "what pinning does" + a vs-latest value summary under the disclosure rules.</div>
+    </a></li>
+    <li><a href="2/">
+      <div class="name"><span class="n">2</span>History approaches — four structural takes</div>
+      <div class="desc">Alex's it-1 verdict: too dense. Four structurally different presentations of the same history, switchable via ?view= + floating bar (arrow keys): a collapsed timeline (expand per row) · b list + detail panes · c activity story (plain-language sentences) · d full-page history table. ADR prose demoted to (?) tooltips in all four.</div>
+    </a></li>
+    <li><a href="1/">
+      <div class="name"><span class="n">1</span>History drawer</div>
+      <div class="desc">Right-side per-env timeline drawer (entry: env-header rev badge, key names filter per key). Diff + restore preview + pin as centered modals; restore stages drafts, publish runs the #21 ceremony. Retention: lineage permanent, payloads last 6 + pinned; auditor role shows the reveal/reveal-history split.</div>
+    </a></li>
+  </ul>
+  <footer><a href="/prototypes/">all prototypes</a></footer>
+</body>
+</html>

--- a/docs/site/scripts/build-pwa.mjs
+++ b/docs/site/scripts/build-pwa.mjs
@@ -6,7 +6,7 @@ const { count, size, warnings } = await generateSW({
   cleanupOutdatedCaches: true,
   clientsClaim: true,
   globDirectory: dist,
-  globIgnores: ['sw.js'],
+  globIgnores: ['sw.js', 'prototypes/**/*'],
   globPatterns: ['**/*.{css,html,js,json,png,svg,txt,webmanifest,woff,woff2}'],
   ignoreURLParametersMatching: [/^deployment$/, /^utm_/, /^fbclid$/],
   inlineWorkboxRuntime: true,

--- a/scripts/ci/check-docs-pwa.sh
+++ b/scripts/ci/check-docs-pwa.sh
@@ -117,6 +117,15 @@ if [ -n "$remote_font_matches" ]; then
 	exit 1
 fi
 
+unsafe_dom_matches=$(grep -R -n -E --include='*.html' \
+	"(blastsub|sidevarlabel)[^;]*\.innerHTML[[:space:]]*=" \
+	"$site_root/prototypes/app-chrome" 2>/dev/null || true)
+if [ -n "$unsafe_dom_matches" ]; then
+	printf 'docs PWA gate: prototype HTML reinterprets DOM-derived text as HTML\n%s\n' \
+		"$unsafe_dom_matches" >&2
+	exit 1
+fi
+
 stale_license_matches=$(grep -R -n -E --include='*.html' \
 	'AGPL|MIT licensed' \
 	"$site_root/prototypes" 2>/dev/null || true)

--- a/scripts/ci/check-docs-pwa.sh
+++ b/scripts/ci/check-docs-pwa.sh
@@ -66,4 +66,64 @@ for cached_path in \
 	require_text "$site_root/sw.js" "$cached_path"
 done
 
-printf 'docs PWA gate: manifest, registration, icons, and offline precache passed\n'
+for prototype_family in \
+	app-chrome \
+	env-matrix \
+	landing-opus-4.8 \
+	landing-opus-5 \
+	machine-access \
+	reveal-edit \
+	revision-history; do
+	require_file "$site_root/prototypes/$prototype_family/index.html"
+done
+require_file "$site_root/prototypes/index.html"
+
+prototype_pngs=$(find "$site_root/prototypes" -type f -name '*.png' -print)
+if [ -n "$prototype_pngs" ]; then
+	printf 'docs PWA gate: prototype screenshots must not be published\n%s\n' \
+		"$prototype_pngs" >&2
+	exit 1
+fi
+
+if grep -F -- 'prototypes/' "$site_root/sw.js" >/dev/null; then
+	printf 'docs PWA gate: prototype assets must not be precached\n' >&2
+	exit 1
+fi
+
+legacy_matches=$(grep -R -n -i -E --include='*.html' \
+	'wenv|(^|[^[:alnum:]])ew_' "$site_root/prototypes" 2>/dev/null |
+	grep -F -v -- 'wenv/change-token/v1' || true)
+if [ -n "$legacy_matches" ]; then
+	printf 'docs PWA gate: prototype HTML contains legacy product identity\n%s\n' \
+		"$legacy_matches" >&2
+	exit 1
+fi
+
+private_matches=$(grep -R -n -i -E --include='*.html' \
+	'(^|[^[:alnum:]_])marc([^[:alnum:]_]|$)|([[:alnum:]_-]+\.)*went\.io|went-io|projects/dbugit|dbugit|pi-cluster|tail-net|adhd-kanban|poketracker|initiative-tracker|dunky13|id:.homelab.' \
+	"$site_root/prototypes" 2>/dev/null || true)
+if [ -n "$private_matches" ]; then
+	printf 'docs PWA gate: prototype HTML contains personal or internal coordinates\n%s\n' \
+		"$private_matches" >&2
+	exit 1
+fi
+
+remote_font_matches=$(grep -R -n -E --include='*.html' \
+	'fonts\.googleapis\.com|fonts\.gstatic\.com' \
+	"$site_root/prototypes" 2>/dev/null || true)
+if [ -n "$remote_font_matches" ]; then
+	printf 'docs PWA gate: prototype HTML loads remote Google Fonts\n%s\n' \
+		"$remote_font_matches" >&2
+	exit 1
+fi
+
+stale_license_matches=$(grep -R -n -E --include='*.html' \
+	'AGPL|MIT licensed' \
+	"$site_root/prototypes" 2>/dev/null || true)
+if [ -n "$stale_license_matches" ]; then
+	printf 'docs PWA gate: prototype HTML contains stale license claims\n%s\n' \
+		"$stale_license_matches" >&2
+	exit 1
+fi
+
+printf 'docs PWA gate: manifest, sanitized prototypes, registration, icons, and offline precache passed\n'


### PR DESCRIPTION
## Summary

- publish seven interactive prototype families at `/prototypes/`
- sanitize legacy identity and private demo coordinates; use current MPL-2.0 claims
- keep prototype HTML out of the PWA precache and reject screenshots/unsafe content in CI

## Verification

- `./scripts/ci/verify-docs.sh`
- `shellcheck scripts/ci/check-docs-pwa.sh`
- `node --check docs/site/scripts/build-pwa.mjs`
- local T3 browser: `/prototypes/` and `/prototypes/landing-opus-5/2/?variant=c`
- standards review R3 CLEAN; spec review R3 SOUND

Signed-off-by: Marc Went <marc@went.io>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789654022&installation_model_id=432348&pr_number=166&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F166&signature=24f29e7833182534250d9aceace29d1e37dcfee2175b9c7d43444efbb3bd316e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->