### PR TITLE
ci: install kind as a pinned binary — repo allowlist blocks helm/kind-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,12 +592,23 @@ jobs:
           restore-keys: |
             go-k8s-e2e-${{ runner.os }}-${{ hashFiles('go.sum') }}-
             go-k8s-e2e-${{ runner.os }}-
-      # install_only: the runner script creates and deletes the cluster itself,
-      # so kind-action provides only the pinned `kind` binary on PATH.
-      - name: Install kind
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          install_only: true
+      # A pinned, checksummed binary download (the shellcheck pattern above):
+      # the repository's Actions allowlist is deliberately narrow, and kind is
+      # a single static binary — no third-party action needed.
+      - name: Install kind (pinned archive)
+        env:
+          KIND_VERSION: v0.32.0
+          KIND_SHA256: 50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54
+        run: |
+          binary="$RUNNER_TEMP/kind"
+          curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error \
+            --retry 4 --retry-delay 2 --retry-all-errors \
+            "https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/kind-linux-amd64" \
+            --output "$binary"
+          printf '%s  %s\n' "$KIND_SHA256" "$binary" | sha256sum --check --strict
+          chmod +x "$binary"
+          mv "$binary" /usr/local/bin/kind
+          kind version
       - name: Operator kind e2e
         run: ./scripts/ci/k8s-e2e.sh
       - name: Save k8s-e2e Go cache


### PR DESCRIPTION
Follow-up to #176. The push run of `ci` on `58b93aa` ended in `startup_failure` (zero jobs): the repository's Actions permissions are `selected` with a narrow pattern allowlist, and the new `k8s-e2e` job referenced `helm/kind-action`, which is not on it. PRs execute the base branch's `ci.yml`, so the PR gate could not catch this — it surfaced on the first main run, as flagged in #176's bootstrap note.

Fix: drop the third-party action and install kind as a pinned, sha256-checked binary download (the existing shellcheck pattern), keeping the deliberately narrow allowlist intact. `actionlint` clean; the k8s-e2e job itself still first executes on the post-merge push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768288&installation_model_id=432348&pr_number=177&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F177&signature=e9a68ea46d7c15daf3a259e0a5695846b780c1b8dd177a4445082c7abf21d350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->