### PR TITLE
perf(ci): shard the flow suite by viewport across two runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,10 +340,31 @@ jobs:
   # pass before a browser is worth starting, and the flow registry's closure
   # check runs first of all — a locked surface without a flow should fail in
   # seconds, not after a full browser suite has passed.
+  #
+  # One job, TWO RUNNERS: the flow suite is sharded by viewport project, which
+  # is the only axis that parallelises it without weakening anything. The
+  # harness holds one administrator per run — a TOTP ledger where a code is
+  # single-use per step, a passkey whose signature counter must advance, a
+  # shared browser session flows re-mint — so two workers inside one process
+  # would race all three. Two RUNNERS share none of it: each boots its own pair
+  # of instances, seeds its own tenant, mints its own passkey. And because both
+  # projects run every flow, each shard still executes every claim the registry
+  # makes, so the teardown closure check keeps its full force on both.
+  #
+  # The matrix stays inside the `web` job rather than becoming a second job:
+  # `needs.web.result` already aggregates the legs, so branch protection and
+  # `check-required-jobs.sh` need no adjustment, and each leg keeps the ordering
+  # above intact instead of starting a browser behind a Go suite that failed.
   web:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      # A flow that only passes at 1280px has not passed, so the viewport that
+      # broke must be named — cancelling its sibling would hide half the answer.
+      fail-fast: false
+      matrix:
+        project: [desktop, mobile]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -414,18 +435,25 @@ jobs:
         working-directory: web
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Flow suite (desktop + mobile)
+      # `playwright test` directly, not `pnpm run e2e`: the script rebuilds the
+      # SPA so a developer cannot run the flows against a stale bundle, and the
+      # step above has already built this run's.
+      - name: Flow suite (${{ matrix.project }})
         working-directory: web
