### PR TITLE
feat(web): history drawer, restore flow, pin lifecycle UI (#59)

### DIFF
--- a/api/apigen/apigen.gen.go
+++ b/api/apigen/apigen.gen.go
@@ -4087,7 +4087,18 @@ type RevealWindow struct {
 // Revision defines model for Revision.
 type Revision struct {
 	ChangedKeys []ChangedKey `json:"changed_keys"`
-	PublishedAt time.Time    `json:"published_at"`
+
+	// CollectedPolicy The retention policy stamped at collection, verbatim, and present
+	// only when `payload_present` is false. It is what the named refusal
+	// reports forever, so it is carried as an opaque string.
+	CollectedPolicy *string `json:"collected_policy,omitempty"`
+
+	// PayloadPresent Whether this revision's payload still exists. Lineage is retained
+	// forever; a payload collected by retention policy leaves the entry
+	// in the history with this bit false, and diff, restore, pin and
+	// reveal on it are refused loud rather than reconstructed.
+	PayloadPresent bool      `json:"payload_present"`
+	PublishedAt    time.Time `json:"published_at"`
 
 	// PublishedBy A prefixed UUIDv7, e.g. `org_0198…`.
 	PublishedBy    ID    `json:"published_by"`

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9950,7 +9950,7 @@ components:
           type: integer
     Revision:
       type: object
-      required: [revision, schema_revision, published_by, published_at, changed_keys]
+      required: [revision, schema_revision, published_by, published_at, changed_keys, payload_present]
       additionalProperties: false
       properties:
         revision:
@@ -9968,6 +9968,19 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ChangedKey"
+        payload_present:
+          type: boolean
+          description: |
+            Whether this revision's payload still exists. Lineage is retained
+            forever; a payload collected by retention policy leaves the entry
+            in the history with this bit false, and diff, restore, pin and
+            reveal on it are refused loud rather than reconstructed.
+        collected_policy:
+          type: string
+          description: |
+            The retention policy stamped at collection, verbatim, and present
+            only when `payload_present` is false. It is what the named refusal
+            reports forever, so it is carried as an opaque string.
     RevisionDetail:
       type: object
       required: [revision, schema_revision, published_by, published_at, changed_keys, change_token, keys]

--- a/clients/ts/src/generated/types.gen.ts
+++ b/clients/ts/src/generated/types.gen.ts
@@ -900,6 +900,21 @@ export type Revision = {
     published_by: Id;
     published_at: string;
     changed_keys: Array<ChangedKey>;
+    /**
+     * Whether this revision's payload still exists. Lineage is retained
+     * forever; a payload collected by retention policy leaves the entry
+     * in the history with this bit false, and diff, restore, pin and
+     * reveal on it are refused loud rather than reconstructed.
+     *
+     */
+    payload_present: boolean;
+    /**
+     * The retention policy stamped at collection, verbatim, and present
+     * only when `payload_present` is false. It is what the named refusal
+     * reports forever, so it is carried as an opaque string.
+     *
+     */
+    collected_policy?: string;
 };
 
 export type RevisionDetail = {

--- a/clients/ts/src/generated/zod.gen.ts
+++ b/clients/ts/src/generated/zod.gen.ts
@@ -1122,7 +1122,9 @@ export const zRevision = z.object({
     schema_revision: z.coerce.bigint().min(BigInt('-9223372036854775808'), { error: 'Invalid value: Expected int64 to be >= -9223372036854775808' }).max(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' }),
     published_by: zId,
     published_at: z.iso.datetime(),
-    changed_keys: z.array(zChangedKey)
+    changed_keys: z.array(zChangedKey),
+    payload_present: z.boolean(),
+    collected_policy: z.string().optional()
 });
 
 export const zRevisionList = z.object({

--- a/docs/handoff/57-env-matrix.md
+++ b/docs/handoff/57-env-matrix.md
@@ -27,8 +27,8 @@ drift signal anywhere in this surface).
   refusals), filter bar "⚠ filter active: problems — showing n of m keys" +
   "✕ show all keys", filter survives group jumps, filtered-out groups render dimmed
   and inert (title "hidden by the problems filter"), group badges carry counts.
-- `web/src/routes/MatrixRowEditor.tsx` — centered row editor opened from the key name
-  or a cell: one field per readable environment, protected markers, fill-all,
+- `web/src/routes/MatrixRowEditor.tsx` — centered row editor opened from a cell
+  (since #59 the key NAME opens that key's history, per revision-history it-6): one field per readable environment, protected markers, fill-all,
   write-only secret placeholders, live per-field declaration checks, per-cell clear,
   and provenance per environment. Dirty state distinguishes untouched, explicit
   empty `set`, and `unset`. Config copy-to keeps its protected confirmation + ceremony;

--- a/docs/handoff/59-history-drawer.md
+++ b/docs/handoff/59-history-drawer.md
@@ -195,11 +195,17 @@ written at all.
     code so copy changes cannot hide the offer. `pinSchemaOverrideOffered`
     positively matches all three `validateResolved` schema-refusal shapes: value
     rule, presence rule and key-group rule. The value-rule browser path is green.
-14. **Key-name click has a prototype conflict, disposition pending Marc.**
-    Environment-matrix iteration 31 makes the name open the row editor;
-    revision-history iteration 1 makes it open the history drawer. Shipped
-    matrix behavior keeps row editing; the explicit `History for <KEY>` action
-    opens history until Marc dispositions the conflict.
+14. **The matrix KEY NAME opens the drawer filtered to that key** (Marc's
+    disposition "a", 2026-08-19). The first cut kept #57's key-name → row-editor
+    binding and called it a prototype-vs-prototype conflict; that was wrong:
+    env-matrix iteration 31 wires NOTHING to the key name (`.kn` is a plain span),
+    the row-editor-on-name was #57's own choice, and revision-history it-1/it-6
+    is the only lock that speaks ("a key name click opens the same drawer
+    filtered to that key"). So the name is now a link (`History of <KEY>`), any
+    cell opens the row editor (unchanged, #57), and the row editor keeps its
+    `History for <KEY>` link. `matrix.spec.ts` opens the editor from a cell;
+    `history.spec.ts` proves both entries (matrix name, changed-key row) and the
+    deep link. #57's handoff line is corrected in place.
 15. **The pin-sheet comparison is a READ, not a disclosure.** It calls
     `exportValues` with `reveal:false`: config plaintext rides `read` (the same
     authority the matrix reads config under), secret lines are lineage

--- a/docs/handoff/59-history-drawer.md
+++ b/docs/handoff/59-history-drawer.md
@@ -1,0 +1,383 @@
+# Handoff — #59 History drawer + restore + pin lifecycle UI
+
+Ticket: [#59](https://github.com/Hikyo-Org/hikyo/issues/59) (parent #41). Blocked-by
+#52 (rollback & pins), #53 (retention & GC), #56 (UI shell / flow registry), #57
+(environment matrix) and #58 (reveal ceremonies) — all merged before this work.
+
+Binds the frozen prototype `prototype/revision-history/6` (branch `wayfinder-docs`,
+locked 2026-08-05: panes drawer from iteration 2 verdict **b**, pin clarity from
+iteration 3, pin-as-workload-binding + sole-keeper language from iteration 4,
+read-only retention line from iteration 6), `docs/adr/revision-model.md` read
+through its flat-model amendment banner (restore is two-way `set | unset`; no
+masks), and `docs/adr/mvp-boundary.md` rows **C5 [UI]** and **S3**.
+
+## What shipped
+
+**A new locked surface, `history`.** `web/src/app/navigation.ts` gains
+`/orgs/:org/projects/:project/matrix/history`, `section: null`, chrome-wearing.
+The element in `App.tsx` is `<Matrix historyOpen />` — the same component, told
+by the ROUTE TABLE that its drawer is open. That is the shape the prototype
+locked: the panes render *over* the matrix, not instead of it, and the matrix
+stays addressable behind them. It also means no second component owns the
+project's catalogue, values and signals, which the drawer needs anyway.
+
+Environment and per-key filter are QUERY PARAMETERS (`?env=`, `?key=`, `?rev=`),
+because per-key history is a filter over the same lineage and not a second
+surface — the prototype's first decision. Every part of the drawer's state is
+therefore deep-linkable, and the flow asserts the deep link.
+
+- `web/src/routes/HistoryDrawer.tsx` — the drawer: head (current revision,
+  protected marker, environment tabs, others'-drafts summary, read-only retention
+  line, active key filter), the list + detail panes, the restore sheet, the pin
+  sheet and the sole-keeper release confirmation. Below 800px the two panes
+  become one — list, then detail, with a back affordance — because a split 440px
+  drawer is neither pane.
+- `web/src/routes/history-state.ts` + `history-state.test.ts` — the pure seam
+  (39 cases): revision action gating, per-key filter projection, pin action
+  label, expiry tiers, the sole-keeper predicate, restore preview chips, the two
+  ceremony units, the pin-refusal classifier, the retention line, relative age.
+- `web/src/api/history.ts` + `history.test.ts` — the API boundary: revisions,
+  gated detail, pins, project retention; rollback, pin set, pin release; refusal
+  text. Two contract invariants are re-stated as `superRefine`s because their
+  violation would be a disclosure rather than a rendering bug (below).
+- `web/src/routes/Matrix.tsx` — the `rev N · history` link in each environment
+  column header and the drawer render. On mobile the matrix becomes `inert`
+  while the drawer is open; focus lands on the drawer title, moves to revision
+  detail, and returns to the selected row on back.
+- `web/src/routes/MatrixRowEditor.tsx` — the per-key affordance,
+  `History for <KEY>`, which is the history surface with `key` set.
+- `web/src/routes/Ceremony.tsx` / `useProtectedPublishCeremony.ts` — two new
+  told-the-human purposes (`restore`, `pin`) that SIGN `reveal`, and an optional
+  `purpose` on a ceremony target. Same controller as publish and copy, so the
+  "prompt or not" decision stays in one place.
+- `web/src/styles/app.css` — the `history__*` block and `.btn--danger`.
+
+### Secret safety on this surface
+
+Nothing here can render secret material, and three separate things enforce that:
+
+- the lineage rows carry write-presence only (`added` / `edited` / `removed`)
+  and mark the key 🔒 — never a value, a length, a digest or a comparison;
+- `zHistoryRollbackResult` refuses an impact row that carries `before`/`after`
+  for a `secret` key, or an `after` on a clear, at the parse boundary;
+- the restore impact rows render `secret — <status>, write-presence only` by
+  construction rather than by omission.
+
+## API addition (additive, both engines)
+
+`Revision` gains **`payload_present`** (boolean, required) and
+**`collected_policy`** (string, optional — present only when collected, and
+carrying the store's own `formatRetentionPolicy` vocabulary verbatim).
+They are intentionally on `listRevisions` rows only, not `RevisionDetail`:
+`Show` refuses collected revisions before producing detail, so the detail bit
+would be invariantly true and its policy invariantly absent. Machine clients can
+also reach `getRevision`, so its response should not advertise a misleading
+payload lifecycle contract that it can never represent.
+
+The bit already existed on `store.Snapshot` (#52's `payload_present`, #53's
+`collected_policy`); it simply never reached the wire. It has to, because
+`getRevision` **409s on a collected revision** — it derives a change token over
+the snapshot's manifest — so the drawer cannot learn "this payload was collected"
+from the detail endpoint. `listRevisions` is the only read that still works, and
+without the bit the surface would have to discover a collected revision by
+failing on it.
+
+- `internal/service/revisions.go` — `RevisionView.PayloadPresent` /
+  `.CollectedPolicy`, filled in `History`. `collectedPolicy()` reports
+  the stamped policy ONLY for a collected payload: the column carries a default
+  while the payload is live, and emitting that would read as a fact about
+  nothing.
+- `internal/server/revisions.go` — `wireRevision` renders list rows only;
+  `GetRevision` renders the detail fields directly without lifecycle members.
+- Regenerated `api/apigen` (`go tool oapi-codegen --config api/oapi-codegen.yaml
+  api/openapi.yaml`) and `clients/ts` (`pnpm run verify` under Node 24).
+- Tests: `TestLineageWireCarriesTheCollectionBit` (transport, both directions)
+  and an assertion inside `runRetentionGCC6` (isolation, **sqlite + postgres**)
+  that the bit and the stamped policy survive a real GC sweep on the read that
+  still works.
+
+No migration, no store change, no registry/formula change — so no
+`annotated_queries.json` / `audited_exemptions.json` / `operation_formulas.json`
+re-pin was needed. Verification is in the table at the end of this document.
+
+### One server-side fix this ticket required
+
+`validateValue` (`internal/service/values.go`) raised its refusal as a bare
+`domain.ErrInvalid`, so the wire carried a 400 with **no detail** — and C5
+requires a schema-failing restore to "block loud, naming the keys". Its own
+comment already says the text is schema-derived and carries nothing the caller
+may not see, so it now uses `invalidDetail` like the presence vetoes beside it.
+`matrixMutationError` quotes the server's caller-safe detail verbatim rather than
+paraphrasing it. Without this pair the flow's schema-refusal assertion cannot be
+written at all.
+
+## Decisions, and divergences from the locked prototype BY NAME
+
+1. **Revision-to-revision diff modal: OUT.** The prototype offers "diff vs
+   previous" and "diff vs current". No API computes a rev↔rev diff — `diffValues`
+   compares two ENVIRONMENTS — and neither C5 nor S3 names one. The restore
+   **impact preview** is this surface's "what would change" view. Deferred, not
+   dropped: it needs an endpoint first.
+2. **Same-revision re-pin is a RENEW, not a refused no-op.** Iteration 4 refuses
+   it ("a workload fetches exactly one revision"). The API/CLI taxonomy locked
+   afterwards (#52, api-cli-surface) makes it a renew: it extends the expiry,
+   revalidates against the current schema, and records the drift that
+   revalidation finds. That is not nothing, so the sheet relabels to
+   `Renew pin on rN` and says what renewing does. The label is what the human
+   agrees to; the outcome toast reports the SERVER's `RevisionPinResult.action`.
+3. **Restore previews AFTER it stages, not before.** Iteration 1 previews, then
+   stages on confirmation. `rollbackRevision` does both in one call — it writes
+   the drafts and returns the impact preview with the token that binds them — so
+   the sheet explains the act before it is taken and reports the exact impact
+   after. Nothing is published either way.
+4. **No "n schema-blocked" chip.** The prototype's third summary chip counted
+   rows the staging step rejected. The shipped model validates at PUBLISH (#52:
+   publish is the only authority), so a successful preview has no blocked rows to
+   count. The refusal is still loud and still names the key; it arrives on the
+   publish leg, where the server decides it.
+5. **Retention is READ-ONLY here** — iteration 6's own verdict. Effective window,
+   inherits-org / custom badge, and a plain-text pointer at project settings ›
+   Policy (#60 owns that surface). One read: `getProjectRetention` already
+   answers with the effective policy AND `inherited`, so `getOrgRetention` is not
+   fetched.
+6. **Human actors are IDs; workloads are names.** Nothing in this API resolves a
+   HUMAN principal id to a display name — there is no member-listing operation,
+   and inventing one is a permission decision this ticket does not own — so
+   `published_by` renders as a shortened id with the whole one in `title`.
+   Workloads DO resolve, through the project's service accounts, which is why
+   pin rows and the consumers line name them.
+7. **The preview token lives in memory, in `Matrix`.** `PendingChange` carries no
+   `source`, so the browser cannot tell a restore-authored draft from an ordinary
+   one after the fact. The token travels from the restore that minted it to the
+   publish that spends it; a reload asks for the restore again rather than
+   guessing. Publish refuses a missing or stale token by name and the sheet
+   quotes it.
+8. **The ceremony purposes `restore` and `pin` SIGN `reveal`.** Both acts read
+   historical secret material and the service gates them with `PurposeReveal`
+   over the enumerated secret-key unit (`internal/service/{rollback,pins}.go`),
+   so that is what the assertion has to commit to — while the modal still tells
+   the human which of the two decisions they are taking. Exactly the
+  told-vs-signed split #58 established for clipboard copy.
+- `web/src/routes/useModalDialog.ts` — one dialog primitive shared by ceremony,
+  row editor, machine-access, restore, pin and release sheets: native modal,
+  initial focus, focus trap, inert background, Escape and focus restoration.
+- `web/src/api/matrix.ts` — a page-lifetime restore-preview store keyed by the
+  exact version-id set. Both the in-drawer `Publish this restore` action and the
+  ordinary matrix publish sheet attach the stored token; partial overlaps are
+  refused client-side before a publish request is sent. The browser flow counts
+  `/publish` requests around that refusal (zero), then around publish-alone
+  (exactly one).
+- The pin sheet includes a read-only comparison (no disclosure event). Config values render as
+  `stays at … — latest: …`; secrets render lineage only. Pin rows state the
+  behind-latest gap and expiry consequence in visible prose, not colour alone.
+9. **`override_schema` is offered only AFTER the server refuses.** An override
+   permanently on screen is an override people tick to make an error go away.
+   `pinSchemaOverrideOffered` classifies the refusal off `pins.go`'s own bounded
+   prefixes (expiry, quota, request shape) — anything else came from
+   `validatePinnedSnapshot`, which is the one refusal the recorded override
+   exists for.
+10. **The expiry bound is not pre-blocked client-side.** The input takes any
+    date and the server's `pin expiry exceeds the maximum 365 days` is surfaced
+    by name. A client-side cap would be a second source of truth for a value the
+    service owns.
+11. **`payload_present` is list-only.** It is intentionally absent from revision
+    detail because collected detail is unreachable; `listRevisions` is the read
+    that survives collection and therefore the only honest lifecycle carrier.
+12. **Secret impact `status` is authorized disclosure.** The server first builds
+    the historical/current secret unit and applies both authorization formulas
+    (`internal/service/rollback.go:138-167`), then requires the reveal ceremony
+    (`rollback.go:168-170`). It computes set-vs-set equality only after those
+    gates (`rollback.go:198-209`). Rendering status without `before`/`after` is
+    therefore server-gated disclosure, not an ungated client inference.
+13. **Schema override discovery is prose-bound for now.** The checkbox appears
+    only after a positive match against the server's schema-refusal wording.
+    That is intentionally fail-closed, but remains pending a structured refusal
+    code so copy changes cannot hide the offer. `pinSchemaOverrideOffered`
+    positively matches all three `validateResolved` schema-refusal shapes: value
+    rule, presence rule and key-group rule. The value-rule browser path is green.
+14. **Key-name click has a prototype conflict, disposition pending Marc.**
+    Environment-matrix iteration 31 makes the name open the row editor;
+    revision-history iteration 1 makes it open the history drawer. Shipped
+    matrix behavior keeps row editing; the explicit `History for <KEY>` action
+    opens history until Marc dispositions the conflict.
+15. **The pin-sheet comparison is a READ, not a disclosure.** It calls
+    `exportValues` with `reveal:false`: config plaintext rides `read` (the same
+    authority the matrix reads config under), secret lines are lineage
+    write-presence, and no secret is ever opened — so the server writes NO
+    `disclosure.value_revealed` event for it (`Export` audits only revealed
+    secret entries, `internal/service/revisions.go`). The first cut of this
+    ticket labelled the section "audited"; that was wrong and is gone. The
+    browser flow pins the contract from both ends: the export request body
+    carries `reveal:false` + the compared revision, and the server trail's
+    disclosure count does not move across the click.
+16. **The schema-override checkbox is the shared `.chk` control** (44px on a
+    coarse pointer). It escaped the pinned sweep because it renders only after a
+    refusal, so the pin-lifecycle flow asserts its touch target explicitly at
+    the moment it exists (`expectTouchTargets`, mobile project) — the gap is
+    closed in the pipeline, not noted.
+
+### Deliberate ceilings (marked `ponytail:` in the code)
+
+- `restoreCeremonyUnit` cannot see WRITTEN-TIME (sticky) classification, so a key
+  reclassified since the target revision was published can put the enumerated
+  unit one key out of step with the server's. The consequence is bounded and
+  loud — a protected environment refuses it as a unit mismatch and the surface
+  says so — never a disclosure. Carry the sticky bit on `SnapshotKey` if it ever
+  shows up in practice.
+  This is the one client-invisible ceremony-unit gap: the ponytail ceiling.
+- `pastNormalRetention` duplicates the GC's own predicate
+  (`ListEligibleSnapshotPayloads`) because no endpoint answers "would this be
+  collected". It only decides how LOUD a release confirmation is; the server
+  still refuses a collected payload by name, so a drifted client warns wrongly
+  rather than deleting wrongly.
+
+## e2e coverage map
+
+`web/e2e/flows/history.spec.ts`, registry flow `history` → surface `history`
+(`web/e2e/registry.ts`). Serial, desktop + mobile projects, dark + light pinned
+passes. The pinned assertion set runs FIRST in the file, deliberately: the two
+ceremony-bearing tests reissue the browser session, so asserting the surface
+before anything mutates it keeps the S3 evidence off that dependency.
+
+| Criterion | Test |
+|---|---|
+| C5 [UI] restore flow from the history drawer | `restores an environment to an earlier revision and publishes the staged drafts` captures rollback and publish at the wire, then proves `preview_token` and the exact version-id set through the in-drawer action |
+| C5 ordinary publish path | `restores one key from the changed-key row` proves the matrix publish sheet carries the same captured token and exact previewed set |
+| C5 partial overlap | `refuses partial restore overlap, then publishes the restore set alone` stages another key in the same environment, proves the named client refusal sends zero `/publish` requests, then re-stages and proves publish-alone sends exactly one request carrying the exact restore set |
+| C5 schema-failing restore | `refuses a schema-failing restore loud, naming the key` proves the exact `value for "WORKERS" is invalid (` alert prefix, then identifies the surviving draft by the restore-returned version ID and asserts its rollback-preview base revision, `revealed: true`, and the older revision's invalid value; no publish success and unchanged revision list |
+| C5 secret restore impact | `renders secret restore impact status-only and never exposes its value` proves a secret-bearing restore has status-only impact, no before/after arrow or fixture value, and spends the rollback token when published |
+| S3 drawer + environment tabs | `opens from the matrix environment header and reads one environment at a time` proves header entry, current revision/list order, per-environment counts, and a retention line with no descendants matching the shared canonical interactive selector |
+| S3 per-key filter | `filters the timeline to one key, by click and by URL` proves the URL carries immutable key ID while visible copy uses key name |
+| S3 lineage secret safety | `shows one revision’s lineage without ever showing a secret value` proves write-presence-only lineage and absence of every seeded secret string in list and detail |
+| S3 pin gap + expiry | `shows the behind-latest gap sentence and warning-tier expiry as text` derives the exact publish gap and expiry tier from live state and proves both visible strings |
+| S3 historical pin + comparison | `requires a fresh-session ceremony for a historical move and audits comparison` requires the ceremony in a new cookie jar, verifies `history_authorized: true`, runs the read-only comparison and proves the export request carried `reveal` not true for the compared revision, the named changed config key plus unchanged-config cardinality, secret write-presence lineage copy, no fixture secret on any visited state (ceremony modals included), and a server-trail disclosure delta of exactly zero |
+| S3 renew, override + release | `runs renew, schema override, and retention-gated one-click release` proves the 365-day refusal, renew, successful-retention one-click release, value-rule override discovery, schema-drift pin, and cleanup |
+| S3 pinned assertion set | `meets the pinned assertion set on Revision history (dark|light)` on both viewport projects |
+| S3 mobile focus | `keeps the mobile matrix inert and restores drawer focus` proves matrix inert, title/detail focus, and selected-row focus restoration |
+| S3 registry closure | Teardown requires both `dark` and `light` executions for every claimed flow/surface; registry unit test proves one-theme-only fails |
+
+**Fixture (`web/e2e/fixtures/seed.ts`).** Its own project, `ledger` — one
+instance serves the whole suite and the matrix flow asserts exact key counts and
+exact cell text in `payments`. Three value publishes in `development` (a secret
+edit and a config edit between them), one in `staging`, a declaration tightened
+afterwards, two workload service accounts, and one pin on the current revision
+with an expiry inside the 30-day warning tier. The break-glass grant loop gains
+`pin` and `reveal-history`.
+
+**Revision numbers used by actions are READ, never assumed.** The fixture carries
+only the seeded baseline count and seeded pin revision so pass one can prove it
+did not repair away global-setup state; every actionable revision is derived.
+Two properties forced this and both are easy to get wrong:
+
+- Every SCHEMA act mints its own revision in every environment of the project —
+  creating a key and tightening a declaration each advance the environment
+  though they change no value — so three publishes are emphatically not
+  `r1..r3`. The first version of this flow hard-coded them and was really a test
+  of when a revision happens to be minted.
+- **The flow MUTATES its project** (it restores and publishes) and Playwright
+  runs it once per viewport project against ONE instance, so pass two starts from
+  whatever pass one left. Any number captured at seed time is wrong by then.
+
+So the flow derives every action target in `beforeAll`, from the same
+`listRevisions` projection, and repairs the two pieces of state pass one moves
+only when drift is actually present:
+the invalid draft the schema-refusal test necessarily leaves staged (superseded
+with a valid value and published — otherwise pass two's restores drag it into
+their publish and are refused for pass one's reason), and the pins (released,
+then one canonical pin re-created on the current revision only when pins differ).
+On a fresh pass the test asserts the seeded revision count, workload, pin
+revision and expiry exactly. Its bearer session is its own password login: the shared storage state
+is re-minted several times per run and re-minting enrols a passkey, which kills
+every session the principal holds — the seeding one included.
+
+### Not reachable in the browser flow, and where it is covered instead
+
+- **Collected-revision gating.** A payload is collected by the GC sweep, which
+  runs at startup and hourly; a fixture cannot age a revision past the retention
+  window inside a run. Covered by `revisionActionGate` in the vitest seam (all
+  four states, including the policy-naming refusal) and by the isolation test
+  above, which asserts the bit round-trips through a REAL sweep on both engines.
+- **Sole-keeper release confirmation.** Same reason: it needs a revision past
+  both retention dimensions. Covered by `soleKeeperPinIds` in the seam (seven
+  cases, including the two-live-pins, expired-pin and already-collected
+  exemptions). The one-click release the flow exercises is the non-sole path,
+  which is what the ticket names for e2e.
+- **Move consequence.** It requires moving the sole keeper of a revision already
+  outside normal retention, the same unreachable retention-window state. Vitest
+  covers the predicate and consequence copy.
+- **Failed retention query.** The browser harness cannot force only that query
+  to fail without request interception that would test a synthetic network
+  response. D1's successful-query one-click path is exercised; failure stays at
+  the query/component seam.
+- **Per-key ID/name conflict.** Producing one requires deleting or replacing a
+  seeded key, outside this fixture's non-destructive API path. Covered in vitest.
+- **Reveal-history refusal naming keys.** Existing seeding has one interactive
+  human principal. Creating a second editable human without `reveal-history`
+  exceeds the bounded fixture change; permission/refusal wording remains seam
+  coverage.
+
+## Verification record (2026-08-19, orchestrator's own runs on the final tree)
+
+| Check | Result |
+|---|---|
+| `gofmt -l .`, `go vet ./...`, `go build ./...` | clean |
+| `go test ./...` (sqlite) | 2151 passed, 45 packages |
+| `go tool oapi-codegen …` + `clients/ts` `pnpm run verify` (Node 24) | regen idempotent (md5 stable), TS client typecheck + 4/4 contract tests |
+| `pnpm --dir web typecheck` | clean |
+| `pnpm --dir web test` (Vitest) | 11 files, 152 tests passed (registry closure incl. the theme-aware negative fixture) |
+| `pnpm --dir web build` | clean |
+| `cd web && pnpm exec playwright test flows/history.spec.ts` (both viewport projects, one invocation) | 27 passed, 1 skipped (the mobile-only focus contract skips on desktop by design) |
+| `cd web && pnpm e2e` — ONE unfiltered invocation, both viewport projects, dark + light, on the committed tree | 157 passed, 1 skipped (3.4 min); global teardown's theme-aware run-log closure ran and passed |
+
+Review record: two-axis Standards + Spec (Claude sub-agents) and a capped
+three-round native Codex (`gpt-5.6-sol`, high) adversarial loop, split by concern
+(Go/API, seam, drawer, e2e). R1 found 11 Go/seam, 5 drawer, 5 e2e, plus
+standards/spec items; all were fixed or dispositioned with evidence (secret
+impact `status` is server-gated — decision 12; sticky written-time
+classification is the one client-invisible ceremony-unit gap; the pin
+comparison is a read, not a disclosure — decision 15). R2 verified the fixes and
+left six partials, all fixed. R3 returned CLEAN on Go/API; its three remaining
+items (opener snapshot at mount, ceremony-state secret negatives, this record)
+were applied by the orchestrator before commit — the affected checks above are
+from AFTER those edits.
+
+Ports for this session: `HIKYO_E2E_PORT=45840 HIKYO_E2E_PORT_B=45841
+HIKYO_E2E_PORT_TLS=45842`.
+
+## Three harness findings, all fixed
+
+1. **The registry's execution check never actually skipped under `--grep`**
+   (campsite fix, `e2e/global-teardown.ts`). The predicate read
+   `String(config.grep) !== '/.*/'`, and Playwright leaves the resolved config's
+   `grep` at `/.*/` — the CLI filter is applied separately. So every filtered run
+   ended, after its tests passed, with a wall of "claims more than it runs" lines
+   about flows nobody asked to run: precisely the "check people work around
+   instead of with" the file's own comment warns against. It now reads the CLI
+   from `process.argv` and still consults the config field, which a `grep` set in
+   `playwright.config.ts` does reach.
+2. **`login answered 401` from `refreshSharedSession` was a STALE INSTANCE, not
+   an auth bug.** A run killed without teardown leaves a server on the port with
+   a different datastore behind it. `startInstanceAt` catches that for a fresh
+   boot, but `mintStorageState` talks to `BASE_URL` directly — so it authenticated
+   the fixture administrator against a stranger's database and got a perfectly
+   correct credential refusal. Cost several hours of chasing an auth path that was
+   working. If it reappears: `lsof -nP -iTCP:<HIKYO_E2E_PORT> -sTCP:LISTEN`
+   first, before reading any Go.
+3. **Theme-aware closure exposed login's missing light pinned-set execution.**
+   `login.spec.ts` had a separate light-palette check, but only the dark test
+   called `expectPinnedAssertionSet`, so final teardown correctly refused the
+   claim. The pinned set now runs as distinct dark and light tests; the next
+   unfiltered run recorded both and passed closure.
+
+## Deferred, by name
+
+- **Revision-to-revision diff** (decision 1). Needs an endpoint.
+- **Retention EDITING** — project settings › Policy and org settings › Policy,
+  #60's surface. This drawer reports the policy and never writes it.
+- **Sole-keeper release confirmation is not exercised in a browser** (above); the
+  predicate and the sheet exist and the seam covers the predicate.
+- **A schema-failing publish flags no matrix CELL.** `matrixPublishValidation`
+  indexes a problem against `(key, environment)`, and the value-rule refusal
+  names a key but no environment (a publish can span several). The alert names
+  the key and points at the row editor, which is the ticket's stated minimum.
+  Naming the environment would need the refusal to carry it.

--- a/internal/isolation/retention_gc_e2e_test.go
+++ b/internal/isolation/retention_gc_e2e_test.go
@@ -209,6 +209,31 @@ func runRetentionGCC6(t *testing.T, db *store.DB) {
 	if refusal.Revision != 1 || refusal.Policy != collectedPolicy {
 		t.Fatalf("collected refusal = %+v, want revision 1 and collecting project policy", refusal)
 	}
+	// The collection bit is LINEAGE, so it has to survive on the read that
+	// still works. `Show` refuses a collected revision outright, which is why
+	// the history drawer (#59) can only gate its diff/restore/pin actions if
+	// `listRevisions` carries the bit and the stamped policy through.
+	history, err := revisions.History(t.Context(), actor, scopeEnv(orgA, prjA1, domain.EnvID("env_gc")))
+	if err != nil {
+		t.Fatalf("history after collection: %v", err)
+	}
+	if len(history) != 6 {
+		t.Fatalf("history entries = %d, want 6 (lineage outlives its payload)", len(history))
+	}
+	for _, entry := range history {
+		wantPresent := entry.Revision != 1 && entry.Revision != 3
+		if entry.PayloadPresent != wantPresent {
+			t.Errorf("r%d payload_present = %v, want %v", entry.Revision, entry.PayloadPresent, wantPresent)
+		}
+		wantPolicy := ""
+		if !wantPresent {
+			wantPolicy = collectedPolicy
+		}
+		if entry.CollectedPolicy != wantPolicy {
+			t.Errorf("r%d collected_policy = %q, want %q", entry.Revision, entry.CollectedPolicy, wantPolicy)
+		}
+	}
+
 	pins := &service.Pins{DB: db, Keyring: probeKeyring(t, db), Now: func() time.Time { return now }}
 	_, err = pins.Set(t.Context(), actor, scopeEnv(orgA, prjA1, domain.EnvID("env_gc")), service.SetPinRequest{
 		WorkloadPrincipalID: mchWork,

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -1411,9 +1411,11 @@ func TestAssuranceRefusalOnATenantRouteIsForbidden(t *testing.T) {
 
 const (
 	// testProjectID and testEnvID are declared with the hierarchy fixtures above.
-	testEnvID2     = "env_0193f0b4-1f2a-7c31-9c1e-2a4b6d8e0f56"
-	cloneRoutePath = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/environments/clone"
-	copyRoutePath  = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/values/copy"
+	testEnvID2       = "env_0193f0b4-1f2a-7c31-9c1e-2a4b6d8e0f56"
+	cloneRoutePath   = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/environments/clone"
+	copyRoutePath    = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/values/copy"
+	declareRoutePath = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/values/declare"
+	setRoutePath     = "/orgs/" + testOrgID + "/projects/" + testProjectID + "/environments/" + testEnvID + "/values/API_SECRET"
 )
 
 // newValueServer builds a test server with injectable environment and value
@@ -1455,6 +1457,49 @@ func TestCloneAbortBodyCarriesTheStrandedKeys(t *testing.T) {
 	body := decodeError(t, payload)
 	if body.Error.Detail == nil || !strings.Contains(*body.Error.Detail, "REQUIRED_TOKEN") {
 		t.Fatalf("clone-abort 400 detail = %v, want it to name the stranded key REQUIRED_TOKEN", body.Error.Detail)
+	}
+}
+
+func TestInvalidSecretValueDetailReachesBothWriteRoutesWithoutInstanceData(t *testing.T) {
+	const (
+		plaintext = `{"tenant-leaf-9f4a":"DO-NOT-ECHO-secret-7c31"}`
+		fragment  = "tenant-leaf-9f4a"
+		detail    = `value for "API_SECRET" is invalid (json_schema/additionalProperties: value failed the declared JSON Schema at #/additionalProperties)`
+	)
+	srv := newValueServer(t, stubEnvs{}, stubValues{stubHierarchy{err: safeDetailErr{detail: detail}}})
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{
+			name:   "declare",
+			method: http.MethodPost,
+			path:   api.PathPrefix + declareRoutePath,
+			body:   map[string]any{"key": "API_SECRET", "environment_ids": []string{testEnvID}, "value": plaintext},
+		},
+		{
+			name:   "value write",
+			method: http.MethodPut,
+			path:   api.PathPrefix + setRoutePath,
+			body:   map[string]any{"value": plaintext},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, payload := call(t, srv, tc.method, tc.path, "hik_1_cli_x", tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status %d, want 400: %s", resp.StatusCode, payload)
+			}
+			got := decodeError(t, payload).Error.Detail
+			if got == nil || !strings.HasPrefix(*got, `value for "API_SECRET" is invalid (`) {
+				t.Fatalf("detail = %v, want named API_SECRET refusal", got)
+			}
+			if strings.Contains(*got, plaintext) || strings.Contains(*got, fragment) || strings.Contains(*got, "DO-NOT-ECHO-secret-7c31") {
+				t.Fatalf("secret validation detail leaked submitted instance data: %q", *got)
+			}
+		})
 	}
 }
 

--- a/internal/server/revisions.go
+++ b/internal/server/revisions.go
@@ -212,6 +212,24 @@ func wireChangedKeys(changes []service.ChangedKey) []apigen.ChangedKey {
 	return out
 }
 
+// wireRevision is one lineage row.
+//
+// `collected_policy` appears ONLY beside a collected payload: the column
+// carries a default while the payload is live, and emitting that would read as
+// "the policy that collected this revision" about a revision nothing collected.
+func wireRevision(rev service.RevisionView) apigen.Revision {
+	item := apigen.Revision{
+		Revision: rev.Revision, SchemaRevision: rev.SchemaRevision,
+		PublishedBy: rev.PublishedBy, PublishedAt: rev.PublishedAt,
+		ChangedKeys: wireChangedKeys(rev.ChangedKeys), PayloadPresent: rev.PayloadPresent,
+	}
+	if rev.CollectedPolicy != "" {
+		policy := rev.CollectedPolicy
+		item.CollectedPolicy = &policy
+	}
+	return item
+}
+
 func (a *API) ListRevisions(ctx context.Context, req apigen.ListRevisionsRequestObject) (apigen.ListRevisionsResponseObject, error) {
 	history, err := a.Revisions.History(ctx, service.Bearer(bearer(ctx)),
 		envScope(req.Org, req.Project, req.Environment))
@@ -220,11 +238,7 @@ func (a *API) ListRevisions(ctx context.Context, req apigen.ListRevisionsRequest
 	}
 	items := make([]apigen.Revision, 0, len(history))
 	for _, rev := range history {
-		items = append(items, apigen.Revision{
-			Revision: rev.Revision, SchemaRevision: rev.SchemaRevision,
-			PublishedBy: rev.PublishedBy, PublishedAt: rev.PublishedAt,
-			ChangedKeys: wireChangedKeys(rev.ChangedKeys),
-		})
+		items = append(items, wireRevision(rev))
 	}
 	return apigen.ListRevisions200JSONResponse(apigen.RevisionList{
 		Items: items, Count: len(items),

--- a/internal/server/revisions_test.go
+++ b/internal/server/revisions_test.go
@@ -68,3 +68,74 @@ func TestCollectedRevisionRefusalNamesRevisionAndPolicyOnWire(t *testing.T) {
 		t.Fatalf("collected detail = %v, want named revision and policy", body.Error.Detail)
 	}
 }
+
+func TestLineageWireCarriesTheCollectionBit(t *testing.T) {
+	const policy = "keep-if-either(max_age=2160h0m0s,last_revisions=10)"
+	api := &API{Revisions: historyRevisionService{history: []service.RevisionView{
+		{Revision: 4, PayloadPresent: true},
+		{Revision: 1, PayloadPresent: false, CollectedPolicy: policy},
+	}}}
+	response, err := api.ListRevisions(t.Context(), apigen.ListRevisionsRequestObject{
+		Org: "org_a", Project: "prj_a", Environment: "env_a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	if err := response.VisitListRevisionsResponse(recorder); err != nil {
+		t.Fatal(err)
+	}
+	var body struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("lineage item count = %d, want 2: %s", len(body.Items), recorder.Body.String())
+	}
+	if present, ok := body.Items[0]["payload_present"]; !ok || present != true {
+		t.Errorf("live payload_present = %#v (present %t), want exact true", present, ok)
+	}
+	if _, ok := body.Items[0]["collected_policy"]; ok {
+		t.Errorf("live row carries collected_policy: %s", recorder.Body.String())
+	}
+	if present, ok := body.Items[1]["payload_present"]; !ok || present != false {
+		t.Errorf("collected payload_present = %#v (present %t), want exact false", present, ok)
+	}
+	if got, ok := body.Items[1]["collected_policy"]; !ok || got != policy {
+		t.Errorf("collected_policy = %#v (present %t), want exact %q", got, ok, policy)
+	}
+}
+
+type historyRevisionService struct {
+	history []service.RevisionView
+}
+
+func (s historyRevisionService) History(context.Context, service.Actor, domain.Scope) ([]service.RevisionView, error) {
+	return s.history, nil
+}
+func (historyRevisionService) PublishPlanned(context.Context, service.Actor, domain.Scope, service.PublishRequest) (service.PublishResult, error) {
+	return service.PublishResult{}, domain.ErrNotFound
+}
+func (historyRevisionService) Restore(context.Context, service.Actor, domain.Scope, int64, string) (service.RestoreResult, error) {
+	return service.RestoreResult{}, domain.ErrNotFound
+}
+func (historyRevisionService) Show(context.Context, service.Actor, domain.Scope, int64) (service.RevisionDetail, error) {
+	return service.RevisionDetail{}, domain.ErrNotFound
+}
+func (historyRevisionService) Signals(context.Context, service.Actor, domain.Scope) (service.EnvironmentSignals, error) {
+	return service.EnvironmentSignals{}, domain.ErrNotFound
+}
+func (historyRevisionService) PendingDrafts(context.Context, service.Actor, domain.Scope) ([]service.PendingDraft, error) {
+	return nil, domain.ErrNotFound
+}
+func (historyRevisionService) Export(context.Context, service.Actor, domain.Scope, int64, bool) ([]service.ExportedValue, int64, error) {
+	return nil, 0, domain.ErrNotFound
+}
+func (historyRevisionService) Watch(context.Context, service.Actor, domain.Scope) (<-chan service.AdvisoryEvent, error) {
+	return nil, domain.ErrNotFound
+}
+func (historyRevisionService) RotateTokenKey(context.Context, service.Actor) (service.TokenKeyRotation, error) {
+	return service.TokenKeyRotation{}, domain.ErrNotFound
+}

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -30,6 +30,14 @@ type RevisionView struct {
 	PublishedBy    string
 	PublishedAt    time.Time
 	ChangedKeys    []ChangedKey
+	// PayloadPresent is the collection bit (#52/#53). Lineage outlives its
+	// payload, so a history entry says which of the two it still has -- and a
+	// surface that offers diff, restore or pin on a collected revision would be
+	// offering an act the service refuses. CollectedPolicy is the policy
+	// stamped at collection, empty while the payload is present; it is what the
+	// named refusal reports forever.
+	PayloadPresent  bool
+	CollectedPolicy string
 }
 
 // RevisionDetail is one revision, plus the change token derived for it under
@@ -126,7 +134,8 @@ func (s *Revisions) History(ctx context.Context, actor Actor, scope domain.Scope
 			out = append(out, RevisionView{
 				Revision: snapshot.Revision, SchemaRevision: snapshot.SchemaRevision,
 				PublishedBy: snapshot.PublishedBy, PublishedAt: snapshot.PublishedAt,
-				ChangedKeys: changedKeys(changes),
+				ChangedKeys:    changedKeys(changes),
+				PayloadPresent: snapshot.PayloadPresent, CollectedPolicy: collectedPolicy(snapshot),
 			})
 		}
 		return nil
@@ -202,7 +211,9 @@ func (s *Revisions) Show(ctx context.Context, actor Actor, scope domain.Scope, r
 			RevisionView: RevisionView{
 				Revision: snapshot.Revision, SchemaRevision: snapshot.SchemaRevision,
 				PublishedBy: snapshot.PublishedBy, PublishedAt: snapshot.PublishedAt,
-				ChangedKeys: changedKeys(changes),
+				ChangedKeys:     changedKeys(changes),
+				PayloadPresent:  snapshot.PayloadPresent,
+				CollectedPolicy: snapshot.CollectedPolicy,
 			},
 			ChangeToken: token,
 			Keys:        keys,
@@ -222,6 +233,16 @@ func readSnapshot(ctx context.Context, snapshots store.SnapshotReader, p authz.P
 		return snapshots.Latest(ctx, p)
 	}
 	return snapshots.AtRevision(ctx, p, revision)
+}
+
+// collectedPolicy reports the stamped policy only for a collected payload. A
+// live snapshot carries whatever the column defaulted to, and reporting that as
+// "the policy that collected this" would be a fact about nothing.
+func collectedPolicy(snapshot store.Snapshot) string {
+	if snapshot.PayloadPresent {
+		return ""
+	}
+	return snapshot.CollectedPolicy
 }
 
 func collectedRevisionError(snapshot store.Snapshot) error {

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -328,12 +328,18 @@ func validateValue(key store.CatalogueKey, value string) error {
 	// Failure text is schema-derived; for a `secret` key the engine never puts
 	// instance data in it in the first place, so this carries nothing the
 	// caller may not see.
+	//
+	// It is a SAFE DETAIL rather than a log-only cause, for the same reason the
+	// presence vetoes beside it are: mvp-boundary C5 requires a schema-failing
+	// restore to block "loud, naming the keys", and a bare 400 leaves the human
+	// with a refusal and no key to act on. It is decided after authorization on
+	// a key the caller already named, so it discloses nothing they could not
+	// read from the catalogue.
 	parts := make([]string, 0, len(verdict.Errors))
 	for _, f := range verdict.Errors {
 		parts = append(parts, f.Keyword+": "+f.Message)
 	}
-	return fmt.Errorf("%w: value for %q is invalid (%s)",
-		domain.ErrInvalid, key.Name, strings.Join(parts, "; "))
+	return invalidDetail("value for %q is invalid (%s)", key.Name, strings.Join(parts, "; "))
 }
 
 // checkNotForbidden refuses a write where the schema says the key must never

--- a/internal/service/values_internal_test.go
+++ b/internal/service/values_internal_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestValidateConfigValueReturnsSchemaLeafInCallerSafeNamedDetail(t *testing.T) {
+	const submitted = `{"unexpected":"caller-visible-config"}`
+	err := validateValue(store.CatalogueKey{
+		Name:           "APP_CONFIG",
+		Classification: "config",
+		Declaration:    `{"rule":{"type":"json","json_schema":{"type":"object","additionalProperties":false}}}`,
+	}, submitted)
+	if err == nil || !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("validateValue error = %v, want domain.ErrInvalid", err)
+	}
+	carrier, ok := err.(interface{ SafeDetail() string })
+	if !ok {
+		t.Fatalf("validateValue error %T has no caller-safe detail", err)
+	}
+	detail := carrier.SafeDetail()
+	if !strings.HasPrefix(detail, `value for "APP_CONFIG" is invalid (`) {
+		t.Fatalf("detail = %q, want named APP_CONFIG refusal", detail)
+	}
+	const leaf = "json_schema/additionalProperties: at '': additional properties 'unexpected' not allowed"
+	if !strings.Contains(detail, leaf) {
+		t.Fatalf("detail = %q, want schema-derived leaf %q", detail, leaf)
+	}
+}
+
+func TestValidateSecretValueReturnsCallerSafeNamedDetail(t *testing.T) {
+	const (
+		plaintext = `{"tenant-leaf-9f4a":"DO-NOT-ECHO-secret-7c31"}`
+		fragment  = "tenant-leaf-9f4a"
+	)
+	err := validateValue(store.CatalogueKey{
+		Name:           "API_SECRET",
+		Classification: "secret",
+		Declaration:    `{"rule":{"type":"json","json_schema":{"type":"object","additionalProperties":false}}}`,
+	}, plaintext)
+	if err == nil || !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("validateValue error = %v, want domain.ErrInvalid", err)
+	}
+	carrier, ok := err.(interface{ SafeDetail() string })
+	if !ok {
+		t.Fatalf("validateValue error %T has no caller-safe detail", err)
+	}
+	detail := carrier.SafeDetail()
+	if !strings.HasPrefix(detail, `value for "API_SECRET" is invalid (`) {
+		t.Fatalf("detail = %q, want named API_SECRET refusal", detail)
+	}
+	if strings.Contains(detail, plaintext) || strings.Contains(detail, fragment) || strings.Contains(detail, "DO-NOT-ECHO-secret-7c31") {
+		t.Fatalf("secret validation detail leaked submitted instance data: %q", detail)
+	}
+}

--- a/web/e2e/fixtures/api.ts
+++ b/web/e2e/fixtures/api.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import type { Page } from '@playwright/test';
+
+import { ADMIN, BASE_URL } from './instance.ts';
+
+export const zFixtureIgnored = z.object({});
+export const zFixtureStaged = z.object({ version_id: z.string() });
+export const zFixtureRevisionList = z.object({
+  items: z.array(
+    z.object({
+      revision: z.number(),
+      changed_keys: z.array(
+        z.object({
+          key_id: z.string(),
+          name: z.string(),
+          change: z.enum(['added', 'edited', 'removed']),
+        }),
+      ),
+    }),
+  ),
+});
+
+/** Mint a password bearer used only by API-driven fixture setup and repair. */
+export async function fixtureBearer(label: string): Promise<string> {
+  const response = await fetch(`${BASE_URL}/api/v1/auth/local/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: ADMIN.username, password: ADMIN.password }),
+  });
+  if (!response.ok) {
+    throw new Error(`${label} could not sign in: ${response.status}`);
+  }
+  return z.object({ session_token: z.string() }).parse(await response.json()).session_token;
+}
+
+/** Call the real API as a bearer and parse every successful response at the boundary. */
+export async function fixtureApiCall<T>(
+  token: string,
+  method: string,
+  path: string,
+  schema: z.ZodType<T>,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} ${path} answered ${response.status}: ${await response.text()}`);
+  }
+  const raw: unknown = response.status === 204 ? {} : await response.json();
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `${method} ${path} answered a shape the fixture does not expect: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+/** Drive the same typed fixture call through an authenticated browser cookie. */
+export async function fixtureBrowserCall<T>(
+  page: Page,
+  method: string,
+  path: string,
+  schema: z.ZodType<T>,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const result = await page.evaluate(
+    async (input: { method: string; path: string; body: Record<string, unknown> | null }) => {
+      const csrf = document.cookie
+        .split(';')
+        .map((part) => part.trim().split('='))
+        .find(([name]) => name === '__Host-hikyo-csrf')
+        ?.slice(1)
+        .join('=') ?? '';
+      const response = await fetch(input.path, {
+        method: input.method,
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf },
+        ...(input.body === null ? {} : { body: JSON.stringify(input.body) }),
+      });
+      return {
+        status: response.status,
+        body: response.status === 204 ? {} : await response.json(),
+      };
+    },
+    { method, path, body: body ?? null },
+  );
+  if (result.status < 200 || result.status >= 300) {
+    throw new Error(`${method} ${path} answered ${String(result.status)}`);
+  }
+  return schema.parse(result.body);
+}

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -507,24 +507,34 @@ export async function expectNoStrayPills(page: Page): Promise<void> {
  * thought about it — and it is a superset of "touched", so it can only be
  * stricter.
  */
+// Keep negative assertions (for deliberately read-only surfaces) on the same
+// canonical set as the positive focus/touch sweep.
+export const INTERACTIVE_ELEMENT_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'summary',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="checkbox"]',
+  '[role="switch"]',
+  '[role="tab"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
 export async function interactiveElements(page: Page): Promise<Locator[]> {
   // The native focusable set, not just the four obvious tags: `summary`,
   // editable regions and media controls are keyboard stops too, and a surface
   // that grows one should be asserted the day it renders.
-  const selector = [
-    'a[href]',
-    'area[href]',
-    'button:not([disabled])',
-    'input:not([disabled]):not([type="hidden"])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    'summary',
-    'iframe',
-    'audio[controls]',
-    'video[controls]',
-    '[contenteditable]:not([contenteditable="false"])',
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(', ');
   // A MODAL DIALOG makes the rest of the document inert, and an inert element
   // is not an interactive one: focusing it is impossible by design, so
   // asserting a focus ring on it would fail for a reason that is the platform
@@ -532,11 +542,12 @@ export async function interactiveElements(page: Page): Promise<Locator[]> {
   // exactly the set inside it.
   const modal = page.locator('dialog[open]');
   const scope = (await modal.count()) > 0 ? modal.first() : page;
-  const all = scope.locator(selector);
+  const all = scope.locator(INTERACTIVE_ELEMENT_SELECTOR);
   const out: Locator[] = [];
   for (let i = 0; i < (await all.count()); i++) {
     const one = all.nth(i);
-    if (await one.isVisible()) {
+    const operable = await one.evaluate((element) => element.closest('[inert]') === null);
+    if (operable && await one.isVisible()) {
       out.push(one);
     }
   }

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -772,6 +772,25 @@ const zSeeded = z.object({
     subject: z.string(),
     audience: z.string(),
   }),
+  history: z.object({
+    project: z.string(),
+    dev: z.string(),
+    staging: z.string(),
+    configKey: z.string(),
+    configKeyId: z.string(),
+    secretKey: z.string(),
+    secretKeyId: z.string(),
+    secretValues: z.array(z.string()),
+    tightenedKey: z.string(),
+    tightenedKeyId: z.string(),
+    pinnedWorkload: z.string(),
+    pinnedWorkloadPrincipal: z.string(),
+    spareWorkload: z.string(),
+    pinExpiryDays: z.number(),
+    revisionCount: z.number(),
+    pinnedRevision: z.number(),
+    pinExpiresAt: z.string(),
+  }),
   /**
    * The instance's sqlite file. Playwright runs global setup and the workers
    * in SEPARATE PROCESSES, so a worker cannot reach the setup process's

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -2,7 +2,14 @@ import { createHmac } from 'node:crypto';
 
 import { z } from 'zod';
 
-import { ADMIN, BASE_URL } from './instance.ts';
+import {
+  fixtureApiCall as call,
+  fixtureBearer,
+  zFixtureIgnored as zIgnored,
+  zFixtureRevisionList as zRevisionList,
+  zFixtureStaged as zStaged,
+} from './api.ts';
+import { ADMIN } from './instance.ts';
 
 /**
  * The fixture tenant the reveal flow needs (#58).
@@ -51,6 +58,53 @@ export type Seeded = {
   config: string;
   /** Required only in production and intentionally absent: matrix problems fixture. */
   matrixRequired: string;
+  /**
+   * The revision-history fixture (#59), all in `dev`.
+   *
+   * Three published revisions with a secret edit and a config edit between
+   * them, plus one key whose declaration is TIGHTENED after publication — the
+   * only way to produce a historical state that is not restorable as-is, and
+   * the same recipe the `schema_failing_restore_blocks_loud` conformance
+   * scenario uses.
+   */
+  history: {
+    /** Its own project: the matrix flow asserts exact counts in `payments`. */
+    project: string;
+    /** The environment carrying the three value publishes. */
+    dev: string;
+    /** A second environment with one, so the drawer's tabs mean something. */
+    staging: string;
+    /** The config key edited between the two value publishes. */
+    configKey: string;
+    configKeyId: string;
+    /** The secret key edited between them: the ceremony's subject. */
+    secretKey: string;
+    secretKeyId: string;
+    /** Exact throwaway fixture material, for negative disclosure assertions only. */
+    secretValues: readonly string[];
+    /** The key whose value was valid when published and is not any more. */
+    tightenedKey: string;
+    tightenedKeyId: string;
+    /** The workload the pin lifecycle moves, by name and by principal id. */
+    pinnedWorkload: string;
+    pinnedWorkloadPrincipal: string;
+    /** A workload that follows latest, so the picker shows both states. */
+    spareWorkload: string;
+    /** The pin's remaining lifetime, inside the 30-day warning tier. */
+    pinExpiryDays: number;
+    /** Seed-state proof consumed only by the first history pass. */
+    revisionCount: number;
+    pinnedRevision: number;
+    pinExpiresAt: string;
+  };
+  /**
+   * NO REVISION NUMBERS travel in this fixture, deliberately.
+   *
+   * The flow MUTATES this project — it restores and publishes — and a two-pass
+   * run (desktop then mobile, one instance) would have the second pass asserting
+   * numbers the first one moved. The flow derives them at `beforeAll` instead,
+   * from the same `listRevisions` projection the seeding used.
+   */
   /** The seeding session's bearer token — the flows use cookies, not this. */
   token: string;
   principal: string;
@@ -142,52 +196,12 @@ export function totpCode(otpauthURI: string, at: Date = new Date()): string {
   return String(binary % 1_000_000).padStart(6, '0');
 }
 
-type Json = Record<string, unknown>;
-
 /** zCreated is every create response this fixture reads: it needs the id. */
 const zCreated = z.object({ id: z.string() });
 const zServiceAccount = z.object({ id: z.string(), principal_id: z.string() });
-const zStaged = z.object({ version_id: z.string() });
 const zEnrolStart = z.object({ otpauth_uri: z.string() });
 const zRotated = z.object({ session_token: z.string() });
 const zWhoAmI = z.object({ principal: z.object({ id: z.string() }) });
-// The fixture reads nothing out of these responses. The parse still earns its
-// place: it proves the server answered an OBJECT rather than, say, an error
-// page that happened to arrive with a 200.
-const zIgnored = z.object({});
-
-async function call<T>(
-  token: string,
-  method: string,
-  path: string,
-  schema: z.ZodType<T>,
-  body?: Json,
-): Promise<T> {
-  const resp = await fetch(`${BASE_URL}${path}`, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      // A bearer caller has no cookie leg and therefore no CSRF contract, which
-      // is what makes seeding a plain fetch rather than a cookie dance.
-      Authorization: `Bearer ${token}`,
-    },
-    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-  });
-  if (!resp.ok) {
-    throw new Error(`${method} ${path} answered ${resp.status}: ${await resp.text()}`);
-  }
-  // Parsed, never trusted — the same rule the SPA's own client keeps. A
-  // fixture that read `resp.json()` straight would fail three frames from the
-  // mistake, in setup, where a clear message matters most.
-  const raw: unknown = resp.status === 204 ? {} : await resp.json();
-  const result = schema.safeParse(raw);
-  if (!result.success) {
-    throw new Error(
-      `${method} ${path} answered a shape the fixture does not expect: ${result.error.message}`,
-    );
-  }
-  return result.data;
-}
 
 /**
  * lastStep is the newest time step this process has spent a code on.
@@ -222,27 +236,7 @@ async function consumeCode(token: string, uri: string, path: string): Promise<st
 
 /** signIn is a fresh password session, as a bearer artifact. */
 async function signIn(): Promise<string> {
-  const resp = await fetch(`${BASE_URL}/api/v1/auth/local/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      username: ADMIN.username,
-      password: ADMIN.password,
-    }),
-  });
-  if (!resp.ok) {
-    throw new Error(`the seeding login answered ${resp.status}`);
-  }
-  const body: unknown = await resp.json();
-  if (typeof body !== 'object' || body === null) {
-    throw new Error('the seeding login answered a non-object body');
-  }
-  const record: Record<string, unknown> = { ...body };
-  const token = record['session_token'];
-  if (typeof token !== 'string') {
-    throw new Error('the seeding login returned no bearer token');
-  }
-  return token;
+  return fixtureBearer('the seeding login');
 }
 
 
@@ -266,6 +260,27 @@ export const REVEAL_GRANT = { capability: 'reveal', scope: 'instance' } as const
  * screen: the whole federation rule is that nothing folds case, resolves a URL
  * or strips a slash, so what is seeded and what is rendered must be one string.
  */
+/**
+ * HISTORY is the revision-history fixture's fixed vocabulary (#59).
+ *
+ * `tightened` is the recipe the `schema_failing_restore_blocks_loud`
+ * conformance scenario uses: publish a value that satisfies the declaration in
+ * force, publish a replacement, then TIGHTEN the declaration. The older
+ * revision is now not restorable as-is and not pinnable without a recorded
+ * override — a state that cannot be created any other way, because publication
+ * correctly refuses a value its own schema rejects.
+ */
+export const HISTORY = {
+  project: 'ledger',
+  configKey: 'LOG_LEVEL',
+  secretKey: 'DB_PASSWORD',
+  tightenedKey: 'WORKERS',
+  pinnedWorkload: 'ledger-api',
+  spareWorkload: 'ledger-batch',
+  /** The seeded pin's remaining lifetime, inside the 30-day warning tier. */
+  pinExpiryDays: 20,
+} as const;
+
 export const MACHINE = {
   workload: 'web-api',
   automation: 'nightly-export',
@@ -326,6 +341,13 @@ export async function seedTenant(
     // accounts, minting and binding are all `manage-identities`, which is a
     // separate atom from administering members.
     'manage-identities',
+    // The history drawer's own two (#59). `pin` is the pin lifecycle's
+    // authority; `reveal-history` is the independent grant that historical
+    // secret material takes — a restore that reads a superseded secret and a
+    // pin onto a non-current revision are both historical disclosures, and
+    // neither is covered by `reveal`.
+    'pin',
+    'reveal-history',
   ]) {
     runAdminGrant(['--principal', principal, '--capability', capability]);
   }
@@ -401,6 +423,47 @@ export async function seedTenant(
   const workload = await created(MACHINE.workload, 'workload');
   await created(MACHINE.automation, 'automation');
   await created(MACHINE.mintable, 'workload');
+
+  // The revision-history fixture lives in its OWN project (#59).
+  //
+  // The matrix flow asserts exact key counts and exact cell text in `payments`,
+  // so adding this ticket's three keys and three publishes there would break a
+  // locked surface's flow for a reason that has nothing to do with either
+  // ticket. One instance serves the whole suite; a second project is the cheap
+  // isolation.
+  const { id: historyProject } = await call(token, 'POST', `/api/v1/orgs/${org}/projects`, zCreated, {
+    name: 'ledger',
+  });
+  const { id: historyDev } = await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${historyProject}/environments`,
+    zCreated,
+    { name: 'development' },
+  );
+  const { id: historyStaging } = await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${historyProject}/environments`,
+    zCreated,
+    { name: 'staging' },
+  );
+  // Two workloads: the one the pin lifecycle moves, and one that stays on
+  // "follows latest" so the picker has both states to show.
+  const pinnedWorkload = await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${historyProject}/service-accounts`,
+    zServiceAccount,
+    { name: HISTORY.pinnedWorkload, kind: 'workload' },
+  );
+  await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${historyProject}/service-accounts`,
+    zServiceAccount,
+    { name: HISTORY.spareWorkload, kind: 'workload' },
+  );
 
   await call(
     token,
@@ -566,7 +629,156 @@ export async function seedTenant(
     { protected: true },
   );
 
+  // --- the revision-history fixture (#59) ----------------------------------
+  //
+  // Three publishes in `development`, a secret edit and a config edit between
+  // them, so the drawer has real lineage to render, a restore has exactly one
+  // clean row to stage, and the ceremony has a real historical secret to gate.
+  const historyKeys = new Map<string, string>();
+  for (const [name, classification, folderPath] of [
+    [HISTORY.configKey, 'config', 'app'],
+    [HISTORY.secretKey, 'secret', 'secrets'],
+    [HISTORY.tightenedKey, 'config', 'ops'],
+  ] as const) {
+    const createdKey = await call(
+      token,
+      'POST',
+      `/api/v1/orgs/${org}/projects/${historyProject}/keys`,
+      zCreated,
+      { name, classification, folder_path: folderPath, declaration: { rule: { type: 'string' } } },
+    );
+    historyKeys.set(name, createdKey.id);
+  }
+
+  const publishHistory = async (
+    environment: string,
+    values: ReadonlyArray<readonly [string, string]>,
+  ) => {
+    const versions: string[] = [];
+    for (const [name, value] of values) {
+      const staged = await call(
+        token,
+        'PUT',
+        `/api/v1/orgs/${org}/projects/${historyProject}/environments/${environment}/values/${name}`,
+        zStaged,
+        { value },
+      );
+      versions.push(staged.version_id);
+    }
+    await call(
+      token,
+      'POST',
+      `/api/v1/orgs/${org}/projects/${historyProject}/environments/${environment}/publish`,
+      zIgnored,
+      { version_ids: versions },
+    );
+  };
+
+  // r1 — everything present. WORKERS holds a value the CURRENT declaration
+  // still accepts; the tightening below is what makes r1 unrestorable.
+  await publishHistory(historyDev, [
+    [HISTORY.configKey, 'debug'],
+    [HISTORY.secretKey, 'hunter2-r1'],
+    [HISTORY.tightenedKey, 'not-an-integer'],
+  ]);
+  // r2 — the SECRET edit, and WORKERS moves to a value the tightened
+  // declaration will still accept, so restoring r2 stays clean.
+  await publishHistory(historyDev, [
+    [HISTORY.secretKey, 'hunter2-r2'],
+    [HISTORY.tightenedKey, '12'],
+  ]);
+  // r3 — the CONFIG edit, and the current revision. Restoring r2 therefore
+  // stages exactly one row: LOG_LEVEL back to `debug`.
+  await publishHistory(historyDev, [[HISTORY.configKey, 'info']]);
+  // Staging gets its own single revision, so the drawer's environment tabs
+  // switch between two real histories rather than one and an empty state.
+  await publishHistory(historyStaging, [[HISTORY.configKey, 'warn']]);
+
+  // The tightening. r1's `not-an-integer` was valid when it was published and
+  // is not any more: restoring it stages fine and PUBLISH refuses loud naming
+  // the key, and pinning r1 refuses until an explicit override is recorded.
+  const tightenedID = historyKeys.get(HISTORY.tightenedKey);
+  if (tightenedID === undefined) {
+    throw new Error('the history fixture did not create its tightened key');
+  }
+  await call(
+    token,
+    'PUT',
+    `/api/v1/orgs/${org}/projects/${historyProject}/keys/${tightenedID}/declaration`,
+    zIgnored,
+    {
+      declaration: { rule: { type: 'integer' } },
+      presence: { required_in: { mode: 'none' }, forbidden_in: { mode: 'none' } },
+    },
+  );
+
+  // A sliding window, as `payments`' development has: without one every
+  // disclosure in this project takes a ceremony, and the flow is about the
+  // history surface rather than about answering four passkey prompts.
+  await call(
+    token,
+    'PUT',
+    `/api/v1/orgs/${org}/projects/${historyProject}/environments/${historyDev}/settings`,
+    zIgnored,
+    { protected: false, reauth_window_seconds: 300 },
+  );
+
+  // The pre-existing pin, on the CURRENT revision so seeding needs no
+  // reveal-history ceremony. Its expiry sits inside the 30-day warning tier,
+  // which is what the drawer's expiry badge renders.
+  // The revision to pin is READ, never assumed: every schema act mints a
+  // revision of its own in every environment of the project — creating a key and
+  // tightening a declaration each advance the environment even though they
+  // change no value — so the three publishes above are emphatically not r1..r3.
+  const devHistory = await call(
+    token,
+    'GET',
+    `/api/v1/orgs/${org}/projects/${historyProject}/environments/${historyDev}/revisions`,
+    zRevisionList,
+  );
+  const currentRevision = devHistory.items[0]?.revision;
+  if (currentRevision === undefined) {
+    throw new Error('the history fixture published no revisions');
+  }
+
+  // Half a day of slack, so the drawer's whole-day countdown still reads
+  // `pinExpiryDays` however long the suite takes: `expires in 19 d` for 19.99
+  // days is the honest rounding, and a fixture that lands exactly on the
+  // boundary tests the clock rather than the badge.
+  const pinExpiry = new Date(Date.now() + (HISTORY.pinExpiryDays * 24 + 12) * 60 * 60 * 1000);
+  await call(
+    token,
+    'POST',
+    `/api/v1/orgs/${org}/projects/${historyProject}/environments/${historyDev}/pins`,
+    zIgnored,
+    {
+      workload_principal_id: pinnedWorkload.principal_id,
+      // The CURRENT revision, so seeding takes no reveal-history ceremony.
+      revision: currentRevision,
+      expires_at: pinExpiry.toISOString(),
+    },
+  );
+
   return {
+    history: {
+      project: historyProject,
+      dev: historyDev,
+      staging: historyStaging,
+      configKey: HISTORY.configKey,
+      configKeyId: historyKeys.get(HISTORY.configKey) ?? '',
+      secretKey: HISTORY.secretKey,
+      secretKeyId: historyKeys.get(HISTORY.secretKey) ?? '',
+      secretValues: ['hunter2-r1', 'hunter2-r2'],
+      tightenedKey: HISTORY.tightenedKey,
+      tightenedKeyId: tightenedID,
+      pinnedWorkload: HISTORY.pinnedWorkload,
+      spareWorkload: HISTORY.spareWorkload,
+      pinnedWorkloadPrincipal: pinnedWorkload.principal_id,
+      pinExpiryDays: HISTORY.pinExpiryDays,
+      revisionCount: devHistory.items.length,
+      pinnedRevision: currentRevision,
+      pinExpiresAt: pinExpiry.toISOString(),
+    },
     org,
     project,
     dev,

--- a/web/e2e/flows/history.spec.ts
+++ b/web/e2e/flows/history.spec.ts
@@ -357,8 +357,21 @@ test.describe('revision history', () => {
   });
 
   test('filters the timeline to one key, by click and by URL', async ({ page }) => {
-    await page.goto(DEV_HISTORY);
+    // Entry 1: the matrix KEY NAME opens the drawer filtered to that key
+    // (revision-history it-1/6 — the name is history; any cell is the editor).
+    await page.goto(MATRIX_PATH);
+    await page.getByRole('link', { name: `History of ${seed.history.configKey}` }).click();
     const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expect(drawer.locator('.history__filter')).toContainText(
+      `filter active: history of ${seed.history.configKey}`,
+    );
+    await expect(page).toHaveURL(
+      new RegExp(`key=${encodeURIComponent(seed.history.configKeyId)}`),
+    );
+    await expectNoFixtureSecret(drawer);
+
+    // Entry 2: a changed-key row inside a revision's detail pane.
+    await page.goto(DEV_HISTORY);
     await expectNoFixtureSecret(drawer);
     const list = drawer.getByRole('list', { name: 'Revisions, newest first' });
 

--- a/web/e2e/flows/history.spec.ts
+++ b/web/e2e/flows/history.spec.ts
@@ -1,0 +1,940 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import {
+  zExportValuesRequest,
+  zPendingDraftList,
+  zPublishRequest,
+  zRevisionPinList,
+  zValueCell,
+} from '@hikyo/zod';
+
+import {
+  INTERACTIVE_ELEMENT_SELECTOR,
+  expectPinnedAssertionSet,
+  expectStatusIsTextAndAria,
+  expectTouchTargets,
+} from '../fixtures/assertions.ts';
+import {
+  fixtureBrowserCall as api,
+  zFixtureIgnored as zAny,
+  zFixtureRevisionList as zRevisions,
+  zFixtureStaged as zStaged,
+} from '../fixtures/api.ts';
+import {
+  countDisclosureEvents,
+  establishSession,
+  installPasskeyAuthenticator,
+  readSeed,
+  refreshSharedSession,
+  STORAGE_STATE,
+} from '../fixtures/instance.ts';
+import { surfacesForFlow } from '../registry.ts';
+import { zHistoryRollbackResult } from '../../src/api/history.ts';
+
+/**
+ * Flow: the revision-history drawer (registry surface `history`).
+ *
+ * Covers mvp-boundary **C5 [UI]** — the restore flow from the history drawer —
+ * and the history half of **S3**: drawer, per-key filter, restore and the pin
+ * lifecycle, on both viewport projects under the pinned assertion set.
+ *
+ * It runs against its OWN project (`seed.history`), not the matrix flow's: one
+ * instance serves the whole suite, and the matrix flow asserts exact key counts
+ * and exact cell text in `payments`.
+ *
+ * The fixture's shape is what makes the hard cases reachable:
+ *
+ *   added    LOG_LEVEL=debug · DB_PASSWORD=hunter2-r1 · WORKERS='not-an-integer'
+ *   edited   DB_PASSWORD=hunter2-r2  (the SECRET edit) · WORKERS='12'
+ *   edited   LOG_LEVEL=info          (the CONFIG edit)
+ *   then WORKERS' declaration is TIGHTENED to `integer`
+ *
+ * so restoring the secret-edit revision stages exactly one clean row while still
+ * opening a historical secret (the ceremony), and restoring or pinning the
+ * key-adding revision is refused naming WORKERS.
+ *
+ * The revision NUMBERS are read out of the fixture, never assumed: every schema
+ * act mints its own revision in every environment of the project, so the three
+ * publishes above are not r1..r3 and hard-coding them would make this flow a
+ * test of when a revision happens to be minted.
+ */
+
+const seed = readSeed();
+const HISTORY_PATH = `/orgs/${seed.org}/projects/${seed.history.project}/matrix/history`;
+const MATRIX_PATH = `/orgs/${seed.org}/projects/${seed.history.project}/matrix`;
+const DEV_HISTORY = `${HISTORY_PATH}?env=${seed.history.dev}`;
+const SCHEMES: readonly ('dark' | 'light')[] = ['dark', 'light'];
+const PROJECT = `/api/v1/orgs/${seed.org}/projects/${seed.history.project}`;
+const DEV = `${PROJECT}/environments/${seed.history.dev}`;
+
+// --- the flow's own fixture repair -----------------------------------------
+//
+// This flow MUTATES its project: it stages restores, publishes them, and moves
+// pins around. One instance serves the whole suite and runs it once per viewport
+// project, so pass two starts from whatever pass one left. Every number this
+// flow asserts is therefore DERIVED at `beforeAll`, and the two pieces of state
+// pass one moves — the leftover invalid draft and the pins — are put back.
+//
+// The alternative, seeding two projects, buys the same property at the cost of a
+// second fixture to keep in step; repairing is what the matrix flow does too,
+// with per-project values.
+
+type Facts = {
+  /** The newest revision when this pass started. */
+  current: number;
+  /** How many rows the drawer's list renders, per environment. */
+  devRevisions: number;
+  stagingRevisions: number;
+  /** The newest revision that EDITED each key. */
+  secretEdit: number;
+  configEdit: number;
+  /** The revision that ADDED the tightened key, and still holds its bad value. */
+  tightened: number;
+  /** How many revisions the per-key filter keeps for the config key. */
+  configKeyRevisions: number;
+  secretKeyRevisions: number;
+  /** True only while the instance still exactly matches global setup. */
+  firstPass: boolean;
+  seededPin: { workload: string; revision: number; expiresAt: string } | null;
+  configBeforeRestore: string;
+};
+
+let facts: Facts;
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext({ storageState: STORAGE_STATE });
+  const apiPage = await context.newPage();
+  await apiPage.goto(DEV_HISTORY);
+
+  // Repair only drift pass one can leave. A fresh pass must exercise the exact
+  // state global setup built, not a state recreated by this hook.
+  const pending = await api(apiPage, 'GET', `${DEV}/pending`, zPendingDraftList);
+  const invalidTightenedDraft = pending.items.find(
+    (draft) =>
+      draft.name === seed.history.tightenedKey &&
+      draft.operation === 'set' &&
+      draft.value !== undefined &&
+      !/^-?\d+$/.test(draft.value),
+  );
+  if (invalidTightenedDraft !== undefined) {
+    const repaired = await api(apiPage, 'PUT', `${DEV}/values/${seed.history.tightenedKey}`, zStaged, {
+      value: '12',
+    });
+    await api(apiPage, 'POST', `${DEV}/publish`, zAny, { version_ids: [repaired.version_id] });
+  }
+
+  const dev = await api(apiPage, 'GET', `${DEV}/revisions`, zRevisions);
+  const staging = await api(
+    apiPage,
+    'GET',
+    `${PROJECT}/environments/${seed.history.staging}/revisions`,
+    zRevisions,
+  );
+  const newest = (key: string, change: 'added' | 'edited', atMost = Number.MAX_SAFE_INTEGER): number => {
+    const found = dev.items.find((item) =>
+      item.revision <= atMost &&
+      item.changed_keys.some((changed) => changed.name === key && changed.change === change),
+    );
+    if (found === undefined) {
+      throw new Error(`no revision in this environment ${change} ${key}`);
+    }
+    return found.revision;
+  };
+  const current = dev.items[0]?.revision;
+  if (current === undefined) {
+    throw new Error('the history fixture published no revisions');
+  }
+
+  const pins = await api(apiPage, 'GET', `${DEV}/pins`, zRevisionPinList);
+  const config = await api(
+    apiPage,
+    'GET',
+    `${DEV}/values/${seed.history.configKey}`,
+    zValueCell,
+  );
+  if (!config.revealed || config.value === undefined) {
+    throw new Error('history config fixture was not readable');
+  }
+  const firstPass = current === seed.history.pinnedRevision;
+  const seededPin = pins.items.length === 1 && pins.items[0] !== undefined
+    ? {
+        workload: pins.items[0].workload_principal_id,
+        revision: Number(pins.items[0].revision),
+        expiresAt: pins.items[0].expires_at,
+      }
+    : null;
+  const canonical = pins.items.length === 1 && pins.items[0] !== undefined &&
+    pins.items[0].workload_principal_id === seed.history.pinnedWorkloadPrincipal &&
+    pins.items[0].revision === BigInt(current) &&
+    !pins.items[0].expired &&
+    new Date(pins.items[0].expires_at).getTime() - Date.now() < 31 * 24 * 60 * 60 * 1000;
+  if (!canonical) {
+    for (const pin of pins.items) {
+      await api(apiPage, 'DELETE', `${DEV}/pins/${pin.workload_principal_id}`, zAny);
+    }
+    const expiry = new Date(Date.now() + (seed.history.pinExpiryDays * 24 + 12) * 60 * 60 * 1000);
+    await api(apiPage, 'POST', `${DEV}/pins`, zAny, {
+      workload_principal_id: seed.history.pinnedWorkloadPrincipal,
+      revision: current,
+      expires_at: expiry.toISOString(),
+    });
+  }
+
+  facts = {
+    current,
+    devRevisions: dev.items.length,
+    stagingRevisions: staging.items.length,
+    secretEdit: newest(seed.history.secretKey, 'edited', seed.history.pinnedRevision),
+    configEdit: newest(seed.history.configKey, 'edited', seed.history.pinnedRevision),
+    tightened: newest(seed.history.tightenedKey, 'added'),
+    configKeyRevisions: dev.items.filter((item) =>
+      item.changed_keys.some((changed) => changed.name === seed.history.configKey),
+    ).length,
+    secretKeyRevisions: dev.items.filter((item) =>
+      item.changed_keys.some((changed) => changed.name === seed.history.secretKey),
+    ).length,
+    firstPass,
+    seededPin,
+    configBeforeRestore: config.value,
+  };
+  await context.close();
+});
+
+async function expectNoFixtureSecret(surface: Locator): Promise<void> {
+  const text = await surface.textContent();
+  for (const value of seed.history.secretValues) {
+    expect(text).not.toContain(value);
+  }
+}
+
+/**
+ * Selects one revision, on either viewport.
+ *
+ * Below 800px the drawer shows ONE pane at a time, so the revision list is not
+ * on screen while a detail is open — and an element that is not rendered is not
+ * in the accessibility tree, which is a click that waits forever rather than a
+ * click that fails. The back affordance is `display: none` on a desktop, so this
+ * is a no-op there.
+ */
+async function openRevision(page: Page, revision: number): Promise<void> {
+  const back = page.locator('#history-detail-back');
+  if (await back.isVisible()) {
+    await back.click();
+  }
+  await page.locator(`[data-history-revision="${String(revision)}"]`).click();
+  await expect(page.locator('#history-detail-title')).toContainText(`r${String(revision)}`);
+  await expectNoFixtureSecret(page.getByRole('complementary', { name: 'Revision history' }));
+}
+
+test.describe('revision history', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: STORAGE_STATE });
+
+  // The pinned assertion set runs FIRST, deliberately.
+  //
+  // The two ceremony-bearing tests below reissue the browser session — a
+  // disclosure reauthentication mints a new cookie — so the suite's shared
+  // storage state is stale afterwards. Asserting the surface before anything
+  // mutates it keeps the S3 evidence off that dependency entirely, and it reads
+  // the seeded state rather than whatever the last restore left behind.
+  for (const surface of surfacesForFlow('history')) {
+    for (const scheme of SCHEMES) {
+      test(`meets the pinned assertion set on ${surface.label} (${scheme})`, async ({ page }) => {
+        await page.emulateMedia({ colorScheme: scheme });
+        await page.goto(DEV_HISTORY);
+
+        const drawer = page.locator('.history');
+        const heading = page.getByRole('heading', { name: '↺ Revision history' });
+        const row = page.locator('.history__row').first();
+        const retention = page.locator('.history__retention');
+        const tab = page.locator('.history__tab').first();
+
+        await expect(heading).toBeVisible();
+        await expectNoFixtureSecret(drawer);
+        if (facts.firstPass) {
+          expect(facts.devRevisions, 'fresh pass must use the seeded revision list').toBe(
+            seed.history.revisionCount,
+          );
+          expect(facts.seededPin?.workload, 'fresh pass must use the seeded workload').toBe(
+            seed.history.pinnedWorkloadPrincipal,
+          );
+          expect(facts.seededPin?.revision, 'fresh pass must use the seeded pin revision').toBe(
+            seed.history.pinnedRevision,
+          );
+          expect(
+            new Date(facts.seededPin?.expiresAt ?? '').getTime(),
+            'fresh pass must use the seeded pin expiry',
+          ).toBe(new Date(seed.history.pinExpiresAt).getTime());
+        }
+        await expectPinnedAssertionSet(page, {
+          flow: 'history',
+          surface: surface.id,
+          theme: scheme,
+          text: [heading, row, retention],
+          radii: [
+            [retention, 'container'],
+            [tab, 'control'],
+          ],
+          fonts: [
+            [heading, 'ui'],
+            [row.locator('.mono').first(), 'mono'],
+          ],
+          colours: [
+            [heading, 'color', '--tx'],
+            [drawer, 'backgroundColor', '--bg-raise'],
+            [retention, 'borderTopColor', '--line'],
+          ],
+          hairlines: [retention],
+          density: [[tab, '--touch']],
+        });
+      });
+    }
+  }
+
+
+  test('opens from the matrix environment header and reads one environment at a time', async ({
+    page,
+  }) => {
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+
+    // Entry point one: the `rev N · history` link in the environment column head.
+    await page
+      .getByRole('link', { name: `rev ${String(facts.current)} · history` })
+      .first()
+      .click();
+    await expect(page).toHaveURL(new RegExp(`/matrix/history\\?env=${seed.history.dev}$`));
+
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await expect(drawer.getByRole('heading', { name: '↺ Revision history' })).toBeVisible();
+    await expect(drawer).toContainText(`current r${String(facts.current)}`);
+
+    // Three revisions of lineage, newest first.
+    const list = drawer.getByRole('list', { name: 'Revisions, newest first' });
+    await expect(list.getByRole('button')).toHaveCount(facts.devRevisions);
+    await expect(list.getByRole('button').first()).toContainText(
+      `r${String(facts.current)}`,
+    );
+    await expect(list.getByRole('button').first()).toContainText('current');
+
+    // The read-only retention line: effective window, inheritance, and a
+    // pointer at the surface that owns the knob. No editing here.
+    const retention = drawer.locator('.history__retention');
+    await expect(retention).toContainText('values kept:');
+    await expect(retention).toContainText('plus pinned');
+    await expect(retention).toContainText('inherits org');
+    await expect(retention).toContainText('→ change it in project settings › Policy');
+    await expect(
+      retention.locator(INTERACTIVE_ELEMENT_SELECTOR),
+    ).toHaveCount(0);
+
+    // Environment tabs: a second environment with its own, shorter history.
+    await drawer.getByRole('button', { name: 'staging' }).click();
+    await expect(page).toHaveURL(new RegExp(`env=${seed.history.staging}`));
+    await expect(list.getByRole('button')).toHaveCount(facts.stagingRevisions);
+    await expectNoFixtureSecret(drawer);
+    await drawer.getByRole('button', { name: 'development' }).click();
+    await expect(list.getByRole('button')).toHaveCount(facts.devRevisions);
+    await expectNoFixtureSecret(drawer);
+  });
+
+  test('shows one revision’s lineage without ever showing a secret value', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, facts.secretEdit);
+
+    // The actor is a principal id, shortened, with the whole one in `title`:
+    // nothing in this API resolves a human principal to a name.
+    await expect(drawer).toContainText('Published by');
+    await expect(drawer).toContainText('Schema revision pinned');
+
+    // r2 is the secret edit. Write-presence only — the marker and the
+    // transition, never a value, a length or a comparison.
+    const changes = drawer.locator('.history__changes');
+    await expect(changes).toContainText(`🔒 ${seed.history.secretKey}`);
+    await expect(changes).toContainText('write-presence only');
+    await expectNoFixtureSecret(drawer);
+  });
+
+  test('filters the timeline to one key, by click and by URL', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    const list = drawer.getByRole('list', { name: 'Revisions, newest first' });
+
+    // The config edit's own revision; clicking its changed key filters to it.
+    await openRevision(page, facts.configEdit);
+    await drawer.getByRole('button', { name: seed.history.configKey, exact: false }).first().click();
+
+    const filter = drawer.locator('.history__filter');
+    await expectStatusIsTextAndAria(page, filter);
+    await expect(filter).toContainText(`filter active: history of ${seed.history.configKey}`);
+    // LOG_LEVEL moved exactly twice: added, then edited.
+    await expect(list.getByRole('button')).toHaveCount(facts.configKeyRevisions);
+    await expectNoFixtureSecret(drawer);
+    await expect(page).toHaveURL(
+      new RegExp(`key=${encodeURIComponent(seed.history.configKeyId)}`),
+    );
+
+    // The same filter is a deep link, which is the whole point of it being a
+    // query parameter rather than a second surface.
+    await page.goto(`${DEV_HISTORY}&key=${encodeURIComponent(seed.history.secretKeyId)}`);
+    await expect(drawer.locator('.history__filter')).toContainText(
+      `history of ${seed.history.secretKey}`,
+    );
+    await expect(list.getByRole('button')).toHaveCount(facts.secretKeyRevisions);
+    await expectNoFixtureSecret(drawer);
+
+    await drawer.getByRole('button', { name: '✕ show every revision' }).click();
+    await expect(list.getByRole('button')).toHaveCount(facts.devRevisions);
+    await expectNoFixtureSecret(drawer);
+  });
+
+  test('restores an environment to an earlier revision and publishes the staged drafts', async ({
+    page,
+  }) => {
+    const persistPasskey = await installPasskeyAuthenticator(page);
+    try {
+      await page.goto(DEV_HISTORY);
+      const drawer = page.getByRole('complementary', { name: 'Revision history' });
+      await expectNoFixtureSecret(drawer);
+      await openRevision(page, facts.secretEdit);
+      await expectNoFixtureSecret(drawer);
+
+      await drawer
+        .getByRole('button', { name: `Restore r${String(facts.secretEdit)}…` })
+        .click();
+      const sheet = page.getByRole('dialog');
+      await expectNoFixtureSecret(sheet);
+      await expect(sheet).toContainText('re-validates against the CURRENT schema');
+      const rollbackResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          new URL(response.url()).pathname === `${DEV}/revisions/${String(facts.secretEdit)}/rollback` &&
+          response.ok(),
+      );
+      await sheet
+        .getByRole('button', { name: `Stage the restore from r${String(facts.secretEdit)}` })
+        .click();
+
+      // Restore reads a superseded secret, so it takes a purpose-bound
+      // ceremony over exactly that key before anything is staged.
+      await expect(page.getByRole('heading', { name: /restore an earlier revision of/ })).toBeVisible();
+      // The ceremony modal enumerates KEYS, never values: assert it on the
+      // ceremony state too, or a secret leaking only there would go unnoticed.
+      await expectNoFixtureSecret(page.getByRole('dialog', { name: /restore an earlier revision of|pin a historical revision of/ }));
+      await expect(page.getByRole('list', { name: 'Keys this decision covers' })).toContainText(
+        seed.history.secretKey,
+      );
+      await page.getByRole('button', { name: 'Use a passkey' }).click();
+      const rollback = zHistoryRollbackResult.parse(await (await rollbackResponse).json());
+      const restoredVersions = rollback.changes.map((change) => change.version_id);
+
+      // The impact preview: a summary chip line, then the rows. Config
+      // plaintext before→after; a secret would be status-only.
+      const preview = page.getByRole('dialog');
+      await expect(preview.locator('.history__chips')).toContainText('1 set');
+      await expect(preview.locator('.history__impact')).toContainText(seed.history.configKey);
+      await expect(preview.locator('.history__impact')).toContainText(
+        `${facts.configBeforeRestore} → debug`,
+      );
+      await expect(preview.locator('.notice')).toContainText('Staged as ordinary drafts');
+      await expectNoFixtureSecret(preview);
+
+      // The in-drawer path spends the exact token and exact version set returned
+      // by rollback. Deleting either assertion leaves this test red.
+      const publishRequest = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' && new URL(request.url()).pathname === `${DEV}/publish`,
+      );
+      await page.locator('#history-restore-publish').click();
+      const publishBody = zPublishRequest.parse((await publishRequest).postDataJSON());
+      expect(publishBody.preview_token).toBe(rollback.preview.token);
+      expect([...publishBody.version_ids].sort()).toEqual([...restoredVersions].sort());
+      await expect(drawer.locator('.notice')).toContainText('Published the restore');
+    } finally {
+      // A disclosure ceremony REISSUES the browser session, so the suite's
+      // shared storage state now holds a dead cookie — the next test would land
+      // on the sign-in page for a reason several tests in its past. Persist the
+      // counter, then re-mint, exactly as the matrix flow does.
+      await persistPasskey();
+      await refreshSharedSession();
+    }
+  });
+
+  test('restores one key from the changed-key row', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, facts.configEdit);
+
+    await drawer.getByRole('button', { name: `Restore ${seed.history.configKey}…` }).click();
+    const sheet = page.getByRole('dialog');
+    await expectNoFixtureSecret(sheet);
+    await expect(sheet).toContainText(`Restore ${seed.history.configKey} from r`);
+    const rollbackResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === `${DEV}/revisions/${String(facts.configEdit)}/rollback` &&
+        response.ok(),
+    );
+    await sheet.getByRole('button', { name: /^Stage the restore from r/ }).click();
+    const rollback = zHistoryRollbackResult.parse(await (await rollbackResponse).json());
+
+    // A config-only restore opens no secret plaintext, so it takes no ceremony.
+    await expect(sheet.locator('.history__chips')).toContainText('1 set');
+    await expect(sheet.locator('.history__impact')).toContainText('debug → info');
+    await expectNoFixtureSecret(sheet);
+    await sheet.locator('#history-restore-back').click();
+    await expect(
+      page.getByRole('button', { name: new RegExp(`${seed.history.configKey} in development:.*draft set`) }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /Review & publish/ }).click();
+    const publishSheet = page.getByRole('region', { name: 'Publish drafts' });
+    await expectNoFixtureSecret(publishSheet);
+    const publishRequest = page.waitForRequest(
+      (request) => request.method() === 'POST' && new URL(request.url()).pathname === `${DEV}/publish`,
+    );
+    await publishSheet.getByRole('button', { name: /Publish selected/ }).click();
+    const publishBody = zPublishRequest.parse((await publishRequest).postDataJSON());
+    expect(publishBody.preview_token).toBe(rollback.preview.token);
+    expect([...publishBody.version_ids].sort()).toEqual(
+      rollback.changes.map((change) => change.version_id).sort(),
+    );
+    await expect(page.locator('.notice')).toContainText('Published atomically: development');
+  });
+
+  test('refuses partial restore overlap, then publishes the restore set alone', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const advanced = await api(page, 'PUT', `${DEV}/values/${seed.history.configKey}`, zStaged, {
+      value: 'trace',
+    });
+    await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [advanced.version_id] });
+    await page.reload();
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, facts.configEdit);
+    await drawer.getByRole('button', { name: `Restore ${seed.history.configKey}…` }).click();
+    const restoreSheet = page.getByRole('dialog');
+    await expectNoFixtureSecret(restoreSheet);
+    await restoreSheet.getByRole('button', { name: /^Stage the restore from r/ }).click();
+    await expect(restoreSheet.locator('.history__impact')).toContainText(seed.history.configKey);
+    await expectNoFixtureSecret(restoreSheet);
+    await restoreSheet.locator('#history-restore-back').click();
+
+    // Another key in the SAME environment makes the matrix sheet's version set
+    // a partial overlap with the remembered restore preview.
+    await page.getByRole('button', {
+      name: new RegExp(`${seed.history.tightenedKey} in development:`),
+    }).click();
+    await page.getByLabel('development value').fill('13');
+    await page.getByRole('button', { name: 'Save 1 draft' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Review & publish/ }).click();
+    const publishSheet = page.getByRole('region', { name: 'Publish drafts' });
+    await expectNoFixtureSecret(publishSheet);
+    await expect(publishSheet).toContainText(seed.history.configKey);
+    await expect(publishSheet).toContainText(seed.history.tightenedKey);
+    let publishRequests = 0;
+    page.on('request', (request) => {
+      if (request.method() === 'POST' && new URL(request.url()).pathname === `${DEV}/publish`) {
+        publishRequests += 1;
+      }
+    });
+    await publishSheet.getByRole('button', { name: /Publish selected/ }).click();
+    await expect(publishSheet.getByRole('alert')).toContainText(
+      'Restore drafts must be published exactly as previewed',
+    );
+    await expectNoFixtureSecret(publishSheet);
+    expect(publishRequests, 'client-side overlap refusal must not call publish').toBe(0);
+
+    // Re-stage through SPA navigation, preserving the module-level preview
+    // store, then the drawer can select only the newly previewed restore set.
+    await page.getByRole('link', { name: /rev \d+ · history/ }).first().click();
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, facts.configEdit);
+    await drawer.getByRole('button', { name: `Restore ${seed.history.configKey}…` }).click();
+    const restagedSheet = page.getByRole('dialog');
+    await expectNoFixtureSecret(restagedSheet);
+    const rollbackResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === `${DEV}/revisions/${String(facts.configEdit)}/rollback` &&
+        response.ok(),
+    );
+    await restagedSheet.getByRole('button', { name: /^Stage the restore from r/ }).click();
+    const rollback = zHistoryRollbackResult.parse(await (await rollbackResponse).json());
+    await expectNoFixtureSecret(restagedSheet);
+    const publishRequest = page.waitForRequest(
+      (request) => request.method() === 'POST' && new URL(request.url()).pathname === `${DEV}/publish`,
+    );
+    await restagedSheet.locator('#history-restore-publish').click();
+    const body = zPublishRequest.parse((await publishRequest).postDataJSON());
+    expect(body.preview_token).toBe(rollback.preview.token);
+    expect([...body.version_ids].sort()).toEqual(
+      rollback.changes.map((change) => change.version_id).sort(),
+    );
+    expect(publishRequests, 'publish-alone action must call publish exactly once').toBe(1);
+    await expect(drawer.locator('.notice')).toContainText('Published the restore');
+  });
+
+  test('renders secret restore impact status-only and never exposes its value', async ({ page }) => {
+    const persistPasskey = await installPasskeyAuthenticator(page);
+    try {
+      await page.goto(DEV_HISTORY);
+      const drawer = page.getByRole('complementary', { name: 'Revision history' });
+      await expectNoFixtureSecret(drawer);
+      await openRevision(page, facts.tightened);
+      await drawer.getByRole('button', { name: `Restore ${seed.history.secretKey}…` }).click();
+      const sheet = page.getByRole('dialog');
+      await expectNoFixtureSecret(sheet);
+      const rollbackResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          new URL(response.url()).pathname === `${DEV}/revisions/${String(facts.tightened)}/rollback` &&
+          response.ok(),
+      );
+      await sheet.getByRole('button', { name: /^Stage the restore from r/ }).click();
+      await expect(page.getByRole('heading', { name: /restore an earlier revision of/ })).toBeVisible();
+      // The ceremony modal enumerates KEYS, never values: assert it on the
+      // ceremony state too, or a secret leaking only there would go unnoticed.
+      await expectNoFixtureSecret(page.getByRole('dialog', { name: /restore an earlier revision of|pin a historical revision of/ }));
+      await page.getByRole('button', { name: 'Use a passkey' }).click();
+      const rollback = zHistoryRollbackResult.parse(await (await rollbackResponse).json());
+
+      const impact = sheet.locator('.history__impact');
+      const secretImpact = impact.getByRole('listitem').filter({ hasText: seed.history.secretKey });
+      await expect(secretImpact.locator('.history__impact-values')).toHaveText(
+        'secret — edited, write-presence only',
+      );
+      await expect(secretImpact.locator('.history__impact-values')).not.toContainText('→');
+      await expectNoFixtureSecret(sheet);
+      const publishRequest = page.waitForRequest(
+        (request) => request.method() === 'POST' && new URL(request.url()).pathname === `${DEV}/publish`,
+      );
+      await sheet.locator('#history-restore-publish').click();
+      const publish = zPublishRequest.parse((await publishRequest).postDataJSON());
+      expect(publish.preview_token).toBe(rollback.preview.token);
+      await expect(drawer.locator('.notice')).toContainText('Published the restore');
+
+      // Put the live secret back on the seeded r2 material so viewport two can
+      // exercise the same r1 impact instead of seeing a no-op restore.
+      const liveSecret = seed.history.secretValues.at(-1);
+      if (liveSecret === undefined) throw new Error('history fixture has no live secret value');
+      const reset = await api(page, 'PUT', `${DEV}/values/${seed.history.secretKey}`, zStaged, {
+        value: liveSecret,
+      });
+      await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [reset.version_id] });
+    } finally {
+      await persistPasskey();
+      await refreshSharedSession();
+    }
+  });
+
+  test('refuses a schema-failing restore loud, naming the key', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const before = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, facts.tightened);
+
+    // Only WORKERS is staged, so the failed publish leaves exactly the invalid
+    // draft the next viewport's drift repair is specified to supersede.
+    await drawer.getByRole('button', { name: `Restore ${seed.history.tightenedKey}…` }).click();
+    const sheet = page.getByRole('dialog');
+    await expectNoFixtureSecret(sheet);
+    const rollbackResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === `${DEV}/revisions/${String(facts.tightened)}/rollback` &&
+        response.ok(),
+    );
+    await sheet.getByRole('button', { name: /^Stage the restore from r/ }).click();
+    const rollback = zHistoryRollbackResult.parse(await (await rollbackResponse).json());
+    const restoredDraft = rollback.changes.find(
+      (change) => change.key_id === seed.history.tightenedKeyId,
+    );
+    const invalidImpact = rollback.preview.environments
+      .flatMap((environment) => environment.changes)
+      .find((change) => change.key_id === seed.history.tightenedKeyId);
+    const restoreEnvironment = rollback.preview.environments.find(
+      (environment) => environment.environment_id === seed.history.dev,
+    );
+    expect(restoredDraft, 'restore must stage the tightened key').toBeDefined();
+    expect(restoreEnvironment, 'restore preview must carry the development environment').toBeDefined();
+    expect(invalidImpact, 'restore preview must carry the tightened key').toMatchObject({
+      classification: 'config',
+      operation: 'set',
+    });
+    expect(invalidImpact?.after, 'older revision must carry the invalid config value').toBeDefined();
+    await expect(sheet.locator('.history__impact')).toContainText(seed.history.tightenedKey);
+    await expectNoFixtureSecret(sheet);
+    await sheet.locator('#history-restore-back').click();
+
+    await expect(
+      page.getByRole('button', {
+        name: new RegExp(`${seed.history.tightenedKey} in development:.*draft set`),
+      }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: /Review & publish/ }).click();
+    const publishSheet = page.getByRole('region', { name: 'Publish drafts' });
+    await expectNoFixtureSecret(publishSheet);
+    await publishSheet.getByRole('button', { name: /Publish selected/ }).click();
+    const refusal = publishSheet.getByRole('alert');
+    await expect(refusal).toHaveAttribute('role', 'alert');
+    await expect(refusal).toContainText(`value for "${seed.history.tightenedKey}" is invalid (`);
+    await expect(page.getByText(/Published atomically/)).toHaveCount(0);
+    await expectNoFixtureSecret(publishSheet);
+
+    const pending = await api(page, 'GET', `${DEV}/pending`, zPendingDraftList);
+    const pendingRestoredDraft = pending.items.find(
+      (draft) => draft.version_id === restoredDraft?.version_id,
+    );
+    expect(pendingRestoredDraft, 'the refused draft must be the one returned by restore').toMatchObject({
+      key_id: seed.history.tightenedKeyId,
+      name: seed.history.tightenedKey,
+      classification: 'config',
+      operation: 'set',
+      staged_from_revision: restoreEnvironment?.base_revision,
+      revealed: true,
+      value: invalidImpact?.after,
+    });
+    const after = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
+    expect(after.items.map((revision) => revision.revision)).toEqual(
+      before.items.map((revision) => revision.revision),
+    );
+  });
+
+  test('shows the behind-latest gap sentence and warning-tier expiry as text', async ({ page }) => {
+    await page.goto(DEV_HISTORY);
+    const revisions = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
+    const pins = await api(page, 'GET', `${DEV}/pins`, zRevisionPinList);
+    const latest = revisions.items[0]?.revision;
+    const pin = pins.items.find(
+      (candidate) => candidate.workload_principal_id === seed.history.pinnedWorkloadPrincipal,
+    );
+    if (latest === undefined || pin === undefined) throw new Error('pin-gap fixture state is missing');
+    const pinnedRevision = Number(pin.revision);
+    const behind = revisions.items.filter((revision) => revision.revision > pinnedRevision).length;
+    const expiryDays = Math.ceil(
+      (new Date(pin.expires_at).getTime() - Date.now()) / (24 * 60 * 60 * 1000),
+    );
+    expect(behind).toBeGreaterThan(0);
+    expect(expiryDays).toBeGreaterThan(7);
+    expect(expiryDays).toBeLessThanOrEqual(30);
+
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await openRevision(page, pinnedRevision);
+    const pinRow = drawer.locator('.history__pin').filter({ hasText: seed.history.pinnedWorkload });
+    await expect(pinRow.locator('.history__pin-gap')).toHaveText(
+      `${seed.history.pinnedWorkload} still runs on r${String(pinnedRevision)}'s values — ${String(behind)} publishes behind latest (r${String(latest)}). New publishes don't reach it.`,
+    );
+    await expect(pinRow.locator('.history__expiry--month')).toHaveText(
+      `! expires in ${String(expiryDays)} d`,
+    );
+  });
+
+  test('requires a fresh-session ceremony for a historical move and audits comparison', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const persistPasskey = await installPasskeyAuthenticator(page);
+    try {
+      await context.clearCookies();
+      await page.goto(DEV_HISTORY);
+      await establishSession(page);
+      await page.goto(DEV_HISTORY);
+      const advanced = await api(page, 'PUT', `${DEV}/values/${seed.history.configKey}`, zStaged, {
+        value: 'current-after-pin-target',
+      });
+      await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [advanced.version_id] });
+      await page.reload();
+      const revisions = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
+      const latest = revisions.items[0]?.revision;
+      const pinsBefore = await api(page, 'GET', `${DEV}/pins`, zRevisionPinList);
+      const existing = pinsBefore.items.find(
+        (pin) => pin.workload_principal_id === seed.history.pinnedWorkloadPrincipal,
+      );
+      if (latest === undefined || existing === undefined) throw new Error('historical-pin fixture state is missing');
+      const drawer = page.getByRole('complementary', { name: 'Revision history' });
+      await expectNoFixtureSecret(drawer);
+      await openRevision(page, facts.configEdit);
+      await drawer.getByRole('button', { name: `Pin r${String(facts.configEdit)}…` }).click();
+      const moveSheet = page.getByRole('dialog');
+      await expectNoFixtureSecret(moveSheet);
+      await moveSheet.getByLabel('Workload').selectOption({
+        label: `${seed.history.pinnedWorkload} — pinned to r${String(existing.revision)}`,
+      });
+      await moveSheet.locator('#history-pin-submit').click();
+
+      // Fresh cookie jar means no sliding reauth window can satisfy this.
+      await expect(page.getByRole('heading', { name: /pin a historical revision of/ })).toBeVisible();
+      // The ceremony modal enumerates KEYS, never values: assert it on the
+      // ceremony state too, or a secret leaking only there would go unnoticed.
+      await expectNoFixtureSecret(page.getByRole('dialog', { name: /restore an earlier revision of|pin a historical revision of/ }));
+      await page.getByRole('button', { name: 'Use a passkey' }).click();
+      await expect(drawer.locator('.notice')).toContainText('Pin reassigned');
+      await expectNoFixtureSecret(drawer);
+      const pinsAfter = await api(page, 'GET', `${DEV}/pins`, zRevisionPinList);
+      const moved = pinsAfter.items.find(
+        (pin) => pin.workload_principal_id === seed.history.pinnedWorkloadPrincipal,
+      );
+      expect(moved?.revision).toBe(BigInt(facts.configEdit));
+      expect(moved?.history_authorized).toBe(true);
+
+      // Same purpose-bound session now owns a live window. Comparison may read
+      // config plaintext, while secret output remains lineage-only.
+      await openRevision(page, facts.configEdit);
+      await drawer.getByRole('button', { name: `Pin r${String(facts.configEdit)}…` }).click();
+      const compareSheet = page.getByRole('dialog');
+      await compareSheet.getByLabel('Workload').selectOption({
+        label: `${seed.history.spareWorkload} — follows latest`,
+      });
+      await expectNoFixtureSecret(compareSheet);
+      const trailBeforeComparison = countDisclosureEvents();
+      // The comparison is a read-only export: `reveal:false` on the wire, so no
+      // secret is ever opened and no disclosure event may be written. Asserting
+      // the body AND the trail delta means a regression that started revealing
+      // (or a server that started logging config reads as disclosures) fails.
+      const exportRequest = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' &&
+          new URL(request.url()).pathname === `${DEV}/values/export`,
+      );
+      await compareSheet.locator('#history-pin-compare').click();
+      const exportBody = zExportValuesRequest.parse((await exportRequest).postDataJSON());
+      expect(exportBody.reveal, 'the comparison must never ask for secret plaintext').not.toBe(true);
+      expect(exportBody.revision).toBe(BigInt(facts.configEdit));
+      const comparison = compareSheet.locator('#history-pin-compare-results');
+      const comparedConfigKeys = [seed.history.configKey, seed.history.tightenedKey];
+      await expect(comparison).toContainText(seed.history.configKey);
+      await expect(comparison).toContainText(
+        `${String(comparedConfigKeys.length - 1)} config key unchanged`,
+      );
+      await expect(compareSheet).toContainText(
+        'Secret lines are write-presence from the lineage, never a value comparison',
+      );
+      await expect(comparison).toContainText(
+        new RegExp(
+          `${seed.history.secretKey} (not written|written again) since r${String(facts.configEdit)}`,
+        ),
+      );
+      await expectNoFixtureSecret(compareSheet);
+      expect(
+        countDisclosureEvents() - trailBeforeComparison,
+        'a read-only config comparison opens no secret and therefore writes no disclosure event',
+      ).toBe(0);
+
+      // Restore canonical state for the remaining lifecycle test without
+      // opening historical material.
+      await api(page, 'POST', `${DEV}/pins`, zAny, {
+        workload_principal_id: seed.history.pinnedWorkloadPrincipal,
+        revision: latest,
+        expires_at: new Date(Date.now() + (seed.history.pinExpiryDays * 24 + 12) * 60 * 60 * 1000).toISOString(),
+      });
+    } finally {
+      await persistPasskey();
+      await context.close();
+    }
+  });
+
+  test('keeps the mobile matrix inert and restores drawer focus', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'mobile-only focus contract');
+    await page.goto(DEV_HISTORY);
+    const drawer = page.getByRole('complementary', { name: 'Revision history' });
+    await expectNoFixtureSecret(drawer);
+    await expect(page.locator('.matrix[inert]')).toBeVisible();
+    await expect(page.locator('#history-title')).toBeFocused();
+
+    const selectedRow = page.locator(`[data-history-revision="${String(facts.current)}"]`);
+    await selectedRow.click();
+    await expect(page.locator('#history-detail-title')).toBeFocused();
+    await expectNoFixtureSecret(drawer);
+    await page.locator('#history-detail-back').click();
+    await expect(selectedRow).toBeFocused();
+    await expectNoFixtureSecret(drawer);
+  });
+
+  test('runs renew, schema override, and retention-gated one-click release', async ({ page }) => {
+    const persistPasskey = await installPasskeyAuthenticator(page);
+    try {
+      await page.goto(DEV_HISTORY);
+      const revisions = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
+      const latest = revisions.items[0]?.revision;
+      if (latest === undefined) throw new Error('pin lifecycle has no current revision');
+      const drawer = page.getByRole('complementary', { name: 'Revision history' });
+      await expectNoFixtureSecret(drawer);
+      await openRevision(page, latest);
+
+      await drawer.getByRole('button', { name: `Pin r${String(latest)}…` }).click();
+      const pinSheet = page.getByRole('dialog');
+      await expectNoFixtureSecret(pinSheet);
+      await pinSheet.getByLabel('Workload').selectOption({
+        label: `${seed.history.pinnedWorkload} — pinned to r${String(latest)}`,
+      });
+      const tooFar = new Date(Date.now() + 400 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      await pinSheet.getByLabel(/Expires on/).fill(tooFar);
+      await pinSheet.locator('#history-pin-submit').click();
+      await expect(drawer.getByRole('alert')).toContainText('pin expiry exceeds the maximum 365 days');
+      await expectNoFixtureSecret(pinSheet);
+      const ok = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      await pinSheet.getByLabel(/Expires on/).fill(ok);
+      await pinSheet.locator('#history-pin-submit').click();
+      await expect(drawer.locator('.notice')).toContainText('Pin renewed');
+      await expectNoFixtureSecret(drawer);
+
+      // Retention read succeeded, so this non-sole current pin releases in one
+      // click without a consequence confirmation sheet.
+      await expect(drawer.locator('.history__retention')).toContainText('values kept:');
+      const renewed = drawer.locator('.history__pin').filter({ hasText: seed.history.pinnedWorkload });
+      await renewed.getByRole('button', { name: 'Release' }).click();
+      const releaseConfirm = page.locator('#history-release-confirm');
+      await expect(releaseConfirm).toHaveCount(0);
+      if (await releaseConfirm.isVisible()) {
+        await expectNoFixtureSecret(releaseConfirm);
+      }
+      await expect(drawer.locator('.notice')).toContainText('resumes latest');
+
+      await openRevision(page, facts.tightened);
+      await drawer.getByRole('button', { name: `Pin r${String(facts.tightened)}…` }).click();
+      const overrideSheet = page.getByRole('dialog');
+      await expectNoFixtureSecret(overrideSheet);
+      await overrideSheet.getByLabel('Workload').selectOption({
+        label: `${seed.history.spareWorkload} — follows latest`,
+      });
+      await expect(overrideSheet.getByRole('checkbox')).toHaveCount(0);
+      await overrideSheet.locator('#history-pin-submit').click();
+      await expect(page.getByRole('heading', { name: /pin a historical revision of/ })).toBeVisible();
+      // The ceremony modal enumerates KEYS, never values: assert it on the
+      // ceremony state too, or a secret leaking only there would go unnoticed.
+      await expectNoFixtureSecret(page.getByRole('dialog', { name: /restore an earlier revision of|pin a historical revision of/ }));
+      await page.getByRole('button', { name: 'Use a passkey' }).click();
+      await expect(drawer.getByRole('alert')).toContainText(seed.history.tightenedKey);
+      await expectNoFixtureSecret(overrideSheet);
+      const override = overrideSheet.getByRole('checkbox');
+      await expect(override).toBeVisible();
+      // The override renders only after a refusal, so the pinned sweep over the
+      // idle surface never reaches it; the touch floor is asserted here, where
+      // it exists (mobile runs the check, desktop is skipped by design).
+      await expectTouchTargets(page, [override]);
+      await override.check();
+      await overrideSheet.locator('#history-pin-submit').click();
+      await expect(drawer.locator('.notice')).toContainText('Pin created');
+      await expectNoFixtureSecret(drawer);
+      const drifted = drawer.locator('.history__pin').filter({ hasText: seed.history.spareWorkload });
+      await expect(drifted).toContainText('Δ schema drift');
+
+      // Clean up the override pin when the product classifier exposes it.
+      await drifted.getByRole('button', { name: 'Release' }).click();
+      await expect(drawer.locator('.notice')).toContainText('resumes latest');
+    } finally {
+      await persistPasskey();
+      await refreshSharedSession();
+    }
+  });
+
+});

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -66,43 +66,46 @@ test.describe('login', () => {
     expect(JSON.stringify(stored)).not.toContain('hik_1_');
   });
 
