### PR TITLE
ci: restore GitHub-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,0 @@
-# Blacksmith runner labels are custom self-hosted labels, so actionlint cannot
-# infer them from GitHub's hosted-label list. Declare every label used by
-# `runs-on:` in .github/workflows so the runner-label rule stays enforced.
-self-hosted-runner:
-  labels:
-    - blacksmith-2vcpu-ubuntu-2404
-    - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -24,7 +24,7 @@ jobs:
   ci-required:
     if: always()
     needs: validation
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Require trusted validation
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   # Keep the required workflow present on every PR, then select jobs inside it.
   # Unknown paths and changes to this classifier fail closed to the full plan.
   changes:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       plan: ${{ steps.classify.outputs.plan }}
     steps:
@@ -65,7 +65,7 @@ jobs:
   lint:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).lint }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -114,7 +114,7 @@ jobs:
 
   dco:
     if: github.event_name != 'push'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -134,7 +134,7 @@ jobs:
   supply-chain-checks:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).supply_chain_checks }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -191,7 +191,7 @@ jobs:
   release-snapshot:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).release_snapshot }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -246,7 +246,7 @@ jobs:
   generated:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).generated }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -292,7 +292,7 @@ jobs:
   client:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).client }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -323,7 +323,7 @@ jobs:
   docs:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).docs }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -358,7 +358,7 @@ jobs:
   web:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       # A flow that only passes at 1280px has not passed, so the viewport that
       # broke must be named — cancelling its sibling would hide half the answer.
@@ -462,7 +462,7 @@ jobs:
   test:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).test }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
@@ -548,7 +548,7 @@ jobs:
   headline-guarantee:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).headline_guarantee }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
@@ -612,7 +612,7 @@ jobs:
       - supply-chain-checks
       - test
       - web
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
       pages: write
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -67,7 +67,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-unsigned-draft:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -136,8 +136,10 @@ jobs:
               -o "image-root/$arch/hikyo" ./cmd/hikyo
           done
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682 # v1.12.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          version: v0.36.1
+          driver-opts: image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679fd # v4.6.0
         with:
           registry: ghcr.io
@@ -150,7 +152,7 @@ jobs:
         run: ./scripts/release/check-oci-unused.sh "$IMAGE:$VERSION"
       - name: Publish unsigned multi-arch image
         id: image
-        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.release

--- a/.github/workflows/security-channel.yml
+++ b/.github/workflows/security-channel.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fallback-channel:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- move all workflow jobs from Blacksmith labels to GitHub-hosted ubuntu-latest
- restore pinned Docker Buildx and build-push actions for release images
- remove Blacksmith-only actionlint runner-label configuration

## Validation

- actionlint v1.7.12
- changed-path classifier fixtures
- trusted CI and required-job contract fixtures
- docs, OSS policy, PWA, browser, and live-doc gates

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789723633&installation_model_id=432348&pr_number=170&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F170&signature=e896e13cb6209c4d538fd86d49068b462cfd99a43d7e5484de375379824e63f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->