### PR TITLE
docs(spec): update legacy branding to Hikyo

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,6 +1,6 @@
-# Wenv — Specification handoff (the destination of wayfinder map [#1](https://github.com/Dunky13/wenv/issues/1))
+# Hikyo — Specification handoff (the destination of wayfinder map [#1](https://github.com/Hikyo-Org/Hikyo/issues/1))
 
-This is the build-ready specification set for Wenv 1.0: a fully open-source, self-hosted control plane for validated secrets and configuration across environments, Docker Compose and Kubernetes first-class. Synthesized 2026-08-06 at ticket [#27](https://github.com/Dunky13/wenv/issues/27) from 26 locked ADRs, 5 locked prototypes, and the map's ticket resolutions.
+This is the build-ready specification set for Hikyo 1.0: a fully open-source, self-hosted control plane for validated secrets and configuration across environments, Docker Compose and Kubernetes first-class. Synthesized 2026-08-06 at ticket [#27](https://github.com/Hikyo-Org/Hikyo/issues/27) from 26 locked ADRs, 5 locked prototypes, and the map's ticket resolutions.
 
 ## How this set works
 
@@ -35,14 +35,14 @@ This is the build-ready specification set for Wenv 1.0: a fully open-source, sel
 | MVP scope & acceptance criteria | [adr/mvp-boundary.md](../adr/mvp-boundary.md) §1–§2, §6 + [self-hoster-checklist.md](./self-hoster-checklist.md) (passed) |
 | Out-of-scope / roadmap appendix | [adr/mvp-boundary.md](../adr/mvp-boundary.md) §4, verbatim |
 | Implementation sequencing | [adr/mvp-boundary.md](../adr/mvp-boundary.md) §5 (CI-invariant subsystems first; promotions design-early/build-late) |
-| License & governance | [LICENSE](../../LICENSE) (MPL 2.0, [#9](https://github.com/Dunky13/wenv/issues/9)) + [adr/oss-mechanics.md](../adr/oss-mechanics.md) |
+| License & governance | [LICENSE](../../LICENSE) (MPL 2.0, [#9](https://github.com/Hikyo-Org/Hikyo/issues/9)) + [adr/oss-mechanics.md](../adr/oss-mechanics.md) |
 | Audit & event model | [adr/audit-model.md](../adr/audit-model.md) |
 | OSS project mechanics | [adr/oss-mechanics.md](../adr/oss-mechanics.md) |
 | Post-spec open items (fog sweep) | [open-items.md](./open-items.md) |
 
 ## Synthesis obligations, discharged
 
-Every "at synthesis (#27)" delegation in the corpus resolves as follows: exact SCIM/SAML/import/multi-instance spellings and serializations → [api-cli-spellings.md](./api-cli-spellings.md); canonical key grammar restatement → [domain-model.md](./domain-model.md); delegated tunable values (SAML, SCIM, multi-instance, import, GitHub adapter) → [ops-catalogue.md](./ops-catalogue.md) (the ops-spec row-15 numbering collision is reported there, deferred to an editorial amendment); the §3 self-hoster checklist (normative deliverable) → [self-hoster-checklist.md](./self-hoster-checklist.md), **passed, no blocking defect**; UI deltas (GitHub adapter knobs, scanning presentation, git-mode banner, declaration-is-public statement) → [ui-spec.md](./ui-spec.md); everything still unspecified → [open-items.md](./open-items.md), none foundational. One contradiction was found and fixed per procedure: oss-mechanics misquoted the license decision as Apache-2.0 (locked: MPL 2.0) — corrected via banner, [#33](https://github.com/Dunky13/wenv/issues/33) reopened and re-closed.
+Every "at synthesis (#27)" delegation in the corpus resolves as follows: exact SCIM/SAML/import/multi-instance spellings and serializations → [api-cli-spellings.md](./api-cli-spellings.md); canonical key grammar restatement → [domain-model.md](./domain-model.md); delegated tunable values (SAML, SCIM, multi-instance, import, GitHub adapter) → [ops-catalogue.md](./ops-catalogue.md) (the ops-spec row-15 numbering collision is reported there, deferred to an editorial amendment); the §3 self-hoster checklist (normative deliverable) → [self-hoster-checklist.md](./self-hoster-checklist.md), **passed, no blocking defect**; UI deltas (GitHub adapter knobs, scanning presentation, git-mode banner, declaration-is-public statement) → [ui-spec.md](./ui-spec.md); everything still unspecified → [open-items.md](./open-items.md), none foundational. One contradiction was found and fixed per procedure: oss-mechanics misquoted the license decision as Apache-2.0 (locked: MPL 2.0) — corrected via banner, [#33](https://github.com/Hikyo-Org/Hikyo/issues/33) reopened and re-closed.
 
 ## The 1.0 gate, in one sentence
 

--- a/docs/spec/api-cli-spellings.md
+++ b/docs/spec/api-cli-spellings.md
@@ -1,4 +1,4 @@
-# Wenv — API & CLI spellings deferred to synthesis (2026-08-06)
+# Hikyo — API & CLI spellings deferred to synthesis (2026-08-06)
 
 [api-cli-surface.md](../adr/api-cli-surface.md) is the API/CLI spec's skeleton; several later ADRs joined its closed grammar at declared join points and delegated their **exact spellings** to this document. Every spelling here is bound by the locked grammar (noun-verb families, output classes, print triad, exit codes, parity rules) and by the delegating ADR's constraints; a spelling that would violate either is a defect here, not a licence to reinterpret the ADR. Nothing here adds a verb class, an output class, or an endpoint outside the declared join points.
 
@@ -7,23 +7,23 @@
 Human-session verbs (full UI↔CLI parity: binding CRUD, mapping-table administration, credential mint/rotate/revoke, provisioned directory views; the *wire* endpoints under `/api/v1/orgs/{org}/scim/v2/{binding}/…` are fixed in the ADR and are parity-exempt protocol paths):
 
 ```
-wenv scim binding create --org <org> --provider <provider>
-wenv scim binding list   [--org <org>]
-wenv scim binding show   <binding>
-wenv scim binding delete <binding>            # runs the ADR's atomic 4-step teardown
+hikyo scim binding create --org <org> --provider <provider>
+hikyo scim binding list   [--org <org>]
+hikyo scim binding show   <binding>
+hikyo scim binding delete <binding>            # runs the ADR's atomic 4-step teardown
 
-wenv scim mapping add    <binding> --group <idp-group-id> --template <template>
-wenv scim mapping update <binding> --group <idp-group-id> --template <template>
-wenv scim mapping remove <binding> --group <idp-group-id>
-wenv scim mapping list   <binding>
+hikyo scim mapping add    <binding> --group <idp-group-id> --template <template>
+hikyo scim mapping update <binding> --group <idp-group-id> --template <template>
+hikyo scim mapping remove <binding> --group <idp-group-id>
+hikyo scim mapping list   <binding>
 
-wenv scim credential mint   <binding>                    # a NEW credential; several may be live
-wenv scim credential list   <binding>                    # ids + metadata, never token material
-wenv scim credential show   <binding> <credential-id>
-wenv scim credential revoke <binding> <credential-id>
+hikyo scim credential mint   <binding>                    # a NEW credential; several may be live
+hikyo scim credential list   <binding>                    # ids + metadata, never token material
+hikyo scim credential show   <binding> <credential-id>
+hikyo scim credential revoke <binding> <credential-id>
 
-wenv scim user  list <binding>                           # provisioned directory views
-wenv scim group list <binding>
+hikyo scim user  list <binding>                           # provisioned directory views
+hikyo scim group list <binding>
 ```
 
 Credentials are **plural and id-addressable**: overlap rotation is mint-new → update IdP → revoke-old, identical authority throughout, per the machine-identity credential model the ADR inherits. `mint` is display-once under the print triad; formula `manage-members(org)` ∧ reauth.
@@ -35,20 +35,20 @@ Admin REST resources (ordinary `/api/v1` grammar, proof-carrying): `/api/v1/orgs
 Joins the **existing `instance-config` verb surface** — no new top-level verb family. Identity providers are a resource under that family (OIDC providers administer identically; `--kind` selects):
 
 ```
-wenv instance-config provider create --kind saml --name <name> \
+hikyo instance-config provider create --kind saml --name <name> \
     --entity-id <byte-exact-entityID> \
     (--metadata-file <xml> | --metadata-url <url>)    # URL fetch runs the fingerprint ceremony
-wenv instance-config provider list
-wenv instance-config provider show    <name>
-wenv instance-config provider update  <name> …
-wenv instance-config provider disable <name>
-wenv instance-config provider remove  <name>
-wenv instance-config provider refresh-metadata <name>   # diff-and-confirm ceremony
+hikyo instance-config provider list
+hikyo instance-config provider show    <name>
+hikyo instance-config provider update  <name> …
+hikyo instance-config provider disable <name>
+hikyo instance-config provider remove  <name>
+hikyo instance-config provider refresh-metadata <name>   # diff-and-confirm ceremony
 
-wenv instance-config saml-sp-key list
-wenv instance-config saml-sp-key rotate                 # old active becomes retiring; both publish
-wenv instance-config saml-sp-key retire <fingerprint>   # retiring only; erases the private key
-wenv instance-config saml-sp-key compromise-retire <fingerprint> # active only; replace atomically
+hikyo instance-config saml-sp-key list
+hikyo instance-config saml-sp-key rotate                 # old active becomes retiring; both publish
+hikyo instance-config saml-sp-key retire <fingerprint>   # retiring only; erases the private key
+hikyo instance-config saml-sp-key compromise-retire <fingerprint> # active only; replace atomically
 ```
 
 All under `instance-config` capability, grant-evaluated `InstanceProof`, network path — never the local-admin class. `refresh-metadata` is the ADR's "action on the provider resource". SP keys are instance-wide, so their noun is deliberately a sibling of `provider`, not a provider subresource. Fingerprints are `sha256:` plus URL-safe unpadded base64 of SubjectPublicKeyInfo, so the exact value is safe as one path segment. `rotate` atomically marks the active key retiring and mints its replacement. Ordinary `retire` accepts only a retiring fingerprint; `compromise-retire` accepts only the active fingerprint and atomically erases and replaces it without an overlap window.
@@ -60,7 +60,7 @@ Admin REST resources (ordinary `/api/v1` grammar, proof-carrying):
 - `DELETE /api/v1/instance/saml-sp-keys/{fingerprint}`
 - `POST /api/v1/instance/saml-sp-keys/{fingerprint}/compromise-retire`
 
-Provider list/show responses carry a required `warnings` array. Its closed warning codes are `metadata_expires_soon`, `metadata_expired`, `signing_certificate_not_yet_valid`, and `signing_certificate_expired`; each item carries `severity`, the relevant timestamp, a server-authored message, and a certificate fingerprint where applicable. The 30-day metadata threshold is server-authoritative. Provider table output names warnings, JSON preserves the structured array, and the existing top-level `wenv doctor [--instance REF] [-o table|json]` reports the same server-authoritative items (no second warning calculation and no additional endpoint). Doctor returns success for no findings or warning-severity findings; metadata-expired is error severity and returns the stable refused exit code after rendering the findings.
+Provider list/show responses carry a required `warnings` array. Its closed warning codes are `metadata_expires_soon`, `metadata_expired`, `signing_certificate_not_yet_valid`, and `signing_certificate_expired`; each item carries `severity`, the relevant timestamp, a server-authored message, and a certificate fingerprint where applicable. The 30-day metadata threshold is server-authoritative. Provider table output names warnings, JSON preserves the structured array, and the existing top-level `hikyo doctor [--instance REF] [-o table|json]` reports the same server-authoritative items (no second warning calculation and no additional endpoint). Doctor returns success for no findings or warning-severity findings; metadata-expired is error severity and returns the stable refused exit code after rendering the findings.
 
 Identity-protocol endpoints (exception class, per-provider, parity-exempt):
 
@@ -75,9 +75,9 @@ Per-provider ACS paths satisfy the validation algorithm's per-provider `Destinat
 One top-level human-only verb `import`; the ADR fixes **three entry modes** — the spellings:
 
 ```
-wenv import                                   # wizard: TTY, no source arguments
-wenv import --from <k8s|sops|vault|infisical> --project <p> --environment <e> [selectors]
-wenv import --mapping <mapping.json>          # replay, non-interactive
+hikyo import                                   # wizard: TTY, no source arguments
+hikyo import --from <k8s|sops|vault|infisical> --project <p> --environment <e> [selectors]
+hikyo import --mapping <mapping.json>          # replay, non-interactive
 ```
 
 `import` without a TTY and without `--from`/`--mapping` is a hard error. Flag-mode selectors per connector: `--file <path>` (file mode, all connectors); live mode: `--live --namespace <ns> [--name <secret>]` (k8s), `--live --mount <m> [--path <prefix>] [--kv-version <1|2>]` (vault; version auto-detected from the mount when omitted); `--env <slug>` selects the source environment inside an Infisical export; SOPS and Infisical are file-only in v1. Flag mode targets exactly one `(project, environment)` and declares every value `string`. Common: `--out-dir <dir>` for the emitted artifacts (values files under the secret-file discipline: dirfd-parent-checked `O_EXCL`, `0600`).

--- a/docs/spec/domain-model.md
+++ b/docs/spec/domain-model.md
@@ -1,12 +1,12 @@
-# Wenv — Domain Model (synthesis, 2026-08-06)
+# Hikyo — Domain Model (synthesis, 2026-08-06)
 
-The ubiquitous language, as locked in the domain-model grilling ([#7](https://github.com/Dunky13/wenv/issues/7)) and amended by the flat-model ADR ([flat-model.md](../adr/flat-model.md), which supersedes the inheritance model in full). This document is the consolidated current state; the owning ADRs hold the rationale and the full semantics. It decides nothing.
+The ubiquitous language, as locked in the domain-model grilling ([#7](https://github.com/Hikyo-Org/Hikyo/issues/7)) and amended by the flat-model ADR ([flat-model.md](../adr/flat-model.md), which supersedes the inheritance model in full). This document is the consolidated current state; the owning ADRs hold the rationale and the full semantics. It decides nothing.
 
 ## Hierarchy
 
 **Instance → Organization → Project → Environment → Folder → Key/Value.**
 
-- **Instance** — one Wenv installation. Holds instance configuration, identity providers, remotes, the operator capability set.
+- **Instance** — one Hikyo installation. Holds instance configuration, identity providers, remotes, the operator capability set.
 - **Organization** — tenancy boundary. All isolation is application-layer, proof-carrying ([tenant-isolation.md](../adr/tenant-isolation.md)); org admins are trusted within their org ([threat-model.md](../adr/threat-model.md)).
 - **Project** — owns the key catalogue (the schema), environments, service accounts, adapters, per-project DEK ([encryption-model.md](../adr/encryption-model.md)).
 - **Environment** — user-defined per project, display-ordered. **No `base` pointer** (deleted by flat-model); no inheritance of any kind.
@@ -31,7 +31,7 @@ Ergonomics for shared values are three explicit operations with no ongoing relat
 ## Identity & principal vocabulary
 
 - **Human account** — local credential and/or linked external identities `(kind ∈ {oidc, saml}, issuer, subject)`, byte-exact matching ([human-auth.md](../adr/human-auth.md)).
-- **Service account** — machine principal, project-owned, kind `workload | automation`; credentials: `wenv-token` (bearer `ew_…`) or `oidc-federation` ([machine-identities.md](../adr/machine-identities.md)).
+- **Service account** — machine principal, project-owned, kind `workload | automation`; credentials: `hikyo-token` (bearer `hik_…`) or `oidc-federation` ([machine-identities.md](../adr/machine-identities.md)).
 - **Provisioning connection** — org-owned machine principal, one per SCIM binding, holds exactly `scim-provision` ([scim-provisioning.md](../adr/scim-provisioning.md)).
 - **Instance connection** — instance-owned machine principal for the multi-instance directory, holds exactly `instance-directory` ([multi-instance.md](../adr/multi-instance.md)).
 - **Grant** — `(principal, capability, scope)` triple with origins (`manual | scim | lockout-retention | structural`); the only authorization input ([permission-model.md](../adr/permission-model.md)).

--- a/docs/spec/open-items.md
+++ b/docs/spec/open-items.md
@@ -1,4 +1,4 @@
-# Wenv — Post-spec open items (synthesis, 2026-08-06)
+# Hikyo — Post-spec open items (synthesis, 2026-08-06)
 
 The map's fog sweep, discharged: everything still unspecified at synthesis is recorded here explicitly. **None of these is a foundational question** — an implementing team is not blocked by any row; each names its owner and its resolution moment. The post-v1 feature register (with dispositions and reopen triggers) is [mvp-boundary.md](../adr/mvp-boundary.md) §4 and is *not* duplicated here.
 
@@ -11,7 +11,7 @@ The map's fog sweep, discharged: everything still unspecified at synthesis is re
 | Forgejo + GitHub PAT minimal-scope exact spellings; GitHub expiry header pin; contract-test fixtures (POST-409 oracle, sealed-box vectors); non-UTF-8 disposition | [deployment-adapter.md](../adr/deployment-adapter.md), [github-adapter.md](../adr/github-adapter.md) | Implementation, against fixture evidence |
 | Exact pinned CI action SHAs, pipeline steps | [oss-mechanics.md](../adr/oss-mechanics.md), [system-architecture.md](../adr/system-architecture.md) | Implementation under #22's pinning rules |
 | Golden-snapshot CLI scenario matrix; S3 closed flow registry enumeration | [api-cli-surface.md](../adr/api-cli-surface.md), [mvp-boundary.md](../adr/mvp-boundary.md) | First CI wiring; gate exists before any build |
-| Repository transfer `Dunky13/wenv` → GitHub organization | [oss-mechanics.md](../adr/oss-mechanics.md) | Fixed implementation step |
+| Repository transfer to `Hikyo-Org/Hikyo` | [oss-mechanics.md](../adr/oss-mechanics.md) | Fixed implementation step |
 
 ## Open items proper (no owner-locked answer yet; none foundational)
 

--- a/docs/spec/ops-catalogue.md
+++ b/docs/spec/ops-catalogue.md
@@ -1,4 +1,4 @@
-# Wenv — Ops catalogue additions landed at synthesis (2026-08-06)
+# Hikyo — Ops catalogue additions landed at synthesis (2026-08-06)
 
 [ops-spec.md](../adr/ops-spec.md) owns every concrete operational value; several post-lock ADRs declared **categories** into its composable-maxima catalogue and delegated the **values** to synthesis. This document lands those values under ops-spec's rules: every bound is a named user-visible refusal; every default is overridable at the stated scope unless marked fixed; all values are sane at the Pi-4/4 GB calibration floor. These rows join the ops-spec decision inventory; contradictions reopen the owning ticket.
 

--- a/docs/spec/product-requirements.md
+++ b/docs/spec/product-requirements.md
@@ -1,6 +1,6 @@
-# Wenv — Product Requirements (synthesis, 2026-08-06)
+# Hikyo — Product Requirements (synthesis, 2026-08-06)
 
-Synthesized from the positioning decision ([#3](https://github.com/Dunky13/wenv/issues/3)), the competitive research ([competitive-landscape.md](../research/competitive-landscape.md)), the license decision ([#9](https://github.com/Dunky13/wenv/issues/9)), the MVP boundary ([mvp-boundary.md](../adr/mvp-boundary.md)), and the product register at the repo root ([PRODUCT.md](../../PRODUCT.md)). This document restates locked decisions; it decides nothing. On any divergence, the owning ADR or ticket resolution wins and the contradiction reopens that ticket.
+Synthesized from the positioning decision ([#3](https://github.com/Hikyo-Org/Hikyo/issues/3)), the competitive research ([competitive-landscape.md](../research/competitive-landscape.md)), the license decision ([#9](https://github.com/Hikyo-Org/Hikyo/issues/9)), the MVP boundary ([mvp-boundary.md](../adr/mvp-boundary.md)), and the product register at the repo root ([PRODUCT.md](../../PRODUCT.md)). This document restates locked decisions; it decides nothing. On any divergence, the owning ADR or ticket resolution wins and the contradiction reopens that ticket.
 
 ## One-liner
 
@@ -17,7 +17,7 @@ Synthesized from the positioning decision ([#3](https://github.com/Dunky13/wenv/
 
 Every surveyed competitor (Infisical, Phase, Vault/OpenBao, SOPS, ESO — [competitive-landscape.md](../research/competitive-landscape.md)) either paywalls the operational core (audit, RBAC, SSO, SCIM, secret scanning — the classic `/ee` lineup) or lacks the environment-matrix + schema-validation combination entirely. No surveyed product combines explicit multi-environment values + schema validation + fully-open licensing.
 
-Wenv's wedge is structural, not promotional:
+Hikyo's wedge is structural, not promotional:
 
 - **MPL 2.0**: file-level copyleft keeps every existing file open in any fork, and DCO means contributors keep their copyright — so the maintainer cannot unilaterally relicense *contributed* work (the specific lever a BUSL-style pivot needs). What this does *not* do is legally prevent new proprietary code beside old open code — that boundary is held by governance, not law. See [oss-mechanics.md](../adr/oss-mechanics.md) and #9.
 - **The no-`/ee` pledge** is published governance (GOVERNANCE.md full text + README sentence), amendable only through the locked-decision procedure: audit, rollback, RBAC, SAML, SCIM, secret scanning ship free.
@@ -34,7 +34,7 @@ Wenv's wedge is structural, not promotional:
 
 ## Delivery overview
 
-Wenv delivers values three ways, presented as a gradient: **fetch-based delivery** under the workload's own identity (`wenv run` / rendered dotenv on Compose, the K8s operator, CI federation fetching at runtime) is the first-class path; **push adapters** (Forgejo, GitHub Actions) exist for destinations whose workflows need standing values before the first fetch. The gradient sentence, carried from [deployment-adapter.md](../adr/deployment-adapter.md) as positioning: ***if your job can fetch, federate; push what must exist before the first fetch.***
+Hikyo delivers values three ways, presented as a gradient: **fetch-based delivery** under the workload's own identity (`hikyo run` / rendered dotenv on Compose, the K8s operator, CI federation fetching at runtime) is the first-class path; **push adapters** (Forgejo, GitHub Actions) exist for destinations whose workflows need standing values before the first fetch. The gradient sentence, carried from [deployment-adapter.md](../adr/deployment-adapter.md) as positioning: ***if your job can fetch, federate; push what must exist before the first fetch.***
 
 ## Scale envelope (v1 designed-for)
 
@@ -42,7 +42,7 @@ Wenv delivers values three ways, presented as a gradient: **fetch-based delivery
 
 ## Success criteria
 
-- An operator trusts Wenv enough to manage production secrets in it.
+- An operator trusts Hikyo enough to manage production secrets in it.
 - Every resolved value's origin is understandable without reading docs.
 - The 1.0 gate ([mvp-boundary.md](../adr/mvp-boundary.md) §1.2, §6) is green on sqlite **and** postgres, and the [self-hoster checklist](./self-hoster-checklist.md) passes wholesale.
 

--- a/docs/spec/self-hoster-checklist.md
+++ b/docs/spec/self-hoster-checklist.md
@@ -1,10 +1,10 @@
-# Wenv — Self-hoster checklist (synthesis deliverable, 2026-08-06)
+# Hikyo — Self-hoster checklist (synthesis deliverable, 2026-08-06)
 
 [mvp-boundary.md](../adr/mvp-boundary.md) §3 binds 1.0 wholesale to the oss-mechanics **decidable self-hoster test**: every capability in the spec set must be fully exercisable by a self-hoster — policy, API shape, recovery path, tenancy behavior, data transformation. Any capability failing is a **synthesis-blocking defect**. This checklist runs the instrument over the §1.2 capability list plus the four promotions. It is re-asserted against the release candidate's capability list at 1.0 (§6 item 4).
 
 Verdict legend: **PASS** = the capability meets the oss-mechanics test, quoted in full:
 
-> **The self-hoster test:** every functional and administrative outcome — running, configuring, backing up, restoring, upgrading, and operating Wenv, including everything a hosted tenant can see or do — must be achievable by a self-hoster using only released open-source artifacts and documented public interfaces. Hosted-side code may *schedule and operate* those public interfaces; it may never contain an exclusive capability, policy engine, API, recovery mechanism, tenancy control, or data transformation.
+> **The self-hoster test:** every functional and administrative outcome — running, configuring, backing up, restoring, upgrading, and operating Hikyo, including everything a hosted tenant can see or do — must be achievable by a self-hoster using only released open-source artifacts and documented public interfaces. Hosted-side code may *schedule and operate* those public interfaces; it may never contain an exclusive capability, policy engine, API, recovery mechanism, tenancy control, or data transformation.
 
 (The hosted-tenant clause and hosted-side-code restriction are vacuously satisfied at 1.0 — no hosted offering exists — and become load-bearing at the follow-on SaaS map's non-preclusion gate; the checklist asserts the 1.0 half: no capability requires anything beyond released artifacts and documented public interfaces.)
 
@@ -23,11 +23,11 @@ Verdict legend: **PASS** = the capability meets the oss-mechanics test, quoted i
 | K1–K3 encryption, backup/restore, headline guarantee | PASS | Root key operator-held; age backups to operator-owned identities; restore drill on floor hardware |
 | S1 API / S2 CLI | PASS | One `/api/v1` surface; CLI local |
 | S3 Web UI | PASS | embed.FS, no CDN |
-| S4 definitions Git flow | PASS | Wenv never reads a repository; any Git host (or none) works |
+| S4 definitions Git flow | PASS | Hikyo never reads a repository; any Git host (or none) works |
 | M1 machine identities & federation | PASS | Bearer path needs nothing external; OIDC federation works against self-hosted CI (Forgejo Actions) and static-JWKS air-gap alternative exists |
 | M2 Compose delivery | PASS | exec wrapper + dotenv, systemd timer |
 | M3 K8s operator | PASS | Own minimal operator, K3s floor documented, Pi-class footprint |
-| M4 deployment adapters | PASS | Forgejo adapter: self-hostable end to end. GitHub adapter: every functional and administrative outcome (configure, plan, sync, adopt, scrub) is achievable using only the released binary and GitHub's documented public REST API — no Wenv-side gate, no undocumented interface; the counterparty being a third-party platform (github.com, or self-hosted GHES best-effort) is the capability's subject, not a barrier the test measures |
+| M4 deployment adapters | PASS | Forgejo adapter: self-hostable end to end. GitHub adapter: every functional and administrative outcome (configure, plan, sync, adopt, scrub) is achievable using only the released binary and GitHub's documented public REST API — no Hikyo-side gate, no undocumented interface; the counterparty being a third-party platform (github.com, or self-hosted GHES best-effort) is the capability's subject, not a barrier the test measures |
 | M5 import | PASS | All connectors read local files or self-hosted sources; ambient credentials only |
 | M6 multi-instance | PASS | Symmetric, no "main"; zero remotes = zero outbound |
 | O1 single binary & migrations | PASS | `--dev` sqlite; prod explicit datastore |

--- a/docs/spec/ui-spec.md
+++ b/docs/spec/ui-spec.md
@@ -1,4 +1,4 @@
-# Wenv — UI & Interaction Specification (synthesis, 2026-08-06)
+# Hikyo — UI & Interaction Specification (synthesis, 2026-08-06)
 
 Binds the design system ([DESIGN.md](../../DESIGN.md) — dual theme dark-default, OKLCH tokens, AAA-leaning accessibility, state-never-color-only), the five locked reference prototypes, and the UI obligations the ADRs delegated to synthesis. The prototypes are the reference for structure and interaction shape; DESIGN.md is the reference for visual language; the owning ADR is the reference for semantics. The 1.0 gate's S3 criterion ([mvp-boundary.md](../adr/mvp-boundary.md)) requires a closed flow registry with one Playwright flow each and the pinned assertion set (axe-core serious/critical = 0, ARIA text with color stripped, focus indicators, contrast ≥ 4.5:1, touch ≥ 44 px, computed styles vs DESIGN.md tokens).
 
@@ -6,11 +6,11 @@ Binds the design system ([DESIGN.md](../../DESIGN.md) — dual theme dark-defaul
 
 | Surface | Reference | Ticket |
 |---|---|---|
-| Environment matrix (signature surface; flat model trialed and adopted here) | `prototype/env-matrix/` iteration 31 | [#20](https://github.com/Dunky13/wenv/issues/20) |
-| Secret reveal, masking & multi-env editing — **ceremony modal**; validation-error presentation; write-only replacement; change review & confirm | `prototype/reveal-edit/` iteration 6 | [#21](https://github.com/Dunky13/wenv/issues/21) |
-| App chrome — organisation, account & access surfaces (incl. `definitions_source` select + read-only consequence) | `prototype/app-chrome/` iteration 15 | [#29](https://github.com/Dunky13/wenv/issues/29) |
-| Version history & rollback — list + detail, write-presence-only secret signals, others'-pending markers, least-blast restore preview, pins | `prototype/revision-history/` iteration 6 | [#30](https://github.com/Dunky13/wenv/issues/30) |
-| Workload integration & machine-identity surfaces — write-only credential list, display-once mint, grant-mutation warning, federation management, restore reconciliation, K8s CR-condition vocabulary | `prototype/machine-access/` iteration 3 | [#31](https://github.com/Dunky13/wenv/issues/31) |
+| Environment matrix (signature surface; flat model trialed and adopted here) | `prototype/env-matrix/` iteration 31 | [#20](https://github.com/Hikyo-Org/Hikyo/issues/20) |
+| Secret reveal, masking & multi-env editing — **ceremony modal**; validation-error presentation; write-only replacement; change review & confirm | `prototype/reveal-edit/` iteration 6 | [#21](https://github.com/Hikyo-Org/Hikyo/issues/21) |
+| App chrome — organisation, account & access surfaces (incl. `definitions_source` select + read-only consequence) | `prototype/app-chrome/` iteration 15 | [#29](https://github.com/Hikyo-Org/Hikyo/issues/29) |
+| Version history & rollback — list + detail, write-presence-only secret signals, others'-pending markers, least-blast restore preview, pins | `prototype/revision-history/` iteration 6 | [#30](https://github.com/Hikyo-Org/Hikyo/issues/30) |
+| Workload integration & machine-identity surfaces — write-only credential list, display-once mint, grant-mutation warning, federation management, restore reconciliation, K8s CR-condition vocabulary | `prototype/machine-access/` iteration 3 | [#31](https://github.com/Hikyo-Org/Hikyo/issues/31) |
 
 ## ADR-delegated UI deltas (carried by synthesis)
 
@@ -26,7 +26,7 @@ Binds the design system ([DESIGN.md](../../DESIGN.md) — dual theme dark-defaul
 
 ## Git-mode definitions state ([source-of-truth.md](../adr/source-of-truth.md))
 
-When `definitions_source: git`, definition-editing surfaces are read-only with a persistent banner: **"Definitions for this project are managed in Git — changes arrive through `definitions plan` / `definitions apply`."** A blocked edit explains itself with that sentence plus the last-applied provenance labels (commit/ref/actor) when present — labels are display-only, never trusted. Wenv stores no repository URL (it never reads a repository), so the banner names the mechanism, not a repo link.
+When `definitions_source: git`, definition-editing surfaces are read-only with a persistent banner: **"Definitions for this project are managed in Git — changes arrive through `definitions plan` / `definitions apply`."** A blocked edit explains itself with that sentence plus the last-applied provenance labels (commit/ref/actor) when present — labels are display-only, never trusted. Hikyo stores no repository URL (it never reads a repository), so the banner names the mechanism, not a repo link.
 
 **Declaration authoring statement** (every declaration ingress, both modes): free-text declaration fields (descriptions, enum labels, schema annotations) are **exported to Git in definitions bundles and are to be treated as public — never paste secret values**. This is the UI restatement of the bundle's documentation-class guarantee; the structural backstop is S2 scanning.
 


### PR DESCRIPTION
## Summary

- replace all envweave and wenv references under docs/spec with Hikyo terminology
- update CLI, token, and repository references to current Hikyo spellings

## Verification

- ./scripts/ci/verify-docs.sh
- git diff --check
- case-insensitive docs/spec scan returns zero legacy-name matches

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789734851&installation_model_id=432348&pr_number=172&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F172&signature=378ec50d4d6290687257cd03e0875db9563585c538b1f889fd4e30dc41b91ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->