-  test('meets the pinned assertion set', async ({ page }) => {
-    await page.goto('/login');
+  for (const scheme of ['dark', 'light'] as const) {
+    test(`meets the pinned assertion set (${scheme})`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      await page.goto('/login');
 
-    const card = page.locator('.login__card');
-    const submit = page.getByRole('button', { name: 'Sign in' });
-    const heading = page.getByRole('heading', { name: 'Sign in to Hikyo' });
-    const lede = page.getByText('Use the credential you established');
+      const card = page.locator('.login__card');
+      const submit = page.getByRole('button', { name: 'Sign in' });
+      const heading = page.getByRole('heading', { name: 'Sign in to Hikyo' });
+      const lede = page.getByText('Use the credential you established');
 
-    // Every interactive element is discovered and asserted; what the flow
-    // declares is only the DESIGN.md conformance that needs a name.
-    await expectPinnedAssertionSet(page, {
-      flow: 'login',
-      surface: 'login',
-      theme: 'dark',
-      text: [heading, lede],
-      radii: [
-        [card, 'container'],
-        [submit, 'control'],
-        [page.getByLabel('Username'), 'control'],
-        [page.getByLabel('Password'), 'control'],
-      ],
-      fonts: [
-        [heading, 'ui'],
-        [lede, 'ui'],
-      ],
-      colours: [
-        [heading, 'color', '--tx'],
-        [lede, 'color', '--tx-dim'],
-        [card, 'backgroundColor', '--bg-raise'],
-        [card, 'borderTopColor', '--line'],
-        [submit, 'backgroundColor', '--accent'],
-        [submit, 'color', '--on-accent'],
-      ],
-      hairlines: [card, page.getByLabel('Username')],
-      density: [[submit, '--touch']],
+      // Every interactive element is discovered and asserted; what the flow
+      // declares is only the DESIGN.md conformance that needs a name.
+      await expectPinnedAssertionSet(page, {
+        flow: 'login',
+        surface: 'login',
+        theme: scheme,
+        text: [heading, lede],
+        radii: [
+          [card, 'container'],
+          [submit, 'control'],
+          [page.getByLabel('Username'), 'control'],
+          [page.getByLabel('Password'), 'control'],
+        ],
+        fonts: [
+          [heading, 'ui'],
+          [lede, 'ui'],
+        ],
+        colours: [
+          [heading, 'color', '--tx'],
+          [lede, 'color', '--tx-dim'],
+          [card, 'backgroundColor', '--bg-raise'],
+          [card, 'borderTopColor', '--line'],
+          [submit, 'backgroundColor', '--accent'],
+          [submit, 'color', '--on-accent'],
+        ],
+        hairlines: [card, page.getByLabel('Username')],
+        density: [[submit, '--touch']],
+      });
     });
-  });
+  }
 
   // The palette is a dual-theme palette, so conformance is a dual-theme claim.
   test('matches the DESIGN.md palette in the light theme too', async ({ page }) => {

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -184,7 +184,7 @@ test.describe('environment matrix', () => {
         await page.setViewportSize({ width: 375, height: 812 });
       }
 
-      await page.getByRole('button', { name: 'Edit LOG_LEVEL across environments' }).click();
+      await page.getByRole('button', { name: /^LOG_LEVEL in development:/ }).click();
       const editor = page.getByRole('dialog');
       await expect(editor).toBeVisible();
       await expect(editor).toContainText('Updated by');
@@ -233,7 +233,7 @@ test.describe('environment matrix', () => {
       await expect(page.locator('.notice')).toContainText('whitespace was removed from 2 values');
       await expect(page.getByRole('button', { name: /LOG_LEVEL in development:.*draft set/ })).toBeVisible();
 
-      await page.getByRole('button', { name: 'Edit LOG_LEVEL across environments' }).click();
+      await page.getByRole('button', { name: /^LOG_LEVEL in development:/ }).click();
       const reopened = page.getByRole('dialog');
       await expect(reopened.getByLabel('development value')).toHaveValue(value);
       await expect(reopened.getByLabel('production value')).toHaveValue(`${value}-production`);

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -10,7 +10,7 @@ import { readRunLog, unexecutedClaims } from './registry.ts';
  * entry to a flow's claim list passes the closure check while asserting
  * nothing about the new page.
  *
- * It is skipped under `--grep`, and only under `--grep`: a filtered run is
+ * It is skipped under `--grep` or a positional spec filter: a filtered run is
  * deliberately partial, and failing it would make the check something people
  * work around instead of with. CI runs unfiltered.
  *
@@ -32,9 +32,23 @@ export default function globalTeardown(config: FullConfig): void {
     );
   }
 
-  const filtered = String(config.grep) !== '/.*/';
+  // `config.grep` is NOT where a CLI `--grep` lands: Playwright leaves the
+  // resolved config's `grep` at `/.*/` and applies the CLI filter separately, so
+  // reading it alone made this check fire on every filtered run — after the
+  // tests passed, with a wall of lines about flows nobody asked to run. That is
+  // exactly the "check people work around instead of with" the note above warns
+  // against. The CLI is read from `process.argv` (global teardown runs in
+  // Playwright's own process), and the config field is still consulted because a
+  // `grep` set in `playwright.config.ts` does land there.
+  const grepped = process.argv.some(
+    (arg) => arg === '--grep' || arg === '-g' || arg.startsWith('--grep='),
+  );
+  const specFiltered = process.argv.some(
+    (arg) => arg.endsWith('.spec.ts') || arg.includes('/flows/'),
+  );
+  const filtered = grepped || specFiltered || String(config.grep) !== '/.*/';
   if (filtered) {
-    process.stdout.write('flow-registry execution check skipped: this run was filtered by --grep\n');
+    process.stdout.write('flow-registry execution check skipped: this run was filtered\n');
     return;
   }
   const missing = unexecutedClaims(readRunLog());

--- a/web/e2e/registry.test.ts
+++ b/web/e2e/registry.test.ts
@@ -108,13 +108,23 @@ describe('the execution half of closure', () => {
   const claims = FLOWS.flatMap((flow) => flow.surfaces.map((surface) => [flow.id, surface]));
 
   it('is satisfied when every claim ran', () => {
-    expect(unexecutedClaims(log(...claims.map(([f, s]) => `${f}\t${s}\tdark`)))).toEqual([]);
+    expect(
+      unexecutedClaims(
+        log(...claims.flatMap(([f, s]) => [`${f}\t${s}\tdark`, `${f}\t${s}\tlight`])),
+      ),
+    ).toEqual([]);
+  });
+
+  it('fails when every surface ran in only one theme', () => {
+    const problems = unexecutedClaims(log(...claims.map(([f, s]) => `${f}\t${s}\tdark`)));
+    expect(problems).toHaveLength(claims.length);
+    expect(problems.every((problem) => problem.includes('in light theme'))).toBe(true);
   });
 
   it('fails a surface that was claimed but never asserted', () => {
     const [first = ['', '']] = claims;
     const problems = unexecutedClaims(log(`${first[0]}\t${first[1]}\tdark`));
-    expect(problems).toHaveLength(claims.length - 1);
+    expect(problems).toHaveLength(claims.length * 2 - 1);
     for (const [, surface] of claims.slice(1)) {
       expect(problems.join(' ')).toContain(
         `claims surface "${surface}" but the pinned assertion set never ran`,
@@ -123,7 +133,7 @@ describe('the execution half of closure', () => {
   });
 
   it('fails everything when nothing ran at all', () => {
-    expect(unexecutedClaims('')).toHaveLength(claims.length);
+    expect(unexecutedClaims('')).toHaveLength(claims.length * 2);
   });
 
   it('does not accept another flow\'s execution as this one\'s', () => {
@@ -131,6 +141,6 @@ describe('the execution half of closure', () => {
     const problems = unexecutedClaims(log('shell\tlogin\tdark'), [
       { id: 'login', spec: 'flows/login.spec.ts', surfaces: ['login'] },
     ]);
-    expect(problems).toHaveLength(1);
+    expect(problems).toHaveLength(2);
   });
 });

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -39,6 +39,7 @@ export const FLOWS: readonly Flow[] = [
   { id: 'shell', spec: 'flows/shell.spec.ts', surfaces: ['overview', 'projects', 'settings'] },
   { id: 'reveal', spec: 'flows/reveal.spec.ts', surfaces: ['values'] },
   { id: 'matrix', spec: 'flows/matrix.spec.ts', surfaces: ['matrix'] },
+  { id: 'history', spec: 'flows/history.spec.ts', surfaces: ['history'] },
   {
     id: 'machine-access',
     spec: 'flows/machine-access.spec.ts',
@@ -184,18 +185,20 @@ export function unexecutedClaims(log: string, flows: readonly ClosureCandidate[]
       .map((line) => line.trim())
       .filter((line) => line !== '')
       .map((line) => {
-        const [flow = '', surface = ''] = line.split('\t');
-        return `${flow}/${surface}`;
+        const [flow = '', surface = '', theme = ''] = line.split('\t');
+        return `${flow}/${surface}/${theme}`;
       }),
   );
   const missing: string[] = [];
   for (const flow of flows) {
     for (const surface of flow.surfaces) {
-      if (!ran.has(`${flow.id}/${surface}`)) {
-        missing.push(
-          `flow "${flow.id}" claims surface "${surface}" but the pinned assertion set never ran ` +
-            `on it — a claim nothing executes is a claim nothing checks`,
-        );
+      for (const theme of ['dark', 'light'] as const) {
+        if (!ran.has(`${flow.id}/${surface}/${theme}`)) {
+          missing.push(
+            `flow "${flow.id}" claims surface "${surface}" but the pinned assertion set never ran ` +
+              `on it in ${theme} theme — a claim nothing executes is a claim nothing checks`,
+          );
+        }
       }
     }
   }

--- a/web/src/api/history.test.ts
+++ b/web/src/api/history.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  historyHref,
+  revisionNumber,
+  zHistoryRevisionList,
+  zHistoryRollbackResult,
+} from './history.ts';
+
+const lineage = {
+  revision: 3,
+  schema_revision: 7,
+  published_by: 'usr_0198aaaa-bbbb-7ccc-8ddd-eeeeffff0001',
+  published_at: '2026-08-01T10:00:00Z',
+  changed_keys: [{ key_id: 'key_0198aaaa-bbbb-7ccc-8ddd-eeeeffff0002', name: 'LOG_LEVEL', change: 'edited' }],
+  payload_present: true,
+};
+
+describe('history revision boundary', () => {
+  it('accepts a live revision that names no collection policy', () => {
+    const parsed = zHistoryRevisionList.parse({ items: [lineage], count: 1 });
+    expect(parsed.items[0]?.payload_present).toBe(true);
+    expect(parsed.items[0]?.revision).toBe(3n);
+  });
+
+  it('accepts a collected revision that names the policy that collected it', () => {
+    const parsed = zHistoryRevisionList.parse({
+      items: [{ ...lineage, payload_present: false, collected_policy: 'keep-if-either(x)' }],
+      count: 1,
+    });
+    expect(parsed.items[0]?.collected_policy).toBe('keep-if-either(x)');
+  });
+
+  it('refuses a collected revision with no policy — the refusal has to name one', () => {
+    expect(() => zHistoryRevisionList.parse({ items: [{ ...lineage, payload_present: false }], count: 1 }))
+      .toThrow(/collected revision must name the policy/);
+  });
+
+  it('refuses a live revision carrying a collection policy', () => {
+    expect(() =>
+      zHistoryRevisionList.parse({
+        items: [{ ...lineage, collected_policy: 'keep-if-either(x)' }],
+        count: 1,
+      }),
+    ).toThrow(/only a collected revision carries/);
+  });
+});
+
+describe('restore result boundary', () => {
+  const preview = (change: Record<string, unknown>) => ({
+    revision: 3,
+    changes: [],
+    preview: {
+      token: 'tok',
+      environments: [
+        {
+          environment_id: 'env_0198aaaa-bbbb-7ccc-8ddd-eeeeffff0003',
+          base_revision: 5,
+          schema_revision: 7,
+          protected: false,
+          changes: [change],
+        },
+      ],
+    },
+  });
+
+  const configSet = {
+    version_id: 'pcv_0198aaaa-bbbb-7ccc-8ddd-eeeeffff0004',
+    key_id: 'key_0198aaaa-bbbb-7ccc-8ddd-eeeeffff0002',
+    name: 'LOG_LEVEL',
+    classification: 'config',
+    operation: 'set',
+    status: 'edited',
+    before: 'warn',
+    after: 'debug',
+  };
+
+  it('keeps config plaintext, which is what the impact preview is for', () => {
+    const parsed = zHistoryRollbackResult.parse(preview(configSet));
+    expect(parsed.preview.environments[0]?.changes[0]?.after).toBe('debug');
+  });
+
+  it('refuses a secret row carrying material on either side', () => {
+    expect(() => zHistoryRollbackResult.parse(preview({ ...configSet, classification: 'secret' })))
+      .toThrow(/secret impact rows are status-only/);
+  });
+
+  it('refuses a clear that claims an after value', () => {
+    expect(() =>
+      zHistoryRollbackResult.parse(preview({ ...configSet, operation: 'unset', status: 'removed' })),
+    ).toThrow(/a clear has no after value/);
+  });
+});
+
+describe('historyHref', () => {
+  it('encodes path and query parameters while keeping key as the immutable id', () => {
+    expect(historyHref({
+      org: 'team/one',
+      project: 'app name',
+      env: 'env?prod',
+      keyId: 'key/id',
+      rev: 42n,
+    })).toBe('/orgs/team%2Fone/projects/app%20name/matrix/history?env=env%3Fprod&key=key%2Fid&rev=42');
+  });
+});
+
+describe('revisionNumber', () => {
+  it('narrows a parsed revision to the request shape', () => {
+    expect(revisionNumber(42n)).toBe(42);
+  });
+
+  it('fails loud rather than rounding a revision it cannot address exactly', () => {
+    expect(() => revisionNumber(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow(/outside the range/);
+    expect(() => revisionNumber(0n)).toThrow(/outside the range/);
+  });
+});

--- a/web/src/api/history.ts
+++ b/web/src/api/history.ts
@@ -1,0 +1,314 @@
+import {
+  createRevisionPin,
+  getProjectRetention,
+  getRevision,
+  listRevisionPins,
+  listRevisions,
+  releaseRevisionPin,
+  rollbackRevision,
+} from '@hikyo/client';
+import {
+  zProjectRetentionPolicy,
+  zRevisionDetail,
+  zRevisionList,
+  zRevisionPinList,
+  zRevisionPinResult,
+  zRollbackResult,
+} from '@hikyo/zod';
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { ApiError, ok, parsed } from './client.ts';
+import type { MatrixRef } from './matrix.ts';
+import { valuesKey, type EnvRef } from './values.ts';
+
+/**
+ * The revision-history API boundary (#59).
+ *
+ * Everything the drawer reads crosses the generated Zod at this seam, and two
+ * contract invariants are re-stated as refinements because they are the ones
+ * whose violation would be a DISCLOSURE rather than a rendering bug:
+ *
+ *  1. A collected revision names the policy that collected it, and a live one
+ *     names none. That pairing is what makes the drawer's refusal quotable.
+ *  2. An impact row for a `secret` key carries no material on either side —
+ *     not a plaintext, not a length, not a comparison status beyond
+ *     write-presence — and a `unset` row carries no `after` at all.
+ */
+
+export type HistoryRevisionList = z.infer<typeof zRevisionList>;
+export type HistoryRevisionItem = HistoryRevisionList['items'][number];
+export type HistoryRevisionDetail = z.infer<typeof zRevisionDetail>;
+export type RevisionPinList = z.infer<typeof zRevisionPinList>;
+export type RevisionPinItem = RevisionPinList['items'][number];
+export type RestoreResult = z.infer<typeof zRollbackResult>;
+export type ProjectRetention = z.infer<typeof zProjectRetentionPolicy>;
+
+function refineCollectionBit(
+  entry: { readonly payload_present: boolean; readonly collected_policy?: string | undefined },
+  context: z.RefinementCtx,
+  path: readonly (string | number)[],
+): void {
+  if (!entry.payload_present && (entry.collected_policy ?? '') === '') {
+    context.addIssue({
+      code: 'custom',
+      path: [...path, 'collected_policy'],
+      message: 'a collected revision must name the policy that collected it',
+    });
+  }
+  if (entry.payload_present && entry.collected_policy !== undefined) {
+    context.addIssue({
+      code: 'custom',
+      path: [...path, 'collected_policy'],
+      message: 'only a collected revision carries a collection policy',
+    });
+  }
+}
+
+export const zHistoryRevisionList = zRevisionList.superRefine((list, context) => {
+  list.items.forEach((item, index) => {
+    refineCollectionBit(item, context, ['items', index]);
+  });
+});
+
+export const zHistoryRevisionDetail = zRevisionDetail;
+
+export const zHistoryRollbackResult = zRollbackResult.superRefine((result, context) => {
+  result.preview.environments.forEach((environment, environmentIndex) => {
+    environment.changes.forEach((change, changeIndex) => {
+      const path = ['preview', 'environments', environmentIndex, 'changes', changeIndex] as const;
+      if (change.classification === 'secret' && (change.before !== undefined || change.after !== undefined)) {
+        context.addIssue({
+          code: 'custom',
+          path: [...path],
+          message: 'secret impact rows are status-only and must carry no material',
+        });
+      }
+      if (change.operation === 'unset' && change.after !== undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: [...path, 'after'],
+          message: 'a clear has no after value',
+        });
+      }
+    });
+  });
+});
+
+/**
+ * revisionNumber narrows a parsed revision back to the wire's request shape.
+ *
+ * Responses parse `int64` to `bigint` (no precision loss); the generated
+ * REQUEST types are plain `number`, which is the generator's shape and not
+ * something this file gets to change. The conversion is therefore explicit and
+ * fails loud past `Number.MAX_SAFE_INTEGER` rather than silently addressing a
+ * revision nobody asked for — a rounded revision number in a restore or a pin
+ * is the wrong snapshot, delivered confidently.
+ */
+export function revisionNumber(revision: bigint): number {
+  if (revision > BigInt(Number.MAX_SAFE_INTEGER) || revision < 1n) {
+    throw new Error(`revision ${String(revision)} is outside the range this client can address`);
+  }
+  return Number(revision);
+}
+
+export function historyHref(input: {
+  readonly org: string;
+  readonly project: string;
+  readonly env?: string;
+  readonly keyId?: string;
+  readonly rev?: bigint;
+}): string {
+  const query = [
+    input.env === undefined ? null : `env=${encodeURIComponent(input.env)}`,
+    input.keyId === undefined ? null : `key=${encodeURIComponent(input.keyId)}`,
+    input.rev === undefined ? null : `rev=${encodeURIComponent(String(input.rev))}`,
+  ].filter((part) => part !== null);
+  const path =
+    `/orgs/${encodeURIComponent(input.org)}/projects/${encodeURIComponent(input.project)}` +
+    '/matrix/history';
+  return query.length === 0 ? path : `${path}?${query.join('&')}`;
+}
+
+export const revisionsKey = (env: EnvRef) =>
+  ['revisions', env.org, env.project, env.environment] as const;
+export const revisionDetailKey = (env: EnvRef, revision: string) =>
+  ['revision-detail', env.org, env.project, env.environment, revision] as const;
+export const pinsKey = (env: EnvRef) =>
+  ['revision-pins', env.org, env.project, env.environment] as const;
+export const projectRetentionKey = (ref: MatrixRef) =>
+  ['project-retention', ref.org, ref.project] as const;
+
+const enabledEnv = (env: EnvRef): boolean =>
+  env.org !== '' && env.project !== '' && env.environment !== '';
+
+export function useRevisionHistory(env: EnvRef): UseQueryResult<HistoryRevisionList> {
+  return useQuery({
+    queryKey: revisionsKey(env),
+    queryFn: () => parsed(listRevisions({ path: { ...env } }), zHistoryRevisionList),
+    enabled: enabledEnv(env),
+    retry: false,
+  });
+}
+
+/**
+ * useRevisionDetail reads ONE revision's delivered key set.
+ *
+ * It is deliberately gated on the lineage row's collection bit rather than
+ * fetched optimistically: `getRevision` derives a change token over the
+ * snapshot's manifest, so it refuses a collected revision with a 409. Asking
+ * anyway would turn "this payload was collected, here is the policy" — a fact
+ * the history row already carries — into an error state the drawer would have
+ * to un-explain.
+ */
+export function useRevisionDetail(
+  env: EnvRef,
+  revision: bigint | null,
+  payloadPresent: boolean,
+): UseQueryResult<HistoryRevisionDetail> {
+  const label = revision === null ? '' : String(revision);
+  return useQuery({
+    queryKey: revisionDetailKey(env, label),
+    queryFn: () =>
+      parsed(getRevision({ path: { ...env, revision: label } }), zHistoryRevisionDetail),
+    enabled: enabledEnv(env) && revision !== null && payloadPresent,
+    retry: false,
+  });
+}
+
+export function useRevisionPins(env: EnvRef): UseQueryResult<RevisionPinList> {
+  return useQuery({
+    queryKey: pinsKey(env),
+    queryFn: () => parsed(listRevisionPins({ path: { ...env } }), zRevisionPinList),
+    enabled: enabledEnv(env),
+    retry: false,
+  });
+}
+
+/**
+ * useProjectRetention is the drawer head's read-only line.
+ *
+ * The project endpoint answers with the EFFECTIVE policy and whether it is
+ * inherited, which is the whole line — so the org read is not fetched here. A
+ * second request to render a badge the first response already determines is a
+ * second thing that can fail.
+ */
+export function useProjectRetention(ref: MatrixRef): UseQueryResult<ProjectRetention> {
+  return useQuery({
+    queryKey: projectRetentionKey(ref),
+    queryFn: () => parsed(getProjectRetention({ path: { ...ref } }), zProjectRetentionPolicy),
+    enabled: ref.org !== '' && ref.project !== '',
+    retry: false,
+  });
+}
+
+/**
+ * useRestoreRevision stages the two-way diff as ordinary drafts.
+ *
+ * Nothing is published here. The returned preview token is what publish must
+ * carry: restore-authored drafts are refused without it, and it binds the exact
+ * versions, base revision, schema revision and grant generation the preview was
+ * computed against.
+ */
+export function useRestoreRevision(env: EnvRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { readonly revision: bigint; readonly key?: string }) =>
+      parsed(
+        rollbackRevision({
+          path: { ...env, revision: revisionNumber(input.revision) },
+          body: input.key === undefined ? {} : { key: input.key },
+        }),
+        zHistoryRollbackResult,
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queries.invalidateQueries({ queryKey: valuesKey(env) }),
+        queries.invalidateQueries({ queryKey: ['matrix-signals', env.org, env.project] }),
+        queries.invalidateQueries({ queryKey: ['matrix-pending', env.org, env.project] }),
+      ]),
+  });
+}
+
+export function useSetRevisionPin(env: EnvRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      readonly workloadPrincipalID: string;
+      readonly revision: bigint;
+      readonly expiresAt: string;
+      readonly overrideSchema: boolean;
+    }) =>
+      parsed(
+        createRevisionPin({
+          path: { ...env },
+          body: {
+            workload_principal_id: input.workloadPrincipalID,
+            revision: revisionNumber(input.revision),
+            expires_at: input.expiresAt,
+            override_schema: input.overrideSchema,
+          },
+        }),
+        zRevisionPinResult,
+      ),
+    onSuccess: () => queries.invalidateQueries({ queryKey: pinsKey(env) }),
+  });
+}
+
+export function useReleaseRevisionPin(env: EnvRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (workloadPrincipalID: string) =>
+      ok(releaseRevisionPin({ path: { ...env, workloadPrincipal: workloadPrincipalID } })),
+    onSuccess: () =>
+      Promise.all([
+        queries.invalidateQueries({ queryKey: pinsKey(env) }),
+        queries.invalidateQueries({ queryKey: revisionsKey(env) }),
+      ]),
+  });
+}
+
+export type HistoryAction = 'restore' | 'pin' | 'release';
+
+/** Quotes a caller-safe API detail without rewording it. */
+export function callerSafeRefusal(error: unknown, prefix: string): string | null {
+  if (error instanceof ApiError && error.detail !== undefined && error.detail !== '') {
+    return `${prefix}: ${error.detail}`;
+  }
+  return null;
+}
+
+/**
+ * historyRefusalText surfaces a refusal by name.
+ *
+ * The server's caller-safe detail is quoted verbatim wherever there is one:
+ * every refusal on this surface — collected payload, schema failure, expiry
+ * bound, quota, missing reveal-history — is named by the service, and
+ * paraphrasing it here would put a second, drifting vocabulary in front of the
+ * one the CLI and the audit trail use. Only a refusal with no detail gets a
+ * sentence of our own, and it says which status it was.
+ */
+export function historyRefusalText(error: unknown, action: HistoryAction): string {
+  const verb = {
+    restore: 'stage this restore',
+    pin: 'pin this revision',
+    release: 'release this pin',
+  }[action];
+  const detailed = callerSafeRefusal(error, 'Refused');
+  if (detailed !== null) {
+    return detailed;
+  }
+  if (error instanceof ApiError) {
+    if (error.status === 403) {
+      return (
+        `You may not ${verb} here. A historical secret needs reveal-history, and a ` +
+        'protected environment needs a fresh passkey ceremony for exactly these keys.'
+      );
+    }
+    if (error.status === 404) {
+      return `The server does not have that revision any more, so it could not ${verb}.`;
+    }
+    return `The server could not ${verb} (error ${String(error.status)}).`;
+  }
+  return `The server could not ${verb}.`;
+}

--- a/web/src/api/matrix.test.ts
+++ b/web/src/api/matrix.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ApiError } from './client.ts';
 import {
   matrixPublishValidation,
+  matrixMutationError,
+  forgetRestorePreviews,
   parseMatrixEnvironmentSignals,
   parseMatrixPendingDrafts,
   pendingConfigPreview,
+  rememberRestorePreview,
+  restorePreviewFor,
   revisionAdvanced,
   signalsRequireValuesRefresh,
 } from './matrix.ts';
@@ -14,6 +18,48 @@ const envDev = 'env_01989abc-def0-7123-8123-123456789abc';
 const keyLog = 'key_01989abc-def0-7123-8123-123456789abc';
 const keyOther = 'key_01989abc-def0-7123-8123-123456789abd';
 const version = 'ver_01989abc-def0-7123-8123-123456789abc';
+const ref = { org: 'org', project: 'project' };
+
+beforeEach(() => {
+  forgetRestorePreviews(ref, [version, 'ver_second', 'ver_other']);
+});
+
+describe('restore preview lifecycle', () => {
+  it('matches exact sorted version sets without overwriting another restore', () => {
+    rememberRestorePreview(ref, [version, 'ver_second'], 'token-one');
+    rememberRestorePreview(ref, ['ver_other'], 'token-two');
+    expect(restorePreviewFor(ref, ['ver_second', version])).toEqual({ token: 'token-one' });
+    expect(restorePreviewFor(ref, ['ver_other'])).toEqual({ token: 'token-two' });
+  });
+
+  it('returns overlapping version ids for a partial selection and null for no overlap', () => {
+    rememberRestorePreview(ref, [version, 'ver_second'], 'token-one');
+    expect(restorePreviewFor(ref, [version, 'ver_other'])).toEqual({ conflict: [version] });
+    expect(restorePreviewFor(ref, ['ver_other'])).toBeNull();
+  });
+
+  it('keeps the client-side exact-selection refusal actionable', () => {
+    rememberRestorePreview(ref, [version, 'ver_second'], 'token-one');
+    const preview = restorePreviewFor(ref, [version, 'ver_other']);
+    expect(preview).toEqual({ conflict: [version] });
+  });
+
+  it('forgets a preview after its versions publish', () => {
+    rememberRestorePreview(ref, [version], 'token-one');
+    forgetRestorePreviews(ref, [version]);
+    expect(restorePreviewFor(ref, [version])).toBeNull();
+  });
+
+  it('names a detail-less 409 as stale only when a preview token was attached', () => {
+    const conflict = new ApiError(409, 'request failed with 409');
+    expect(matrixMutationError(conflict, 'publish', true)).toBe(
+      'Publish refused: the restore preview is stale or missing — stage the restore again from the history drawer.',
+    );
+    expect(matrixMutationError(conflict, 'publish', false)).toBe(
+      'Publish was refused. Fix the named matrix problems, then retry.',
+    );
+  });
+});
 
 describe('matrix signal boundary', () => {
   it('refuses a pending version without its operation', () => {
@@ -114,13 +160,13 @@ describe('pending draft preview boundary', () => {
       count: 1,
     });
     const byVersion = new Map(drafts.items.map((item) => [item.version_id, item]));
-    const signal = {
+    const signal: Parameters<typeof pendingConfigPreview>[0] = {
       key_id: keyLog,
       name: 'LOG_LEVEL',
-      classification: 'config' as const,
+      classification: 'config',
       pending_by_others: false,
       pending_version_id: version,
-      pending_operation: 'set' as const,
+      pending_operation: 'set',
     };
     expect(pendingConfigPreview(signal, byVersion)).toBe('debug');
     expect(pendingConfigPreview({ ...signal, pending_version_id: 'ver_other' }, byVersion)).toBeUndefined();

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -27,6 +27,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 import { z } from 'zod';
 
 import { ApiError, parsed } from './client.ts';
+import { callerSafeRefusal, pinsKey, revisionsKey } from './history.ts';
 import { useEnvironments, valuesKey, type EnvRef } from './values.ts';
 
 /**
@@ -43,6 +44,77 @@ export type MatrixRef = { readonly org: string; readonly project: string };
 export type MatrixKeyList = z.infer<typeof zKeyList>;
 export type MatrixEnvironmentSignals = z.infer<typeof zEnvironmentSignals>;
 export type MatrixSignalCell = MatrixEnvironmentSignals['cells'][number];
+
+type RestorePreview = { readonly versionIds: readonly string[]; readonly token: string };
+
+/**
+ * Restore previews intentionally live only for this page load, but outside any
+ * route component so matrix/history SPA navigation cannot drop them. A browser
+ * reload clears the store and requires the restore to be staged again.
+ */
+const restorePreviews = new Map<string, readonly RestorePreview[]>();
+const previewAttachedErrors = new WeakSet<Error>();
+
+class RestorePreviewSelectionError extends Error {}
+
+const restorePreviewKey = (ref: MatrixRef): string => `${ref.org}/${ref.project}`;
+const sortedVersionIds = (versionIds: readonly string[]): readonly string[] =>
+  [...new Set(versionIds)].sort((left, right) => left.localeCompare(right));
+
+function sameVersionSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((versionId, index) => versionId === right[index]);
+}
+
+export function rememberRestorePreview(
+  ref: MatrixRef,
+  versionIds: readonly string[],
+  token: string,
+): void {
+  const normalized = sortedVersionIds(versionIds);
+  if (normalized.length === 0) {
+    throw new Error('Cannot remember a restore preview without version ids.');
+  }
+  const key = restorePreviewKey(ref);
+  const existing = restorePreviews.get(key) ?? [];
+  restorePreviews.set(key, [
+    ...existing.filter((entry) => !sameVersionSet(entry.versionIds, normalized)),
+    { versionIds: normalized, token },
+  ]);
+}
+
+export function restorePreviewFor(
+  ref: MatrixRef,
+  selectedVersionIds: readonly string[],
+): { readonly token: string } | { readonly conflict: readonly string[] } | null {
+  const selected = sortedVersionIds(selectedVersionIds);
+  const remembered = restorePreviews.get(restorePreviewKey(ref)) ?? [];
+  const exact = remembered.find((entry) => sameVersionSet(entry.versionIds, selected));
+  if (exact !== undefined) {
+    return { token: exact.token };
+  }
+  const selectedSet = new Set(selected);
+  const overlaps = sortedVersionIds(
+    remembered.flatMap((entry) => entry.versionIds.filter((versionId) => selectedSet.has(versionId))),
+  );
+  return overlaps.length === 0 ? null : { conflict: overlaps };
+}
+
+export function forgetRestorePreviews(ref: MatrixRef, versionIds: readonly string[]): void {
+  const key = restorePreviewKey(ref);
+  const forgotten = new Set(versionIds);
+  const remaining = (restorePreviews.get(key) ?? []).filter(
+    (entry) => !entry.versionIds.some((versionId) => forgotten.has(versionId)),
+  );
+  if (remaining.length === 0) {
+    restorePreviews.delete(key);
+  } else {
+    restorePreviews.set(key, remaining);
+  }
+}
+
+export function restorePreviewWasAttached(error: Error): boolean {
+  return previewAttachedErrors.has(error);
+}
 
 const zMatrixEnvironmentSignals = zEnvironmentSignals.superRefine((signals, context) => {
   signals.cells.forEach((cell, index) => {
@@ -311,13 +383,32 @@ export function usePublishMatrix(ref: MatrixRef) {
       readonly environmentIds: readonly string[];
       readonly versionIds: readonly string[];
     }) => {
-      const result = await parsed(
-        publishPendingChanges({
-          path: { ...ref, environment: input.addressedEnvironment },
-          body: { version_ids: [...input.versionIds] },
-        }),
-        zPublishResult,
-      );
+      const preview = restorePreviewFor(ref, input.versionIds);
+      if (preview !== null && 'conflict' in preview) {
+        throw new RestorePreviewSelectionError(
+          'Restore drafts must be published exactly as previewed — deselect the other drafts or ' +
+          `stage the restore again. Overlapping version ids: ${preview.conflict.join(', ')}.`,
+        );
+      }
+      const previewToken = preview?.token;
+      let result: z.infer<typeof zPublishResult>;
+      try {
+        result = await parsed(
+          publishPendingChanges({
+            path: { ...ref, environment: input.addressedEnvironment },
+            body: {
+              version_ids: [...input.versionIds],
+              ...(previewToken === undefined ? {} : { preview_token: previewToken }),
+            },
+          }),
+          zPublishResult,
+        );
+      } catch (error) {
+        if (previewToken !== undefined && error instanceof Error) {
+          previewAttachedErrors.add(error);
+        }
+        throw error;
+      }
       const publishedEnvironmentIds = new Set(
         result.environments.map((environment) => environment.environment_id),
       );
@@ -331,12 +422,21 @@ export function usePublishMatrix(ref: MatrixRef) {
       }
       return result;
     },
-    onSuccess: () =>
-      Promise.all([
+    onSuccess: (result, input) => {
+      forgetRestorePreviews(ref, input.versionIds);
+      return Promise.all([
         queries.invalidateQueries({ queryKey: ['values', ref.org, ref.project] }),
         queries.invalidateQueries({ queryKey: ['matrix-signals', ref.org, ref.project] }),
         queries.invalidateQueries({ queryKey: ['matrix-pending', ref.org, ref.project] }),
-      ]),
+        ...result.environments.flatMap((published) => {
+          const env = { ...ref, environment: published.environment_id };
+          return [
+            queries.invalidateQueries({ queryKey: revisionsKey(env) }),
+            queries.invalidateQueries({ queryKey: pinsKey(env) }),
+          ];
+        }),
+      ]);
+    },
   });
 }
 
@@ -371,11 +471,34 @@ export function useCopyMatrixConfig(ref: MatrixRef) {
   });
 }
 
+/**
+ * matrixMutationError turns a refusal into something the human can act on.
+ *
+ * The server's caller-safe detail is quoted VERBATIM whenever there is one.
+ * Every refusal that names a key — a presence veto, a value that fails the
+ * current schema, a stale or missing restore preview token — carries it, and
+ * mvp-boundary C5 requires a schema-failing restore to block loud naming the
+ * keys. Paraphrasing would put a second vocabulary in front of the one the CLI
+ * and the audit trail use, and dropping it leaves a 400 with nothing to fix.
+ */
 export function matrixMutationError(
   error: Error,
   action: 'stage' | 'clear' | 'copy' | 'publish',
+  restorePreviewAttached = false,
 ): string {
+  if (error instanceof RestorePreviewSelectionError) {
+    return error.message;
+  }
+  if (action === 'publish' && restorePreviewAttached && error instanceof ApiError && error.status === 409) {
+    return 'Publish refused: the restore preview is stale or missing — stage the restore again from the history drawer.';
+  }
   if (error instanceof ApiError) {
+    const detailed = callerSafeRefusal(error, action === 'publish' ? 'Publish refused' : 'Refused');
+    if (detailed !== null) {
+      return action === 'publish'
+        ? `${detailed} Fix the named key in the matrix row editor, then publish again.`
+        : detailed;
+    }
     if (error.status === 403) {
       return action === 'publish'
         ? 'You do not have permission to publish the selected drafts.'

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -33,6 +33,10 @@ const ELEMENTS: Record<SurfaceId, ReactElement> = {
   remotes: <Remotes />,
   settings: <Sessions />,
   matrix: <Matrix />,
+  // The same surface with its history drawer open. The route table is the only
+  // place that knows the path, so the element reads the state as a prop rather
+  // than sniffing the location.
+  history: <Matrix historyOpen />,
   values: <Values />,
   'machine-access': <MachineAccess />,
   'cli-reauth': <CLIReauth />,

--- a/web/src/app/navigation.ts
+++ b/web/src/app/navigation.ts
@@ -18,6 +18,7 @@ export type SurfaceId =
   | 'projects'
   | 'settings'
   | 'matrix'
+  | 'history'
   | 'values'
   | 'machine-access'
   | 'remotes'
@@ -45,6 +46,18 @@ export const SURFACES: readonly Surface[] = [
     id: 'matrix',
     path: '/orgs/:org/projects/:project/matrix',
     label: 'Environment matrix',
+    section: null,
+  },
+  // The revision-history drawer (#59). It is the matrix WITH its history drawer
+  // open — the locked prototype's list+detail panes render over the matrix, not
+  // instead of it — so the path nests under the matrix and the element is the
+  // same component. `section: null` for the matrix's own reason: it addresses
+  // one project, and the environment and the per-key filter are query
+  // parameters, because per-key history is a filter and not a second surface.
+  {
+    id: 'history',
+    path: '/orgs/:org/projects/:project/matrix/history',
+    label: 'Revision history',
     section: null,
   },
   // The reveal / copy / write-only-edit surface (#58). `section: null` because

--- a/web/src/routes/Ceremony.tsx
+++ b/web/src/routes/Ceremony.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useRef, useState, type FormEvent } from 'react';
 
 import {
   ceremonyRefusalText,
@@ -6,6 +6,7 @@ import {
   runTOTPCeremony,
   type RevealWindow,
 } from '../api/values.ts';
+import { useModalDialog } from './useModalDialog.ts';
 
 /**
  * The purpose-bound ceremony modal (#58, locked prototype #21 iteration 6,
@@ -49,13 +50,15 @@ import {
  * the server — the same route, the same audit surface — but they are not the
  * same sentence to a person, and the modal owes them the true one.
  */
-export type CeremonyPurpose = 'reveal' | 'clipboard' | 'copy' | 'publish';
+export type CeremonyPurpose = 'reveal' | 'clipboard' | 'copy' | 'publish' | 'restore' | 'pin';
 
 const PURPOSE_VERB: Record<CeremonyPurpose, string> = {
   reveal: 'reveal',
   clipboard: 'copy to clipboard',
   copy: 'copy',
   publish: 'publish into',
+  restore: 'restore an earlier revision of',
+  pin: 'pin a historical revision of',
 };
 
 /**
@@ -76,6 +79,14 @@ const SIGNED_OPERATION: Record<CeremonyPurpose, 'reveal' | 'copy' | 'publish'> =
   clipboard: 'reveal',
   copy: 'copy',
   publish: 'publish',
+  // Restore and pin both READ historical secret material: staging an earlier
+  // value decrypts it, and pinning a non-current revision routes it to a
+  // workload. The service gates both with `PurposeReveal` over the enumerated
+  // secret-key unit (`internal/service/{rollback,pins}.go`), so that is what the
+  // assertion has to commit to — while the modal still tells the human which of
+  // the two decisions they are actually taking.
+  restore: 'reveal',
+  pin: 'reveal',
 };
 
 export type CeremonyRequest = {
@@ -102,18 +113,8 @@ export function Ceremony({
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
-  const dialog = useRef<HTMLDialogElement>(null);
   const first = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    // showModal, not the `open` attribute: only the former puts the element in
-    // the top layer, makes the rest of the document inert and traps focus.
-    const element = dialog.current;
-    if (element !== null && !element.open) {
-      element.showModal();
-    }
-    first.current?.focus();
-  }, []);
+  const dialog = useModalDialog(first);
 
   const attempt = async (run: () => Promise<void>) => {
     setBusy(true);

--- a/web/src/routes/HistoryDrawer.tsx
+++ b/web/src/routes/HistoryDrawer.tsx
@@ -1,0 +1,1612 @@
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { exportValues } from '@hikyo/client';
+import { zExportedValues } from '@hikyo/zod';
+import { useMutation } from '@tanstack/react-query';
+import { generatePath, Link, useNavigate, useSearchParams } from 'react-router';
+
+import {
+  callerSafeRefusal,
+  historyRefusalText,
+  revisionNumber,
+  useReleaseRevisionPin,
+  useRestoreRevision,
+  useRevisionDetail,
+  useRevisionHistory,
+  useRevisionPins,
+  useProjectRetention,
+  useSetRevisionPin,
+  type HistoryRevisionItem,
+  type RestoreResult,
+  type RevisionPinItem,
+} from '../api/history.ts';
+import { useServiceAccounts } from '../api/identities.ts';
+import { ApiError, parsed } from '../api/client.ts';
+import {
+  matrixMutationError,
+  rememberRestorePreview,
+  restorePreviewWasAttached,
+  usePublishMatrix,
+  type MatrixKeyList,
+  type MatrixRef,
+} from '../api/matrix.ts';
+import type { EnvironmentList, EnvRef, ValueCell } from '../api/values.ts';
+import { surfaceById } from '../app/navigation.ts';
+import { Ceremony } from './Ceremony.tsx';
+import {
+  defaultPinExpiry,
+  historyKeyDisplay,
+  pinAction,
+  pinCeremonyUnit,
+  pinExpiry,
+  pinExpiryInstant,
+  pinComparedToLatest,
+  pinSchemaOverrideOffered,
+  relativeAge,
+  restoreCeremonyUnit,
+  restoreKeyName,
+  restorePreviewSummary,
+  retentionLine,
+  revisionActionGate,
+  revisionsForKeyFilter,
+  soleKeeperPinIds,
+  soleKeeperReleaseConsequences,
+  SOLE_KEEPER_RELEASE_BUTTON,
+  SOLE_KEEPER_RELEASE_TITLE,
+  toHistoryRetention,
+  workloadLabel,
+  type CeremonyKey,
+  type HistoryCurrentCell,
+  type HistoryImpactChange,
+  type HistoryPin,
+  type HistoryRevision,
+  type HistorySnapshotKey,
+  type PinComparison,
+  type RevisionActionGate,
+} from './history-state.ts';
+import { useProtectedPublishCeremony } from './useProtectedPublishCeremony.ts';
+import { useModalDialog } from './useModalDialog.ts';
+
+type Environment = EnvironmentList['items'][number];
+type MatrixKey = MatrixKeyList['items'][number];
+
+const zPinComparisonValues = zExportedValues.superRefine((values, context) => {
+  values.items.forEach((value, index) => {
+    if (value.classification === 'secret' && (value.revealed || value.value !== undefined)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['items', index],
+        message: 'pin comparison secret values must remain write-presence only',
+      });
+    }
+    if (value.classification === 'config' && (!value.revealed || value.value === undefined)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['items', index],
+        message: 'pin comparison config values must carry plaintext',
+      });
+    }
+  });
+});
+
+/**
+ * The revision-history drawer (#59, locked prototype `revision-history/6`).
+ *
+ * The shape is iteration 2's verdict **b**: a slim revision list beside a
+ * detail pane, rendered over the matrix rather than instead of it. Below the
+ * chrome's 800px breakpoint the two panes become one — list, then detail, with
+ * a back affordance — because a 440px drawer split in two is neither.
+ *
+ * Three properties are the surface's whole point and none of them is decoration:
+ *
+ *  - **Lineage outlives its payload.** A collected revision keeps its row, its
+ *    actor and its changed keys, gains a `payload collected` tag, and loses
+ *    restore and pin with the stamped policy named. Nothing is reconstructed.
+ *  - **Secrets are write-presence only.** The changed-key list says added /
+ *    edited / removed and marks the key 🔒. No value, no length, no digest, no
+ *    comparison status reaches this surface for a secret, ever.
+ *  - **Restore is not a privileged path.** It stages ordinary drafts; the
+ *    matrix's own draft dots appear and the ordinary publish sheet commits
+ *    them, carrying the preview token that binds them.
+ *
+ * **Deferred, by name: the revision-to-revision diff modal.** The prototype
+ * offers "diff vs previous" / "diff vs current"; no API computes a rev↔rev diff
+ * (`diffValues` compares two ENVIRONMENTS), and neither C5 nor S3 names one. The
+ * restore impact preview is this surface's "what would change" view.
+ */
+export function HistoryDrawer({
+  refData,
+  environments,
+  keys,
+  currentRevisions,
+  protectedEnvironmentIds,
+  cellsByEnvironment,
+  pendingByEnvironment,
+  pendingByOthersByEnvironment,
+  currentValuesByEnvironment,
+  openerRef,
+}: {
+  refData: MatrixRef;
+  environments: readonly Environment[];
+  keys: readonly MatrixKey[];
+  currentRevisions: ReadonlyMap<string, bigint>;
+  protectedEnvironmentIds: readonly string[];
+  cellsByEnvironment: ReadonlyMap<string, readonly HistoryCurrentCell[]>;
+  pendingByEnvironment: ReadonlyMap<string, number>;
+  pendingByOthersByEnvironment: ReadonlyMap<string, number>;
+  currentValuesByEnvironment: ReadonlyMap<string, readonly ValueCell[]>;
+  openerRef: RefObject<HTMLAnchorElement | null>;
+}) {
+  const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
+  const fallbackEnvironment = environments[0]?.id ?? '';
+  const requested = params.get('env') ?? '';
+  const environmentId = environments.some((candidate) => candidate.id === requested)
+    ? requested
+    : fallbackEnvironment;
+  const environment = environments.find((candidate) => candidate.id === environmentId);
+  const keyFilter = params.get('key');
+  const env = { ...refData, environment: environmentId };
+
+  const history = useRevisionHistory(env);
+  const pins = useRevisionPins(env);
+  const retention = useProjectRetention(refData);
+  const accounts = useServiceAccounts(refData);
+  const restore = useRestoreRevision(env);
+  const setPin = useSetRevisionPin(env);
+  const releasePin = useReleaseRevisionPin(env);
+  const publish = usePublishMatrix(refData);
+  const comparePin = useMutation({
+    mutationFn: (input: { readonly environmentId: string; readonly revision: bigint }) =>
+      parsed(
+        exportValues({
+          path: { ...refData, environment: input.environmentId },
+          body: { revision: revisionNumber(input.revision), reveal: false },
+        }),
+        zPinComparisonValues,
+      ),
+  });
+  const guard = useProtectedPublishCeremony(refData);
+
+  const [sheet, setSheet] = useState<Sheet | null>(null);
+  const [outcome, setOutcome] = useState<string | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [mobileDetail, setMobileDetail] = useState(false);
+  const drawerHeading = useRef<HTMLHeadingElement>(null);
+  const detailHeading = useRef<HTMLHeadingElement>(null);
+  const selectedRow = useRef<HTMLButtonElement>(null);
+  const currentEnvironment = useRef(environmentId);
+  currentEnvironment.current = environmentId;
+
+  // The clock is read once per mount rather than per row: a timeline
+  // whose rows disagree about "now" by a few milliseconds can render two
+  // different expiry tiers for the same instant.
+  const [now] = useState(() => new Date());
+
+  const revisions = useMemo<readonly HistoryRevision[]>(
+    () => (history.data?.items ?? []).map(toHistoryRevision),
+    [history.data],
+  );
+  const filtered = useMemo(
+    () => revisionsForKeyFilter(revisions, keyFilter),
+    [keyFilter, revisions],
+  );
+  const currentRevision = currentRevisions.get(environmentId) ?? 0n;
+  const requestedRevision = params.get('rev');
+  const selected =
+    filtered.find((entry) => String(entry.revision) === requestedRevision) ?? filtered[0];
+  const keyDisplay =
+    keyFilter === null || !history.isSuccess
+      ? null
+      : historyKeyDisplay(keyFilter, keys, selected);
+
+  const pinRows = useMemo<readonly HistoryPin[]>(
+    () => (pins.data?.items ?? []).map(toHistoryPin),
+    [pins.data],
+  );
+  const soleKeepers = useMemo(
+    () =>
+      retention.data === undefined
+        ? new Set<string>()
+        : soleKeeperPinIds({
+            pins: pinRows,
+            revisions,
+            policy: toHistoryRetention({
+              mode: retention.data.mode,
+              ...(retention.data.max_age_seconds == null
+                ? {}
+                : { max_age_seconds: retention.data.max_age_seconds }),
+              ...(retention.data.last_revisions == null
+                ? {}
+                : { last_revisions: retention.data.last_revisions }),
+            }),
+            now,
+          }),
+    [now, pinRows, retention.data, revisions],
+  );
+
+  const workloads = (accounts.data?.items ?? []).filter((account) => account.kind === 'workload');
+  // A pin binds a WORKLOAD, and a workload does resolve to a name — through the
+  // project's service accounts. (A human publisher does not: nothing in this
+  // API maps a human principal id to a display name, so those stay ids.)
+  const workloadNames = new Map(
+    (accounts.data?.items ?? []).map((account) => [account.principal_id, account.name]),
+  );
+  const selectedGate =
+    selected === undefined ? null : revisionActionGate(selected, currentRevision);
+
+  const setParam = (name: string, value: string | null) => {
+    const next = new URLSearchParams(params);
+    if (value === null) {
+      next.delete(name);
+    } else {
+      next.set(name, value);
+    }
+    setParams(next, { replace: true });
+  };
+
+  const matrixPath = generatePath(surfaceById('matrix').path, refData);
+
+  useEffect(() => {
+    setSheet(null);
+    setOutcome(null);
+    setRefusal(null);
+  }, [environmentId, keyFilter]);
+
+  useEffect(() => {
+    // Snapshot the opener at MOUNT: the matrix stays interactive behind a desktop
+    // drawer, so a later click can re-point the shared ref, and close must return
+    // focus to the element that actually opened this drawer, not the last one
+    // touched. The current-environment link is the fallback when that element
+    // is gone (an environment hidden, a re-render that replaced the header).
+    const opener = openerRef.current;
+    drawerHeading.current?.focus();
+    return () => {
+      requestAnimationFrame(() => {
+        if (opener?.isConnected === true) {
+          opener.focus();
+          return;
+        }
+        Array.from(document.querySelectorAll<HTMLAnchorElement>('.matrix__history-link'))
+          .find((link) => link.dataset['historyEnvironment'] === currentEnvironment.current)
+          ?.focus();
+      });
+    };
+  }, [openerRef]);
+
+  useEffect(() => {
+    if (mobileDetail) {
+      detailHeading.current?.focus();
+    }
+  }, [mobileDetail, selected?.revision]);
+
+  if (environment === undefined) {
+    return null;
+  }
+
+  const secretByKeyId = new Map(keys.map((key) => [key.id, key.classification === 'secret']));
+
+  /** Runs the disclosure ceremony for `unit` when the guard needs one, then acts. */
+  const withCeremony = (
+    unit: readonly CeremonyKey[],
+    purpose: 'restore' | 'pin',
+    act: () => void,
+  ) => {
+    setRefusal(null);
+    if (unit.length === 0) {
+      act();
+      return;
+    }
+    void guard.run(
+      [
+        {
+          environmentId: environment.id,
+          environmentName: environment.name,
+          keys: [...unit],
+          purpose,
+        },
+      ],
+      act,
+      'The disclosure guard could not be read, so nothing was staged',
+    );
+  };
+
+  const runRestore = (revision: bigint, keyId: string | null, keyName: string | null) => {
+    const unit = restoreCeremonyUnit({
+      revisionKeys: sheetRevisionKeys(sheet),
+      currentCells: cellsByEnvironment.get(environment.id) ?? [],
+      keyId,
+    });
+    withCeremony(unit, 'restore', () => {
+      restore.mutate(
+        keyName === null ? { revision } : { revision, key: keyName },
+        {
+          onSuccess: (result) => {
+            rememberRestorePreview(
+              refData,
+              result.changes.map((change) => change.version_id),
+              result.preview.token,
+            );
+            setSheet({
+              kind: 'restore',
+              revision,
+              keyId,
+              keyName,
+              keys: sheetRevisionKeys(sheet),
+              result: {
+                changes: result.changes,
+                preview: { environments: result.preview.environments },
+              },
+            });
+            setOutcome(
+              `Staged ${String(result.changes.length)} draft${result.changes.length === 1 ? '' : 's'} from r${String(revision)} — nothing is published yet.`,
+            );
+          },
+          onError: (error) =>
+            setRefusal(historyMutationRefusal(error, 'restore', unit, environment.name)),
+        },
+      );
+    });
+  };
+
+  const runPin = (input: {
+    readonly revision: bigint;
+    readonly workloadPrincipalID: string;
+    readonly expiresAt: string;
+    readonly overrideSchema: boolean;
+    readonly revisionKeys: readonly HistorySnapshotKey[];
+  }) => {
+    const historical = input.revision !== currentRevision;
+    const unit = historical
+      ? pinCeremonyUnit(input.revisionKeys, cellsByEnvironment.get(environment.id) ?? [])
+      : [];
+    withCeremony(unit, 'pin', () => {
+      setPin.mutate(
+        {
+          workloadPrincipalID: input.workloadPrincipalID,
+          revision: input.revision,
+          expiresAt: pinExpiryInstant(input.expiresAt),
+          overrideSchema: input.overrideSchema,
+        },
+        {
+          onSuccess: (result) => {
+            setSheet(null);
+            // The verb is the SERVER's (`RevisionPinResult.action`), not the
+            // label the sheet guessed: created, reassigned and renewed are the
+            // locked taxonomy, and the outcome reports what happened.
+            setOutcome(
+              `Pin ${result.action}: r${String(result.pin.revision)} for ${
+                workloadLabel(result.pin.workload_principal_id, workloadNames)
+              }, expiring ${result.pin.expires_at.slice(0, 10)}.`,
+            );
+          },
+          onError: (error) => {
+            setRefusal(historyMutationRefusal(error, 'pin', unit, environment.name));
+            setSheet((current) =>
+              current !== null && current.kind === 'pin'
+                ? {
+                    ...current,
+                    offerOverride: pinSchemaOverrideOffered(
+                      error instanceof ApiError ? error.detail : undefined,
+                    ),
+                  }
+                : current,
+            );
+          },
+        },
+      );
+    });
+  };
+
+  const publishRestore = (revision: bigint, result: RestoreSheetResult) => {
+    const versionIds = result.changes.map((change) => change.version_id);
+    const act = () => {
+      setRefusal(null);
+      publish.mutate(
+        {
+          addressedEnvironment: environment.id,
+          environmentIds: [environment.id],
+          versionIds,
+        },
+        {
+          onSuccess: (published) => {
+            const target = published.environments.find(
+              (entry) => entry.environment_id === environment.id,
+            );
+            if (target === undefined) {
+              throw new Error(`restore publish returned no revision for ${environment.id}`);
+            }
+            setSheet(null);
+            setOutcome(
+              `Published the restore from r${String(revision)} as ${environment.name} r${String(target.revision)}.`,
+            );
+          },
+          onError: (error) =>
+            setRefusal(
+              matrixMutationError(error, 'publish', restorePreviewWasAttached(error)),
+            ),
+        },
+      );
+    };
+    if (!protectedEnvironmentIds.includes(environment.id)) {
+      act();
+      return;
+    }
+    void guard.run(
+      [
+        {
+          environmentId: environment.id,
+          environmentName: environment.name,
+          keys: result.changes.map((change) => ({ id: change.key_id, name: change.name })),
+          purpose: 'publish',
+        },
+      ],
+      act,
+      'The protected publish guard could not be read, so nothing was published',
+    );
+  };
+
+  const runRelease = (pin: HistoryPin) => {
+    setRefusal(null);
+    releasePin.mutate(pin.workloadPrincipalId, {
+      onSuccess: () => {
+        setSheet(null);
+        setOutcome(
+          soleKeepers.has(pin.id)
+            ? `Pin released. ${soleKeeperReleaseConsequences(pin.revision)} The workload resumes latest on its next fetch.`
+            : `Pin released — the workload resumes latest (r${String(currentRevision)}) on its next fetch. r${String(pin.revision)}'s values stay inside the retention window.`,
+        );
+      },
+      onError: (error) => setRefusal(historyRefusalText(error, 'release')),
+    });
+  };
+
+  const stagedByMe = pendingByEnvironment.get(environment.id) ?? 0;
+  const stagedByOthers = pendingByOthersByEnvironment.get(environment.id) ?? 0;
+  const line = retention.data === undefined
+    ? null
+    : retentionLine({
+        inherited: retention.data.inherited,
+        ...toHistoryRetention({
+          mode: retention.data.mode,
+          ...(retention.data.max_age_seconds == null
+            ? {}
+            : { max_age_seconds: retention.data.max_age_seconds }),
+          ...(retention.data.last_revisions == null
+            ? {}
+            : { last_revisions: retention.data.last_revisions }),
+        }),
+      });
+
+  return (
+    <>
+      <aside
+        className={`history${mobileDetail ? ' history--detail' : ''}`}
+        aria-label="Revision history"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape' && sheet === null) {
+            event.preventDefault();
+            void navigate(matrixPath);
+          }
+        }}
+      >
+        <div className="history__head">
+          <div className="history__title">
+            <h2 id="history-title" ref={drawerHeading} tabIndex={-1}>↺ Revision history</h2>
+            <span className="history__current count">{`current r${String(currentRevision)}`}</span>
+            {protectedEnvironmentIds.includes(environment.id) ? (
+              <span className="history__protected">PROTECTED</span>
+            ) : null}
+            <Link id="history-close" className="btn history__close" to={matrixPath} aria-label="Close revision history">
+              ✕ Close
+            </Link>
+          </div>
+
+          {/*
+            Plain toggle buttons, deliberately NOT `role="tab"`. These do not
+            switch a panel inside the page — they rewrite the URL the whole
+            surface is addressed by, and a tab role would promise keyboard
+            semantics (arrow-key roving, an owned tabpanel) that a set of links
+            to different states does not have.
+          */}
+          <div className="history__tabs">
+            {environments.map((candidate) => (
+              <button
+                key={candidate.id}
+                type="button"
+                className="btn history__tab"
+                aria-pressed={candidate.id === environment.id}
+                onClick={() => {
+                  const next = new URLSearchParams(params);
+                  next.set('env', candidate.id);
+                  next.delete('rev');
+                  setParams(next, { replace: true });
+                  setMobileDetail(false);
+                }}
+              >
+                {candidate.name}
+              </button>
+            ))}
+          </div>
+
+          {stagedByMe === 0 && stagedByOthers === 0 ? null : (
+            <p className="history__pending" role="status">
+              {stagedByMe === 0
+                ? ''
+                : `${String(stagedByMe)} staged by you (unpublished)`}
+              {stagedByMe > 0 && stagedByOthers > 0 ? ' · ' : ''}
+              {stagedByOthers === 0
+                ? ''
+                : `${String(stagedByOthers)} pending by other people`}
+            </p>
+          )}
+
+          {line === null ? null : (
+            <p className="history__retention">
+              <span>{line.window}</span>
+              <span className="history__badge" title={line.badgeTitle}>
+                {line.badge}
+              </span>
+              <span className="history__settings-pointer">
+                → change it in project settings › Policy
+              </span>
+            </p>
+          )}
+
+          {keyFilter === null ? null : (
+            <p className="history__filter" role="status">
+              <span>{`⚠ filter active: history of ${keyDisplay?.label ?? keyFilter} — showing ${String(filtered.length)} of ${String(revisions.length)} revisions`}</span>
+              <button type="button" className="btn" onClick={() => setParam('key', null)}>
+                ✕ show every revision
+              </button>
+            </p>
+          )}
+        </div>
+
+        {outcome === null ? null : (
+          <p className="notice" role="status">
+            <span aria-hidden="true">✓</span>
+            <span>{outcome}</span>
+          </p>
+        )}
+        {refusal === null && guard.error === null ? null : (
+          <p id="history-drawer-refusal" className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">!</span>
+            <span>{refusal ?? guard.error}</span>
+          </p>
+        )}
+        {retention.isError ? (
+          <p id="history-retention-error" className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">!</span>
+            <span>Retention policy could not be read. Pin release is disabled until it succeeds.</span>
+          </p>
+        ) : null}
+
+        {history.isPending ? (
+          <p role="status">Loading revision history…</p>
+        ) : history.isError ? (
+          <p className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">!</span>
+            <span>The revision history could not be read. Reload to try again.</span>
+          </p>
+        ) : filtered.length === 0 ? (
+          <p className="history__empty" role="status">
+            {keyFilter === null
+              ? 'No revisions published in this environment yet.'
+              : `No revision has moved ${keyDisplay?.label ?? keyFilter} in this environment.`}
+          </p>
+        ) : (
+          <div className="history__panes">
+            <ol className="history__list" aria-label="Revisions, newest first">
+              {filtered.map((entry) => {
+                const pinnedHere = pinRows.filter((pin) => pin.revision === entry.revision);
+                return (
+                  <li key={String(entry.revision)}>
+                    <button
+                      data-history-revision={String(entry.revision)}
+                      ref={entry.revision === selected?.revision ? selectedRow : undefined}
+                      type="button"
+                      className="btn history__row"
+                      aria-current={entry.revision === selected?.revision}
+                      onClick={() => {
+                        setParam('rev', String(entry.revision));
+                        setMobileDetail(true);
+                      }}
+                    >
+                      <span className="mono">{`r${String(entry.revision)}`}</span>
+                      {entry.revision === currentRevision ? (
+                        <span className="history__tag">current</span>
+                      ) : null}
+                      {pinnedHere.length === 0 ? null : (
+                        <span className="history__tag" title={`pinned by ${String(pinnedHere.length)} workload(s)`}>
+                          ⚲ pinned
+                        </span>
+                      )}
+                      {entry.payloadPresent ? null : (
+                        <span className="history__tag history__tag--collected">payload collected</span>
+                      )}
+                      <span className="history__age">{relativeAge(entry.publishedAt, now)}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ol>
+
+            <div className="history__detail">
+              <button
+                id="history-detail-back"
+                type="button"
+                className="btn history__back"
+                onClick={() => {
+                  setMobileDetail(false);
+                  requestAnimationFrame(() => selectedRow.current?.focus());
+                }}
+              >
+                ← All revisions
+              </button>
+              {selected === undefined || selectedGate === null ? null : (
+                <RevisionDetail
+                  env={env}
+                  revision={selected}
+                  revisions={revisions}
+                  headingRef={detailHeading}
+                  gate={selectedGate}
+                  currentRevision={currentRevision}
+                  pins={pinRows}
+                  workloadNames={workloadNames}
+                  soleKeepers={soleKeepers}
+                  releaseAvailable={retention.isSuccess}
+                  releaseUnavailableReason={
+                    retention.isError
+                      ? 'Release disabled: retention policy could not be read.'
+                      : 'Release disabled until the retention policy has loaded.'
+                  }
+                  secretByKeyId={secretByKeyId}
+                  now={now}
+                  keyFilter={keyFilter}
+                  onFilterKey={(keyId) => {
+                    setParam('key', keyId);
+                    // "Show me this key's history" answers with a LIST, so the
+                    // phone's single pane goes back to it. On a desktop both
+                    // panes are on screen and this changes nothing.
+                    setMobileDetail(false);
+                    requestAnimationFrame(() => selectedRow.current?.focus());
+                  }}
+                  onRestore={(revisionKeys, keyId) => {
+                    setRefusal(null);
+                    let keyName: string | null = null;
+                    if (keyId !== null) {
+                      try {
+                        keyName = restoreKeyName(keyId, keys, selected);
+                      } catch (error) {
+                        if (!(error instanceof Error)) {
+                          throw error;
+                        }
+                        setRefusal(error.message);
+                        return;
+                      }
+                    }
+                    setSheet({
+                      kind: 'restore',
+                      revision: selected.revision,
+                      keyId,
+                      keyName,
+                      keys: revisionKeys,
+                      result: null,
+                    });
+                  }}
+                  onPin={(revisionKeys) => {
+                    setRefusal(null);
+                    setSheet({
+                      kind: 'pin',
+                      revision: selected.revision,
+                      keys: revisionKeys,
+                      workloadPrincipalID: workloads[0]?.principal_id ?? '',
+                      expiresAt: defaultPinExpiry(now),
+                      overrideSchema: false,
+                      offerOverride: false,
+                    })
+                  }}
+                  onRelease={(pin) => {
+                    setRefusal(null);
+                    if (soleKeepers.has(pin.id)) {
+                      setSheet({ kind: 'release', pin });
+                    } else {
+                      runRelease(pin);
+                    }
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </aside>
+
+      {sheet?.kind === 'restore' ? (
+        <RestoreSheet
+          environmentName={environment.name}
+          revision={sheet.revision}
+          keyName={sheet.keyName}
+          result={sheet.result}
+          busy={restore.isPending}
+          publishBusy={publish.isPending}
+          refusal={refusal ?? guard.error}
+          matrixPath={matrixPath}
+          onStage={() => runRestore(sheet.revision, sheet.keyId, sheet.keyName)}
+          onPublish={() => {
+            if (sheet.result === null) {
+              throw new Error('restore publish started without a staged result');
+            }
+            publishRestore(sheet.revision, sheet.result);
+          }}
+          onClose={() => setSheet(null)}
+        />
+      ) : null}
+
+      {sheet?.kind === 'pin' ? (
+        <PinSheet
+          environmentName={environment.name}
+          revision={sheet.revision}
+          isCurrent={sheet.revision === currentRevision}
+          currentRevision={currentRevision}
+          soleKeepers={soleKeepers}
+          retentionReady={retention.isSuccess}
+          workloads={workloads.map((account) => ({
+            principalID: account.principal_id,
+            name: account.name,
+            pinnedRevision: pinRows.find((pin) => pin.workloadPrincipalId === account.principal_id)
+              ?.revision,
+            pinID: pinRows.find((pin) => pin.workloadPrincipalId === account.principal_id)?.id,
+          }))}
+          state={sheet}
+          busy={setPin.isPending}
+          refusal={refusal ?? guard.error}
+          comparisonBusy={comparePin.isPending}
+          comparisonError={
+            comparePin.isError &&
+            comparePin.variables.environmentId === environment.id &&
+            comparePin.variables.revision === sheet.revision
+              ? comparisonRefusal(comparePin.error, sheet.revision)
+              : null
+          }
+          comparison={
+            comparePin.isSuccess &&
+            comparePin.variables.environmentId === environment.id &&
+            comparePin.variables.revision === sheet.revision
+              ? pinComparedToLatest({
+                  revision: sheet.revision,
+                  revisionKeys: sheet.keys,
+                  historical: comparePin.data.items,
+                  latest: (currentValuesByEnvironment.get(environment.id) ?? []).map((value) => ({
+                    keyId: value.key_id,
+                    name: value.name,
+                    classification: value.classification,
+                    set: value.set,
+                    revealed: value.revealed,
+                    ...(value.value === undefined ? {} : { value: value.value }),
+                  })),
+                  laterRevisions: revisions.filter(
+                    (revision) => revision.revision > sheet.revision,
+                  ),
+                })
+              : null
+          }
+          onCompare={() => comparePin.mutate({ environmentId: environment.id, revision: sheet.revision })}
+          onChange={(next) => setSheet({ ...sheet, ...next })}
+          onSubmit={() =>
+            runPin({
+              revision: sheet.revision,
+              workloadPrincipalID: sheet.workloadPrincipalID,
+              expiresAt: sheet.expiresAt,
+              overrideSchema: sheet.overrideSchema,
+              revisionKeys: sheet.keys,
+            })
+          }
+          onClose={() => setSheet(null)}
+        />
+      ) : null}
+
+      {sheet?.kind === 'release' ? (
+        <ReleaseSheet
+          pin={sheet.pin}
+          currentRevision={currentRevision}
+          workloadName={
+            workloadLabel(sheet.pin.workloadPrincipalId, workloadNames)
+          }
+          busy={releasePin.isPending}
+          releaseAllowed={retention.isSuccess}
+          onRelease={() => runRelease(sheet.pin)}
+          onClose={() => setSheet(null)}
+        />
+      ) : null}
+
+      {guard.request === null ? null : (
+        <Ceremony
+          request={guard.request}
+          onAuthorised={guard.onAuthorised}
+          onCancel={guard.onCancel}
+        />
+      )}
+    </>
+  );
+}
+
+type Sheet =
+  | {
+      readonly kind: 'restore';
+      readonly revision: bigint;
+      readonly keyId: string | null;
+      readonly keyName: string | null;
+      readonly keys: readonly HistorySnapshotKey[];
+      readonly result: RestoreSheetResult | null;
+    }
+  | {
+      readonly kind: 'pin';
+      readonly revision: bigint;
+      readonly keys: readonly HistorySnapshotKey[];
+      readonly workloadPrincipalID: string;
+      readonly expiresAt: string;
+      readonly overrideSchema: boolean;
+      readonly offerOverride: boolean;
+    }
+  | { readonly kind: 'release'; readonly pin: HistoryPin };
+
+type RestoreSheetResult = {
+  readonly changes: RestoreResult['changes'];
+  readonly preview: {
+    readonly environments: RestoreResult['preview']['environments'];
+  };
+};
+
+function sheetRevisionKeys(sheet: Sheet | null): readonly HistorySnapshotKey[] {
+  return sheet !== null && sheet.kind !== 'release' ? sheet.keys : [];
+}
+
+/**
+ * The detail pane: one revision's lineage, its consumers, and its two actions.
+ *
+ * The delivered key set comes from `getRevision`, which is NOT fetched for a
+ * collected revision — that endpoint derives a change token over the snapshot's
+ * manifest and refuses a collected payload by name. The changed-key list below
+ * is lineage and survives collection either way.
+ */
+function RevisionDetail({
+  env,
+  revision,
+  revisions,
+  headingRef,
+  gate,
+  currentRevision,
+  pins,
+  workloadNames,
+  soleKeepers,
+  releaseAvailable,
+  releaseUnavailableReason,
+  secretByKeyId,
+  now,
+  keyFilter,
+  onFilterKey,
+  onRestore,
+  onPin,
+  onRelease,
+}: {
+  env: EnvRef;
+  revision: HistoryRevision;
+  revisions: readonly HistoryRevision[];
+  headingRef: RefObject<HTMLHeadingElement | null>;
+  gate: RevisionActionGate;
+  currentRevision: bigint;
+  pins: readonly HistoryPin[];
+  workloadNames: ReadonlyMap<string, string>;
+  soleKeepers: ReadonlySet<string>;
+  releaseAvailable: boolean;
+  releaseUnavailableReason: string;
+  secretByKeyId: ReadonlyMap<string, boolean>;
+  now: Date;
+  keyFilter: string | null;
+  onFilterKey: (keyId: string) => void;
+  onRestore: (revisionKeys: readonly HistorySnapshotKey[], keyId: string | null) => void;
+  onPin: (revisionKeys: readonly HistorySnapshotKey[]) => void;
+  onRelease: (pin: HistoryPin) => void;
+}) {
+  const detail = useRevisionDetail(env, revision.revision, revision.payloadPresent);
+  const revisionKeys: readonly HistorySnapshotKey[] = (detail.data?.keys ?? []).map((key) => ({
+    keyId: key.key_id,
+    name: key.name,
+    classification: key.classification,
+  }));
+  const pinnedHere = pins.filter((pin) => pin.revision === revision.revision);
+
+  return (
+    <section aria-labelledby="history-detail-title">
+      <h3 id="history-detail-title" className="mono" ref={headingRef} tabIndex={-1}>
+        {`r${String(revision.revision)}`}
+        {revision.revision === currentRevision ? <span className="history__tag">current</span> : null}
+        {revision.payloadPresent ? null : (
+          <span className="history__tag history__tag--collected">payload collected</span>
+        )}
+      </h3>
+      <dl className="history__meta">
+        <div>
+          <dt>Published by</dt>
+          {/*
+            Principal IDS, not names. Nothing in this API resolves a HUMAN
+            principal id to a display name — there is no member-listing
+            operation, and inventing one is a permission decision this ticket
+            does not own — so the row shows a shortened id and carries the whole
+            one in `title`. Workloads DO resolve, through the project's service
+            accounts, which is why the pin rows below name them.
+          */}
+          <dd className="mono" title={revision.publishedBy}>
+            {shortPrincipal(revision.publishedBy)}
+          </dd>
+        </div>
+        <div>
+          <dt>Published</dt>
+          <dd>
+            <time dateTime={revision.publishedAt}>{relativeAge(revision.publishedAt, now)}</time>
+          </dd>
+        </div>
+        <div>
+          <dt>Schema revision pinned</dt>
+          <dd className="mono">{`s${String(revision.schemaRevision)}`}</dd>
+        </div>
+      </dl>
+
+      {pinnedHere.length === 0 ? null : (
+        <p className="history__consumers">
+          {`⚲ ${pinnedHere
+            .map((pin) => workloadLabel(pin.workloadPrincipalId, workloadNames))
+            .join(', ')} receive${pinnedHere.length === 1 ? 's' : ''} this revision's values`}
+          {revision.revision === currentRevision ? '' : ` instead of latest (r${String(currentRevision)})`}
+          {' — until the pin is released or expires.'}
+        </p>
+      )}
+
+      {gate.reason === null ? null : (
+        <p className="history__gate" role="status">
+          {gate.reason}
+        </p>
+      )}
+      {detail.isError ? (
+        <p id="history-detail-error" className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">!</span>
+          <span>{revisionDetailRefusal(detail.error, revision.revision)}</span>
+        </p>
+      ) : null}
+
+      <h4>{`Changed keys (${String(revision.changedKeys.length)})`}</h4>
+      <ul className="history__changes">
+        {revision.changedKeys.map((changed) => {
+          const secret = secretByKeyId.get(changed.keyId) === true;
+          return (
+            <li key={changed.keyId}>
+              <button
+                type="button"
+                className="btn history__change mono"
+                aria-pressed={keyFilter === changed.keyId}
+                onClick={() => onFilterKey(changed.keyId)}
+              >
+                {secret ? <span aria-hidden="true">🔒 </span> : null}
+                {changed.name}
+              </button>
+              <span className="history__kind">{changed.change}</span>
+              {secret ? <span className="history__presence">write-presence only</span> : null}
+              <button
+                type="button"
+                className="btn"
+                disabled={!gate.restore || !detail.isSuccess}
+                onClick={() => onRestore(revisionKeys, changed.keyId)}
+              >
+                {`Restore ${changed.name}…`}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="history__actions">
+        <button
+          type="button"
+          className="btn btn--primary"
+          disabled={!gate.restore || !detail.isSuccess}
+          title={gate.restore ? undefined : gate.reason ?? undefined}
+          onClick={() => onRestore(revisionKeys, null)}
+        >
+          {`Restore r${String(revision.revision)}…`}
+        </button>
+        <button
+          type="button"
+          className="btn"
+          disabled={!gate.pin || !detail.isSuccess}
+          title={gate.pin ? undefined : gate.reason ?? undefined}
+          onClick={() => onPin(revisionKeys)}
+        >
+          {`Pin r${String(revision.revision)}…`}
+        </button>
+      </div>
+
+      <h4>{`Pins (${String(pins.length)})`}</h4>
+      <p className="history__pin-note">
+        A pinned workload stops following latest — it keeps receiving exactly the pinned
+        revision&apos;s values, restarts included, until the pin is released or expires.
+      </p>
+      {releaseAvailable ? null : (
+        <p
+          id="history-release-disabled"
+          className="history__gate"
+          role={releaseUnavailableReason.includes('could not') ? 'alert' : 'status'}
+        >
+          {releaseUnavailableReason}
+        </p>
+      )}
+      {pins.length === 0 ? (
+        <p className="history__empty">{`No pins — every workload here follows latest (r${String(currentRevision)}).`}</p>
+      ) : (
+        <ul className="history__pins">
+          {pins.map((pin) => {
+            const expiry = pinExpiry(pin.expiresAt, now);
+            const sole = soleKeepers.has(pin.id);
+            const workload = workloadLabel(pin.workloadPrincipalId, workloadNames);
+            const publishesBehind = revisions.filter(
+              (entry) => entry.revision > pin.revision,
+            ).length;
+            const gap = pin.revision === currentRevision
+              ? `${workload} is pinned to the current revision r${String(pin.revision)} — it will keep these values when the next publish lands.`
+              : `${workload} still runs on r${String(pin.revision)}'s values — ${String(publishesBehind)} publishes behind latest (r${String(currentRevision)}). New publishes don't reach it.`;
+            return (
+              <li key={pin.id} className="history__pin">
+                <span className="mono">{`⚲ r${String(pin.revision)}`}</span>
+                <span className="mono" title={pin.workloadPrincipalId}>
+                  {workload}
+                </span>
+                <span className={`history__expiry history__expiry--${expiry.tier}`}>
+                  {expiry.tier === 'expired'
+                    ? `expired — still delivering r${String(pin.revision)} while its payload survives`
+                    : expiry.text}
+                </span>
+                <span className="history__pin-gap">{gap}</span>
+                {sole ? (
+                  <span
+                    className="history__warn"
+                    title={soleKeeperReleaseConsequences(pin.revision)}
+                  >
+                    ⚠ sole keeper
+                  </span>
+                ) : null}
+                {pin.schemaOverride ? (
+                  <span className="history__warn" title="Pinned despite a current-schema failure, recorded as an explicit override. Pinned delivery is verbatim.">
+                    Δ schema drift
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn"
+                  disabled={!releaseAvailable}
+                  aria-describedby={releaseAvailable ? undefined : 'history-release-disabled'}
+                  onClick={() => onRelease(pin)}
+                >
+                  Release
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/**
+ * The restore sheet: what a restore does, then what it did.
+ *
+ * **Divergence from the prototype, named.** Iteration 1 previews first and
+ * stages on confirmation. The shipped verb does both in one call —
+ * `rollbackRevision` writes the drafts and returns the impact preview with the
+ * token that binds them — so this sheet explains the act before it is taken and
+ * reports the exact impact after. Nothing is published either way: the drafts
+ * are ordinary, the matrix's draft dots appear, and the ordinary publish sheet
+ * commits them.
+ */
+function RestoreSheet({
+  environmentName,
+  revision,
+  keyName,
+  result,
+  busy,
+  publishBusy,
+  refusal,
+  matrixPath,
+  onStage,
+  onPublish,
+  onClose,
+}: {
+  environmentName: string;
+  revision: bigint;
+  keyName: string | null;
+  result: RestoreSheetResult | null;
+  busy: boolean;
+  publishBusy: boolean;
+  refusal: string | null;
+  matrixPath: string;
+  onStage: () => void;
+  onPublish: () => void;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  const changes: readonly HistoryImpactChange[] =
+    result === null
+      ? []
+      : result.preview.environments.flatMap((environment) =>
+          environment.changes.map((change) => ({
+            keyId: change.key_id,
+            name: change.name,
+            classification: change.classification,
+            operation: change.operation,
+            status: change.status,
+            ...(change.before === undefined ? {} : { before: change.before }),
+            ...(change.after === undefined ? {} : { after: change.after }),
+          })),
+        );
+  const summary = restorePreviewSummary(changes);
+
+  return (
+    <dialog className="matrix-editor history-sheet" ref={dialog} onClose={onClose}>
+      <div className="matrix-editor__head">
+        <div>
+          <h2>
+            {keyName === null
+              ? `Restore r${String(revision)} · ${environmentName}`
+              : `Restore ${keyName} from r${String(revision)} · ${environmentName}`}
+          </h2>
+          <p>
+            Stages drafts reproducing r{String(revision)}. Publishing them runs the normal
+            pipeline and re-validates against the CURRENT schema — history is never rewritten.
+          </p>
+        </div>
+        <button type="button" className="btn matrix-editor__close" aria-label="Close restore" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+
+      {refusal === null ? null : (
+        <p id="history-restore-refusal" className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">!</span>
+          <span>{refusal}</span>
+        </p>
+      )}
+
+      {result === null ? (
+        <div className="matrix-editor__actions">
+          <button type="button" className="btn btn--primary" disabled={busy} onClick={onStage}>
+            {busy ? 'Staging…' : `Stage the restore from r${String(revision)}`}
+          </button>
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <>
+          <p className="history__chips" role="status">
+            {summary.chips.map((chip) => (
+              <span className="count" key={chip}>
+                {chip}
+              </span>
+            ))}
+          </p>
+          <ul className="history__impact">
+            {changes.map((change) => (
+              <li key={change.keyId}>
+                <span className="mono">
+                  {change.classification === 'secret' ? <span aria-hidden="true">🔒 </span> : null}
+                  {change.name}
+                </span>
+                <span className="history__kind">{change.operation === 'set' ? 'set' : 'clear'}</span>
+                <span className="mono history__impact-values">
+                  {change.classification === 'secret'
+                    ? `secret — ${change.status}, write-presence only`
+                    : change.operation === 'unset'
+                      ? `${change.before ?? '(absent)'} → (cleared)`
+                      : `${change.before ?? '(absent)'} → ${change.after ?? '(unreadable)'}`}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="notice" role="status">
+            <span aria-hidden="true">✓</span>
+            <span>
+              Staged as ordinary drafts. Review and publish them from the matrix — the publish
+              carries the preview token that binds this exact restore.
+            </span>
+          </p>
+          <div className="matrix-editor__actions">
+            <button
+              id="history-restore-publish"
+              type="button"
+              className="btn btn--primary"
+              disabled={publishBusy || result.changes.length === 0}
+              aria-describedby={result.changes.length === 0 ? 'history-restore-no-drafts' : undefined}
+              onClick={onPublish}
+            >
+              {publishBusy
+                ? 'Publishing this restore…'
+                : restorePublishLabel(revision, result)}
+            </button>
+            <Link id="history-restore-back" className="btn" to={matrixPath}>
+              Back to the matrix
+            </Link>
+          </div>
+          {result.changes.length === 0 ? (
+            <p id="history-restore-no-drafts" className="history__gate" role="status">
+              Nothing changed, so this restore has no drafts to publish.
+            </p>
+          ) : null}
+        </>
+      )}
+    </dialog>
+  );
+}
+
+/** The pin sheet: what pinning does, to which workload, until when. */
+function PinSheet({
+  environmentName,
+  revision,
+  isCurrent,
+  currentRevision,
+  workloads,
+  soleKeepers,
+  retentionReady,
+  state,
+  busy,
+  refusal,
+  comparisonBusy,
+  comparisonError,
+  comparison,
+  onCompare,
+  onChange,
+  onSubmit,
+  onClose,
+}: {
+  environmentName: string;
+  revision: bigint;
+  isCurrent: boolean;
+  currentRevision: bigint;
+  workloads: readonly {
+    readonly principalID: string;
+    readonly name: string;
+    readonly pinnedRevision: bigint | undefined;
+    readonly pinID: string | undefined;
+  }[];
+  soleKeepers: ReadonlySet<string>;
+  retentionReady: boolean;
+  state: {
+    readonly workloadPrincipalID: string;
+    readonly expiresAt: string;
+    readonly overrideSchema: boolean;
+    readonly offerOverride: boolean;
+  };
+  busy: boolean;
+  refusal: string | null;
+  comparisonBusy: boolean;
+  comparisonError: string | null;
+  comparison: PinComparison | null;
+  onCompare: () => void;
+  onChange: (next: Partial<{ workloadPrincipalID: string; expiresAt: string; overrideSchema: boolean }>) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  const chosen = workloads.find((workload) => workload.principalID === state.workloadPrincipalID);
+  const plan = pinAction(chosen?.pinnedRevision, revision);
+  const moveNeedsRetention = plan.kind === 'move' && !retentionReady;
+
+  return (
+    <dialog className="matrix-editor history-sheet" ref={dialog} onClose={onClose}>
+      <div className="matrix-editor__head">
+        <div>
+          <h2>{`⚲ Pin r${String(revision)} · ${environmentName}`}</h2>
+          <p>One pin per workload and environment. Quota 100 per project; expiry is mandatory.</p>
+        </div>
+        <button type="button" className="btn matrix-editor__close" aria-label="Close pin sheet" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+
+      {refusal === null ? null : (
+        <p id="history-pin-refusal" className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">!</span>
+          <span>{refusal}</span>
+        </p>
+      )}
+
+      <div className="history__pin-what">
+        <h3>What pinning does</h3>
+        <ul>
+          <li>
+            The workload keeps receiving exactly r{String(revision)}&apos;s values — across
+            restarts and redeploys — instead of following latest.
+          </li>
+          <li>
+            New publishes to {environmentName} stop reaching this workload while the pin lives;
+            everyone else still gets latest.
+          </li>
+          <li>r{String(revision)}&apos;s values are kept from retention clean-up while the pin exists.</li>
+          <li>
+            On release the workload resumes latest on its next fetch. On EXPIRY it keeps
+            delivering the pinned revision until the payload is collected — expiry never silently
+            changes delivery.
+          </li>
+        </ul>
+      </div>
+
+      {isCurrent ? null : (
+        <p className="history__gate" role="status">
+          Non-current revision: this routes HISTORICAL content to a workload, so it takes
+          reveal-history and one disclosure ceremony over the revision&apos;s secret keys.
+        </p>
+      )}
+
+      <label className="history__field" htmlFor="history-pin-workload">
+        Workload
+      </label>
+      <select
+        id="history-pin-workload"
+        className="btn"
+        value={state.workloadPrincipalID}
+        onChange={(event) => onChange({ workloadPrincipalID: event.target.value })}
+      >
+        {workloads.length === 0 ? <option value="">No workloads in this project</option> : null}
+        {workloads.map((workload) => (
+          <option key={workload.principalID} value={workload.principalID}>
+            {`${workload.name} — ${workload.pinnedRevision === undefined ? 'follows latest' : `pinned to r${String(workload.pinnedRevision)}`}`}
+          </option>
+        ))}
+      </select>
+
+      {plan.kind === 'move' && chosen?.pinnedRevision !== undefined ? (
+        <>
+          <p className="history__gate" role="status">
+            {`${chosen.name} is currently pinned to r${String(chosen.pinnedRevision)} — one pin per workload, so this MOVES it to r${String(revision)} and replaces the old pin atomically.`}
+          </p>
+          {chosen.pinID !== undefined && soleKeepers.has(chosen.pinID) ? (
+            <p id="history-pin-move-collection-warning" className="history__gate" role="alert">
+              {soleKeeperReleaseConsequences(chosen.pinnedRevision)}
+            </p>
+          ) : null}
+        </>
+      ) : null}
+      {moveNeedsRetention ? (
+        <p className="history__gate" role="status" id="history-pin-retention-wait">
+          Move disabled until the retention policy has loaded, so the old revision&apos;s collection consequence can be checked.
+        </p>
+      ) : null}
+      {plan.kind === 'renew' ? (
+        <p className="history__gate" role="status">
+          {`${chosen?.name ?? 'This workload'} is already pinned to r${String(revision)}. Pinning again RENEWS it: the expiry is extended and the pin is re-validated against the current schema, which surfaces any new drift.`}
+        </p>
+      ) : null}
+
+      <label className="history__field" htmlFor="history-pin-expiry">
+        Expires on (default 180 days, maximum 365)
+      </label>
+      <input
+        id="history-pin-expiry"
+        className="mono"
+        type="date"
+        value={state.expiresAt}
+        onChange={(event) => onChange({ expiresAt: event.target.value })}
+      />
+
+      {state.offerOverride ? (
+        <label className="history__field history__override chk">
+          <input
+            type="checkbox"
+            checked={state.overrideSchema}
+            onChange={(event) => onChange({ overrideSchema: event.target.checked })}
+          />
+          <span>
+            Pin despite the current-schema failure above. Pinned delivery is verbatim, so this is
+            recorded as an explicit override and the pin is surfaced as drift afterwards.
+          </span>
+        </label>
+      ) : null}
+
+      <section className="history__comparison" aria-labelledby="history-pin-compare-heading">
+        <h3 id="history-pin-compare-heading">
+          {`Compare r${String(revision)} to latest (reads r${String(revision)}'s config values)`}
+        </h3>
+        <p>Secret lines are write-presence from the lineage, never a value comparison.</p>
+        <button
+          id="history-pin-compare"
+          type="button"
+          className="btn"
+          disabled={comparisonBusy}
+          aria-expanded={comparison !== null}
+          aria-controls="history-pin-compare-results"
+          onClick={onCompare}
+        >
+          {comparisonBusy ? 'Comparing…' : 'Run comparison'}
+        </button>
+        {comparisonError === null ? null : (
+          <p id="history-pin-compare-error" className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">!</span>
+            <span>{comparisonError}</span>
+          </p>
+        )}
+        {comparison === null ? null : (
+          <div id="history-pin-compare-results" role="status" aria-live="polite">
+            {comparison.lines.length === 0 ? (
+              <p>No set keys differ from latest.</p>
+            ) : (
+              <ul className="history__comparison-lines">
+                {comparison.lines.map((line) => <li key={line}>{line}</li>)}
+              </ul>
+            )}
+            {comparison.unchangedConfigKeys === 0 ? null : (
+              <p>{`${String(comparison.unchangedConfigKeys)} config key${comparison.unchangedConfigKeys === 1 ? '' : 's'} unchanged`}</p>
+            )}
+          </div>
+        )}
+      </section>
+
+      <div className="matrix-editor__actions">
+        <button
+          id="history-pin-submit"
+          type="button"
+          className="btn btn--primary"
+          disabled={busy || state.workloadPrincipalID === '' || moveNeedsRetention}
+          aria-describedby={moveNeedsRetention ? 'history-pin-retention-wait' : undefined}
+          onClick={onSubmit}
+        >
+          {busy ? 'Pinning…' : plan.label}
+        </button>
+        <button type="button" className="btn" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+      <p>{`Latest in ${environmentName} is r${String(currentRevision)}.`}</p>
+    </dialog>
+  );
+}
+
+/** The sole-keeper release confirmation: three consequences and a danger label. */
+function ReleaseSheet({
+  pin,
+  currentRevision,
+  workloadName,
+  busy,
+  releaseAllowed,
+  onRelease,
+  onClose,
+}: {
+  pin: HistoryPin;
+  currentRevision: bigint;
+  workloadName: string;
+  busy: boolean;
+  releaseAllowed: boolean;
+  onRelease: () => void;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  return (
+    <dialog className="matrix-editor history-sheet" ref={dialog} onClose={onClose}>
+      <div className="matrix-editor__head">
+        <div>
+          <h2>{SOLE_KEEPER_RELEASE_TITLE}</h2>
+          <p id="history-release-consequence" role="alert">{soleKeeperReleaseConsequences(pin.revision)}</p>
+        </div>
+        <button type="button" className="btn matrix-editor__close" aria-label="Close release confirmation" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+      <ul className="history__consequences">
+        <li>{`r${String(pin.revision)} is past normal retention — this pin is the only thing keeping its values.`}</li>
+        <li>If a retention sweep collects the values, restore, reveal, and export stop; the lineage entry stays.</li>
+        <li>{`${workloadName} resumes latest (r${String(currentRevision)}) on its next fetch.`}</li>
+      </ul>
+      {releaseAllowed ? null : (
+        <p className="alert" role="alert" id="history-release-sheet-disabled">
+          <span className="alert__glyph" aria-hidden="true">!</span>
+          <span>Release disabled because the retention policy is no longer available.</span>
+        </p>
+      )}
+      <div className="matrix-editor__actions">
+        <button
+          id="history-release-confirm"
+          type="button"
+          className="btn btn--danger"
+          disabled={busy || !releaseAllowed}
+          aria-describedby={releaseAllowed ? undefined : 'history-release-sheet-disabled'}
+          onClick={onRelease}
+        >
+          {busy ? 'Releasing…' : SOLE_KEEPER_RELEASE_BUTTON}
+        </button>
+        <button type="button" className="btn" onClick={onClose}>
+          Keep the pin
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+function toHistoryRevision(item: HistoryRevisionItem): HistoryRevision {
+  const shared = {
+    revision: item.revision,
+    schemaRevision: item.schema_revision,
+    publishedBy: item.published_by,
+    publishedAt: item.published_at,
+    changedKeys: item.changed_keys.map((changed) => ({
+      keyId: changed.key_id,
+      name: changed.name,
+      change: changed.change,
+    })),
+  };
+  if (item.payload_present) {
+    return { ...shared, payloadPresent: true };
+  }
+  if (item.collected_policy === undefined) {
+    throw new Error(`Collected revision r${String(item.revision)} does not name its retention policy.`);
+  }
+  return { ...shared, payloadPresent: false, collectedPolicy: item.collected_policy };
+}
+
+function historyMutationRefusal(
+  error: unknown,
+  action: 'restore' | 'pin',
+  unit: readonly CeremonyKey[],
+  environmentName: string,
+): string {
+  if (error instanceof ApiError && error.status === 403 && unit.length > 0) {
+    return (
+      `Refused: reading the earlier secret values of ${unit.map((key) => key.name).join(', ')} ` +
+      `requires reveal-history on ${environmentName}.`
+    );
+  }
+  return historyRefusalText(error, action);
+}
+
+function revisionDetailRefusal(error: unknown, revision: bigint): string {
+  const detailed = callerSafeRefusal(error, `Revision r${String(revision)} detail refused`);
+  if (detailed !== null) {
+    return detailed;
+  }
+  if (error instanceof ApiError) {
+    return `Revision r${String(revision)} detail could not be read (error ${String(error.status)}).`;
+  }
+  return `Revision r${String(revision)} detail could not be read.`;
+}
+
+function comparisonRefusal(error: unknown, revision: bigint): string {
+  const detailed = callerSafeRefusal(error, `Comparison of r${String(revision)} refused`);
+  if (detailed !== null) {
+    return detailed;
+  }
+  if (error instanceof ApiError) {
+    return `Comparison of r${String(revision)} could not be read (error ${String(error.status)}).`;
+  }
+  return `Comparison of r${String(revision)} could not be read.`;
+}
+
+function restorePublishLabel(revision: bigint, result: RestoreSheetResult): string {
+  const preview = result.preview.environments[0];
+  if (preview === undefined) {
+    throw new Error('restore result has no preview environment');
+  }
+  return `Publish this restore (r${String(revision)} → r${String(preview.base_revision + 1n)})`;
+}
+
+function toHistoryPin(pin: RevisionPinItem): HistoryPin {
+  return {
+    id: pin.id,
+    workloadPrincipalId: pin.workload_principal_id,
+    revision: pin.revision,
+    expiresAt: pin.expires_at,
+    expired: pin.expired,
+    schemaOverride: pin.schema_override,
+  };
+}
+
+/** A prefixed UUIDv7 is unreadable at a glance; the whole one lives in `title`. */
+function shortPrincipal(id: string): string {
+  const separator = id.indexOf('_');
+  return separator < 0 ? id : `${id.slice(0, separator + 1)}${id.slice(separator + 1, separator + 9)}…`;
+}

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -41,6 +41,7 @@ import {
   type ServiceAccount,
 } from '../api/identities.ts';
 import { runPasskeyCeremony, useEnvironments } from '../api/values.ts';
+import { useModalDialog } from './useModalDialog.ts';
 
 /**
  * The machine-access surface (#67, locked prototype #31 iteration 3).
@@ -754,24 +755,6 @@ function claimText(pin: ClaimPin): string {
     return String(pin.bool_value);
   }
   return 'unpinned';
-}
-
-/**
- * useModalDialog opens a native `<dialog>` with `showModal()`.
- *
- * The platform gives a real focus trap, an inert document behind it, Escape and
- * the top layer — every part of which a hand-rolled `role="dialog"` has to
- * reimplement, and the focus trap is the part everyone gets wrong.
- */
-function useModalDialog() {
-  const ref = useRef<HTMLDialogElement>(null);
-  useEffect(() => {
-    const element = ref.current;
-    if (element !== null && !element.open) {
-      element.showModal();
-    }
-  }, []);
-  return ref;
 }
 
 /**

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -219,6 +219,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
   const visibleEnvironments = environments.filter((environment) =>
     visibleEnvironmentIds.includes(environment.id),
   );
+  const firstVisibleEnvironment = visibleEnvironments[0];
   const pendingByEnvironment = useMemo(() => {
     const pending = new Map<string, readonly MatrixPendingEntry[]>();
     environments.forEach((environment, index) => {
@@ -664,15 +665,25 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
                         ref={rowVirtualizer.measureElement}
                       >
                         <th scope="row" title={key.name}>
-                          <button
-                            type="button"
+                          {/* The key NAME opens its history (revision-history it-1/6:
+                              "a key name click opens the same drawer filtered to
+                              that key"); any CELL opens the row editor. env-matrix 31
+                              wires nothing to the name, so the history lock is the only
+                              one that speaks. */}
+                          <Link
                             className="matrix__key mono"
-                            aria-label={`Edit ${key.name} across environments`}
-                            onClick={() => setSelection({ keyId: key.id })}
+                            aria-label={`History of ${key.name}`}
+                            to={historyHref({
+                              ...ref,
+                              ...(firstVisibleEnvironment === undefined
+                                ? {}
+                                : { env: firstVisibleEnvironment.id }),
+                              keyId: key.id,
+                            })}
                           >
                             {key.classification === 'secret' ? <span aria-hidden="true">🔒 </span> : null}
                             {key.name}
-                          </button>
+                          </Link>
                           <span className="matrix__required">{requiredLabel(key, environments)}</span>
                         </th>
                         {visibleEnvironments.map((environment) => {

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -1,11 +1,13 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 
+import { historyHref } from '../api/history.ts';
 import {
   matrixPublishValidation,
   matrixMutationError,
   pendingConfigPreview,
+  restorePreviewWasAttached,
   useClearMatrixValue,
   useCopyMatrixConfig,
   useMatrixProject,
@@ -20,6 +22,8 @@ import {
   type EnvironmentList,
   type ValueCell,
 } from '../api/values.ts';
+import { HistoryDrawer } from './HistoryDrawer.tsx';
+import type { HistoryCurrentCell } from './history-state.ts';
 import {
   MatrixPublishSheet,
   type MatrixPendingEntry,
@@ -62,7 +66,7 @@ type DisplayRow =
  * cross-environment comparison survive here. Lineage is one gesture away in
  * the row editor as the API's actor, timestamp, and revision facts.
  */
-export function Matrix() {
+export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) {
   const params = useParams();
   const ref: MatrixRef = { org: params['org'] ?? '', project: params['project'] ?? '' };
   const matrix = useMatrixProject(ref);
@@ -83,6 +87,23 @@ export function Matrix() {
   const [notice, setNotice] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const matrixScroll = useRef<HTMLDivElement>(null);
+  const historyOpener = useRef<HTMLAnchorElement>(null);
+  const [mobileLayout, setMobileLayout] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(max-width: 800px)').matches,
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const query = window.matchMedia('(max-width: 800px)');
+    const update = () => setMobileLayout(query.matches);
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, []);
 
   const environmentSignature = environments.map((environment) => environment.id).join('/');
   useEffect(() => {
@@ -240,7 +261,52 @@ export function Matrix() {
   const protectedEnvironmentIds = environments.flatMap((environment, index) =>
     matrix.settings[index]?.data?.protected === true ? [environment.id] : [],
   );
-
+  const pendingCountByEnvironment = useMemo<ReadonlyMap<string, number>>(
+    () =>
+      new Map(
+        [...pendingByEnvironment.entries()].map(([environmentId, entries]) => [
+          environmentId,
+          entries.length,
+        ]),
+      ),
+    [pendingByEnvironment],
+  );
+  const pendingByOthersByEnvironment = useMemo<ReadonlyMap<string, number>>(() => {
+    const counts = new Map<string, number>();
+    environments.forEach((environment, index) => {
+      counts.set(
+        environment.id,
+        (matrix.signals[index]?.data?.cells ?? []).filter((cell) => cell.pending_by_others).length,
+      );
+    });
+    return counts;
+  }, [environments, matrix.signals]);
+  // The history drawer needs the CURRENT cell state to enumerate the ceremony
+  // unit a restore will need: the comparison opens current secret plaintext only
+  // where a set secret is being replaced.
+  const cellsByEnvironment = useMemo<ReadonlyMap<string, readonly HistoryCurrentCell[]>>(() => {
+    const cells = new Map<string, readonly HistoryCurrentCell[]>();
+    for (const environment of environments) {
+      cells.set(
+        environment.id,
+        keys.map((key) => ({
+          keyId: key.id,
+          classification: key.classification,
+          set: valuesByCell.get(cellID(key.id, environment.id))?.set === true,
+        })),
+      );
+    }
+    return cells;
+  }, [environments, keys, valuesByCell]);
+  const currentValuesByEnvironment = useMemo<
+    ReadonlyMap<string, readonly ValueCell[]>
+  >(() => {
+    const values = new Map<string, readonly ValueCell[]>();
+    environments.forEach((environment, index) => {
+      values.set(environment.id, matrix.values[index]?.data?.items ?? []);
+    });
+    return values;
+  }, [environments, matrix.values]);
   const loading =
     matrix.environments.isPending ||
     matrix.keys.isPending ||
@@ -349,9 +415,13 @@ export function Matrix() {
       : selection.environmentId === undefined
         ? environments[0]
         : environments.find((environment) => environment.id === selection.environmentId);
-
   return (
-    <section className="matrix" aria-labelledby="matrix-title">
+    <>
+    <section
+      className="matrix"
+      aria-labelledby="matrix-title"
+      inert={historyOpen && mobileLayout}
+    >
       <div className="matrix__head">
         <div>
           <h1 id="matrix-title">Environment matrix</h1>
@@ -400,7 +470,15 @@ export function Matrix() {
           problems={problems}
           protectedEnvironmentIds={protectedEnvironmentIds}
           busy={publish.isPending}
-          mutationError={publish.isError ? matrixMutationError(publish.error, 'publish') : null}
+          mutationError={
+            publish.isError
+              ? matrixMutationError(
+                  publish.error,
+                  'publish',
+                  restorePreviewWasAttached(publish.error),
+                )
+              : null
+          }
           onPublish={publishSelected}
         />
       ) : null}
@@ -501,9 +579,26 @@ export function Matrix() {
                 <thead>
                   <tr>
                     <th scope="col">Key</th>
-                    {visibleEnvironments.map((environment) => (
-                      <th scope="col" key={environment.id}>{environment.name}</th>
-                    ))}
+                    {visibleEnvironments.map((environment) => {
+                      const revision = revisionsByEnvironment.get(environment.id);
+                      return (
+                        <th scope="col" key={environment.id}>
+                          <span>{environment.name}</span>
+                          {revision === undefined ? null : (
+                            <Link
+                              className="btn matrix__history-link"
+                              data-history-environment={environment.id}
+                              to={historyHref({ ...ref, env: environment.id })}
+                              onClick={(event) => {
+                                historyOpener.current = event.currentTarget;
+                              }}
+                            >
+                              {`rev ${String(revision)} · history`}
+                            </Link>
+                          )}
+                        </th>
+                      );
+                    })}
                   </tr>
                 </thead>
                 <tbody>
@@ -695,7 +790,24 @@ export function Matrix() {
           }}
         />
       )}
+
     </section>
+
+      {historyOpen ? (
+        <HistoryDrawer
+          refData={ref}
+          environments={environments}
+          keys={keys}
+          currentRevisions={revisionsByEnvironment}
+          protectedEnvironmentIds={protectedEnvironmentIds}
+          cellsByEnvironment={cellsByEnvironment}
+          pendingByEnvironment={pendingCountByEnvironment}
+          pendingByOthersByEnvironment={pendingByOthersByEnvironment}
+          currentValuesByEnvironment={currentValuesByEnvironment}
+          openerRef={historyOpener}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/web/src/routes/MatrixRowEditor.tsx
+++ b/web/src/routes/MatrixRowEditor.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { generatePath, Link } from 'react-router';
 
+import { historyHref } from '../api/history.ts';
 import type {
   MatrixKeyList,
   MatrixRef,
@@ -21,6 +22,7 @@ import {
   useProtectedPublishCeremony,
   type ProtectedPublishTarget,
 } from './useProtectedPublishCeremony.ts';
+import { useModalDialog } from './useModalDialog.ts';
 
 type MatrixKey = MatrixKeyList['items'][number];
 type Environment = EnvironmentList['items'][number];
@@ -62,7 +64,7 @@ export function MatrixRowEditor({
   onApply: (changes: readonly MatrixEditorChange[]) => Promise<void>;
   onCopy: (destinations: readonly string[], confirmProtected: boolean) => void;
 }) {
-  const dialog = useRef<HTMLDialogElement>(null);
+  const dialog = useModalDialog();
   const initialDrafts = useMemo(
     () =>
       new Map(
@@ -88,11 +90,6 @@ export function MatrixRowEditor({
   const [destinations, setDestinations] = useState<readonly string[]>([]);
   const [protectedCopyConfirmed, setProtectedCopyConfirmed] = useState(false);
   const protectedGuard = useProtectedPublishCeremony(refData);
-
-  useEffect(() => {
-    dialog.current?.showModal();
-    return () => dialog.current?.close();
-  }, []);
 
   const valuesPath = generatePath(surfaceById('values').path, {
     org: refData.org,
@@ -322,6 +319,17 @@ export function MatrixRowEditor({
               {busy || applying ? 'Saving drafts…' : `Save ${String(changes.length)} draft${changes.length === 1 ? '' : 's'}`}
             </button>
             <Link className="btn" to={valuesPath}>Open Values</Link>
+            {/*
+              The per-key history entry point. Per-key history is a FILTER over
+              the same lineage, so it is the history surface with `key` set —
+              never a second surface, and never a second fetch.
+            */}
+            <Link
+              className="btn"
+              to={historyHref({ ...refData, env: environment.id, keyId: keyRecord.id })}
+            >
+              {`History for ${keyRecord.name}`}
+            </Link>
             {keyRecord.classification === 'config' && sourceSet ? (
               <button
                 type="button"

--- a/web/src/routes/history-state.test.ts
+++ b/web/src/routes/history-state.test.ts
@@ -1,0 +1,593 @@
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  pinAction,
+  pinExpiry,
+  pinExpiryInstant,
+  pinComparedToLatest,
+  revisionActionGate,
+  revisionsForKeyFilter,
+  defaultPinExpiry,
+  historyKeyDisplay,
+  pinCeremonyUnit,
+  pinSchemaOverrideOffered,
+  relativeAge,
+  restoreKeyName,
+  restoreCeremonyUnit,
+  restorePreviewSummary,
+  retentionLine,
+  SOLE_KEEPER_RELEASE_BUTTON,
+  SOLE_KEEPER_RELEASE_TITLE,
+  soleKeeperReleaseConsequences,
+  soleKeeperPinIds,
+  toHistoryRetention,
+  workloadLabel,
+  type HistoryPin,
+  type PinLatestValue,
+  type HistoryRetention,
+  type HistoryRevision,
+  type HistorySnapshotKey,
+} from './history-state.ts';
+
+const previousTZ = process.env.TZ;
+process.env.TZ = 'America/New_York';
+afterAll(() => {
+  process.env.TZ = previousTZ;
+});
+
+const collectedPolicy = 'keep-if-either(max_age=2160h0m0s,last_revisions=10)';
+
+type LiveRevision = Extract<HistoryRevision, { readonly payloadPresent: true }>;
+
+function revision(overrides: Partial<Omit<LiveRevision, 'payloadPresent'>> = {}): LiveRevision {
+  return {
+    revision: 3n,
+    schemaRevision: 7n,
+    publishedBy: 'usr_0198aaaa',
+    publishedAt: '2026-08-01T10:00:00Z',
+    payloadPresent: true,
+    changedKeys: [{ keyId: 'key_log', name: 'LOG_LEVEL', change: 'edited' }],
+    ...overrides,
+  };
+}
+
+describe('revisionActionGate', () => {
+  it('allows restore and pin on a retained, non-current revision', () => {
+    const gate = revisionActionGate(revision(), 5n);
+    expect(gate).toEqual({ restore: true, pin: true, reason: null });
+  });
+
+  it('refuses restore on the current revision because it would stage nothing', () => {
+    const gate = revisionActionGate(revision({ revision: 5n }), 5n);
+    expect(gate.restore).toBe(false);
+    expect(gate.pin).toBe(true);
+    expect(gate.reason).toBe('r5 is already the current revision — a restore would stage nothing.');
+  });
+
+  it('refuses both and names the stamped policy when the payload was collected', () => {
+    const gate = revisionActionGate(
+      collectedRevision(),
+      5n,
+    );
+    expect(gate).toEqual({
+      restore: false,
+      pin: false,
+      reason: `r3's payload was collected by retention policy ${collectedPolicy} — restore and pin are refused; the lineage stays.`,
+    });
+  });
+});
+
+function collectedRevision(
+  overrides: Partial<Omit<Extract<HistoryRevision, { readonly payloadPresent: false }>, 'payloadPresent' | 'collectedPolicy'>> = {},
+): Extract<HistoryRevision, { readonly payloadPresent: false }> {
+  return {
+    revision: 3n,
+    schemaRevision: 7n,
+    publishedBy: 'usr_0198aaaa',
+    publishedAt: '2026-08-01T10:00:00Z',
+    payloadPresent: false,
+    collectedPolicy,
+    changedKeys: [{ keyId: 'key_log', name: 'LOG_LEVEL', change: 'edited' }],
+    ...overrides,
+  };
+}
+
+describe('revisionsForKeyFilter', () => {
+  const logRevision = revision({
+    revision: 2n,
+    changedKeys: [
+      { keyId: 'key_log', name: 'LOG_LEVEL', change: 'edited' },
+      { keyId: 'key_db', name: 'DB_PASSWORD', change: 'added' },
+    ],
+  });
+  const history: readonly HistoryRevision[] = [
+    revision({ revision: 3n, changedKeys: [{ keyId: 'key_db', name: 'DB_PASSWORD', change: 'edited' }] }),
+    logRevision,
+    revision({ revision: 1n, changedKeys: [{ keyId: 'key_log', name: 'LOG_LEVEL', change: 'added' }] }),
+  ];
+
+  it('returns the whole history when no key is filtered', () => {
+    expect(revisionsForKeyFilter(history, null).map((r) => r.revision)).toEqual([3n, 2n, 1n]);
+  });
+
+  it('keeps only revisions for the immutable key id across a rename', () => {
+    const renamed = [
+      revision({ revision: 3n, changedKeys: [{ keyId: 'key_log', name: 'APP_LOG_LEVEL', change: 'edited' }] }),
+      ...history,
+    ];
+    expect(revisionsForKeyFilter(renamed, 'key_log').map((r) => r.revision)).toEqual([3n, 2n, 1n]);
+  });
+
+  it('does not merge a deleted key with a replacement that reused its name', () => {
+    const reusedName = [
+      revision({ revision: 4n, changedKeys: [{ keyId: 'key_new', name: 'LOG_LEVEL', change: 'added' }] }),
+      ...history,
+    ];
+    expect(revisionsForKeyFilter(reusedName, 'key_log').map((r) => r.revision)).toEqual([2n, 1n]);
+  });
+
+  it('labels the current catalogue name, or the historical name when the key is gone', () => {
+    expect(historyKeyDisplay('key_log', [{ id: 'key_log', name: 'APP_LOG_LEVEL' }], logRevision)).toEqual({
+      name: 'APP_LOG_LEVEL',
+      label: 'APP_LOG_LEVEL (current name)',
+      current: true,
+    });
+    expect(historyKeyDisplay('key_log', [], logRevision)).toEqual({
+      name: 'LOG_LEVEL',
+      label: 'LOG_LEVEL (historical name; key no longer exists)',
+      current: false,
+    });
+  });
+
+  it('uses the current name for a per-key restore and refuses a deleted key loud', () => {
+    expect(restoreKeyName('key_log', [{ id: 'key_log', name: 'APP_LOG_LEVEL' }], logRevision)).toBe('APP_LOG_LEVEL');
+    expect(() => restoreKeyName('key_log', [], logRevision)).toThrow(
+      'Cannot restore LOG_LEVEL: key key_log no longer exists in the current catalogue.',
+    );
+  });
+});
+
+describe('pinAction', () => {
+  it('is a plain pin when the workload follows latest', () => {
+    expect(pinAction(undefined, 3n)).toEqual({
+      kind: 'pin',
+      label: 'Create pin',
+    });
+  });
+
+  it('is a renew when the workload is already pinned to the same revision', () => {
+    expect(pinAction(4n, 4n)).toEqual({
+      kind: 'renew',
+      label: 'Renew pin on r4',
+    });
+  });
+
+  it('is a move when the workload is pinned elsewhere', () => {
+    expect(pinAction(2n, 4n)).toEqual({
+      kind: 'move',
+      label: 'Move pin from r2 to r4',
+    });
+  });
+});
+
+describe('pinExpiry', () => {
+  const now = new Date('2026-08-19T12:00:00Z');
+
+  it('reports a comfortable pin with no warning', () => {
+    expect(pinExpiry('2026-12-19T12:00:00Z', now)).toEqual({
+      days: 122,
+      tier: 'ok',
+      text: 'expires in 122 d',
+    });
+  });
+
+  it('uses raw-millisecond warning boundaries and separate display rounding', () => {
+    expect(pinExpiry('2026-09-18T12:00:00.001Z', now).tier).toBe('ok');
+    expect(pinExpiry('2026-09-18T12:00:00Z', now)).toEqual({
+      days: 30,
+      tier: 'month',
+      text: '! expires in 30 d',
+    });
+    expect(pinExpiry('2026-08-26T12:00:00Z', now)).toEqual({
+      days: 7,
+      tier: 'week',
+      text: '!! expires in 7 d',
+    });
+    expect(pinExpiry('2026-08-20T12:00:00Z', now)).toEqual({
+      days: 1,
+      tier: 'day',
+      text: '!!! expires in 1 d',
+    });
+    expect(pinExpiry('2026-08-19T12:00:00.001Z', now)).toEqual({
+      days: 1,
+      tier: 'day',
+      text: '!!! expires today',
+    });
+    expect(pinExpiry('2026-08-19T12:00:00Z', now)).toEqual({
+      days: 0,
+      tier: 'expired',
+      text: 'expired — still delivering until its payload is collected',
+    });
+    expect(pinExpiry('2026-08-19T11:59:59.999Z', now)).toEqual({
+      days: -1,
+      tier: 'expired',
+      text: 'expired — still delivering until its payload is collected',
+    });
+  });
+});
+
+describe('soleKeeperPinIds', () => {
+  const now = new Date('2026-08-19T12:00:00Z');
+  const keepIfEither: HistoryRetention = {
+    mode: 'keep-if-either',
+    maxAgeSeconds: 90 * 24 * 60 * 60,
+    lastRevisions: 2,
+  };
+  // r5 newest → rank 1, r4 → 2, r3 → 3 (past the last-2 window), and r3 is
+  // also older than the 90-day age window, so only a pin holds it.
+  const history: readonly HistoryRevision[] = [
+    revision({ revision: 5n, publishedAt: '2026-08-18T12:00:00Z' }),
+    revision({ revision: 4n, publishedAt: '2026-08-17T12:00:00Z' }),
+    revision({ revision: 3n, publishedAt: '2026-01-01T12:00:00Z' }),
+  ];
+
+  function pin(overrides: Partial<HistoryPin> = {}): HistoryPin {
+    return {
+      id: 'pin_a',
+      workloadPrincipalId: 'prn_workload_a',
+      revision: 3n,
+      expiresAt: '2026-11-19T12:00:00Z',
+      expired: false,
+      schemaOverride: false,
+      ...overrides,
+    };
+  }
+
+  it('finds the pin that is the only thing keeping a past-retention payload', () => {
+    expect([...soleKeeperPinIds({ pins: [pin()], revisions: history, policy: keepIfEither, now })])
+      .toEqual(['pin_a']);
+  });
+
+  it('holds nobody sole when a second live pin keeps the same revision', () => {
+    const pins = [pin(), pin({ id: 'pin_b', workloadPrincipalId: 'prn_workload_b' })];
+    expect(soleKeeperPinIds({ pins, revisions: history, policy: keepIfEither, now }).size).toBe(0);
+  });
+
+  it('exempts a revision still inside the last-N window', () => {
+    const pins = [pin({ revision: 4n })];
+    expect(soleKeeperPinIds({ pins, revisions: history, policy: keepIfEither, now }).size).toBe(0);
+  });
+
+  it('exempts a revision still inside the age window even when it is past last-N', () => {
+    const young: readonly HistoryRevision[] = [
+      revision({ revision: 5n, publishedAt: '2026-08-18T12:00:00Z' }),
+      revision({ revision: 4n, publishedAt: '2026-08-17T12:00:00Z' }),
+      revision({ revision: 3n, publishedAt: '2026-08-16T12:00:00Z' }),
+    ];
+    expect(soleKeeperPinIds({ pins: [pin()], revisions: young, policy: keepIfEither, now }).size).toBe(0);
+  });
+
+  it('holds nobody sole under an unlimited policy, where no payload is ever collected', () => {
+    const unlimited: HistoryRetention = {
+      mode: 'unlimited',
+      maxAgeSeconds: null,
+      lastRevisions: null,
+    };
+    expect(soleKeeperPinIds({ pins: [pin()], revisions: history, policy: unlimited, now }).size).toBe(0);
+  });
+
+  it('does not call an EXPIRED pin a sole keeper — it no longer holds the payload back', () => {
+    const pins = [pin({ expired: true, expiresAt: '2026-08-01T12:00:00Z' })];
+    expect(soleKeeperPinIds({ pins, revisions: history, policy: keepIfEither, now }).size).toBe(0);
+  });
+
+  it('uses expiresAt rather than the fetch-time expired display flag', () => {
+    expect([...soleKeeperPinIds({ pins: [pin({ expired: true })], revisions: history, policy: keepIfEither, now })])
+      .toEqual(['pin_a']);
+    expect(soleKeeperPinIds({
+      pins: [pin({ expired: false, expiresAt: '2026-08-19T11:59:59.999Z' })],
+      revisions: history,
+      policy: keepIfEither,
+      now,
+    }).size).toBe(0);
+  });
+
+  it('does not call a pin on an ALREADY collected revision a sole keeper', () => {
+    const collected: readonly HistoryRevision[] = [
+      revision({ revision: 5n, publishedAt: '2026-08-18T12:00:00Z' }),
+      revision({ revision: 4n, publishedAt: '2026-08-17T12:00:00Z' }),
+      collectedRevision({ revision: 3n, publishedAt: '2026-01-01T12:00:00Z' }),
+    ];
+    expect(soleKeeperPinIds({ pins: [pin()], revisions: collected, policy: keepIfEither, now }).size).toBe(0);
+  });
+});
+
+describe('restorePreviewSummary', () => {
+  it('counts the two staged operations separately', () => {
+    const summary = restorePreviewSummary([
+      { keyId: 'k1', name: 'A', classification: 'config', operation: 'set', status: 'edited' },
+      { keyId: 'k2', name: 'B', classification: 'secret', operation: 'set', status: 'edited' },
+      { keyId: 'k3', name: 'C', classification: 'config', operation: 'unset', status: 'removed' },
+    ]);
+    expect(summary).toEqual({ set: 2, clear: 1, total: 3, chips: ['2 set', '1 clear'] });
+  });
+
+  it('says so when the environment already matches the revision', () => {
+    expect(restorePreviewSummary([])).toEqual({
+      set: 0,
+      clear: 0,
+      total: 0,
+      chips: ['already matches — nothing to stage'],
+    });
+  });
+});
+
+describe('restoreCeremonyUnit', () => {
+  const revisionKeys: readonly HistorySnapshotKey[] = [
+    { keyId: 'k_secret', name: 'DB_PASSWORD', classification: 'secret' },
+    { keyId: 'k_config', name: 'LOG_LEVEL', classification: 'config' },
+    { keyId: 'k_declassified', name: 'PAYMENT_PIN', classification: 'config' },
+  ];
+
+  it('enumerates the historical secrets the staging will open', () => {
+    expect(
+      restoreCeremonyUnit({ revisionKeys, currentCells: [], keyId: null }),
+    ).toEqual([{ id: 'k_secret', name: 'DB_PASSWORD' }]);
+  });
+
+  it('adds a key whose CURRENT value is a set secret, because the comparison opens it', () => {
+    expect(
+      restoreCeremonyUnit({
+        revisionKeys,
+        currentCells: [{ keyId: 'k_config', classification: 'secret', set: true }],
+        keyId: null,
+      }).map((entry) => entry.id),
+    ).toEqual(['k_secret', 'k_config']);
+  });
+
+  it('ignores a current secret that is ABSENT, because nothing is compared', () => {
+    expect(
+      restoreCeremonyUnit({
+        revisionKeys,
+        currentCells: [{ keyId: 'k_config', classification: 'secret', set: false }],
+        keyId: null,
+      }).map((entry) => entry.id),
+    ).toEqual(['k_secret']);
+  });
+
+  it('narrows to one key for a per-key restore', () => {
+    expect(restoreCeremonyUnit({ revisionKeys, currentCells: [], keyId: 'k_config' })).toEqual([]);
+    expect(
+      restoreCeremonyUnit({ revisionKeys, currentCells: [], keyId: 'k_secret' }),
+    ).toEqual([{ id: 'k_secret', name: 'DB_PASSWORD' }]);
+  });
+
+  it('narrows a renamed secret by immutable key id', () => {
+    expect(
+      restoreCeremonyUnit({
+        revisionKeys: [{ keyId: 'K', name: 'OLD_NAME', classification: 'secret' }],
+        currentCells: [{ keyId: 'K', classification: 'secret', set: true }],
+        keyId: 'K',
+      }),
+    ).toEqual([{ id: 'K', name: 'OLD_NAME' }]);
+  });
+});
+
+describe('pinCeremonyUnit', () => {
+  it('unions snapshot-time and current secret classification in both directions', () => {
+    expect(
+      pinCeremonyUnit(
+        [
+          { keyId: 'k_secret_then_config', name: 'OLD_SECRET', classification: 'secret' },
+          { keyId: 'k_config_then_secret', name: 'NEW_SECRET', classification: 'config' },
+          { keyId: 'k_config', name: 'CONFIG', classification: 'config' },
+        ],
+        [
+          { keyId: 'k_secret_then_config', classification: 'config', set: true },
+          { keyId: 'k_config_then_secret', classification: 'secret', set: true },
+          { keyId: 'k_config', classification: 'config', set: true },
+        ],
+      ),
+    ).toEqual([
+      { id: 'k_secret_then_config', name: 'OLD_SECRET' },
+      { id: 'k_config_then_secret', name: 'NEW_SECRET' },
+    ]);
+  });
+});
+
+describe('retentionLine', () => {
+  it('reads the effective keep-if-either window and marks it inherited', () => {
+    expect(
+      retentionLine({
+        inherited: true,
+        mode: 'keep-if-either',
+        maxAgeSeconds: 90 * 24 * 60 * 60,
+        lastRevisions: 10,
+      }),
+    ).toEqual({
+      window: 'values kept: 90 d or the last 10 revisions, whichever is longer, plus pinned',
+      badge: 'inherits org',
+      badgeTitle:
+        'this project has no retention of its own — it follows the org default and moves when the org value moves',
+    });
+  });
+
+  it('marks a project override as custom', () => {
+    expect(
+      retentionLine({
+        inherited: false,
+        mode: 'keep-if-either',
+        maxAgeSeconds: 7 * 24 * 60 * 60,
+        lastRevisions: 3,
+      }).badge,
+    ).toBe('custom');
+  });
+
+  it('states an unlimited policy without inventing a window', () => {
+    expect(
+      retentionLine({ inherited: true, mode: 'unlimited', maxAgeSeconds: null, lastRevisions: null })
+        .window,
+    ).toBe('values kept: unlimited — no payload is ever collected');
+  });
+});
+
+describe('pinSchemaOverrideOffered', () => {
+  it('does not offer an override for the expiry bound — an override would not fix it', () => {
+    expect(pinSchemaOverrideOffered('pin expiry exceeds the maximum 365 days')).toBe(false);
+    expect(pinSchemaOverrideOffered('pin expiry must be in the future')).toBe(false);
+  });
+
+  it('does not offer an override for the project quota', () => {
+    expect(pinSchemaOverrideOffered('pin quota 100 per project is exhausted')).toBe(false);
+  });
+
+  it('does not offer an override for unrelated collected, authorization, workload, revision, or expiry refusals', () => {
+    for (const refusal of [
+      'revision 3 payload was collected by retention policy keep-if-either',
+      'reveal-history authorization is required',
+      'pin workload principal is required',
+      'pin revision must be positive',
+      'pin expiry must be in the future',
+    ]) {
+      expect(pinSchemaOverrideOffered(refusal)).toBe(false);
+    }
+  });
+
+  it('offers the recorded override for every current-schema refusal validateResolved can raise', () => {
+    for (const refusal of [
+      'key "DB_POOL_SIZE" is `required_in` environment env_prod and resolves to absent: publish is vetoed',
+      'key "DEBUG" is `forbidden_in` environment env_prod and resolves to set: publish is vetoed',
+      'value for "WORKERS" is invalid (max: value is above the declared `max` of 8)',
+      "key group db resolves partially in environment env_prod: set [DB_HOST], absent [DB_PORT]: a group's presence is all-or-none",
+    ]) {
+      expect(pinSchemaOverrideOffered(refusal), refusal).toBe(true);
+    }
+  });
+
+  it('offers nothing when the server named no reason at all', () => {
+    expect(pinSchemaOverrideOffered(undefined)).toBe(false);
+  });
+
+  it('does not offer an override for an incomplete value refusal prefix', () => {
+    expect(pinSchemaOverrideOffered('value for "WORKERS"')).toBe(false);
+  });
+});
+
+describe('defaultPinExpiry', () => {
+  it('adds 180 local calendar days and submits the end of the chosen local day', () => {
+    expect(defaultPinExpiry(new Date('2026-03-07T15:00:00Z'))).toBe('2026-09-03');
+    expect(pinExpiryInstant('2026-03-08')).toBe('2026-03-09T03:59:59.999Z');
+  });
+
+  it('refuses an impossible date input loudly', () => {
+    expect(() => pinExpiryInstant('2026-02-30')).toThrow('Invalid pin expiry date: 2026-02-30');
+  });
+});
+
+describe('sole-keeper release copy', () => {
+  it('states collection eligibility rather than immediate deletion', () => {
+    expect(SOLE_KEEPER_RELEASE_TITLE).toBe('Release sole-keeper pin');
+    expect(SOLE_KEEPER_RELEASE_BUTTON).toBe('Release pin — values become eligible for collection');
+    expect(soleKeeperReleaseConsequences(3n)).toBe(
+      "Releasing makes r3's values eligible for collection at the next retention sweep — they will then be deleted permanently.",
+    );
+  });
+});
+
+describe('shared history display mappers', () => {
+  it('maps the API retention shape once', () => {
+    expect(toHistoryRetention({
+      mode: 'keep-if-either',
+      max_age_seconds: 60,
+      last_revisions: 2,
+    })).toEqual({ mode: 'keep-if-either', maxAgeSeconds: 60, lastRevisions: 2 });
+  });
+
+  it('labels a workload by name with a stable shortened-id fallback', () => {
+    const names = new Map([['prn_known', 'deploy']]);
+    expect(workloadLabel('prn_known', names)).toBe('deploy');
+    expect(workloadLabel('prn_0198aaaabbbb', names)).toBe('prn_0198aaaa…');
+  });
+});
+
+describe('pinComparedToLatest', () => {
+  const revisionKeys: readonly HistorySnapshotKey[] = [
+    { keyId: 'k_same', name: 'SAME', classification: 'config' },
+    { keyId: 'k_changed', name: 'CHANGED', classification: 'config' },
+    { keyId: 'k_removed', name: 'REMOVED', classification: 'config' },
+    { keyId: 'k_secret', name: 'SECRET', classification: 'secret' },
+  ];
+
+  it('phrases config presence and value changes from the pinned workload view', () => {
+    expect(pinComparedToLatest({
+      revision: 3n,
+      revisionKeys,
+      historical: [
+        { name: 'SAME', classification: 'config', revealed: true, value: 'same' },
+        { name: 'CHANGED', classification: 'config', revealed: true, value: 'old' },
+        { name: 'REMOVED', classification: 'config', revealed: true, value: 'kept' },
+        { name: 'SECRET', classification: 'secret', revealed: false },
+      ],
+      latest: [
+        { keyId: 'k_same', name: 'SAME', classification: 'config', set: true, revealed: true, value: 'same' },
+        { keyId: 'k_changed', name: 'CHANGED', classification: 'config', set: true, revealed: true, value: 'new' },
+        { keyId: 'k_removed', name: 'REMOVED', classification: 'config', set: false, revealed: false },
+        { keyId: 'k_secret', name: 'SECRET', classification: 'secret', set: true, revealed: false },
+        { keyId: 'k_added', name: 'ADDED', classification: 'config', set: true, revealed: true, value: 'latest' },
+      ],
+      laterRevisions: [revision({ revision: 4n, changedKeys: [{ keyId: 'k_secret', name: 'SECRET', change: 'edited' }] })],
+    })).toEqual({
+      lines: [
+        'CHANGED stays at old — latest: new',
+        'keeps REMOVED',
+        'SECRET written again since r3 (r4)',
+        "won't have ADDED",
+      ],
+      unchangedConfigKeys: 1,
+    });
+  });
+
+  it('uses lineage alone for an unchanged secret and refuses secret material', () => {
+    const secretRevisionKeys: readonly HistorySnapshotKey[] = [
+      { keyId: 'k_secret', name: 'SECRET', classification: 'secret' },
+    ];
+    const latest: readonly PinLatestValue[] = [
+      {
+        keyId: 'k_secret',
+        name: 'SECRET',
+        classification: 'secret',
+        set: true,
+        revealed: false,
+      },
+    ];
+    const laterRevisions: readonly HistoryRevision[] = [];
+    const base = {
+      revision: 3n,
+      revisionKeys: secretRevisionKeys,
+      latest,
+      laterRevisions,
+    };
+    expect(pinComparedToLatest({
+      ...base,
+      historical: [{ name: 'SECRET', classification: 'secret', revealed: false }],
+    }).lines).toEqual(['SECRET not written since r3']);
+    expect(() => pinComparedToLatest({
+      ...base,
+      historical: [{ name: 'SECRET', classification: 'secret', revealed: true, value: 'forbidden' }],
+    })).toThrow('historical secret SECRET exposed material in a pin comparison.');
+  });
+});
+
+describe('relativeAge', () => {
+  const now = new Date('2026-08-19T12:00:00Z');
+
+  it('reads in minutes, hours and days as the gap grows', () => {
+    expect(relativeAge('2026-08-19T11:40:00Z', now)).toBe('20 minutes ago');
+    expect(relativeAge('2026-08-19T04:00:00Z', now)).toBe('8 hours ago');
+    expect(relativeAge('2026-08-05T12:00:00Z', now)).toBe('14 days ago');
+  });
+
+  it('says "just now" rather than "0 minutes ago"', () => {
+    expect(relativeAge('2026-08-19T11:59:50Z', now)).toBe('now');
+  });
+});

--- a/web/src/routes/history-state.ts
+++ b/web/src/routes/history-state.ts
@@ -1,0 +1,729 @@
+/**
+ * Pure state for the revision-history drawer (#59, frozen prototype
+ * `revision-history/6`).
+ *
+ * Kept free of React and API clients for the same reason `matrix-state.ts` is:
+ * these are the drawer's domain decisions — what a pin mutation actually does,
+ * when a pin is the last thing keeping a payload alive, which revisions a
+ * collected payload takes off the table, what the impact preview summarises to.
+ * A UI test that clicked its way to those answers would be slower, less exact,
+ * and would not fail when the rule changed.
+ *
+ * Revision numbers are `bigint` throughout, because that is what the generated
+ * Zod hands the boundary (`int64`). Mixing them with `number` is how an
+ * ordering comparison silently stops being one.
+ */
+
+export type HistoryChangedKey = {
+  readonly keyId: string;
+  readonly name: string;
+  readonly change: 'added' | 'edited' | 'removed';
+};
+
+type HistoryRevisionBase = {
+  readonly revision: bigint;
+  readonly schemaRevision: bigint;
+  readonly publishedBy: string;
+  readonly publishedAt: string;
+  readonly changedKeys: readonly HistoryChangedKey[];
+};
+
+export type HistoryRevision = HistoryRevisionBase &
+  (
+    | {
+        /** A live payload carries no collection policy. */
+        readonly payloadPresent: true;
+        readonly collectedPolicy?: never;
+      }
+    | {
+        /** The lineage survives collection and permanently names its policy. */
+        readonly payloadPresent: false;
+        readonly collectedPolicy: string;
+      }
+  );
+
+export type RevisionActionGate = {
+  readonly restore: boolean;
+  readonly pin: boolean;
+  /** Why the refused actions are refused, in the words the surface renders. */
+  readonly reason: string | null;
+};
+
+/**
+ * revisionActionGate decides which of the drawer's two mutations a revision
+ * still admits, and says why when it does not.
+ *
+ * A collected payload closes both, naming the policy the store stamped at
+ * collection — that string is what the server's own refusal reports forever, so
+ * the UI repeats it rather than paraphrasing. The current revision closes only
+ * restore: restoring it compares a state against itself and stages nothing,
+ * which the service answers with an empty change set rather than an error, and
+ * an enabled button whose whole outcome is "nothing happened" is a lie.
+ */
+export function revisionActionGate(
+  revision: HistoryRevision,
+  currentRevision: bigint,
+): RevisionActionGate {
+  if (!revision.payloadPresent) {
+    return {
+      restore: false,
+      pin: false,
+      reason:
+        `r${String(revision.revision)}'s payload was collected by retention policy ${revision.collectedPolicy} — ` +
+        'restore and pin are refused; the lineage stays.',
+    };
+  }
+  if (revision.revision === currentRevision) {
+    return {
+      restore: false,
+      pin: true,
+      reason: `r${String(revision.revision)} is already the current revision — a restore would stage nothing.`,
+    };
+  }
+  return { restore: true, pin: true, reason: null };
+}
+
+/**
+ * revisionsForKeyFilter is the per-key history projection.
+ *
+ * Per-key history is a FILTER over the same lineage, never a second surface —
+ * the locked prototype's first decision — so it is a projection here and a
+ * query parameter in the route, not a different fetch.
+ *
+ * The query carries the immutable key ID. Names can change and can be reused
+ * after deletion; neither event changes which lineage belongs to this key.
+ */
+export function revisionsForKeyFilter(
+  revisions: readonly HistoryRevision[],
+  keyId: string | null,
+): readonly HistoryRevision[] {
+  if (keyId === null || keyId === '') {
+    return revisions;
+  }
+  return revisions.filter((revision) =>
+    revision.changedKeys.some((changed) => changed.keyId === keyId),
+  );
+}
+
+export type HistoryCatalogueKey = { readonly id: string; readonly name: string };
+export type HistoryKeyDisplay = {
+  readonly name: string;
+  readonly label: string;
+  readonly current: boolean;
+};
+
+/** Resolves a key-id filter without hiding whether the displayed name is current or historical. */
+export function historyKeyDisplay(
+  keyId: string,
+  catalogue: readonly HistoryCatalogueKey[],
+  revision: HistoryRevision | undefined,
+): HistoryKeyDisplay {
+  const current = catalogue.find((key) => key.id === keyId);
+  if (current !== undefined) {
+    return { name: current.name, label: `${current.name} (current name)`, current: true };
+  }
+  const historical = revision?.changedKeys.find((key) => key.keyId === keyId);
+  if (historical === undefined) {
+    throw new Error(`History filter names unknown key ${keyId}.`);
+  }
+  return {
+    name: historical.name,
+    label: `${historical.name} (historical name; key no longer exists)`,
+    current: false,
+  };
+}
+
+/** The rollback wire addresses a key by its current catalogue name, never its historical name. */
+export function restoreKeyName(
+  keyId: string,
+  catalogue: readonly HistoryCatalogueKey[],
+  revision: HistoryRevision,
+): string {
+  const current = catalogue.find((key) => key.id === keyId);
+  if (current !== undefined) {
+    return current.name;
+  }
+  const historical = historyKeyDisplay(keyId, catalogue, revision);
+  throw new Error(
+    `Cannot restore ${historical.name}: key ${keyId} no longer exists in the current catalogue.`,
+  );
+}
+
+export type PinActionKind = 'pin' | 'move' | 'renew';
+
+export type PinActionPlan = {
+  readonly kind: PinActionKind;
+  /** What the sheet's primary button says. */
+  readonly label: string;
+};
+
+/**
+ * pinAction names what pinning THIS revision does to THIS workload.
+ *
+ * A pin is a workload binding — at most one per (workload, environment) — so
+ * the same gesture is three different acts depending on where that workload
+ * already points, and the sheet has to say which one before it is taken.
+ *
+ * **Divergence from the locked prototype, deliberately.** Iteration 4 refuses a
+ * same-revision re-pin as a no-op ("a workload fetches exactly one revision").
+ * The API/CLI taxonomy locked afterwards (#52) makes it a RENEW: it extends the
+ * expiry, revalidates against the current schema, and records the drift that
+ * revalidation finds. That is not nothing, so the button says "renew" rather
+ * than being disabled. The server is the authority on which of the three it
+ * performed; this label is what the human is asked to agree to, and the outcome
+ * toast comes from `RevisionPinResult.action`.
+ */
+export function pinAction(
+  pinnedRevision: bigint | undefined,
+  targetRevision: bigint,
+): PinActionPlan {
+  if (pinnedRevision === undefined) {
+    return { kind: 'pin', label: 'Create pin' };
+  }
+  if (pinnedRevision === targetRevision) {
+    return {
+      kind: 'renew',
+      label: `Renew pin on r${String(targetRevision)}`,
+    };
+  }
+  return {
+    kind: 'move',
+    label: `Move pin from r${String(pinnedRevision)} to r${String(targetRevision)}`,
+  };
+}
+
+export type PinExpiryTier = 'ok' | 'month' | 'week' | 'day' | 'expired';
+
+export type PinExpiry = {
+  /** Display days: ceiled while live, zero or negative once expired. */
+  readonly days: number;
+  readonly tier: PinExpiryTier;
+  /** The row's own words. Never colour-only: the tier is legible as text. */
+  readonly text: string;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * pinExpiry is the 30 / 7 / 1-day warning ladder #52 deferred to this surface.
+ *
+ * Two properties are load-bearing:
+ *
+ *  - **The tier is spelled, not coloured.** `!`, `!!`, `!!!` ride in the text,
+ *    so the escalation survives forced-colours and a screen reader.
+ *  - **An expired pin is not a dead pin.** Expiry never changes delivery: the
+ *    workload keeps receiving the pinned revision until its payload is
+ *    collected (#52), and a row that said "expired" and stopped there would
+ *    have someone chasing an outage that is not happening. The row says so.
+ */
+export function pinExpiry(expiresAt: string, now: Date): PinExpiry {
+  const remaining = new Date(expiresAt).getTime() - now.getTime();
+  if (remaining <= 0) {
+    return {
+      days: Math.floor(remaining / DAY_MS),
+      tier: 'expired',
+      text: 'expired — still delivering until its payload is collected',
+    };
+  }
+  const days = Math.ceil(remaining / DAY_MS);
+  if (remaining < DAY_MS) {
+    return { days, tier: 'day', text: '!!! expires today' };
+  }
+  if (remaining <= DAY_MS) {
+    return { days, tier: 'day', text: '!!! expires in 1 d' };
+  }
+  if (remaining <= 7 * DAY_MS) {
+    return { days, tier: 'week', text: `!! expires in ${String(days)} d` };
+  }
+  if (remaining <= 30 * DAY_MS) {
+    return { days, tier: 'month', text: `! expires in ${String(days)} d` };
+  }
+  return { days, tier: 'ok', text: `expires in ${String(days)} d` };
+}
+
+export type HistoryRetention = {
+  readonly mode: 'keep-if-either' | 'unlimited';
+  readonly maxAgeSeconds: number | null;
+  readonly lastRevisions: number | null;
+};
+
+export function toHistoryRetention(policy: {
+  readonly mode: 'keep-if-either' | 'unlimited';
+  readonly max_age_seconds?: number;
+  readonly last_revisions?: number;
+}): HistoryRetention {
+  return {
+    mode: policy.mode,
+    maxAgeSeconds: policy.max_age_seconds ?? null,
+    lastRevisions: policy.last_revisions ?? null,
+  };
+}
+
+export type HistoryPin = {
+  readonly id: string;
+  readonly workloadPrincipalId: string;
+  readonly revision: bigint;
+  readonly expiresAt: string;
+  readonly expired: boolean;
+  readonly schemaOverride: boolean;
+};
+
+/**
+ * pastNormalRetention mirrors the GC's own predicate, exactly.
+ *
+ * `keep-if-either` keeps a payload while EITHER dimension still covers it, so a
+ * payload is past normal retention only when BOTH are exceeded: older than the
+ * age window AND further back than the last-N window. `rankFromNewest` is
+ * 1-based, matching the sweep's `ROW_NUMBER() … ORDER BY revision DESC`, and
+ * `unlimited` never collects anything.
+ *
+ * ponytail: the predicate is duplicated from `ListEligibleSnapshotPayloads`
+ * rather than asked of the server, because there is no endpoint that answers
+ * "would this be collected". It is only ever used to decide how LOUD a release
+ * confirmation is — the server still refuses a collected payload by name — so a
+ * client that drifts warns wrongly, it does not delete wrongly. If a
+ * collectability endpoint ever lands, read it instead.
+ */
+export function pastNormalRetention(input: {
+  readonly policy: HistoryRetention;
+  readonly ageSeconds: number;
+  readonly rankFromNewest: number;
+}): boolean {
+  const { policy } = input;
+  if (policy.mode === 'unlimited' || policy.maxAgeSeconds === null || policy.lastRevisions === null) {
+    return false;
+  }
+  return input.ageSeconds > policy.maxAgeSeconds && input.rankFromNewest > policy.lastRevisions;
+}
+
+/**
+ * soleKeeperPinIds is the set of pins whose release makes a payload eligible
+ * for deletion by the next retention sweep.
+ *
+ * The prototype's iteration-4 verdict is that "holds payload" is jargon: the
+ * consequence language names the next retention sweep and permanent deletion.
+ * This is the predicate behind that wording.
+ *
+ * A pin is a sole keeper when its revision is past normal retention, its
+ * payload is STILL PRESENT (a collected revision has nothing left for a release
+ * to delete), and no other LIVE pin holds the same revision. An expired pin is
+ * never a sole keeper: GC only spares a payload for a pin with
+ * `expires_at > now`, so an expired one is already not what is keeping it.
+ *
+ * `revisions` must be the environment's whole history, newest first — the
+ * last-N window is a position in it.
+ */
+export function soleKeeperPinIds(input: {
+  readonly pins: readonly HistoryPin[];
+  readonly revisions: readonly HistoryRevision[];
+  readonly policy: HistoryRetention;
+  readonly now: Date;
+}): ReadonlySet<string> {
+  const live = input.pins.filter((pin) => new Date(pin.expiresAt).getTime() > input.now.getTime());
+  const keepersByRevision = new Map<bigint, number>();
+  for (const pin of live) {
+    keepersByRevision.set(pin.revision, (keepersByRevision.get(pin.revision) ?? 0) + 1);
+  }
+  const sole = new Set<string>();
+  for (const pin of live) {
+    if ((keepersByRevision.get(pin.revision) ?? 0) !== 1) {
+      continue;
+    }
+    const rankFromNewest = input.revisions.findIndex((entry) => entry.revision === pin.revision) + 1;
+    const target = input.revisions[rankFromNewest - 1];
+    if (rankFromNewest === 0 || target === undefined || !target.payloadPresent) {
+      continue;
+    }
+    const ageSeconds = (input.now.getTime() - new Date(target.publishedAt).getTime()) / 1_000;
+    if (pastNormalRetention({ policy: input.policy, ageSeconds, rankFromNewest })) {
+      sole.add(pin.id);
+    }
+  }
+  return sole;
+}
+
+export type HistoryImpactChange = {
+  readonly keyId: string;
+  readonly name: string;
+  readonly classification: 'config' | 'secret';
+  readonly operation: 'set' | 'unset';
+  readonly status: 'added' | 'edited' | 'removed' | 'not-edited';
+  readonly before?: string;
+  readonly after?: string;
+};
+
+export type RestoreSummary = {
+  readonly set: number;
+  readonly clear: number;
+  readonly total: number;
+  /** The prototype's summary chip line, prose only on the rows themselves. */
+  readonly chips: readonly string[];
+};
+
+/**
+ * restorePreviewSummary is the chip line above the impact rows.
+ *
+ * **Divergence from the locked prototype, named.** Iteration 2 gives the line a
+ * third chip, "n schema-blocked", because the prototype validated the restore
+ * at staging. The shipped model validates at PUBLISH — restore stages ordinary
+ * drafts and publish is the only authority (#52) — so a successful preview has
+ * no blocked rows to count. The schema refusal is still loud and still names
+ * the keys; it arrives on the publish leg, where the server decides it.
+ */
+export function restorePreviewSummary(
+  changes: readonly HistoryImpactChange[],
+): RestoreSummary {
+  const set = changes.filter((change) => change.operation === 'set').length;
+  const clear = changes.filter((change) => change.operation === 'unset').length;
+  const chips: string[] = [];
+  if (set > 0) {
+    chips.push(`${String(set)} set`);
+  }
+  if (clear > 0) {
+    chips.push(`${String(clear)} clear`);
+  }
+  if (chips.length === 0) {
+    chips.push('already matches — nothing to stage');
+  }
+  return { set, clear, total: changes.length, chips };
+}
+
+export type HistorySnapshotKey = {
+  readonly keyId: string;
+  readonly name: string;
+  readonly classification: 'config' | 'secret';
+};
+
+export type HistoryCurrentCell = {
+  readonly keyId: string;
+  readonly classification: 'config' | 'secret';
+  readonly set: boolean;
+};
+
+export type CeremonyKey = { readonly id: string; readonly name: string };
+
+/**
+ * restoreCeremonyUnit enumerates the secret keys a restore will decrypt.
+ *
+ * The server binds a purpose-bound ceremony to `(environment, sorted key ids)`
+ * over exactly this set, so the modal has to list exactly it or a
+ * single-decision window is spent against a binding that does not match. Both
+ * sides count and they are independent (#52): the HISTORICAL secret is read to
+ * stage it, and the CURRENT secret is read only to compare two set values — a
+ * restore-to-absent opens no current plaintext and must not demand it.
+ *
+ * ponytail: written-time STICKY bits are invisible to the browser; everything
+ * knowable client-side is unioned. Carry the sticky bit on `SnapshotKey` when
+ * the wire exposes it so the browser can exactly reproduce the server unit.
+ */
+export function restoreCeremonyUnit(input: {
+  readonly revisionKeys: readonly HistorySnapshotKey[];
+  readonly currentCells: readonly HistoryCurrentCell[];
+  readonly keyId: string | null;
+}): readonly CeremonyKey[] {
+  const currentByKey = new Map(input.currentCells.map((cell) => [cell.keyId, cell]));
+  return input.revisionKeys
+    .filter((key) => input.keyId === null || key.keyId === input.keyId)
+    .filter((key) => {
+      if (key.classification === 'secret') {
+        return true;
+      }
+      const current = currentByKey.get(key.keyId);
+      return current !== undefined && current.set && current.classification === 'secret';
+    })
+    .map((key) => ({ id: key.keyId, name: key.name }));
+}
+
+/**
+ * pinCeremonyUnit unions the pinned revision's and current catalogue's known
+ * secret classifications.
+ *
+ * Pinning a non-current revision is disclosure BY PROXY: it routes historical
+ * secret material to a workload, so the server takes `reveal-history` and one
+ * ceremony over the snapshot's secrets, and audits each of them against the
+ * pinned revision.
+ */
+export function pinCeremonyUnit(
+  revisionKeys: readonly HistorySnapshotKey[],
+  currentCells: readonly HistoryCurrentCell[],
+): readonly CeremonyKey[] {
+  const currentByKey = new Map(currentCells.map((cell) => [cell.keyId, cell]));
+  return revisionKeys
+    .filter(
+      (key) =>
+        key.classification === 'secret' ||
+        currentByKey.get(key.keyId)?.classification === 'secret',
+    )
+    .map((key) => ({ id: key.keyId, name: key.name }));
+}
+
+export type RetentionLine = {
+  readonly window: string;
+  readonly badge: 'inherits org' | 'custom';
+  readonly badgeTitle: string;
+};
+
+/**
+ * retentionLine is the drawer head's READ-ONLY retention statement.
+ *
+ * The locked prototype moved editing to the settings surfaces at iteration 6:
+ * the retention knob is `project-settings` / org-policy authority, and this
+ * surface reports the policy rather than owning it. So there is no stepper here
+ * and no write path — only the effective window, whether it is inherited, and a
+ * pointer at where it is changed (#60's surface).
+ */
+export function retentionLine(policy: HistoryRetention & {
+  readonly inherited: boolean;
+}): RetentionLine {
+  const badge = policy.inherited ? 'inherits org' : 'custom';
+  const badgeTitle = policy.inherited
+    ? 'this project has no retention of its own — it follows the org default and moves when the org value moves'
+    : 'this project overrode the org default — org changes no longer touch it';
+  if (policy.mode === 'unlimited' || policy.maxAgeSeconds === null || policy.lastRevisions === null) {
+    return {
+      window: 'values kept: unlimited — no payload is ever collected',
+      badge,
+      badgeTitle,
+    };
+  }
+  const days = Math.round(policy.maxAgeSeconds / (24 * 60 * 60));
+  return {
+    window:
+      `values kept: ${String(days)} d or the last ${String(policy.lastRevisions)} revisions, ` +
+      'whichever is longer, plus pinned',
+    badge,
+    badgeTitle,
+  };
+}
+
+/**
+ * pinSchemaOverrideOffered decides whether to put the override in front of the
+ * human at all.
+ *
+ * The checkbox is offered ONLY after the server has actually refused for a
+ * current-schema failure — never up front. An override that is always on screen
+ * is an override people tick to make an error go away; one that appears with
+ * the refusal it answers is a decision, and #52 records it as such (and only
+ * when it is actually consumed).
+ */
+export function pinSchemaOverrideOffered(detail: string | undefined): boolean {
+  if (detail === undefined || detail === '') {
+    return false;
+  }
+  // ponytail: replace this prose match with a structured schema-refusal code in
+  // the Error contract once the API exposes one. Until then this is a POSITIVE
+  // match on the three refusals `validateResolved` (internal/service/publish.go)
+  // can raise — a value rule, a presence rule, a key-group rule — which is the
+  // whole set `override_schema` exists to override. Anything else is refused for
+  // a reason an override cannot fix, and the checkbox stays away.
+  return (
+    /^value for "[^"]+" is invalid \(/.test(detail) ||
+    (detail.startsWith('key "') && detail.endsWith(': publish is vetoed')) ||
+    (detail.startsWith('key group ') && detail.endsWith("a group's presence is all-or-none"))
+  );
+}
+
+/** The service's own default pin lifetime (180 days), as a `<input type=date>` value. */
+export function defaultPinExpiry(now: Date): string {
+  const at = new Date(now.getTime());
+  at.setDate(at.getDate() + 180);
+  return localDateInputValue(at);
+}
+
+function localDateInputValue(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${String(date.getFullYear())}-${month}-${day}`;
+}
+
+/**
+ * Converts an `<input type=date>` local calendar day to its end-of-local-day
+ * instant. "Expires on" therefore includes the entire date the human chose.
+ */
+export function pinExpiryInstant(dateInputValue: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateInputValue);
+  if (match === null) {
+    throw new Error(`Invalid pin expiry date: ${dateInputValue}`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const instant = new Date(year, month - 1, day, 23, 59, 59, 999);
+  if (
+    instant.getFullYear() !== year ||
+    instant.getMonth() !== month - 1 ||
+    instant.getDate() !== day
+  ) {
+    throw new Error(`Invalid pin expiry date: ${dateInputValue}`);
+  }
+  return instant.toISOString();
+}
+
+export const SOLE_KEEPER_RELEASE_TITLE = 'Release sole-keeper pin';
+export const SOLE_KEEPER_RELEASE_BUTTON = 'Release pin — values become eligible for collection';
+
+export function soleKeeperReleaseConsequences(revision: bigint): string {
+  return (
+    `Releasing makes r${String(revision)}'s values eligible for collection at the next ` +
+    'retention sweep — they will then be deleted permanently.'
+  );
+}
+
+/** Human-readable workload identity with the complete id retained by the caller's title. */
+export function workloadLabel(id: string, names: ReadonlyMap<string, string>): string {
+  const name = names.get(id);
+  if (name !== undefined) {
+    return name;
+  }
+  const separator = id.indexOf('_');
+  return separator < 0 ? id : `${id.slice(0, separator + 1)}${id.slice(separator + 1, separator + 9)}…`;
+}
+
+export type PinHistoricalValue = {
+  readonly name: string;
+  readonly classification: 'config' | 'secret';
+  readonly revealed: boolean;
+  readonly value?: string;
+};
+
+export type PinLatestValue = {
+  readonly keyId: string;
+  readonly name: string;
+  readonly classification: 'config' | 'secret';
+  readonly set: boolean;
+  readonly revealed: boolean;
+  readonly value?: string;
+};
+
+export type PinComparison = {
+  readonly lines: readonly string[];
+  readonly unchangedConfigKeys: number;
+};
+
+/** Builds the pin comparison without ever comparing secret material. */
+export function pinComparedToLatest(input: {
+  readonly revision: bigint;
+  readonly revisionKeys: readonly HistorySnapshotKey[];
+  readonly historical: readonly PinHistoricalValue[];
+  readonly latest: readonly PinLatestValue[];
+  readonly laterRevisions: readonly HistoryRevision[];
+}): PinComparison {
+  const historicalByName = new Map(input.historical.map((value) => [value.name, value]));
+  const latestByKey = new Map(input.latest.map((value) => [value.keyId, value]));
+  const revisionKeyIDs = new Set(input.revisionKeys.map((key) => key.keyId));
+  const lines: string[] = [];
+  let unchangedConfigKeys = 0;
+
+  for (const historical of input.historical) {
+    if (!input.revisionKeys.some((key) => key.name === historical.name)) {
+      throw new Error(`Historical export returned unknown key ${historical.name}.`);
+    }
+    assertComparisonValue(historical, 'historical');
+  }
+  for (const latest of input.latest) {
+    if (latest.set) {
+      assertComparisonValue(latest, 'latest');
+    }
+  }
+
+  const keys = [
+    ...input.revisionKeys,
+    ...input.latest
+      .filter((latest) => !revisionKeyIDs.has(latest.keyId))
+      .map((latest) => ({
+        keyId: latest.keyId,
+        name: latest.name,
+        classification: latest.classification,
+      })),
+  ];
+
+  for (const key of keys) {
+    const historical = historicalByName.get(key.name);
+    const latest = latestByKey.get(key.keyId);
+    const hadHistorical = historical !== undefined;
+    const hasLatest = latest?.set === true;
+    if (!hadHistorical && !hasLatest) {
+      continue;
+    }
+    if (!hadHistorical) {
+      lines.push(`won't have ${latest?.name ?? key.name}`);
+      continue;
+    }
+    if (!hasLatest) {
+      lines.push(`keeps ${key.name}`);
+      continue;
+    }
+
+    const secret =
+      historical.classification === 'secret' ||
+      latest.classification === 'secret' ||
+      key.classification === 'secret';
+    if (secret) {
+      const latestWrite = input.laterRevisions.reduce<HistoryRevision | undefined>(
+        (latestRevision, revision) =>
+          revision.changedKeys.some((entry) => entry.keyId === key.keyId) &&
+          (latestRevision === undefined || revision.revision > latestRevision.revision)
+            ? revision
+            : latestRevision,
+        undefined,
+      );
+      lines.push(
+        latestWrite === undefined
+          ? `${key.name} not written since r${String(input.revision)}`
+          : `${key.name} written again since r${String(input.revision)} (r${String(latestWrite.revision)})`,
+      );
+      continue;
+    }
+
+    if (historical.value === latest.value) {
+      unchangedConfigKeys += 1;
+    } else {
+      lines.push(`${key.name} stays at ${historical.value} — latest: ${latest.value}`);
+    }
+  }
+
+  return { lines, unchangedConfigKeys };
+}
+
+function assertComparisonValue(
+  value: {
+    readonly name: string;
+    readonly classification: 'config' | 'secret';
+    readonly revealed: boolean;
+    readonly value?: string;
+  },
+  source: 'historical' | 'latest',
+): void {
+  if (value.classification === 'secret') {
+    if (value.revealed || value.value !== undefined) {
+      throw new Error(`${source} secret ${value.name} exposed material in a pin comparison.`);
+    }
+    return;
+  }
+  if (!value.revealed || value.value === undefined) {
+    throw new Error(`${source} config ${value.name} has no readable value for comparison.`);
+  }
+}
+
+const RELATIVE = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+/**
+ * relativeAge is the timeline's "when", in the platform's own words.
+ *
+ * `Intl.RelativeTimeFormat` rather than a hand-rolled ladder: it is already in
+ * every browser this SPA supports, it pluralises and it localises, and the three
+ * lines here only pick which unit to hand it.
+ */
+export function relativeAge(publishedAt: string, now: Date): string {
+  const seconds = (new Date(publishedAt).getTime() - now.getTime()) / 1_000;
+  if (Math.abs(seconds) < 60) {
+    return RELATIVE.format(0, 'second');
+  }
+  if (Math.abs(seconds) < 3_600) {
+    return RELATIVE.format(Math.round(seconds / 60), 'minute');
+  }
+  if (Math.abs(seconds) < 86_400) {
+    return RELATIVE.format(Math.round(seconds / 3_600), 'hour');
+  }
+  return RELATIVE.format(Math.round(seconds / 86_400), 'day');
+}

--- a/web/src/routes/useModalDialog.ts
+++ b/web/src/routes/useModalDialog.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/** Opens a native modal dialog and optionally puts focus on its first decision. */
+export function useModalDialog(
+  initialFocus?: RefObject<HTMLElement | null>,
+): RefObject<HTMLDialogElement | null> {
+  const dialog = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const element = dialog.current;
+    if (element !== null && !element.open) {
+      element.showModal();
+    }
+    initialFocus?.current?.focus();
+    return () => {
+      if (element?.open === true) {
+        element.close();
+      }
+    };
+  }, [initialFocus]);
+
+  return dialog;
+}

--- a/web/src/routes/useProtectedPublishCeremony.ts
+++ b/web/src/routes/useProtectedPublishCeremony.ts
@@ -1,20 +1,31 @@
 import { useRef, useState } from 'react';
 
 import { fetchRevealWindow, type EnvRef } from '../api/values.ts';
-import type { CeremonyRequest } from './Ceremony.tsx';
+import type { CeremonyPurpose, CeremonyRequest } from './Ceremony.tsx';
 
 export type ProtectedPublishTarget = {
   readonly environmentId: string;
   readonly environmentName: string;
   readonly keys: CeremonyRequest['keys'];
+  /**
+   * What the human is TOLD they are authorising. `publish` by default, because
+   * that is what publish and copy-into-protected share. The history drawer
+   * (#59) passes `restore` and `pin`: the server gates both as reveals over an
+   * enumerated secret-key unit, so the sequencing and refusal handling here are
+   * exactly the ones those two need, and re-deriving them would be a second
+   * place for the "prompt or not" decision to drift.
+   */
+  readonly purpose?: CeremonyPurpose;
 };
 
 /**
- * Runs the #21 ceremony once per protected destination before one guarded act.
+ * Runs the #21 ceremony once per named target before one guarded act.
  *
  * Copy and publish intentionally share this controller: copying into a
  * protected destination is the same publish-into-protected decision, so both
  * use purpose `publish` and must not drift in sequencing or refusal handling.
+ * Restore staging and historical pinning (#59) join them for the same reason —
+ * one place decides whether a live sliding window already covers the act.
  */
 export function useProtectedPublishCeremony(refData: Omit<EnvRef, 'environment'>) {
   const [request, setRequest] = useState<CeremonyRequest | null>(null);
@@ -50,7 +61,7 @@ export function useProtectedPublishCeremony(refData: Omit<EnvRef, 'environment'>
         void run(targets.slice(1), onComplete, failureMessage);
       };
       setRequest({
-        purpose: 'publish',
+        purpose: target.purpose ?? 'publish',
         environmentId: target.environmentId,
         environmentName: target.environmentName,
         keys: target.keys,

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -894,6 +894,7 @@ select {
   color: var(--tx);
   cursor: pointer;
   text-overflow: ellipsis;
+  text-decoration: none;
   white-space: nowrap;
 }
 
@@ -1212,6 +1213,7 @@ select {
 
   .matrix__key {
     min-height: var(--touch);
+    line-height: var(--touch);
   }
 
   .matrix__environment-picker input,

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1882,3 +1882,402 @@ select {
 .form--inline {
   max-width: none;
 }
+
+/* --- Revision history drawer (#59) ---------------------------------------- */
+
+/*
+ * The locked prototype's list + detail panes, rendered OVER the matrix rather
+ * than instead of it: the matrix stays addressable behind the drawer, which is
+ * what makes "rev N · history" feel like opening a drawer rather than leaving
+ * the surface. Below the chrome's own 800px breakpoint the two panes become one
+ * — list, then detail, with a back affordance — because a split 440px drawer is
+ * neither pane.
+ */
+.history {
+  position: fixed;
+  inset: 0 0 0 auto;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(640px, 100%);
+  padding: 16px;
+  border-left: 1px solid var(--line);
+  background: var(--bg-raise);
+  color: var(--tx);
+  overflow-y: auto;
+}
+
+.history__head {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.history__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.history__title h2 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.history__close {
+  margin-left: auto;
+}
+
+.history__current {
+  padding: 2px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  color: var(--tx-dim);
+  font-size: 11px;
+}
+
+.history__protected {
+  padding: 2px 7px;
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-badge);
+  color: var(--danger);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.history__tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.history__pending,
+.history__retention,
+.history__filter,
+.history__gate,
+.history__consumers,
+.history__pin-note,
+.history__empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+  color: var(--tx-dim);
+  font-size: 12.5px;
+}
+
+.history__retention,
+.history__filter,
+.history__gate {
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+}
+
+.history__badge {
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-badge);
+  color: var(--tx);
+  font-size: 11px;
+}
+
+.history__settings-pointer {
+  color: var(--tx-dim);
+}
+
+.history__panes {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  gap: 12px;
+  min-height: 0;
+}
+
+.history__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.history__row {
+  justify-content: flex-start;
+  width: 100%;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 0 10px;
+  text-align: left;
+  font-size: 12.5px;
+}
+
+.history__row[aria-current='true'] {
+  border-color: var(--accent);
+  background: color-mix(in oklch, var(--bg-raise), var(--accent) 12%);
+}
+
+.history__age {
+  margin-left: auto;
+  color: var(--tx-dim);
+  font-size: 11px;
+}
+
+.history__tag {
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-badge);
+  color: var(--tx-dim);
+  font-size: 10.5px;
+}
+
+.history__tag--collected {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.history__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.history__detail h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.history__detail h4 {
+  margin: 12px 0 0;
+  font-size: 13px;
+  color: var(--tx-dim);
+}
+
+.history__meta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 0;
+  font-size: 12px;
+}
+
+.history__meta dt {
+  color: var(--tx-dim);
+}
+
+.history__meta dd {
+  margin: 0;
+}
+
+.history__changes,
+.history__pins,
+.history__impact,
+.history__consequences {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.history__consequences {
+  padding-left: 18px;
+  list-style: disc;
+  color: var(--tx-dim);
+  font-size: 12.5px;
+}
+
+.history__changes li,
+.history__pins li,
+.history__impact li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+  font-size: 12.5px;
+}
+
+.history__change {
+  justify-content: flex-start;
+  padding: 0 10px;
+}
+
+.history__kind,
+.history__presence,
+.history__expiry,
+.history__warn {
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-badge);
+  color: var(--tx-dim);
+  font-size: 11px;
+}
+
+.history__pin-gap {
+  flex-basis: 100%;
+  color: var(--tx-dim);
+  line-height: 1.4;
+}
+
+/* Never colour alone: `!`, `!!` and `!!!` ride in the text the tier renders. */
+.history__expiry--month,
+.history__expiry--week,
+.history__expiry--day,
+.history__expiry--expired,
+.history__warn {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.history__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.history__impact-values {
+  margin-left: auto;
+  color: var(--tx-dim);
+}
+
+.history__chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.history__chips .count {
+  padding: 3px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  color: var(--tx);
+  font-size: 11.5px;
+}
+
+.history-sheet {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.history__pin-what {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+}
+
+.history__pin-what h3 {
+  margin: 0 0 6px;
+  font-size: 13px;
+}
+
+.history__pin-what ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--tx-dim);
+  font-size: 12.5px;
+}
+
+.history__field {
+  color: var(--tx-dim);
+  font-size: 13px;
+}
+
+.history__override {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history__comparison {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+}
+
+.history__comparison h3,
+.history__comparison p {
+  margin: 0;
+}
+
+.history__comparison h3 {
+  font-size: 13px;
+}
+
+.history__comparison-lines {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--tx-dim);
+  font-size: 12.5px;
+}
+
+.history-sheet input[type='date'] {
+  min-height: var(--touch);
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  background: var(--bg);
+  color: var(--tx);
+}
+
+.history-sheet select {
+  justify-content: flex-start;
+}
+
+.btn--danger {
+  border-color: var(--danger);
+  background: color-mix(in oklch, var(--bg-raise), var(--danger) 16%);
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.matrix__history-link {
+  min-height: var(--touch);
+  padding: 0 10px;
+  font-size: 11.5px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+@media (min-width: 801px) {
+  /* Both panes are on screen, so the back affordance has nothing to go back to. */
+  .history__back {
+    display: none;
+  }
+}
+
+@media (max-width: 800px) {
+  .history {
+    width: 100%;
+    border-left: none;
+  }
+
+  .history__panes {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .history:not(.history--detail) .history__detail,
+  .history--detail .history__list {
+    display: none;
+  }
+}


### PR DESCRIPTION
Closes #59 (parent #41 — do not close).

## What

Version history and rollback UI per the locked prototype `prototype/revision-history/` **iteration 6** (panes drawer from it-2 verdict b, pin clarity from it-3, pin = workload binding + sole-keeper language from it-4, read-only retention line from it-6):

- New locked surface **`history`** (`/orgs/:org/projects/:project/matrix/history`) — the matrix with its list + detail panes drawer open; environment tabs; per-key filter by immutable **key id** (`?key=`, deep-linkable); matrix **key name** opens that key's history (it-6), cells open the row editor.
- **Restore** (env-level and per-key) through `rollbackRevision` → impact preview (config before/after, secrets status-only) → in-drawer "Publish this restore" spending the exact preview token, or the ordinary matrix publish sheet (module-level token store scoped by exact version set; partial overlap refused by name before any request; stale token named). Schema-failing restore blocks loud naming the key (C5).
- **Pins**: create / renew (same revision, per the #52 taxonomy — named divergence from it-4's refused no-op) / move / release; sole-keeper release confirmation (GC-eligibility wording); 30/7/1-day expiry tiers as text (#52 F11); `override_schema` offered only after a current-schema refusal; visible behind-latest gap sentence; read-only compare-to-latest (`exportValues reveal:false`, config plaintext under `read`, secrets lineage write-presence only).
- Read-only **retention line** (effective window, inherits-org/custom badge, settings pointer — editing is #60's); others'-drafts summary; collected-payload gating naming the policy; reveal-history refusals name the keys.
- Mobile: panes collapse <800px with back affordance, matrix `inert`, focus management; every state text + ARIA; ≥44px targets.

## API (additive)

`payload_present` + `collected_policy` on **`listRevisions` rows only** (`Show` refuses collected payloads, so the detail would be invariantly true). `validateValue` now raises a caller-safe detail so a schema-failing restore/publish names the key. Go + TS clients regenerated; isolation test asserts the bit survives a real GC sweep on both engines.

## Tests

- `history-state.ts` pure seam + `api/history.ts` boundary (zod refinements refuse secret material) — vitest 152/152.
- `e2e/flows/history.spec.ts`, registry surface `history`, both viewport projects, dark + light pinned assertion set; C5 proven at the wire (rollback token == publish `preview_token`, exact version set); registry run-log closure is now **theme-aware** (exposed and fixed a login-flow light-theme gap).
- Full Playwright 157 passed / 1 by-design skip; `go test ./...` 2215/45; TS client regen diff-clean.

## Review

Two-axis Standards + Spec, plus the capped three-round native Codex (`gpt-5.6-sol`, high) adversarial loop split by concern (Go/API, seam, drawer, e2e). R1 ≈30 findings → fixed/dispositioned with evidence; R2 6 partials → fixed; R3 Go CLEAN, two post-cap items (opener snapshot, ceremony-state secret negatives) applied and re-verified. Details + dispositions in `docs/handoff/59-history-drawer.md` (decisions 1–16, deferred-by-name: rev↔rev diff needs an endpoint; structured schema-refusal code; sticky written-time classification is the one client-invisible ceremony-unit gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789742134&installation_model_id=432348&pr_number=173&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F173&signature=5b20649d23c526876b793e40d9ad94336f630b7291556029e31e668f9d02fc60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->