### PR TITLE
fix(docs): keep prototypes outside PWA fallback

### DIFF
--- a/docs/site/scripts/build-pwa.mjs
+++ b/docs/site/scripts/build-pwa.mjs
@@ -11,7 +11,7 @@ const { count, size, warnings } = await generateSW({
   ignoreURLParametersMatching: [/^deployment$/, /^utm_/, /^fbclid$/],
   inlineWorkboxRuntime: true,
   navigateFallback: '/index.html',
-  navigateFallbackDenylist: [/^\/api\//],
+  navigateFallbackDenylist: [/^\/api\//, /^\/prototypes(?:\/|$)/],
   skipWaiting: true,
   sourcemap: false,
   swDest: fileURLToPath(new URL('../dist/sw.js', import.meta.url)),

--- a/docs/site/scripts/test-pwa-offline.mjs
+++ b/docs/site/scripts/test-pwa-offline.mjs
@@ -94,6 +94,16 @@ try {
     });
   });
 
+  const prototypeResponse = await page.goto(`${origin}/prototypes/`, {
+    waitUntil: 'networkidle',
+  });
+  assert.ok(prototypeResponse?.ok(), 'online prototype hub did not load successfully');
+  assert.equal(
+    await page.title(),
+    'Hikyo prototypes',
+    'service worker navigation fallback replaced the prototype hub',
+  );
+
   const cacheNames = await page.evaluate(() => caches.keys());
   assert.ok(cacheNames.length > 0, 'service worker created no runtime cache');
 


### PR DESCRIPTION
The site-wide Workbox navigation fallback intercepted /prototypes routes for browsers already controlled by the service worker, replacing prototype HTML with the landing page. Denylist the prototype subtree and exercise the exact controlled-browser navigation in the offline Playwright gate.\n\nValidation:\n- fnm exec --using 24 -- ./scripts/ci/verify-docs.sh\n- node --check on both changed modules\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789656901&installation_model_id=432348&pr_number=167&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F167&signature=e4b8428816cbee6b6b6d67799bcde0747ae3446f5acaf201822859a28454b83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->