-        run: pnpm run e2e
+        run: pnpm exec playwright test --project=${{ matrix.project }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: playwright-traces
+          name: playwright-traces-${{ matrix.project }}
           path: web/test-results/
           retention-days: 7
+      # One leg writes the cache. Both legs compile the same packages against
+      # the same key, so the second upload is 378 MB spent to lose a race.
       - name: Save web Go cache
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          success() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          matrix.project == 'desktop'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -13,9 +13,24 @@ import { readRunLog, unexecutedClaims } from './registry.ts';
  * It is skipped under `--grep`, and only under `--grep`: a filtered run is
  * deliberately partial, and failing it would make the check something people
  * work around instead of with. CI runs unfiltered.
+ *
+ * `--shard` is REFUSED rather than skipped. CI parallelises by project, where
+ * every shard still runs every flow and this check keeps its full force; a
+ * `--shard` run splits the flows themselves, so the log is partial while the
+ * run still looks complete. Left alone it would fail as a wall of "claims more
+ * than it runs" lines that say nothing about the real cause, so it says it.
  */
 export default function globalTeardown(config: FullConfig): void {
   stopInstance();
+
+  if (config.shard !== null) {
+    throw new Error(
+      'the flow suite cannot be sharded with --shard: each shard runs a subset of the flows, ' +
+        'so no shard can check the registry\'s claims and none of them would notice. ' +
+        'Parallelise by project instead (--project=desktop / --project=mobile, as the `web` ' +
+        'job does): both projects run every flow, so every shard checks every claim.',
+    );
+  }
 
   const filtered = String(config.grep) !== '/.*/';
   if (filtered) {

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -147,8 +147,14 @@ export function surfacesForFlow(flowID: string): readonly Surface[] {
 // A plain append-only file rather than anything cleverer: Playwright workers
 // are separate processes, this suite runs with `workers: 1`, and a line per
 // surface-and-theme is a few dozen bytes per run.
-// ponytail: single-writer append; if the suite ever goes parallel, switch to
-// one file per worker and merge at teardown.
+//
+// CI parallelism does not change that. It shards by PROJECT, one runner each,
+// and a runner is a whole run: its own log, its own single writer, and — since
+// both projects run every flow — its own complete set of claims to check.
+// ponytail: single-writer append. The shapes that would need merging are a
+// worker split (blocked by the fixture's single administrator, see
+// playwright.config.ts) and a `--shard` split of the flows, which global
+// teardown refuses by name for exactly this reason.
 
 export const RUN_LOG = fileURLToPath(new URL('.runs/pinned.log', import.meta.url));
 

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,6 +13,26 @@ import { BASE_URL } from './e2e/fixtures/instance.ts';
  * assertion set needs `forced-colors` emulation and axe-core's colour
  * sampling, and Chromium is where both are reliable. Cross-browser rendering
  * is a different question from "is this surface accessible and on-token".
+ *
+ * ## Why `workers: 1`, and where the parallelism lives instead
+ *
+ * A run holds ONE administrator per instance, and three pieces of its state are
+ * strictly sequential: the TOTP ledger (a code is single-use per step, and the
+ * spent step travels between processes in a file), the passkey's signature
+ * counter (a counter that does not advance is how a CLONED authenticator is
+ * detected, so a replayed one disables the credential), and the shared session
+ * itself (a flow that changes grants re-mints it for everybody). Two workers in
+ * one process race all three, and each race surfaces as an `unauthenticated`
+ * several tests away from its cause.
+ *
+ * So the suite is parallelised across RUNNERS instead, one per project — see
+ * the `web` job's matrix in .github/workflows/ci.yml. Two runners share none of
+ * that state: each boots its own instances, seeds its own tenant and mints its
+ * own passkey. Both projects run every flow, so a per-project shard still
+ * executes every claim in the registry and the teardown closure check stays
+ * whole. Sharding any finer (`--shard`) splits the flows themselves and breaks
+ * that property; global teardown refuses it by name rather than failing as a
+ * pile of unexecuted claims.
  */
 export default defineConfig({
   testDir: './e2e/flows',


### PR DESCRIPTION
The `web` job is the long pole in CI, and the flow suite is nearly all of it. Measured on the last run on main (job `95894315132`, 394s total): the flow suite step took **297s**, of which **217s** was 128 tests executing (desktop 124s, mobile 94s) and the rest global setup. CPU on the 2 vCPU runner ran p50 68% / p95 84% / p99 99.5%, no OOM.

Spending that headroom by raising Playwright's `workers` is not available to us. The harness holds one administrator per run and three pieces of its state are strictly sequential: the TOTP ledger (a code is single-use per step, and the spent step travels between processes in a file), the passkey's signature counter (a counter that does not advance is how a cloned authenticator is detected), and the shared browser session, which grant-changing flows re-mint for everybody. Concurrent workers race all three, and each race surfaces as an `unauthenticated` several tests away from its cause.

Two runners share none of that state, so the suite is sharded by viewport project instead, on 4 vCPU legs:

```yaml
  web:
    needs: changes
    if: ${{ fromJSON(needs.changes.outputs.plan).web }}
    runs-on: blacksmith-4vcpu-ubuntu-2404
    strategy:
      # A flow that only passes at 1280px has not passed, so the viewport that
      # broke must be named — cancelling its sibling would hide half the answer.
      fail-fast: false
      matrix:
        project: [desktop, mobile]
```

```yaml
      - name: Flow suite (${{ matrix.project }})
        working-directory: web
        run: pnpm exec playwright test --project=${{ matrix.project }}
```

Project is the one axis that parallelises this suite without weakening anything. Both projects run every flow, so each shard still executes every claim the registry makes and the teardown closure check keeps its full force on both legs, with its own single-writer run log per runner. A finer `--shard` split would divide the flows themselves and leave every shard silently checking a partial log, so global teardown now refuses it by name rather than failing as a wall of "claims more than it runs" lines.

The matrix stays inside the `web` job rather than becoming a second job: `needs.web.result` already aggregates the legs, so `check-required-jobs.sh` and branch protection need no adjustment, and each leg keeps the ordering the job's comment argues for (registry closure first, Go tests before a browser starts) instead of launching a browser behind a Go suite that failed. Trace artifacts are now named per leg, and only the desktop leg saves the Go build cache, since both legs would otherwise race to upload 378 MB against the same key.

Two smaller things fall out: the flow step calls `playwright test` directly instead of `pnpm run e2e`, whose rebuild of the SPA the preceding step has already done, and 4 vCPU is a deliberate size rather than the largest available — one Chromium plus two Go servers cannot use 8, and the parallelism now lives across runners.

Expected effect: the critical path through `web` drops from ~394s to roughly 280-300s, with the desktop leg (the slower half at 124s of tests) setting it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->