### PR TITLE
feat(import): interactive wizard — phase-1 authoring frontend (#112)

### DIFF
--- a/docs/handoff/112-import-wizard.md
+++ b/docs/handoff/112-import-wizard.md
@@ -1,0 +1,67 @@
+# #112 — Interactive import wizard (phase-1 authoring frontend)
+
+Parent: #41. ADR: `docs/adr/import-paths.md`. Serializations: `docs/spec/api-cli-spellings.md` § 3
+(wizard interaction states + mapping template + run manifest). Builds on #68 (framework +
+file sources), #69 (live connectors), #70 (definitions git flow).
+
+The wizard is the **interactive authoring frontend for the mapping template**: it walks the
+source structure and target mapping, records every choice into a `Template`, then runs the
+**same plan path replay uses**. Byte-identity between a wizard session and an equivalent
+flag/replay run (acceptance criterion 1) is therefore structural, not tested-in.
+
+## Locked design decision: created environments are tokenless-by-design
+
+A wizard session may fan out across target environments, **including ones it will create**
+(declared up front, ADR § Targeting and hierarchy creation). The run manifest is a phase-2
+precondition binding a **server-minted occurrence token per (key, environment)**. A
+to-be-created env has no id at phase 1 (phase 1 never writes), so no token can exist.
+
+Decision (Fable advisor, 2026-08-20; Option A / honest tokenless path):
+
+- Created envs carry **zero occurrence rows**. They are named (not id'd) in
+  `target.environments` and `phase_completion.imported`.
+- Created envs sit **outside the precondition entirely**: at phase 2 the CLI invokes
+  `values import` for a created env with `Precondition = nil` — NOT a degraded precondition
+  (`checkPrecondition` rejects every key a manifest reviewed none of). They get the locked
+  manifest-less strict-import semantics (closed schema + skip-by-default).
+- Phase 2 for a created env: `definitions apply` creates it (bundle carries
+  `create environment <name>` lines) → CLI resolves name→id via the `read@project` structure
+  read → `values import` runs strict, no precondition. The server only ever receives real ids.
+- **No server change.** Rejected Option B (server mints name-scoped tokens): a name is mutable
+  and reusable, reintroducing the binding instability the id-scoped HMAC
+  (`crypto/token.go scopedOccurrenceKey`) exists to kill, and needing a client-authored
+  "created by this run" claim = the forgeable gap #68 closed. Its verification reduces to
+  "still absent", which skip-by-default already provides.
+
+Safety: a created env has no `set` bucket at review, so no overwrite consent can exist for it;
+a value set in the apply→import window is **skipped-and-listed, never clobbered**. Accepted
+residual, stated openly: that movement is skipped, not rejected-by-name.
+
+## Build plan
+
+1. **Plan-layer refactor (pure, TDD, server-free).** `BuildProjectPlan(ProjectPlanInput)`:
+   N per-env inputs → one `Template`, one project-wide `definitions.Bundle`, per-env
+   `ValuesFile`, one multi-env `Manifest`. `BuildPlan` (single env) becomes a thin N=1 wrapper
+   so flag/replay bytes are unchanged and byte-identity is structural.
+2. **Reconciliation** — project-scoped identity/type/classification/folder per key. Type
+   suggestion computed across all envs' values (ADR § Typing). Conflicts are wizard-time
+   prompts; a reconciled template replays without conflict; flag mode is single-env so never
+   reconciles.
+3. **Lift the multi-env replay refusal** in `cli/importer.go`, routed through the planner.
+4. **Wizard engine** (9 states, ADR/spec §3) against a `Prompter` interface + injected source
+   and presence readers; server/source calls stay in the CLI. TDD with a scripted prompter.
+5. **CLI TTY entry** (flip the ExitRefused branch; no-TTY error unchanged) + aggregate session
+   bound (30 min / 100 MiB, ops catalogue row).
+6. **Serialization** — `Manifest.Target.Environments` → objects `{id|null, name, create}`;
+   created-env values file `environment:null` + `environment_name`; `phase_completion.imported`
+   keyed by name for creates. `api-cli-spellings.md` §3 updated alongside.
+7. **Tests** — byte-identity goldens (scripted wizard vs flag per connector fixture; multi-env
+   session → replay of its own template), multi-env conformance, no-TTY regression, aggregate
+   bound.
+
+## Note: ops-catalogue vs code bound divergence (pre-existing, do not fix here)
+
+`docs/spec/ops-catalogue.md` lists 10 MiB / 50 MiB / 50 000 / 10 min where
+`internal/importer/importer.go` uses 4 MiB / 16 MiB / 5 000 / 60 s. Pre-existing on main;
+flagged, not changed in this ticket. Wizard aggregate bound cites the catalogue's
+`Wizard session aggregate` row (30 min / 100 MiB).

--- a/docs/handoff/112-import-wizard.md
+++ b/docs/handoff/112-import-wizard.md
@@ -80,18 +80,38 @@ leave a stale token.
 every environment a session touched, but each `values import` is per environment, and importing
 B must not present A's occurrences (A's own import already advanced them).
 
-## Known limitations (for the reviewer / future work)
+## Multi-environment model: one source fanned (ADR "only presence varies")
 
-- **Per-environment source slices in replay.** The wizard reads a source per target environment
-  (so type suggestions can span differing per-env values). The mapping template records ONE
-  `scope` (the first environment's read); a multi-environment REPLAY fans that one recorded source
-  over every environment it names (presence varies, values are the one read's). A template whose
-  environments used genuinely different per-env source files (e.g. Infisical per-slug exports) is
-  not fully reproducible from the single recorded scope. The regenerated manifest is a different
-  run manifest, which the ADR already treats as visible, not silent.
-- **Plaintext-on-disk warning** names the emitted values files but not the wizard's per-environment
-  source export files (flag mode names its single `--file`). A follow-up could thread the read
-  source paths into `reportProject`.
+The wizard reads the source **once** and maps that one read onto one or more target environments
+(existing and/or created). Keys/types/classifications are project-scoped and reconciled once; only
+presence — the buckets and the values written — varies per environment. This is what makes a
+multi-environment session **faithfully replayable**: the template records one `scope`, and replay
+re-reads that one source and fans it the same way, so wizard and replay agree.
+
+A genuinely per-environment-different-source migration (e.g. Infisical staging-slug vs prod-slug
+with different values, which is what would exercise interactive type/classification RECONCILIATION
+conflicts) is **not** covered by v1: run the wizard once per slice. The reconciliation machinery
+still enforces one identity/type/classification/folder per key in the bundle, and the planner
+**refuses** any cross-environment conflict non-interactively (folder conflict → `CodeIncompatible`),
+which is the "refused in replay" half of the acceptance criterion. Future work: record per-environment
+scope in the template to author true multi-source reconciliation interactively.
+
+## Codex review R1 → fixes applied (this branch)
+
+R1 (gpt-5.6-sol high) returned CHANGES; all findings fixed:
+- CRITICAL: `--overwrite` refused for a created-environment (tokenless) values file, before any
+  server contact; wizard refuses `create <existing-env-name>`.
+- HIGH: multi-env replay no longer imports one source's values into every environment (the wizard
+  now uses the one-source-fan model above, so replay reproduces it).
+- HIGH: `values import` requires the target environment to be named in the manifest before slicing
+  its precondition.
+- HIGH: the wizard records an existing non-default declaration (config, or a non-string type) as
+  reviewed consent, so a declared key no longer hits a spurious incompatible refusal.
+- HIGH: folder-conflict-prompt corruption is mooted (one source cannot conflict); the planner keeps
+  the folder-conflict refusal as the safety net for hand-edited templates.
+- MEDIUM: mixed definitions revisions across the session are refused; partial multi-values-file
+  writes are fully cleaned up (no orphan plaintext); the session deadline is checked before emission.
+- The plaintext-on-disk warning now names the wizard's source export file alongside the values files.
 
 ## Note: ops-catalogue vs code bound divergence (pre-existing, do not fix here)
 

--- a/docs/handoff/112-import-wizard.md
+++ b/docs/handoff/112-import-wizard.md
@@ -59,6 +59,40 @@ residual, stated openly: that movement is skipped, not rejected-by-name.
    session → replay of its own template), multi-env conformance, no-TTY regression, aggregate
    bound.
 
+## Status (all landed on this branch)
+
+1. ✅ `BuildProjectPlan` multi-env planner; `BuildPlan` is the N=1 wrapper (byte-identity structural).
+2. ✅ Reconciliation: one class/type/classification/folder per key; folder conflict refused.
+3. ✅ Multi-env replay refusal lifted; routed through the planner.
+4. ✅ Wizard engine (nine states) + `SuggestType`; scripted-prompter tests incl. byte-identity.
+5. ✅ CLI TTY entry, terminal prompter, WizardHost, aggregate session bound (decoded bytes in
+   the engine; wall clock via the session context).
+6. ✅ Created environments: `create environment` bundle lines, `target.created_environments`,
+   `environment_name` values file, tokenless phase-2 path in `values import`.
+7. ✅ Conformance `import_multi_environment_fan_out`; no-TTY regression; prompter tests.
+
+Two presence reads in the wizard: the first (default intent) discovers which keys are already
+declared so classification/type review skips them; the second (final intent) mints the
+occurrence tokens the manifest records, so a downgrade or an accepted type suggestion cannot
+leave a stale token.
+
+`values import` slices the run-manifest precondition to the target environment: a manifest spans
+every environment a session touched, but each `values import` is per environment, and importing
+B must not present A's occurrences (A's own import already advanced them).
+
+## Known limitations (for the reviewer / future work)
+
+- **Per-environment source slices in replay.** The wizard reads a source per target environment
+  (so type suggestions can span differing per-env values). The mapping template records ONE
+  `scope` (the first environment's read); a multi-environment REPLAY fans that one recorded source
+  over every environment it names (presence varies, values are the one read's). A template whose
+  environments used genuinely different per-env source files (e.g. Infisical per-slug exports) is
+  not fully reproducible from the single recorded scope. The regenerated manifest is a different
+  run manifest, which the ADR already treats as visible, not silent.
+- **Plaintext-on-disk warning** names the emitted values files but not the wizard's per-environment
+  source export files (flag mode names its single `--file`). A follow-up could thread the read
+  source paths into `reportProject`.
+
 ## Note: ops-catalogue vs code bound divergence (pre-existing, do not fix here)
 
 `docs/spec/ops-catalogue.md` lists 10 MiB / 50 MiB / 50 000 / 10 min where

--- a/docs/spec/api-cli-spellings.md
+++ b/docs/spec/api-cli-spellings.md
@@ -129,12 +129,15 @@ Phase 2 is the existing pipeline, no new grammar: `definitions plan --file` → 
   "source_versions": [ { "key": "<KEY>", "environment": "<environment-id>",
                          "version": "<resourceVersion | secret_version>" } ],
   "target": { "project": "<project-id>", "environments": ["<environment-id>"],
+              "created_environments": ["<environment-name>"],
               "keys": [ { "name": "<KEY>", "id": "<key-id-or-null>" } ] },
   "definitions_revision": 0,
   "occurrences": [ { "key": "<KEY>", "environment": "<environment-id>", "token": "<server-minted opaque>" } ],
-  "phase_completion": { "authored": true, "applied": false, "imported": { "<environment-id>": false } }
+  "phase_completion": { "authored": true, "applied": false, "imported": { "<environment-id-or-name>": false } }
 }
 ```
+
+**Created environments are tokenless.** A wizard session may fan out across target environments including ones it will create (state 3), declared up front as `create environment` lines in the definitions bundle and named — not id'd — in `target.created_environments` (`omitempty`; absent when the session creates nothing). A created environment has no id at phase 1 (phase 1 never writes), so it carries **no occurrence row** and sits **outside the phase-2 precondition**: its per-environment values file carries `environment_name` in place of `environment`, and `values import` resolves the name to its id after `definitions apply`, binds by name, and attaches no precondition — a precondition that reviewed no occurrence for it would reject every key. Its safety rests on the locked manifest-less strict-import path (closed schema + skip-by-default); the accepted residual is that movement in the apply→import window is skipped-and-listed, not rejected-by-name. `phase_completion.imported` keys created environments by name and existing ones by id. Detail: [import-paths.md](../adr/import-paths.md), `docs/handoff/112-import-wizard.md`.
 
 **Connector fixture contracts** (fixed here; byte content pinned when each connector is built): per connector, (a) true-positive mapping fixtures for its named capture format, (b) adversarial-parser fixtures (malformed/oversized/decompression-bomb inputs failing loudly at the named bound), (c) hostile-provider-error fixtures (errors sanitized structurally: keys/paths/bounds/codes, never content). Recorded in [open-items.md](./open-items.md) as an implementation-pinned moment.
 

--- a/docs/spec/api-cli-spellings.md
+++ b/docs/spec/api-cli-spellings.md
@@ -133,9 +133,12 @@ Phase 2 is the existing pipeline, no new grammar: `definitions plan --file` → 
               "keys": [ { "name": "<KEY>", "id": "<key-id-or-null>" } ] },
   "definitions_revision": 0,
   "occurrences": [ { "key": "<KEY>", "environment": "<environment-id>", "token": "<server-minted opaque>" } ],
+  "values_digests": [ { "environment": "<environment-id-or-name>", "digest": "sha256:…" } ],
   "phase_completion": { "authored": true, "applied": false, "imported": { "<environment-id-or-name>": false } }
 }
 ```
+
+**`values_digests` binds each environment's values file to this run by content.** The occurrence tokens bind the reviewed STATE (that it has not moved), not the plaintext an operator is about to write — and a created environment has no token at all. Without a content binding, two runs targeting the same `(project, environment)` could be mispaired: run B's values imported under run A's manifest, or run A's completion marker stamped for run B. So the manifest records the digest of each writing environment's canonical values file (id for existing environments, name for created ones), and `values import` refuses a values file whose recomputed digest does not match. The digest is deterministic, so a wizard session and a flag run with coinciding choices record the same one.
 
 **Created environments are tokenless.** A wizard session may fan out across target environments including ones it will create (state 3), declared up front as `create environment` lines in the definitions bundle and named — not id'd — in `target.created_environments` (`omitempty`; absent when the session creates nothing). A created environment has no id at phase 1 (phase 1 never writes), so it carries **no occurrence row** and sits **outside the phase-2 precondition**: its per-environment values file carries `environment_name` in place of `environment`, and `values import` resolves the name to its id after `definitions apply`, binds by name, and attaches no precondition — a precondition that reviewed no occurrence for it would reject every key. Its safety rests on the locked manifest-less strict-import path (closed schema + skip-by-default); the accepted residual is that movement in the apply→import window is skipped-and-listed, not rejected-by-name. `phase_completion.imported` keys created environments by name and existing ones by id. Detail: [import-paths.md](../adr/import-paths.md), `docs/handoff/112-import-wizard.md`.
 

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -1,0 +1,452 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/disclose"
+	"github.com/Hikyo-Org/hikyo/internal/importer"
+)
+
+// The interactive import wizard's CLI surface (import-paths ADR § Entry modes).
+// `hikyo import` with no source arguments on a TTY enters it. The engine lives in
+// internal/importer and is I/O-agnostic; this file supplies the impure surface —
+// the terminal, the connector reads, the environment list and the server
+// presence read — and drives artifact emission for the multi-environment plan
+// the engine returns.
+
+// runImportWizard resolves the target project (which must pre-exist), then walks
+// the interactive session under the aggregate session deadline and emits the
+// project's artifacts.
+func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) error {
+	st, err := NewState(ios.Env)
+	if err != nil {
+		return err
+	}
+	client, _, resolved, err := authenticatedTarget(st, ios, c)
+	if err != nil {
+		return err
+	}
+	projectBasePath, err := projectBase(resolved)
+	if err != nil {
+		return err
+	}
+	projectID, err := resolved.Require(DimProject)
+	if err != nil {
+		return err
+	}
+
+	// The whole session runs under the aggregate wall-clock bound; each connector
+	// read and each presence read inherits it.
+	ctx, cancel := context.WithTimeout(ctx, importer.SessionDeadline)
+	defer cancel()
+
+	host := &cliWizardHost{
+		terminalPrompter: newTerminalPrompter(ios),
+		ctx:              ctx, client: client, projectBase: projectBasePath,
+	}
+	plan, err := importer.Wizard(host, projectID)
+	if err != nil {
+		return failf(ExitRefused, "%v", err)
+	}
+	valuesPaths, err := writeProjectArtifacts(ios, outDir, plan)
+	if err != nil {
+		return err
+	}
+	return reportProject(ios, plan, outDir, valuesPaths)
+}
+
+// cliWizardHost is the impure WizardHost the engine calls. It never prints an
+// artifact to stdout — prompts go to stderr through the prompter, and the values
+// files go through the secret-file discipline in writeProjectArtifacts.
+type cliWizardHost struct {
+	*terminalPrompter
+	ctx         context.Context
+	client      *Client
+	projectBase string
+}
+
+// ReadSource performs one connector read for a gathered selector, mapping the
+// wizard's Selector onto the same Run/RunLive the flag mode uses.
+func (h *cliWizardHost) ReadSource(source string, sel importer.Selector) (importer.SourceRead, error) {
+	if sel.Live {
+		res, err := importer.RunLive(h.ctx, source, importer.LiveInput{
+			Context: sel.Context, Namespace: sel.Namespace, Name: sel.Name,
+			Mount: sel.Mount, Path: sel.Path, KVVersion: sel.KVVersion,
+		})
+		if err != nil {
+			return importer.SourceRead{}, err
+		}
+		return importer.SourceRead{Result: res, EnvSlug: sel.EnvSlug}, nil
+	}
+	in, err := importer.ReadExport(sel.File)
+	if err != nil {
+		return importer.SourceRead{}, err
+	}
+	in.EnvSlug = sel.EnvSlug
+	res, err := importer.Run(h.ctx, source, in)
+	if err != nil {
+		return importer.SourceRead{}, err
+	}
+	return importer.SourceRead{Result: res, FileDigest: importer.Digest(in.Data), EnvSlug: sel.EnvSlug}, nil
+}
+
+// ExistingEnvironments lists the project's environments the actor can read.
+func (h *cliWizardHost) ExistingEnvironments() ([]importer.NamedEnv, error) {
+	var list apigen.EnvironmentList
+	if err := h.client.Do(h.ctx, http.MethodGet, h.projectBase+"/environments", nil, &list); err != nil {
+		return nil, err
+	}
+	out := make([]importer.NamedEnv, 0, len(list.Items))
+	for _, e := range list.Items {
+		out = append(out, importer.NamedEnv{ID: string(e.Id), Name: e.Name})
+	}
+	return out, nil
+}
+
+// Presence reads the server's occurrence answer for one existing environment.
+func (h *cliWizardHost) Presence(envID string, candidates []importer.PlannedCandidate) (importer.ServerState, error) {
+	var occurrences apigen.ValueOccurrenceList
+	if err := h.client.Do(h.ctx, http.MethodPost,
+		h.projectBase+"/environments/"+url.PathEscape(envID)+"/values/occurrences",
+		apigen.ValueOccurrencesRequest{Candidates: wireImportCandidates(candidates)}, &occurrences); err != nil {
+		return importer.ServerState{}, err
+	}
+	return importer.ServerState{
+		Environment:         envID,
+		DefinitionsRevision: occurrences.DefinitionsRevision,
+		Keys:                occurrenceKeys(occurrences),
+	}, nil
+}
+
+// occurrenceKeys turns the server's occurrence list into the planner's per-key
+// state. Shared with flag mode so the two cannot read the response differently.
+func occurrenceKeys(occurrences apigen.ValueOccurrenceList) []importer.KeyState {
+	keys := make([]importer.KeyState, 0, len(occurrences.Items))
+	for _, k := range occurrences.Items {
+		row := importer.KeyState{Name: k.Name, Declared: k.Declared, Set: k.Set, Token: k.Token}
+		if k.KeyId != nil {
+			row.ID = *k.KeyId
+		}
+		if k.Classification != nil {
+			row.Classification = string(*k.Classification)
+		}
+		if k.DeclaredType != nil {
+			row.Type = *k.DeclaredType
+		}
+		keys = append(keys, row)
+	}
+	return keys
+}
+
+// runReplayMultiEnv replays a multi-environment template: it fans the one
+// recorded source read over every environment the template names, reads presence
+// per existing environment, and emits the one project-wide bundle and manifest
+// plus a values file per environment. A conflict a wizard would have resolved is
+// refused non-interactively by the planner.
+func runReplayMultiEnv(ctx context.Context, ios IO, client *Client, projectBase, projectID, source string,
+	result importer.Result, fileDigest, envSlug, sourcePath string, template *importer.Template,
+	candidates []importer.PlannedCandidate, outDir string) error {
+	in := importer.ProjectPlanInput{
+		Source: source, Project: projectID, Template: template,
+	}
+	for _, envMap := range template.Environments {
+		env := importer.EnvInput{
+			Records: result.Records, Skipped: result.Skipped, Scope: result.Scope,
+			FileDigest: fileDigest, SourceIdentity: result.Identity,
+		}
+		if envMap.Source != nil {
+			env.EnvSlug = *envMap.Source
+		} else {
+			env.EnvSlug = envSlug
+		}
+		if envMap.Create {
+			env.Create = true
+			env.EnvName = envMap.Target
+		} else {
+			env.EnvID = envMap.Target
+			var occurrences apigen.ValueOccurrenceList
+			if err := client.Do(ctx, http.MethodPost,
+				projectBase+"/environments/"+url.PathEscape(envMap.Target)+"/values/occurrences",
+				apigen.ValueOccurrencesRequest{Candidates: wireImportCandidates(candidates)}, &occurrences); err != nil {
+				return err
+			}
+			env.Keys = occurrenceKeys(occurrences)
+			in.DefinitionsRevision = occurrences.DefinitionsRevision
+		}
+		in.Envs = append(in.Envs, env)
+	}
+	plan, err := importer.BuildProjectPlan(in)
+	if err != nil {
+		return failf(ExitRefused, "%v", err)
+	}
+	valuesPaths, err := writeProjectArtifacts(ios, outDir, plan)
+	if err != nil {
+		return err
+	}
+	return reportProject(ios, plan, outDir, valuesPaths)
+}
+
+// ---------------------------------------------------------------------------
+// Terminal prompter
+// ---------------------------------------------------------------------------
+
+// terminalPrompter is the importer.Prompter over the real terminal: prompts and
+// notices go to stderr (stdout carries the artifact table alone), answers are
+// read from stdin.
+type terminalPrompter struct {
+	in  *bufio.Reader
+	out interface{ Write([]byte) (int, error) }
+}
+
+func newTerminalPrompter(ios IO) *terminalPrompter {
+	return &terminalPrompter{in: bufio.NewReader(ios.Stdin), out: ios.Stderr}
+}
+
+func (p *terminalPrompter) Notice(msg string) { fmt.Fprintf(p.out, "%s\n", msg) }
+
+func (p *terminalPrompter) Confirm(question string, def bool) (bool, error) {
+	hint := "[y/N]"
+	if def {
+		hint = "[Y/n]"
+	}
+	fmt.Fprintf(p.out, "%s %s ", question, hint)
+	line, err := p.readLine()
+	if err != nil {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "":
+		return def, nil
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return def, nil
+	}
+}
+
+func (p *terminalPrompter) Choose(question string, options []string, def int) (int, error) {
+	fmt.Fprintf(p.out, "%s\n", question)
+	for i, o := range options {
+		fmt.Fprintf(p.out, "  %d) %s\n", i+1, o)
+	}
+	fmt.Fprintf(p.out, "choice [%d]: ", def+1)
+	line, err := p.readLine()
+	if err != nil {
+		return 0, err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(line)
+	if err != nil || n < 1 || n > len(options) {
+		return 0, failf(ExitUsage, "%q is not one of the %d options", line, len(options))
+	}
+	return n - 1, nil
+}
+
+func (p *terminalPrompter) Line(question, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(p.out, "%s [%s] ", question, def)
+	} else {
+		fmt.Fprintf(p.out, "%s ", question)
+	}
+	line, err := p.readLine()
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if line == "" {
+		return def, nil
+	}
+	return line, nil
+}
+
+func (p *terminalPrompter) readLine() (string, error) {
+	line, err := p.in.ReadString('\n')
+	if err != nil && line == "" {
+		return "", failf(ExitUsage, "the import wizard reached end of input before the session finished")
+	}
+	return line, nil
+}
+
+// ---------------------------------------------------------------------------
+// Multi-environment artifact emission
+// ---------------------------------------------------------------------------
+
+// writeProjectArtifacts emits the three committable artifacts once and one
+// values file per environment that writes anything. Every values path is
+// preflighted before anything is written, and the committable artifacts are
+// created O_EXCL with a cleanup that covers every file this run created — a
+// collision on any artifact must not leave a half-authored migration on disk.
+func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([]string, error) {
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return nil, failf(ExitRefused, "preparing the output directory: %v", err)
+	}
+
+	type valuesTarget struct {
+		path   string
+		file   importer.ValuesFile
+		envRef string
+	}
+	var valuesTargets []valuesTarget
+	for _, env := range plan.Envs {
+		if !env.HasValues {
+			continue
+		}
+		ref := env.EnvID
+		if env.Create {
+			ref = env.EnvName
+		}
+		valuesTargets = append(valuesTargets, valuesTarget{
+			path: filepath.Join(outDir, "values-"+ref+".json"), file: env.Values, envRef: ref,
+		})
+	}
+
+	// Preflight every values path before writing anything.
+	for _, vt := range valuesTargets {
+		deliver := disclose.Options{OutputFile: vt.path, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
+		if err := disclose.Preflight(deliver); err != nil {
+			return nil, failf(ExitRefused, "the values file for %s has nowhere to go: %v", vt.envRef, err)
+		}
+	}
+
+	bundleBody, err := definitions.Encode(plan.Bundle)
+	if err != nil {
+		return nil, err
+	}
+	mappingBody, err := importer.Encode(plan.Template)
+	if err != nil {
+		return nil, err
+	}
+	manifestBody, err := importer.Encode(plan.Manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var created []string
+	cleanup := func() {
+		for _, path := range created {
+			_ = os.Remove(path)
+		}
+	}
+	for _, artifact := range []struct {
+		name string
+		body []byte
+	}{
+		{bundleFile, bundleBody},
+		{mappingFile, mappingBody},
+		{manifestFile, manifestBody},
+	} {
+		path := filepath.Join(outDir, artifact.name)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			cleanup()
+			if errors.Is(err, fs.ErrExist) {
+				return nil, failf(ExitRefused,
+					"%s already exists: import never overwrites an artifact a human may have reviewed", path)
+			}
+			return nil, failf(ExitRefused, "writing %s: %v", path, err)
+		}
+		created = append(created, path)
+		if _, err := f.Write(artifact.body); err != nil {
+			f.Close()
+			cleanup()
+			return nil, failf(ExitRefused, "writing %s: %v", path, err)
+		}
+		if err := f.Close(); err != nil {
+			cleanup()
+			return nil, failf(ExitRefused, "writing %s: %v", path, err)
+		}
+	}
+
+	var valuesPaths []string
+	for _, vt := range valuesTargets {
+		body, err := importer.Encode(vt.file)
+		if err != nil {
+			cleanup()
+			return nil, err
+		}
+		if len(body) > importer.MaxFileBytes {
+			cleanup()
+			return nil, failf(ExitRefused,
+				"the values file for %s would be %d bytes, exceeding the %d-byte per-file cap; split the import",
+				vt.envRef, len(body), importer.MaxFileBytes)
+		}
+		deliver := disclose.Options{OutputFile: vt.path, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
+		if _, err := disclose.Emit("values for "+vt.envRef, strings.TrimRight(string(body), "\n"), deliver); err != nil {
+			cleanup()
+			return nil, failf(ExitRefused, "writing the values file for %s: %v", vt.envRef, err)
+		}
+		valuesPaths = append(valuesPaths, vt.path)
+	}
+	return valuesPaths, nil
+}
+
+// reportProject prints the session summary: renames, near misses, per-environment
+// buckets, the artifact table, and the plaintext-still-on-disk warning.
+func reportProject(ios IO, plan *importer.ProjectPlan, outDir string, valuesPaths []string) error {
+	w := ios.Stderr
+	for _, r := range plan.Renames {
+		fmt.Fprintf(w, "rename: %s -> %s (%s)\n",
+			importer.QuoteName(r.From), importer.QuoteName(r.To), r.Transform)
+	}
+	for _, n := range plan.NearMisses {
+		fmt.Fprintf(w, "near miss: %s is one edit from the declared key %s\n",
+			importer.QuoteName(n.Imported), importer.QuoteName(n.Declared))
+	}
+	if len(plan.SkippedBySource) > 0 {
+		fmt.Fprintf(w, "skipped at the source: %s\n", quoteImportNames(plan.SkippedBySource))
+	}
+	if len(plan.PlaintextHints) > 0 {
+		fmt.Fprintf(w, "plaintext at the source (a classification HINT; nothing was downgraded): %s\n",
+			quoteImportNames(plan.PlaintextHints))
+	}
+	if len(plan.AlreadyDeclared) > 0 {
+		fmt.Fprintf(w, "already declared (not re-declared): %s\n", quoteImportNames(plan.AlreadyDeclared))
+	}
+	for _, env := range plan.Envs {
+		ref := env.EnvName
+		if ref == "" {
+			ref = env.EnvID
+		}
+		verb := "existing"
+		if env.Create {
+			verb = "to create"
+		}
+		fmt.Fprintf(w, "environment %s (%s): %d new, %d already set\n", ref, verb, len(env.New), len(env.Set))
+	}
+
+	rows := [][]string{
+		{"bundle", filepath.Join(outDir, bundleFile), "committable"},
+		{"mapping", filepath.Join(outDir, mappingFile), "committable"},
+		{"manifest", filepath.Join(outDir, manifestFile), "committable"},
+	}
+	for _, path := range valuesPaths {
+		rows = append(rows, []string{"values", path, "NEVER commit"})
+	}
+	if err := Render(ios.Stdout, FormatTable, Table{
+		Columns: []string{"ARTIFACT", "PATH", "HANDLING"}, Rows: rows,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "\nnext: review the bundle, apply it with `definitions plan|apply`, then run\n"+
+		"`hikyo values import` once per environment with its values file and the run manifest.\n\n")
+	fmt.Fprintln(w, importer.PlaintextWarning("", valuesPaths))
+	return nil
+}

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -60,6 +60,13 @@ func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) 
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
+	// The session may have paused on a prompt past its deadline without any
+	// network call observing the expiry (a create-only session makes no read
+	// after the source). Refuse before emitting rather than write artifacts a
+	// stale session authored.
+	if err := ctx.Err(); err != nil {
+		return failf(ExitRefused, "the import session exceeded its %s deadline before emitting artifacts", importer.SessionDeadline)
+	}
 	valuesPaths, err := writeProjectArtifacts(ios, outDir, plan)
 	if err != nil {
 		return err
@@ -400,6 +407,10 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 			cleanup()
 			return nil, failf(ExitRefused, "writing the values file for %s: %v", vt.envRef, err)
 		}
+		// Track the emitted plaintext file so a LATER values-file failure removes
+		// it too — a half-authored migration must not leave one environment's
+		// plaintext on disk beside a missing sibling.
+		created = append(created, vt.path)
 		valuesPaths = append(valuesPaths, vt.path)
 	}
 	return valuesPaths, nil

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -64,7 +64,7 @@ func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) 
 	if err != nil {
 		return err
 	}
-	return reportProject(ios, plan, outDir, valuesPaths)
+	return reportProject(ios, plan, outDir, host.sourceFiles, valuesPaths)
 }
 
 // cliWizardHost is the impure WizardHost the engine calls. It never prints an
@@ -75,6 +75,9 @@ type cliWizardHost struct {
 	ctx         context.Context
 	client      *Client
 	projectBase string
+	// sourceFiles are the export files read this session, for the
+	// plaintext-still-on-disk warning. Live reads contribute none.
+	sourceFiles []string
 }
 
 // ReadSource performs one connector read for a gathered selector, mapping the
@@ -99,6 +102,7 @@ func (h *cliWizardHost) ReadSource(source string, sel importer.Selector) (import
 	if err != nil {
 		return importer.SourceRead{}, err
 	}
+	h.sourceFiles = append(h.sourceFiles, sel.File)
 	return importer.SourceRead{Result: res, FileDigest: importer.Digest(in.Data), EnvSlug: sel.EnvSlug}, nil
 }
 
@@ -195,7 +199,11 @@ func runReplayMultiEnv(ctx context.Context, ios IO, client *Client, projectBase,
 	if err != nil {
 		return err
 	}
-	return reportProject(ios, plan, outDir, valuesPaths)
+	var sources []string
+	if sourcePath != "" {
+		sources = []string{sourcePath}
+	}
+	return reportProject(ios, plan, outDir, sources, valuesPaths)
 }
 
 // ---------------------------------------------------------------------------
@@ -399,7 +407,7 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 
 // reportProject prints the session summary: renames, near misses, per-environment
 // buckets, the artifact table, and the plaintext-still-on-disk warning.
-func reportProject(ios IO, plan *importer.ProjectPlan, outDir string, valuesPaths []string) error {
+func reportProject(ios IO, plan *importer.ProjectPlan, outDir string, sourceFiles, valuesPaths []string) error {
 	w := ios.Stderr
 	for _, r := range plan.Renames {
 		fmt.Fprintf(w, "rename: %s -> %s (%s)\n",
@@ -447,6 +455,8 @@ func reportProject(ios IO, plan *importer.ProjectPlan, outDir string, valuesPath
 
 	fmt.Fprintf(w, "\nnext: review the bundle, apply it with `definitions plan|apply`, then run\n"+
 		"`hikyo values import` once per environment with its values file and the run manifest.\n\n")
-	fmt.Fprintln(w, importer.PlaintextWarning("", valuesPaths))
+	// Every plaintext file this session left on disk — the source exports it read
+	// and the values files it emitted — is named so the human deletes them all.
+	fmt.Fprintln(w, importer.PlaintextWarning("", append(append([]string{}, sourceFiles...), valuesPaths...)))
 	return nil
 }

--- a/internal/cli/import_wizard_internal_test.go
+++ b/internal/cli/import_wizard_internal_test.go
@@ -112,7 +112,7 @@ func TestValuesImportRefusesMismatchedManifestProject(t *testing.T) {
 	}
 	manifestBody, err := importer.Encode(importer.Manifest{
 		FormatVersion: importer.FormatVersion, ConnectorContractVersion: importer.ConnectorContractVersion,
-		Target: importer.Target{Project: "prj_Q", Environments: []string{"env_staging"}},
+		Target:          importer.Target{Project: "prj_Q", Environments: []string{"env_staging"}},
 		PhaseCompletion: importer.PhaseCompletion{Authored: true, Imported: map[string]bool{"env_staging": false}},
 	})
 	if err != nil {

--- a/internal/cli/import_wizard_internal_test.go
+++ b/internal/cli/import_wizard_internal_test.go
@@ -94,6 +94,55 @@ func TestValuesImportRefusesOverwriteForCreatedEnvFile(t *testing.T) {
 	}
 }
 
+// TestValuesImportRefusesMismatchedManifestProject: a values file paired with a
+// run manifest from a DIFFERENT project is refused before any server contact, so
+// the unrelated manifest's phase-completion marker is never corrupted.
+func TestValuesImportRefusesMismatchedManifestProject(t *testing.T) {
+	dir := t.TempDir()
+	valuesBody, err := importer.Encode(importer.ValuesFile{
+		FormatVersion: importer.FormatVersion, Project: "prj_P", Environment: "env_staging",
+		Entries: []importer.ValuesEntry{{Key: "API_KEY", Value: "v"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	valuesPath := filepath.Join(dir, "values-env_staging.json")
+	if err := os.WriteFile(valuesPath, valuesBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestBody, err := importer.Encode(importer.Manifest{
+		FormatVersion: importer.FormatVersion, ConnectorContractVersion: importer.ConnectorContractVersion,
+		Target: importer.Target{Project: "prj_Q", Environments: []string{"env_staging"}},
+		PhaseCompletion: importer.PhaseCompletion{Authored: true, Imported: map[string]bool{"env_staging": false}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "run-manifest.json")
+	if err := os.WriteFile(manifestPath, manifestBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	ios := IO{
+		Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{},
+		Env: Env{Getenv: func(k string) string {
+			if k == "HIKYO_STATE_DIR" {
+				return stateDir
+			}
+			return ""
+		}},
+	}
+	err = runValuesImport(context.Background(), ios,
+		[]string{"--file", valuesPath, "--manifest", manifestPath, "--env", "env_staging", "--instance", "unknown-ref"})
+	var cliErr *Error
+	if !errors.As(err, &cliErr) || cliErr.Code != ExitRefused {
+		t.Fatalf("err = %v, want ExitRefused", err)
+	}
+	if !strings.Contains(err.Error(), "same run") {
+		t.Fatalf("err = %v, want the mispaired-manifest refusal", err)
+	}
+}
+
 func TestTerminalPrompter(t *testing.T) {
 	newP := func(input string) (*terminalPrompter, *bytes.Buffer) {
 		var out bytes.Buffer

--- a/internal/cli/import_wizard_internal_test.go
+++ b/internal/cli/import_wizard_internal_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// nopWriteCloser backs an injected OpenTerminal: its existence is what
+// onTerminal checks, nothing is written to it.
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// TestImportOnTerminalEntersWizard is acceptance criterion 3's TTY half: `import`
+// with no source arguments on a terminal enters the wizard rather than printing
+// the flag-mode usage error. The wizard then fails at target resolution (no
+// project resolves in this test), which proves entry: the error is not the
+// no-arguments usage refusal.
+func TestImportOnTerminalEntersWizard(t *testing.T) {
+	var stderr bytes.Buffer
+	ios := IO{
+		Stdin:  strings.NewReader(""),
+		Stdout: &bytes.Buffer{},
+		Stderr: &stderr,
+		Env:    Env{Getenv: func(string) string { return "" }},
+		OpenTerminal: func() (io.WriteCloser, error) {
+			return nopWriteCloser{io.Discard}, nil
+		},
+	}
+	err := runImport(context.Background(), ios, nil)
+	if err == nil {
+		t.Fatal("the wizard entry returned no error despite no resolvable target")
+	}
+	if strings.Contains(err.Error(), "needs --from or --mapping") {
+		t.Fatalf("import on a terminal fell through to the flag-mode usage error: %v", err)
+	}
+}
+
+// TestImportNoTerminalIsAHardError is the no-TTY half: without a terminal and
+// without --from/--mapping, import is a hard usage error, never a hung prompt.
+func TestImportNoTerminalIsAHardError(t *testing.T) {
+	err := runImport(context.Background(), IO{Stderr: &bytes.Buffer{}}, nil)
+	var cliErr *Error
+	if !errors.As(err, &cliErr) || cliErr.Code != ExitUsage {
+		t.Fatalf("err = %v, want ExitUsage", err)
+	}
+	if !strings.Contains(err.Error(), "needs --from or --mapping") {
+		t.Fatalf("err = %v, want the no-arguments usage refusal", err)
+	}
+}
+
+func TestTerminalPrompter(t *testing.T) {
+	newP := func(input string) (*terminalPrompter, *bytes.Buffer) {
+		var out bytes.Buffer
+		return newTerminalPrompter(IO{Stdin: strings.NewReader(input), Stderr: &out}), &out
+	}
+
+	t.Run("confirm defaults on empty", func(t *testing.T) {
+		p, _ := newP("\n")
+		got, err := p.Confirm("go?", true)
+		if err != nil || !got {
+			t.Fatalf("got %v, %v; want default true", got, err)
+		}
+	})
+	t.Run("confirm yes", func(t *testing.T) {
+		p, _ := newP("y\n")
+		got, err := p.Confirm("go?", false)
+		if err != nil || !got {
+			t.Fatalf("got %v, %v; want true", got, err)
+		}
+	})
+	t.Run("choose one-indexed", func(t *testing.T) {
+		p, _ := newP("2\n")
+		got, err := p.Choose("pick", []string{"a", "b", "c"}, 0)
+		if err != nil || got != 1 {
+			t.Fatalf("got %d, %v; want index 1", got, err)
+		}
+	})
+	t.Run("choose out of range refuses", func(t *testing.T) {
+		p, _ := newP("9\n")
+		if _, err := p.Choose("pick", []string{"a", "b"}, 0); err == nil {
+			t.Fatal("an out-of-range choice was accepted")
+		}
+	})
+	t.Run("line falls back to default", func(t *testing.T) {
+		p, _ := newP("\n")
+		got, err := p.Line("name", "fallback")
+		if err != nil || got != "fallback" {
+			t.Fatalf("got %q, %v; want fallback", got, err)
+		}
+	})
+	t.Run("eof is a loud error", func(t *testing.T) {
+		p, _ := newP("")
+		if _, err := p.Line("name", ""); err == nil {
+			t.Fatal("end of input was not surfaced as an error")
+		}
+	})
+}

--- a/internal/cli/import_wizard_internal_test.go
+++ b/internal/cli/import_wizard_internal_test.go
@@ -5,8 +5,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/importer"
 )
 
 // nopWriteCloser backs an injected OpenTerminal: its existence is what
@@ -50,6 +54,43 @@ func TestImportNoTerminalIsAHardError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "needs --from or --mapping") {
 		t.Fatalf("err = %v, want the no-arguments usage refusal", err)
+	}
+}
+
+// TestValuesImportRefusesOverwriteForCreatedEnvFile: a created-environment
+// values file (name-addressed, tokenless) may not be imported with --overwrite —
+// the overwrite would bypass skip-by-default with no occurrence review. Refused
+// before any server contact.
+func TestValuesImportRefusesOverwriteForCreatedEnvFile(t *testing.T) {
+	body, err := importer.Encode(importer.ValuesFile{
+		FormatVersion: importer.FormatVersion, Project: "prj_x", EnvironmentName: "staging",
+		Entries: []importer.ValuesEntry{{Key: "API_KEY", Value: "v"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "values-staging.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	ios := IO{
+		Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{},
+		Env: Env{Getenv: func(k string) string {
+			if k == "HIKYO_STATE_DIR" {
+				return stateDir
+			}
+			return ""
+		}},
+	}
+	err = runValuesImport(context.Background(), ios,
+		[]string{"--file", path, "--overwrite", "API_KEY", "--env", "env_staging", "--instance", "unknown-ref"})
+	var cliErr *Error
+	if !errors.As(err, &cliErr) || cliErr.Code != ExitRefused {
+		t.Fatalf("err = %v, want ExitRefused", err)
+	}
+	if !strings.Contains(err.Error(), "tokenless") {
+		t.Fatalf("err = %v, want the tokenless-overwrite refusal", err)
 	}
 }
 

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -718,6 +718,39 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		}
 	}
 
+	// Bind the values file to THIS run by content. Project and environment alone
+	// do not distinguish two runs targeting the same target: without this, run B's
+	// values could import under run A's manifest (its occurrence tokens bind the
+	// reviewed STATE, not the plaintext), and for a tokenless created environment
+	// there is no token at all. A digest mismatch means the file is not the one
+	// this manifest reviewed.
+	if manifest != nil && len(manifest.ValuesDigests) > 0 {
+		ref := env
+		if createdEnvFile {
+			ref = values.EnvironmentName
+		}
+		reencoded, err := importer.Encode(values)
+		if err != nil {
+			return err
+		}
+		var recorded string
+		found := false
+		for _, d := range manifest.ValuesDigests {
+			if d.Environment == ref {
+				recorded, found = d.Digest, true
+				break
+			}
+		}
+		if !found {
+			return failf(ExitRefused,
+				"the run manifest records no values digest for %s; pair the values file with the manifest from the same run", ref)
+		}
+		if importer.Digest(reencoded) != recorded {
+			return failf(ExitRefused,
+				"the values file does not match the run manifest's recorded digest for %s; it is not the values file this manifest reviewed", ref)
+		}
+	}
+
 	var result apigen.ImportValuesResult
 	if err := client.Do(ctx, http.MethodPost,
 		project+"/environments/"+url.PathEscape(env)+"/values/import", body, &result); err != nil {

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -641,11 +641,19 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 			if err != nil {
 				return failf(ExitRefused, "%v", err)
 			}
+			// The precondition is sliced to THIS environment. A run manifest spans
+			// every environment a session touched, but `values import` is per
+			// environment, and importing environment B must not present
+			// environment A's occurrences — importing A first advances them, so a
+			// whole-manifest precondition would reject B on A's now-stale tokens.
 			pre := apigen.ImportPrecondition{
 				DefinitionsRevision: manifest.DefinitionsRevision,
-				EnvironmentIds:      manifest.Target.Environments,
+				EnvironmentIds:      []string{env},
 			}
 			for _, o := range manifest.Occurrences {
+				if o.Environment != env {
+					continue
+				}
 				pre.Occurrences = append(pre.Occurrences, struct {
 					EnvironmentId apigen.ID      `json:"environment_id"`
 					Key           apigen.KeyName `json:"key"`

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -576,6 +576,18 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		}{Key: e.Key, Value: e.Value})
 	}
 	if list := splitList(overwrite); len(list) > 0 {
+		// A created-environment values file is tokenless and takes no
+		// precondition, so skip-by-default is the only thing between an import and
+		// a clobber. `--overwrite` would defeat it with no occurrence-token review
+		// behind it — the unreviewed overwrite the two-phase binding exists to
+		// prevent — and a freshly created environment has nothing to overwrite.
+		// Refused up front, before any server contact.
+		if values.EnvironmentName != "" {
+			return failf(ExitRefused,
+				"--overwrite is refused for a created-environment values file: it is tokenless, so the overwrite "+
+					"would not be reviewed against an occurrence; import into the created environment first, then "+
+					"overwrite with a fresh reviewed run")
+		}
 		body.Overwrite = &list
 	}
 
@@ -640,6 +652,16 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 			manifest, err := importer.ParseManifest(rawManifest)
 			if err != nil {
 				return failf(ExitRefused, "%v", err)
+			}
+			// The manifest must actually name this environment. Without the check,
+			// a manifest naming only environment A but carrying copied occurrence
+			// rows for B could be presented against B, and the slice below would
+			// synthesize a precondition for an environment the reviewed manifest
+			// never covered.
+			if !slices.Contains(manifest.Target.Environments, env) {
+				return failf(ExitRefused,
+					"the run manifest does not name environment %s; it records %v — pair the values file with the "+
+						"manifest from the same run", env, manifest.Target.Environments)
 			}
 			// The precondition is sliced to THIS environment. A run manifest spans
 			// every environment a session touched, but `values import` is per

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -591,6 +591,32 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		body.Overwrite = &list
 	}
 
+	// The run manifest, if any, is parsed and bound to THIS run before it is
+	// consumed as a precondition or stamped by markImported. It must agree with
+	// the values file on the project: a manifest from an unrelated run must never
+	// be accepted, or it would either forge a precondition for an environment it
+	// never reviewed, or — for a tokenless created environment, where the import
+	// itself proceeds — get its phase-completion marker corrupted for a run this
+	// file is not part of. The project cross-check needs no server contact.
+	var manifest *importer.Manifest
+	if manifestPath != "" {
+		rawManifest, err := importer.ReadFile(manifestPath)
+		if err != nil {
+			return failf(ExitUsage, "reading the run manifest: %v", err)
+		}
+		parsed, err := importer.ParseManifest(rawManifest)
+		if err != nil {
+			return failf(ExitRefused, "%v", err)
+		}
+		if parsed.Target.Project != values.Project {
+			return failf(ExitRefused,
+				"the run manifest was authored for project %s but the values file is for %s; pair the values file "+
+					"with the manifest from the same run",
+				importer.QuoteName(parsed.Target.Project), importer.QuoteName(values.Project))
+		}
+		manifest = &parsed
+	}
+
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
 	if err != nil {
 		return err
@@ -614,13 +640,17 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	// name against the now-resolved environment. A created environment is
 	// tokenless by construction, so it takes NO precondition — a manifest
 	// precondition, which reviewed no occurrence for it, would reject every key.
+	// The values file itself must target the resolved project. With the
+	// manifest↔values project cross-check above, this also pins the manifest to
+	// the invocation's project.
+	if values.Project != targetProject {
+		return failf(ExitRefused,
+			"the values file was authored for project %s but this invocation targets %s",
+			importer.QuoteName(values.Project), importer.QuoteName(targetProject))
+	}
+
 	createdEnvFile := values.EnvironmentName != ""
 	if createdEnvFile {
-		if values.Project != targetProject {
-			return failf(ExitRefused,
-				"the values file was authored for project %s but this invocation targets %s",
-				importer.QuoteName(values.Project), importer.QuoteName(targetProject))
-		}
 		var envObj apigen.Environment
 		if err := client.Do(ctx, http.MethodGet,
 			project+"/environments/"+url.PathEscape(env), nil, &envObj); err != nil {
@@ -632,7 +662,17 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 					"apply the definitions bundle so the environment exists, then target it",
 				importer.QuoteName(values.EnvironmentName), env, importer.QuoteName(envObj.Name))
 		}
-		if manifestPath != "" {
+		// A created environment is tokenless, so it takes no precondition. But if a
+		// manifest was supplied, it must actually name this created environment —
+		// otherwise markImported would stamp a marker onto a run this file is not
+		// part of.
+		if manifest != nil {
+			if !slices.Contains(manifest.Target.CreatedEnvironments, values.EnvironmentName) {
+				return failf(ExitRefused,
+					"the run manifest does not name the created environment %s; it records %v — pair the values "+
+						"file with the manifest from the same run",
+					importer.QuoteName(values.EnvironmentName), manifest.Target.CreatedEnvironments)
+			}
 			fmt.Fprintf(ios.Stderr,
 				"note: %s is a created environment and is tokenless; the run manifest's precondition does not apply to it\n",
 				envObj.Name)
@@ -644,15 +684,7 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		if err := validateImportArtifactTargets(values, targetProject, env); err != nil {
 			return err
 		}
-		if manifestPath != "" {
-			rawManifest, err := importer.ReadFile(manifestPath)
-			if err != nil {
-				return failf(ExitUsage, "reading the run manifest: %v", err)
-			}
-			manifest, err := importer.ParseManifest(rawManifest)
-			if err != nil {
-				return failf(ExitRefused, "%v", err)
-			}
+		if manifest != nil {
 			// The manifest must actually name this environment. Without the check,
 			// a manifest naming only environment A but carrying copied occurrence
 			// rows for B could be presented against B, and the slice below would

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -578,28 +578,6 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	if list := splitList(overwrite); len(list) > 0 {
 		body.Overwrite = &list
 	}
-	if manifestPath != "" {
-		rawManifest, err := importer.ReadFile(manifestPath)
-		if err != nil {
-			return failf(ExitUsage, "reading the run manifest: %v", err)
-		}
-		manifest, err := importer.ParseManifest(rawManifest)
-		if err != nil {
-			return failf(ExitRefused, "%v", err)
-		}
-		pre := apigen.ImportPrecondition{
-			DefinitionsRevision: manifest.DefinitionsRevision,
-			EnvironmentIds:      manifest.Target.Environments,
-		}
-		for _, o := range manifest.Occurrences {
-			pre.Occurrences = append(pre.Occurrences, struct {
-				EnvironmentId apigen.ID      `json:"environment_id"`
-				Key           apigen.KeyName `json:"key"`
-				Token         string         `json:"token"`
-			}{EnvironmentId: o.Environment, Key: o.Key, Token: o.Token})
-		}
-		body.Precondition = &pre
-	}
 
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
 	if err != nil {
@@ -617,11 +595,65 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	// The values file binds both target dimensions even without a manifest.
-	// Same environment ids and key names can exist in different projects; a
-	// one-dimensional check would silently retarget reviewed plaintext.
-	if err := validateImportArtifactTargets(values, targetProject, env); err != nil {
-		return err
+
+	// A created-environment values file (authored by a wizard session that will
+	// create the environment) carries the environment NAME, not an id: the id did
+	// not exist at phase 1. `definitions apply` has since created it, so bind by
+	// name against the now-resolved environment. A created environment is
+	// tokenless by construction, so it takes NO precondition — a manifest
+	// precondition, which reviewed no occurrence for it, would reject every key.
+	createdEnvFile := values.EnvironmentName != ""
+	if createdEnvFile {
+		if values.Project != targetProject {
+			return failf(ExitRefused,
+				"the values file was authored for project %s but this invocation targets %s",
+				importer.QuoteName(values.Project), importer.QuoteName(targetProject))
+		}
+		var envObj apigen.Environment
+		if err := client.Do(ctx, http.MethodGet,
+			project+"/environments/"+url.PathEscape(env), nil, &envObj); err != nil {
+			return err
+		}
+		if envObj.Name != values.EnvironmentName {
+			return failf(ExitRefused,
+				"the values file was authored for the environment named %s but %s resolves to %s; "+
+					"apply the definitions bundle so the environment exists, then target it",
+				importer.QuoteName(values.EnvironmentName), env, importer.QuoteName(envObj.Name))
+		}
+		if manifestPath != "" {
+			fmt.Fprintf(ios.Stderr,
+				"note: %s is a created environment and is tokenless; the run manifest's precondition does not apply to it\n",
+				envObj.Name)
+		}
+	} else {
+		// The values file binds both target dimensions even without a manifest.
+		// Same environment ids and key names can exist in different projects; a
+		// one-dimensional check would silently retarget reviewed plaintext.
+		if err := validateImportArtifactTargets(values, targetProject, env); err != nil {
+			return err
+		}
+		if manifestPath != "" {
+			rawManifest, err := importer.ReadFile(manifestPath)
+			if err != nil {
+				return failf(ExitUsage, "reading the run manifest: %v", err)
+			}
+			manifest, err := importer.ParseManifest(rawManifest)
+			if err != nil {
+				return failf(ExitRefused, "%v", err)
+			}
+			pre := apigen.ImportPrecondition{
+				DefinitionsRevision: manifest.DefinitionsRevision,
+				EnvironmentIds:      manifest.Target.Environments,
+			}
+			for _, o := range manifest.Occurrences {
+				pre.Occurrences = append(pre.Occurrences, struct {
+					EnvironmentId apigen.ID      `json:"environment_id"`
+					Key           apigen.KeyName `json:"key"`
+					Token         string         `json:"token"`
+				}{EnvironmentId: o.Environment, Key: o.Key, Token: o.Token})
+			}
+			body.Precondition = &pre
+		}
 	}
 
 	var result apigen.ImportValuesResult
@@ -636,7 +668,13 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	// not exist, and claiming it here would be a marker for an act nobody
 	// performed.
 	if manifestPath != "" {
-		if err := markImported(manifestPath, env); err != nil {
+		// The manifest keys created environments by name (they had no id at
+		// phase 1) and existing ones by id.
+		ref := env
+		if createdEnvFile {
+			ref = values.EnvironmentName
+		}
+		if err := markImported(manifestPath, ref); err != nil {
 			fmt.Fprintf(ios.Stderr,
 				"the import landed, but the run manifest could not be updated (%v); "+
 					"a resumed migration will read it as not yet imported\n", err)

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -99,8 +99,10 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	switch {
 	case *from == "" && *mapping == "":
 		if onTerminal(ios) {
-			return failf(ExitRefused,
-				"the interactive import wizard is not served by this build. Use flag mode or a recorded mapping:\n%s", importUsage)
+			// Wizard: no source arguments on a TTY. The target project is resolved
+			// from the ambient chain (it must pre-exist); the environments are
+			// chosen interactively, so no --environment is required here.
+			return runImportWizard(ctx, ios, c, *outDir)
 		}
 		return failf(ExitUsage, "hikyo import needs --from or --mapping (there is no terminal to prompt on).\n%s", importUsage)
 	case *from != "" && *mapping != "":
@@ -170,20 +172,16 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 		if err != nil {
 			return failf(ExitRefused, "%v", err)
 		}
-		// A multi-environment template is a wizard session's artifact. Replaying
-		// only its first environment would import a fraction of what the human
-		// reviewed and say nothing about the rest, so it is refused by name
-		// until the wizard exists to replay it properly.
-		if len(parsed.Environments) != 1 {
-			return failf(ExitRefused,
-				"this mapping template maps %d environments; an import run targets exactly one "+
-					"(project, environment). Multi-environment sessions are the wizard's, which this build "+
-					"does not serve", len(parsed.Environments))
-		}
+		// A multi-environment template is a wizard session's artifact; the replay
+		// fans the recorded source over every environment it names (§ multi-env
+		// replay below). A single-environment template targets exactly one, the
+		// way flag mode does.
 		template = &parsed
 		source = parsed.Source
 		c.Project = parsed.Project
-		c.Env = parsed.Environments[0].Target
+		if len(parsed.Environments) == 1 {
+			c.Env = parsed.Environments[0].Target
+		}
 		*envSlug = parsed.Scope.EnvSlug
 		if parsed.Scope.FileDigest == "" && (source == "k8s" || source == "vault") {
 			if *file != "" {
@@ -258,6 +256,16 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Multi-environment replay fans the one recorded source read over every
+	// environment the template names — presence varies per environment, the
+	// bundle and manifest are one. A conflict the wizard would have resolved
+	// interactively is refused here, non-interactively, by the planner.
+	if template != nil && len(template.Environments) > 1 {
+		return runReplayMultiEnv(ctx, ios, client, project, projectID, source, result, fileDigest,
+			*envSlug, sourcePath, template, candidates, *outDir)
+	}
+
 	envID, err := addressed(resolved, DimEnv, "", "import --environment")
 	if err != nil {
 		return err
@@ -276,19 +284,7 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 		Project:             projectID,
 		Environment:         envID,
 		DefinitionsRevision: occurrences.DefinitionsRevision,
-	}
-	for _, k := range occurrences.Items {
-		row := importer.KeyState{Name: k.Name, Declared: k.Declared, Set: k.Set, Token: k.Token}
-		if k.KeyId != nil {
-			row.ID = *k.KeyId
-		}
-		if k.Classification != nil {
-			row.Classification = string(*k.Classification)
-		}
-		if k.DeclaredType != nil {
-			row.Type = *k.DeclaredType
-		}
-		planIn.State.Keys = append(planIn.State.Keys, row)
+		Keys:                occurrenceKeys(occurrences),
 	}
 
 	plan, err := importer.BuildPlan(planIn)

--- a/internal/conformance/import_test.go
+++ b/internal/conformance/import_test.go
@@ -32,6 +32,7 @@ func init() {
 		scenario{"import_e2e_live_source_fixtures", scenarioImportLiveSourcesE2E},
 		scenario{"import_precondition_is_not_an_oracle", scenarioImportPreconditionOracle},
 		scenario{"import_undeclared_transition_binds_declaration", scenarioImportUndeclaredTransition},
+		scenario{"import_multi_environment_fan_out", scenarioMultiEnvImportE2E},
 	)
 }
 
@@ -594,6 +595,122 @@ func scenarioImportPerSourceE2E(t *testing.T, db *store.DB) {
 			}
 		})
 	}
+}
+
+// scenarioMultiEnvImportE2E is #112's multi-environment acceptance: one source
+// fanned over two target environments emits ONE project-wide bundle reconciled
+// to one identity/type/classification per key, plus a values file per
+// environment. The documented flow runs end to end with no re-plan, and each
+// environment's import presents only its own occurrences — so importing the
+// second does not fail on the first's now-advanced tokens.
+func scenarioMultiEnvImportE2E(t *testing.T, db *store.DB) {
+	who, scope, values, envs, keys := valueFixture(t, db, "importmultienv")
+	actor := service.LocalPrincipal(who)
+	staging := mustEnv(t, envs, actor, scope, "staging")
+	prod := mustEnv(t, envs, actor, scope, "prod")
+
+	raw, err := os.ReadFile(filepath.Join("..", "importer", "testdata", "k8s-multi.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := importer.Run(t.Context(), "k8s", importer.Input{Path: "k8s-multi.yaml", Data: raw})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{"API_KEY", "DB_HOST", "DB_PASSWORD", "DB_PORT"}
+
+	plan := mustProjectPlan(t, "k8s", result, values, actor, scope, raw, staging, prod)
+	if len(plan.Bundle.Keys) != len(wantKeys) {
+		t.Fatalf("bundle declares %d keys, want ONE project-wide declaration per key (%d)",
+			len(plan.Bundle.Keys), len(wantKeys))
+	}
+	if len(plan.Envs) != 2 || len(plan.Manifest.Target.Environments) != 2 {
+		t.Fatalf("plan does not span both environments: envs=%d manifest=%v",
+			len(plan.Envs), plan.Manifest.Target.Environments)
+	}
+
+	// Apply the one bundle by hand (definitions plan|apply is #70), then import
+	// each environment's values file against the original manifest.
+	for _, k := range plan.Bundle.Keys {
+		mustKey(t, keys, actor, scope, k.Name, k.Classification, schema.DefaultPresenceRules())
+	}
+	for _, env := range []domain.Scope{staging, prod} {
+		req := importRequestForEnv(t, plan, string(env.Env))
+		imported, err := values.Import(t.Context(), actor, env, req)
+		if err != nil {
+			t.Fatalf("phase 2 refused %s the run its own phase 1 authored: %v", env.Env, err)
+		}
+		if strings.Join(imported.Imported, ",") != strings.Join(wantKeys, ",") {
+			t.Fatalf("%s imported = %v, want %v", env.Env, imported.Imported, wantKeys)
+		}
+	}
+}
+
+// mustProjectPlan mirrors the wizard/multi-env CLI: transform names, ask each
+// environment about every candidate, then plan the whole project at once.
+func mustProjectPlan(t *testing.T, source string, result importer.Result, values *service.Values,
+	actor service.Actor, scope domain.Scope, raw []byte, envs ...domain.Scope) *importer.ProjectPlan {
+	t.Helper()
+	planned, err := importer.PlannedCandidates(importer.PlanInput{Source: source, Records: result.Records})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates := make([]service.ImportCandidate, 0, len(planned))
+	for _, c := range planned {
+		candidates = append(candidates, service.ImportCandidate{
+			Name: c.Name, IntendedClassification: c.Classification, IntendedType: c.Type,
+		})
+	}
+	in := importer.ProjectPlanInput{Source: source, Project: string(scope.Project)}
+	for _, env := range envs {
+		presence, err := values.Occurrences(t.Context(), actor, env, candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		in.DefinitionsRevision = presence.DefinitionsRevision
+		envIn := importer.EnvInput{
+			Records: result.Records, Skipped: result.Skipped, Scope: result.Scope,
+			FileDigest: importer.Digest(raw), EnvID: string(env.Env),
+		}
+		for _, k := range presence.Keys {
+			envIn.Keys = append(envIn.Keys, importer.KeyState{
+				Name: k.Name, ID: k.KeyID, Declared: k.Declared,
+				Classification: k.Classification, Type: k.Type, Set: k.Set, Token: k.Token,
+			})
+		}
+		in.Envs = append(in.Envs, envIn)
+	}
+	plan, err := importer.BuildProjectPlan(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+// importRequestForEnv builds one environment's phase-2 call from a project plan,
+// slicing the manifest precondition to that environment — the way the CLI's
+// per-environment `values import` does.
+func importRequestForEnv(t *testing.T, plan *importer.ProjectPlan, envID string) service.ImportRequest {
+	t.Helper()
+	req := service.ImportRequest{Precondition: &service.ImportPrecondition{
+		DefinitionsRevision: plan.Manifest.DefinitionsRevision,
+		Environments:        []string{envID},
+	}}
+	for _, env := range plan.Envs {
+		if env.EnvID == envID {
+			for _, e := range env.Values.Entries {
+				req.Entries = append(req.Entries, service.ImportEntry{Key: e.Key, Value: e.Value})
+			}
+		}
+	}
+	for _, o := range plan.Manifest.Occurrences {
+		if o.Environment != envID {
+			continue
+		}
+		req.Precondition.Occurrences = append(req.Precondition.Occurrences,
+			service.ImportOccurrenceRef{Key: o.Key, Environment: o.Environment, Token: o.Token})
+	}
+	return req
 }
 
 // scenarioImportUndeclaredTransition pins the declaration intent carried by an

--- a/internal/importer/artifacts.go
+++ b/internal/importer/artifacts.go
@@ -173,6 +173,19 @@ type ManifestOccurrence struct {
 	Token       string `json:"token"`
 }
 
+// ValuesDigest binds one environment's values file to THIS run by content. The
+// occurrence tokens bind the reviewed STATE (that it has not moved), not the
+// plaintext an operator is about to write; without this, two runs targeting the
+// same (project, environment) could be mispaired — run B's values imported under
+// run A's manifest, or run A's completion marker stamped for run B — because
+// project and environment alone do not distinguish runs. The digest is over the
+// canonical values-file serialization, so it is deterministic: a wizard session
+// and a flag run with coinciding choices produce the same digest.
+type ValuesDigest struct {
+	Environment string `json:"environment"`
+	Digest      string `json:"digest"`
+}
+
 // PhaseCompletion records how far a run got, so a resumed migration knows where
 // it stopped.
 type PhaseCompletion struct {
@@ -191,6 +204,7 @@ type Manifest struct {
 	Target                   Target               `json:"target"`
 	DefinitionsRevision      int64                `json:"definitions_revision"`
 	Occurrences              []ManifestOccurrence `json:"occurrences"`
+	ValuesDigests            []ValuesDigest       `json:"values_digests"`
 	PhaseCompletion          PhaseCompletion      `json:"phase_completion"`
 }
 

--- a/internal/importer/artifacts.go
+++ b/internal/importer/artifacts.go
@@ -145,11 +145,18 @@ type TargetKey struct {
 	ID   *string `json:"id"`
 }
 
-// Target is the run's target identity.
+// Target is the run's target identity. Environments names the EXISTING target
+// environments by their server-owned id; CreatedEnvironments names the ones the
+// session will create, by NAME, because they have no id at phase 1 (phase 1
+// never writes). Created environments are tokenless by construction — they carry
+// no occurrence row and sit outside the phase-2 precondition
+// (docs/handoff/112-import-wizard.md) — so their names never occupy an id slot,
+// which is why they live in a distinct field rather than mixed into Environments.
 type Target struct {
-	Project      string      `json:"project"`
-	Environments []string    `json:"environments"`
-	Keys         []TargetKey `json:"keys"`
+	Project             string      `json:"project"`
+	Environments        []string    `json:"environments"`
+	CreatedEnvironments []string    `json:"created_environments,omitempty"`
+	Keys                []TargetKey `json:"keys"`
 }
 
 // ManifestOccurrence is one server-minted opaque occurrence token, per
@@ -200,11 +207,17 @@ type ValuesEntry struct {
 // ValuesFile is one target environment's material for `values import`. It is
 // the ONLY artifact this package produces that carries plaintext, and the CLI
 // writes it through the secret-file discipline — never to stdout.
+//
+// An EXISTING environment's file carries Environment (its id). A CREATED
+// environment has no id at phase 1, so its file carries EnvironmentName instead
+// and Environment is empty; `values import` resolves the name to its id after
+// `definitions apply` creates the environment.
 type ValuesFile struct {
-	FormatVersion int           `json:"format_version"`
-	Project       string        `json:"project"`
-	Environment   string        `json:"environment"`
-	Entries       []ValuesEntry `json:"entries"`
+	FormatVersion   int           `json:"format_version"`
+	Project         string        `json:"project"`
+	Environment     string        `json:"environment,omitempty"`
+	EnvironmentName string        `json:"environment_name,omitempty"`
+	Entries         []ValuesEntry `json:"entries"`
 }
 
 // ---------------------------------------------------------------------------
@@ -309,14 +322,20 @@ func ParseManifest(raw []byte) (Manifest, error) {
 		return Manifest{}, failure("import", CodeMalformed, "run-manifest.json",
 			"the manifest names no target project")
 	}
-	if len(m.Target.Environments) == 0 {
+	if len(m.Target.Environments) == 0 && len(m.Target.CreatedEnvironments) == 0 {
 		return Manifest{}, failure("import", CodeMalformed, "run-manifest.json",
-			"the manifest names no target environment; the precondition re-evaluates read(E) for every environment it names")
+			"the manifest names no target environment; the precondition re-evaluates read(E) for every existing environment it names")
 	}
 	for i, env := range m.Target.Environments {
 		if env == "" {
 			return Manifest{}, failure("import", CodeMalformed, "run-manifest.json",
 				"target environment %d is empty", i+1)
+		}
+	}
+	for i, env := range m.Target.CreatedEnvironments {
+		if env == "" {
+			return Manifest{}, failure("import", CodeMalformed, "run-manifest.json",
+				"created environment %d is empty", i+1)
 		}
 	}
 	return m, nil
@@ -338,9 +357,13 @@ func ParseValuesFile(raw []byte) (ValuesFile, error) {
 		return ValuesFile{}, failure("import", CodeMalformed, "values file",
 			"the values file names no project")
 	}
-	if v.Environment == "" {
+	if v.Environment == "" && v.EnvironmentName == "" {
 		return ValuesFile{}, failure("import", CodeMalformed, "values file",
 			"the values file names no environment; `values import` is per environment")
+	}
+	if v.Environment != "" && v.EnvironmentName != "" {
+		return ValuesFile{}, failure("import", CodeMalformed, "values file",
+			"the values file names both an environment id and an environment name; a created environment carries only its name")
 	}
 	if len(v.Entries) == 0 {
 		return ValuesFile{}, failure("import", CodeMalformed, "values file", "the values file holds no entries")

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -258,6 +258,11 @@ type Result struct {
 	// variable or helper kind). It is reported to the operator, never persisted
 	// in a mapping or manifest.
 	Resolution string
+	// DecodedBytes is how many decoded bytes this read charged. A wizard session
+	// sums it across the fan-out to enforce the aggregate session bound (ops
+	// catalogue: Wizard session aggregate). A single flag/replay read is already
+	// bounded per run and ignores it.
+	DecodedBytes int
 }
 
 // Connector is the in-process connector interface. It is deliberately narrow
@@ -444,8 +449,19 @@ func validateResult(name string, result Result, b *Budget) (Result, error) {
 			"%d value(s) are not UTF-8 text (invalid encoding or a NUL byte); Hikyo values are UTF-8 text: %s",
 			len(binary), strings.Join(binary, ", "))
 	}
+	result.DecodedBytes = b.decoded
 	return result, nil
 }
+
+// The aggregate wizard-session bound (ops catalogue: "Wizard session aggregate",
+// 30 min / 100 MiB). It bounds the whole fan-out of connector reads in one
+// interactive session, over and above each read's own per-run bounds — a
+// session that reads a hundred sources cannot slip a hundred near-cap reads past
+// the per-run caps.
+const (
+	MaxSessionDecodedBytes = 100 << 20
+	SessionDeadline        = 30 * time.Minute
+)
 
 // nonNil renders a nil slice as an empty one before serialization. `[]` says
 // "nothing here"; a JSON null would read as "unknown" for a fact the artifact

--- a/internal/importer/plan.go
+++ b/internal/importer/plan.go
@@ -518,6 +518,21 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Created environments are explicit, reviewable bundle lines (ADR § Targeting
+	// and hierarchy creation): `definitions apply` creates them. Deduped and
+	// sorted so the bundle is byte-stable.
+	seenEnv := map[string]bool{}
+	var created []string
+	for _, e := range in.Envs {
+		if e.Create && !seenEnv[e.EnvName] {
+			seenEnv[e.EnvName] = true
+			created = append(created, e.EnvName)
+		}
+	}
+	slices.Sort(created)
+	for _, name := range created {
+		plan.Bundle.Environments = append(plan.Bundle.Environments, definitions.Environment{Name: name})
+	}
 	plan.Bundle, err = definitions.Normalize(plan.Bundle)
 	if err != nil {
 		return nil, fmt.Errorf("import: normalizing definitions bundle: %w", err)
@@ -649,7 +664,13 @@ func planEnvironment(in ProjectPlanInput, e EnvInput, rows []mappedRecord, decis
 	envPlan.Values = ValuesFile{
 		FormatVersion: FormatVersion,
 		Project:       in.Project,
-		Environment:   envID,
+	}
+	// A created environment has no id at phase 1, so its values file carries the
+	// name; `values import` resolves it after `definitions apply`.
+	if e.Create {
+		envPlan.Values.EnvironmentName = e.EnvName
+	} else {
+		envPlan.Values.Environment = envID
 	}
 	for _, row := range rows {
 		rec, target := row.record, row.target
@@ -771,9 +792,14 @@ func buildManifest(in ProjectPlanInput, encodedTemplate []byte, envRows [][]mapp
 	for i, e := range in.Envs {
 		envRef := e.EnvID
 		if e.Create {
+			// Created environments are named, not id'd, and sit in a distinct
+			// field: they are tokenless (no presence read happened), so they
+			// contribute no occurrence row and are outside the precondition.
 			envRef = e.EnvName
+			m.Target.CreatedEnvironments = append(m.Target.CreatedEnvironments, e.EnvName)
+		} else {
+			m.Target.Environments = append(m.Target.Environments, e.EnvID)
 		}
-		m.Target.Environments = append(m.Target.Environments, envRef)
 		m.PhaseCompletion.Imported[envRef] = false
 		state := make(map[string]KeyState, len(e.Keys))
 		for _, k := range e.Keys {
@@ -820,6 +846,7 @@ func buildManifest(in ProjectPlanInput, encodedTemplate []byte, envRows [][]mapp
 	for _, key := range keyOrder {
 		m.Target.Keys = append(m.Target.Keys, TargetKey{Name: key, ID: keyID[key]})
 	}
+	m.Target.Environments = nonNil(m.Target.Environments)
 	m.SourceVersions = nonNil(m.SourceVersions)
 	m.Occurrences = nonNil(m.Occurrences)
 	return m, nil

--- a/internal/importer/plan.go
+++ b/internal/importer/plan.go
@@ -150,7 +150,7 @@ func PlannedNames(in PlanInput) ([]string, error) {
 // declaration choice here and in BuildPlan behind desiredDeclaration prevents
 // the token intent from drifting from the bundle it binds.
 func PlannedCandidates(in PlanInput) ([]PlannedCandidate, error) {
-	rows, _, err := mapRecords(in)
+	rows, _, err := mapRecords(in.Source, in.Records, in.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -182,10 +182,10 @@ type mappedRecord struct {
 // per-import" is not satisfied by a message that happens to name one key: a
 // two-hundred-key migration with four unmappable names must be four fixes in
 // one edit, not four runs.
-func mapRecords(in PlanInput) ([]mappedRecord, []Rename, error) {
+func mapRecords(source string, records []Record, template *Template) ([]mappedRecord, []Rename, error) {
 	manual := map[string]string{}
-	if in.Template != nil {
-		for _, r := range in.Template.Renames {
+	if template != nil {
+		for _, r := range template.Renames {
 			if r.Transform == TransformManual {
 				manual[r.From] = r.To
 			}
@@ -198,7 +198,7 @@ func mapRecords(in PlanInput) ([]mappedRecord, []Rename, error) {
 		collisions []string
 	)
 	origin := map[string]string{} // target name -> source path that claimed it
-	for _, rec := range in.Records {
+	for _, rec := range records {
 		sourcePath := recordPath(rec)
 		target, transform, err := targetName(rec.SourceName, manual)
 		if err != nil {
@@ -221,13 +221,13 @@ func mapRecords(in PlanInput) ([]mappedRecord, []Rename, error) {
 	}
 	if len(unmappable) > 0 {
 		slices.Sort(unmappable)
-		return nil, nil, failure(in.Source, CodeUnmappableName, "",
+		return nil, nil, failure(source, CodeUnmappableName, "",
 			"%d source name(s) fall outside the documented transform; name each one explicitly in the "+
 				"mapping template's `renames`: %s", len(unmappable), strings.Join(unmappable, ", "))
 	}
 	if len(collisions) > 0 {
 		slices.Sort(collisions)
-		return nil, nil, failure(in.Source, CodeNameCollision, "",
+		return nil, nil, failure(source, CodeNameCollision, "",
 			"%d post-transform collision(s); resolve each with an explicit rename in the mapping template: %s",
 			len(collisions), strings.Join(collisions, "; "))
 	}
@@ -236,38 +236,164 @@ func mapRecords(in PlanInput) ([]mappedRecord, []Rename, error) {
 	return rows, renames, nil
 }
 
-// BuildPlan runs the whole phase-1 decision surface.
+// BuildPlan runs the phase-1 decision surface for a single (project,
+// environment) — flag mode and single-environment replay. It is a thin wrapper
+// over BuildProjectPlan with exactly one target environment, so a flag/replay
+// run and a single-environment wizard session author byte-identical artifacts:
+// there is one planner, reached two ways.
 func BuildPlan(in PlanInput) (*Plan, error) {
 	if in.State.Project == "" || in.State.Environment == "" {
 		return nil, failure("import", CodeMalformed, "",
 			"a phase-1 plan targets exactly one (project, environment)")
 	}
-	state := make(map[string]KeyState, len(in.State.Keys))
-	declaredNames := make([]string, 0, len(in.State.Keys))
-	for _, k := range in.State.Keys {
-		state[k.Name] = k
-		if k.Declared {
-			declaredNames = append(declaredNames, k.Name)
-		}
-	}
-	slices.Sort(declaredNames)
-
-	rows, renames, err := mapRecords(in)
+	project, err := BuildProjectPlan(ProjectPlanInput{
+		Source:              in.Source,
+		Project:             in.State.Project,
+		DefinitionsRevision: in.State.DefinitionsRevision,
+		Template:            in.Template,
+		Envs: []EnvInput{{
+			Records: in.Records, Skipped: in.Skipped, Scope: in.Scope,
+			FileDigest: in.FileDigest, EnvSlug: in.EnvSlug, SourceIdentity: in.SourceIdentity,
+			EnvID: in.State.Environment, Keys: in.State.Keys,
+		}},
+	})
 	if err != nil {
 		return nil, err
 	}
-	plan := &Plan{SkippedBySource: append([]string{}, in.Skipped...), Renames: renames}
+	return project.single(), nil
+}
 
-	// One Secret -> one folder named after the Secret; a SINGLE-Secret import
-	// may target the environment root. That provision is the K8S ROW's and no
-	// other: a SOPS file's top-level map and an Infisical `secretPath` are
-	// folder structure the source states outright, and collapsing them because
-	// this particular export happened to have one branch would silently flatten
-	// a tree the operator will grow tomorrow.
-	rootCollapse := in.Source == k8sSource && singleSourceFolder(in.Records)
+// EnvInput is one target environment's phase-1 material inside a session. A
+// created environment carries no server-read Keys (it does not exist yet) and
+// is addressed by EnvName; an existing environment is addressed by EnvID and
+// carries the presence read the server returned for it.
+type EnvInput struct {
+	Records        []Record
+	Skipped        []string
+	Scope          Scope
+	FileDigest     string
+	EnvSlug        string
+	SourceIdentity string
+	// EnvID is the server-owned id of an existing target environment. Empty for
+	// a created environment.
+	EnvID string
+	// EnvName is the environment's portable name. Required for a created
+	// environment (which has no id yet); optional otherwise.
+	EnvName string
+	// Create marks an environment the session will create at phase 2 through the
+	// bundle's `create environment` line. Created environments are tokenless by
+	// construction: no presence read happened, so no occurrence is bound and the
+	// manifest names them without an id (docs/handoff/112-import-wizard.md).
+	Create bool
+	// Keys is the per-environment presence read. Empty for a created environment.
+	Keys []KeyState
+}
 
-	overwrite := templateOverwrites(in.Template, in.State.Environment)
-	trimAck := templateTrimAcks(in.Template, in.State.Environment)
+// ProjectPlanInput is one phase-1 session's whole material: one source, one
+// project, and one or more target environments. Keys, types and classifications
+// are project-scoped and reconciled to one canonical identity per key across the
+// fan-out; only presence — the buckets and the values written — varies by
+// environment (import-paths ADR § The two-phase invariant).
+type ProjectPlanInput struct {
+	Source              string
+	Project             string
+	DefinitionsRevision int64
+	Template            *Template
+	Envs                []EnvInput
+}
+
+// EnvPlan is one environment's slice of a project plan: its buckets and its
+// values file.
+type EnvPlan struct {
+	EnvID   string
+	EnvName string
+	Create  bool
+	// New and Set are the two collision buckets the flat-model ADR leaves, for
+	// this environment. Set is skipped by default and listed by name.
+	New []string
+	Set []string
+	// Overwritten names the `set` keys an enumerated overwrite selection admitted
+	// in this environment.
+	Overwritten []string
+	Values      ValuesFile
+	// HasValues reports whether this environment's values file carries anything.
+	HasValues bool
+}
+
+// ProjectPlan is a whole session's result: the four artifact families, with one
+// project-wide bundle and manifest and one values file per environment that
+// writes anything.
+type ProjectPlan struct {
+	Template Template
+	Manifest Manifest
+	Bundle   definitions.Bundle
+	Envs     []EnvPlan
+
+	Renames         []Rename
+	NearMisses      []NearMiss
+	SkippedBySource []string
+	PlaintextHints  []string
+	AlreadyDeclared []string
+}
+
+// single collapses a one-environment project plan into the legacy single-env
+// Plan the flag/replay CLI and the conformance harness consume. The artifact
+// bytes are the project plan's own, so a single-environment wizard session and
+// a flag run produce identical Template, Bundle and Manifest.
+func (p *ProjectPlan) single() *Plan {
+	env := p.Envs[0]
+	return &Plan{
+		Template: p.Template, Manifest: p.Manifest, Bundle: p.Bundle,
+		Values: env.Values, HasValues: env.HasValues,
+		Renames: p.Renames, NearMisses: p.NearMisses,
+		New: env.New, Set: env.Set, Overwritten: env.Overwritten,
+		SkippedBySource: p.SkippedBySource, PlaintextHints: p.PlaintextHints,
+		AlreadyDeclared: p.AlreadyDeclared,
+	}
+}
+
+// keyDecision is the project-scoped, per-key reconciled decision: one identity,
+// classification, type and folder, canonical across every environment the key
+// appears in.
+type keyDecision struct {
+	target       string
+	class        string
+	declType     schema.Type
+	typeSupplied bool
+	downgraded   bool
+	folder       string
+	declared     bool // an existing compatible declaration governs; not re-declared
+}
+
+// BuildProjectPlan runs the whole phase-1 decision surface across one or more
+// target environments. Keys, classifications and types are decided once,
+// project-wide, and reconciled to one canonical identity per key; each key's
+// folder must agree across every environment it appears in. Buckets, values,
+// occurrences and source versions are then decided per environment.
+func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
+	if in.Source == "" {
+		return nil, failure("import", CodeMalformed, "", "a phase-1 plan names no source")
+	}
+	if in.Project == "" {
+		return nil, failure("import", CodeMalformed, "",
+			"a phase-1 plan targets exactly one (project, environment)")
+	}
+	if len(in.Envs) == 0 {
+		return nil, failure(in.Source, CodeMalformed, "",
+			"a phase-1 plan targets at least one environment")
+	}
+	for i := range in.Envs {
+		e := &in.Envs[i]
+		if e.Create && e.EnvName == "" {
+			return nil, failure(in.Source, CodeMalformed, "",
+				"a created environment is named, not id'd")
+		}
+		if !e.Create && e.EnvID == "" {
+			return nil, failure(in.Source, CodeMalformed, "",
+				"a phase-1 plan targets exactly one (project, environment)")
+		}
+	}
+
 	classChoice, downgraded := templateClassifications(in.Template)
 	typeChoice, err := templateTypes(in.Template)
 	if err != nil {
@@ -278,16 +404,48 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 		return nil, err
 	}
 
-	var (
-		importedNames []string
-		folders       = map[string]string{}
-		trimOffenders []string
-		incompatible  []string
-	)
-	plan.Values = ValuesFile{
-		FormatVersion: FormatVersion,
-		Project:       in.State.Project,
-		Environment:   in.State.Environment,
+	// Per-environment name mapping, and the project-wide declared-key set. A key
+	// is declared for the project if any environment's read reports it declared;
+	// the declaration is project-scoped, so the fields agree across environments.
+	declaredNames := map[string]bool{}
+	declaredState := map[string]KeyState{}
+	envRows := make([][]mappedRecord, len(in.Envs))
+	var renames []Rename
+	renameSeen := map[string]bool{}
+	for i, e := range in.Envs {
+		rows, envRenames, err := mapRecords(in.Source, e.Records, in.Template)
+		if err != nil {
+			return nil, err
+		}
+		envRows[i] = rows
+		for _, r := range envRenames {
+			if !renameSeen[r.From] {
+				renameSeen[r.From] = true
+				renames = append(renames, r)
+			}
+		}
+		for _, k := range e.Keys {
+			if k.Declared {
+				declaredNames[k.Name] = true
+				declaredState[k.Name] = k
+			}
+		}
+	}
+	sort.SliceStable(renames, func(i, j int) bool { return renames[i].From < renames[j].From })
+
+	// The project pass: one reconciled decision per key, in sorted target order.
+	// Folder is computed per environment (root-collapse is a per-source fact) and
+	// must reconcile to one value — the bundle carries one folder_path per key.
+	decisions, order, folders, plaintextHints, err := reconcileKeys(in, envRows, recordedFolders,
+		classChoice, downgraded, typeChoice, declaredState)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &ProjectPlan{
+		SkippedBySource: mergeSkipped(in.Envs),
+		Renames:         renames,
+		PlaintextHints:  plaintextHints,
 	}
 	plan.Bundle = definitions.Bundle{
 		FormatVersion: definitions.FormatVersion,
@@ -296,119 +454,52 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 		Keys:          []definitions.Key{},
 	}
 
-	for _, row := range rows {
-		rec, target := row.record, row.target
-		sourcePath := recordPath(rec)
+	var importedNames []string
+	for _, target := range order {
+		d := decisions[target]
 		importedNames = append(importedNames, target)
-		if rec.PlaintextHint {
-			plan.PlaintextHints = append(plan.PlaintextHints, target)
-		}
-
-		// Write-time trim preflight. The schema layer trims edge whitespace on
-		// write, so a certificate with a trailing newline or a padded token
-		// would import CHANGED, silently. Every offender is collected; the
-		// refusal names them all, so one template edit acknowledges the lot.
-		if schema.Normalize(rec.Value) != rec.Value && !trimAck[target] {
-			trimOffenders = append(trimOffenders, quoteName(target))
-			continue
-		}
-
-		// Folder mapping. A source path maps onto a folder chain; the k8s
-		// single-container case takes the environment root. A replayed template
-		// that RECORDED a folder choice wins — the template is the record of
-		// every choice, and silently recomputing one makes it a suggestion.
-		sourceFolder := strings.Join(rec.Folder, "/")
-		targetFolder, ok := recordedFolders[sourceFolder]
-		if !ok {
-			if len(recordedFolders) > 0 {
-				return nil, failure(in.Source, CodeMalformed, sourcePath,
-					"the mapping template records no folder for source path %s; a replay against a source with "+
-						"folders the template never saw is a different mapping, not the same one",
-					quoteName(sourceFolder))
-			}
-			if targetFolder, err = targetFolderPath(rec.Folder, rootCollapse); err != nil {
-				return nil, err
-			}
-		}
-		folders[sourceFolder] = targetFolder
-
-		// Classification and type.
-		//
-		// EVERY IMPORTED KEY DEFAULTS `secret`, from every source. The only
-		// thing that can move it is an explicit per-key template downgrade.
-		class, declType, typeSupplied := desiredDeclaration(target, classChoice, typeChoice)
-		wasDowngraded := downgraded[target]
-
-		// An EXISTING declaration is not modified — an additive bundle may not —
-		// so a declaration that disagrees with what this import would declare is
-		// a conflict the human resolves, not one the importer absorbs. Refusing
-		// here rather than at phase 2 is the same refusal one command earlier,
-		// and it closes the case where a secret-store value lands quietly under
-		// a `config` declaration that every plain-`read` holder can see.
-		//
-		// The escape hatch is the template line itself: a template that declares
-		// `config` for this key IS the reviewed, recorded, committable consent
-		// the ADR means by "resolved by hand".
-		existing, isDeclared := state[target]
-		if isDeclared && existing.Declared {
-			switch {
-			case existing.Classification != class:
-				incompatible = append(incompatible, fmt.Sprintf(
-					"%s is declared `%s` but this import would declare `%s`",
-					quoteName(target), existing.Classification, class))
-				continue
-			case !compatibleImportedType(existing.Type, declType):
-				incompatible = append(incompatible, fmt.Sprintf(
-					"%s is declared type `%s` but this import would declare `%s`",
-					quoteName(target), existing.Type, declType))
-				continue
-			}
+		if d.declared {
 			plan.AlreadyDeclared = append(plan.AlreadyDeclared, target)
 		} else {
-			rule := schema.Rule{Type: declType}
+			rule := schema.Rule{Type: d.declType}
 			plan.Bundle.Keys = append(plan.Bundle.Keys, definitions.Key{
 				Name:           target,
-				FolderPath:     targetFolder,
-				Classification: class,
+				FolderPath:     d.folder,
+				Classification: d.class,
 				Declaration:    schema.Declaration{Rule: &rule},
-				RequiredIn: definitions.Presence{
-					Mode:         string(schema.PresenceNone),
-					Environments: []string{},
-				},
-				ForbiddenIn: definitions.Presence{
-					Mode:         string(schema.PresenceNone),
-					Environments: []string{},
-				},
+				RequiredIn:     definitions.Presence{Mode: string(schema.PresenceNone), Environments: []string{}},
+				ForbiddenIn:    definitions.Presence{Mode: string(schema.PresenceNone), Environments: []string{}},
 			})
 		}
-
 		plan.Template.Classifications = append(plan.Template.Classifications,
-			ClassificationChoice{Key: target, Class: class, Downgraded: wasDowngraded})
+			ClassificationChoice{Key: target, Class: d.class, Downgraded: d.downgraded})
 		// For an already-declared key, absence of a template type row means the
-		// existing declaration governs. Recording the default `string` here
-		// would fabricate consent the template author never supplied.
-		if !isDeclared || !existing.Declared || typeSupplied {
+		// existing declaration governs; recording the default `string` would
+		// fabricate consent the template author never supplied.
+		if !d.declared || d.typeSupplied {
 			plan.Template.Types = append(plan.Template.Types,
-				TypeChoice{Key: target, Type: string(declType), Accepted: true})
+				TypeChoice{Key: target, Type: string(d.declType), Accepted: true})
 		}
-
-		// Bucketing on the target environment's state. Two buckets, because
-		// local state IS resolved state once inheritance is gone.
-		switch {
-		case existing.Set && !overwrite[target]:
-			// `set`: skipped by default, listed by name. Skip-by-default is
-			// what makes a re-run naturally idempotent.
-			plan.Set = append(plan.Set, target)
-			continue
-		case existing.Set:
-			plan.Set = append(plan.Set, target)
-			plan.Overwritten = append(plan.Overwritten, target)
-		default:
-			plan.New = append(plan.New, target)
-		}
-		plan.Values.Entries = append(plan.Values.Entries, ValuesEntry{Key: target, Value: rec.Value})
 	}
 
+	sortedDeclared := make([]string, 0, len(declaredNames))
+	for name := range declaredNames {
+		sortedDeclared = append(sortedDeclared, name)
+	}
+	slices.Sort(sortedDeclared)
+	plan.NearMisses = NearMisses(importedNames, sortedDeclared)
+
+	// The per-environment pass: buckets, values, occurrences and trim preflight.
+	var trimOffenders []string
+	trimSeen := map[string]bool{}
+	for i := range in.Envs {
+		e := in.Envs[i]
+		envPlan, err := planEnvironment(in, e, envRows[i], decisions, &trimOffenders, trimSeen)
+		if err != nil {
+			return nil, err
+		}
+		plan.Envs = append(plan.Envs, envPlan)
+	}
 	if len(trimOffenders) > 0 {
 		slices.Sort(trimOffenders)
 		return nil, failure(in.Source, CodeTrim, "",
@@ -416,135 +507,345 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 				"`trim_acknowledgements`, or fix the values at the source: %s",
 			len(trimOffenders), strings.Join(trimOffenders, ", "))
 	}
-	if len(incompatible) > 0 {
-		slices.Sort(incompatible)
-		return nil, failure(in.Source, CodeIncompatible, "",
-			"%d key(s) already carry a declaration this import disagrees with; import never modifies a "+
-				"declaration, so resolve each by declaring the existing classification and type for that key "+
-				"in the mapping template, or by reclassifying the key first: %s",
-			len(incompatible), strings.Join(incompatible, "; "))
-	}
 
-	plan.NearMisses = NearMisses(importedNames, declaredNames)
-
-	// The template: flag mode records its effective template identically to a
-	// wizard session, so a flag-mode run is replayable without ceremony.
-	plan.Template.FormatVersion = FormatVersion
-	plan.Template.ConnectorContractVersion = ConnectorContractVersion
-	plan.Template.Source = in.Source
-	plan.Template.Project = in.State.Project
-	// The connector states its own scope shape (k8s reports the namespace and
-	// the Secret names it parsed); the framework stamps the file digest and the
-	// slice slug, which are its facts and not the connector's.
-	plan.Template.Scope = in.Scope
-	plan.Template.Scope.FileDigest = in.FileDigest
-	if in.EnvSlug != "" {
-		plan.Template.Scope.EnvSlug = in.EnvSlug
-	}
-	plan.Template.Environments = []EnvironmentMapping{{
-		Source: sourceEnvironment(in.EnvSlug),
-		Target: in.State.Environment,
-		// Import never creates the environment in flag mode: the target is
-		// addressed by id and must already resolve for the presence read to
-		// have happened at all.
-		Create: false,
-	}}
-	plan.Template.Folders = folderRows(folders)
-	if plan.Template.Renames == nil {
-		plan.Template.Renames = plan.Renames
-	}
-	for _, name := range plan.Overwritten {
-		plan.Template.Overwrites = append(plan.Template.Overwrites,
-			KeyEnvironment{Key: name, Environment: in.State.Environment})
-	}
-	for name := range trimAck {
-		plan.Template.TrimAcknowledgements = append(plan.Template.TrimAcknowledgements,
-			KeyEnvironment{Key: name, Environment: in.State.Environment})
-	}
-	sort.Slice(plan.Template.TrimAcknowledgements, func(i, j int) bool {
-		return plan.Template.TrimAcknowledgements[i].Key < plan.Template.TrimAcknowledgements[j].Key
-	})
-	emptySlices(&plan.Template)
+	plan.Template = buildTemplate(in, plan.Template, plan.Renames, folders, plan.Envs)
 
 	encoded, err := Encode(plan.Template)
 	if err != nil {
 		return nil, err
 	}
-
-	// The manifest: the bound record of THIS run, and the phase-2 precondition.
-	// It carries the occurrence token for every key the run touches — including
-	// the ones it skipped, so a later `--overwrite` re-run reviews the same
-	// occurrences it was shown.
-	plan.Manifest = Manifest{
-		FormatVersion:            FormatVersion,
-		ConnectorContractVersion: ConnectorContractVersion,
-		Template:                 TemplateReference{Digest: Digest(encoded)},
-		SourceIdentity:           SourceIdentity{Kind: in.Source, Context: sourceIdentity(in)},
-		Target: Target{
-			Project:      in.State.Project,
-			Environments: []string{in.State.Environment},
-		},
-		DefinitionsRevision: in.State.DefinitionsRevision,
-		PhaseCompletion: PhaseCompletion{
-			Authored: true,
-			Applied:  false,
-			Imported: map[string]bool{in.State.Environment: false},
-		},
+	plan.Manifest, err = buildManifest(in, encoded, envRows, decisions)
+	if err != nil {
+		return nil, err
 	}
-	// EVERY planned key gets a manifest row, declared or not. A key the project
-	// does not declare yet is exactly the key an import is about to create, and
-	// leaving it tokenless would leave the one row phase 2 cannot check —
-	// the row an edited manifest would choose to forge.
-	var missing []string
-	for _, row := range rows {
-		key := row.target
-		observed, ok := state[key]
-		if !ok {
-			missing = append(missing, quoteName(key))
-			continue
-		}
-		var id *string
-		if observed.Declared {
-			keyID := observed.ID
-			id = &keyID
-		}
-		plan.Manifest.Occurrences = append(plan.Manifest.Occurrences, ManifestOccurrence{
-			Key: key, Environment: in.State.Environment, Token: observed.Token,
-		})
-		plan.Manifest.Target.Keys = append(plan.Manifest.Target.Keys, TargetKey{Name: key, ID: id})
-		if row.record.Version != "" {
-			plan.Manifest.SourceVersions = append(plan.Manifest.SourceVersions, SourceVersion{
-				Key: key, Environment: in.State.Environment, Version: row.record.Version,
-			})
-		}
-	}
-	if len(missing) > 0 {
-		slices.Sort(missing)
-		return nil, failure(in.Source, CodeMalformed, "",
-			"the presence read returned no occurrence for %d planned key(s): %s — phase 1 must ask about "+
-				"every key it plans", len(missing), strings.Join(missing, ", "))
-	}
-	plan.Manifest.SourceVersions = nonNil(plan.Manifest.SourceVersions)
-	plan.Manifest.Occurrences = nonNil(plan.Manifest.Occurrences)
 	plan.Bundle, err = definitions.Normalize(plan.Bundle)
 	if err != nil {
 		return nil, fmt.Errorf("import: normalizing definitions bundle: %w", err)
 	}
-	// A run that writes nothing emits NO values file. An empty one is an
-	// artifact its own phase 2 refuses ("the values file holds no entries"),
-	// which would end every idempotent re-run in a refusal for having correctly
-	// done nothing.
-	if len(plan.Values.Entries) > 0 {
-		plan.HasValues = true
-	}
 	return plan, nil
 }
 
-func sourceIdentity(in PlanInput) string {
-	if in.SourceIdentity != "" {
-		return in.SourceIdentity
+// reconcileKeys makes the project-scoped, per-key decision across every
+// environment. It returns the decisions keyed by target, the sorted target
+// order, the folder rows for the template, the plaintext hints, or a refusal —
+// an existing declaration this import disagrees with, or a key whose folder
+// differs between environments (two environments proposing one key under two
+// folders is the reconciliation conflict the wizard resolves interactively and
+// flag mode cannot reach, since flag mode has one environment).
+func reconcileKeys(in ProjectPlanInput, envRows [][]mappedRecord, recordedFolders map[string]string,
+	classChoice map[string]string, downgraded map[string]bool, typeChoice map[string]schema.Type,
+	declaredState map[string]KeyState) (map[string]keyDecision, []string, map[string]string, []string, error) {
+	decisions := map[string]keyDecision{}
+	var order []string
+	folders := map[string]string{}
+	folderOf := map[string]string{} // target key -> reconciled folder
+	plaintextSeen := map[string]bool{}
+	var plaintextHints []string
+	var incompatible []string
+	var folderConflicts []string
+
+	for i, rows := range envRows {
+		rootCollapse := in.Source == k8sSource && singleSourceFolder(in.Envs[i].Records)
+		for _, row := range rows {
+			rec, target := row.record, row.target
+			sourcePath := recordPath(rec)
+
+			sourceFolder := strings.Join(rec.Folder, "/")
+			targetFolder, ok := recordedFolders[sourceFolder]
+			if !ok {
+				if len(recordedFolders) > 0 {
+					return nil, nil, nil, nil, failure(in.Source, CodeMalformed, sourcePath,
+						"the mapping template records no folder for source path %s; a replay against a source with "+
+							"folders the template never saw is a different mapping, not the same one",
+						quoteName(sourceFolder))
+				}
+				var err error
+				if targetFolder, err = targetFolderPath(rec.Folder, rootCollapse); err != nil {
+					return nil, nil, nil, nil, err
+				}
+			}
+			if prior, seen := folderOf[target]; seen && prior != targetFolder {
+				folderConflicts = append(folderConflicts, fmt.Sprintf(
+					"%s maps onto folder %s and %s in different environments",
+					quoteName(target), quoteName(prior), quoteName(targetFolder)))
+				continue
+			}
+			folderOf[target] = targetFolder
+			folders[sourceFolder] = targetFolder
+
+			if rec.PlaintextHint && !plaintextSeen[target] {
+				plaintextSeen[target] = true
+				plaintextHints = append(plaintextHints, target)
+			}
+
+			if _, done := decisions[target]; done {
+				continue
+			}
+			class, declType, typeSupplied := desiredDeclaration(target, classChoice, typeChoice)
+			existing, isDeclared := declaredState[target]
+			declared := false
+			if isDeclared {
+				switch {
+				case existing.Classification != class:
+					incompatible = append(incompatible, fmt.Sprintf(
+						"%s is declared `%s` but this import would declare `%s`",
+						quoteName(target), existing.Classification, class))
+					continue
+				case !compatibleImportedType(existing.Type, declType):
+					incompatible = append(incompatible, fmt.Sprintf(
+						"%s is declared type `%s` but this import would declare `%s`",
+						quoteName(target), existing.Type, declType))
+					continue
+				}
+				declared = true
+			}
+			decisions[target] = keyDecision{
+				target: target, class: class, declType: declType, typeSupplied: typeSupplied,
+				downgraded: downgraded[target], folder: targetFolder, declared: declared,
+			}
+			order = append(order, target)
+		}
 	}
-	return in.FileDigest
+	// A key seen first under a conflicting folder still has its decision folder
+	// from the first environment; the conflict list forces a refusal regardless,
+	// so a stale folder in a discarded decision never reaches an artifact.
+	if len(incompatible) > 0 {
+		slices.Sort(incompatible)
+		return nil, nil, nil, nil, failure(in.Source, CodeIncompatible, "",
+			"%d key(s) already carry a declaration this import disagrees with; import never modifies a "+
+				"declaration, so resolve each by declaring the existing classification and type for that key "+
+				"in the mapping template, or by reclassifying the key first: %s",
+			len(incompatible), strings.Join(incompatible, "; "))
+	}
+	if len(folderConflicts) > 0 {
+		slices.Sort(folderConflicts)
+		return nil, nil, nil, nil, failure(in.Source, CodeIncompatible, "",
+			"%d key(s) reconcile to different folders across environments; one bundle declares one folder per "+
+				"key, so resolve each with an explicit folder in the mapping template: %s",
+			len(folderConflicts), strings.Join(folderConflicts, "; "))
+	}
+	slices.Sort(order)
+	return decisions, order, folders, plaintextHints, nil
+}
+
+// planEnvironment decides one environment's buckets and values. Trim offenders
+// are collected project-wide (deduped by key) so the refusal names them once.
+func planEnvironment(in ProjectPlanInput, e EnvInput, rows []mappedRecord, decisions map[string]keyDecision,
+	trimOffenders *[]string, trimSeen map[string]bool) (EnvPlan, error) {
+	envID := e.EnvID
+	envRef := envID
+	if e.Create {
+		envRef = e.EnvName
+	}
+	overwrite := templateOverwrites(in.Template, envRef)
+	trimAck := templateTrimAcks(in.Template, envRef)
+
+	state := make(map[string]KeyState, len(e.Keys))
+	for _, k := range e.Keys {
+		state[k.Name] = k
+	}
+
+	envPlan := EnvPlan{EnvID: envID, EnvName: e.EnvName, Create: e.Create}
+	envPlan.Values = ValuesFile{
+		FormatVersion: FormatVersion,
+		Project:       in.Project,
+		Environment:   envID,
+	}
+	for _, row := range rows {
+		rec, target := row.record, row.target
+		if _, planned := decisions[target]; !planned {
+			// The key was dropped in reconciliation (a folder conflict), which is
+			// already a refusal; never reachable on the success path.
+			continue
+		}
+		if schema.Normalize(rec.Value) != rec.Value && !trimAck[target] {
+			if !trimSeen[target] {
+				trimSeen[target] = true
+				*trimOffenders = append(*trimOffenders, quoteName(target))
+			}
+			continue
+		}
+		// A created environment has no prior state: every key is absent, so it is
+		// `new` and there is nothing to overwrite.
+		existing := state[target]
+		switch {
+		case existing.Set && !overwrite[target]:
+			envPlan.Set = append(envPlan.Set, target)
+			continue
+		case existing.Set:
+			envPlan.Set = append(envPlan.Set, target)
+			envPlan.Overwritten = append(envPlan.Overwritten, target)
+		default:
+			envPlan.New = append(envPlan.New, target)
+		}
+		envPlan.Values.Entries = append(envPlan.Values.Entries, ValuesEntry{Key: target, Value: rec.Value})
+	}
+	envPlan.HasValues = len(envPlan.Values.Entries) > 0
+	return envPlan, nil
+}
+
+// buildTemplate assembles the mapping template. Flag mode records its effective
+// template identically to a wizard session, so a flag-mode run is replayable
+// without ceremony.
+func buildTemplate(in ProjectPlanInput, tmpl Template, renames []Rename, folders map[string]string,
+	envs []EnvPlan) Template {
+	tmpl.FormatVersion = FormatVersion
+	tmpl.ConnectorContractVersion = ConnectorContractVersion
+	tmpl.Source = in.Source
+	tmpl.Project = in.Project
+	// The scope is one connector read's shape. A single-environment session (flag
+	// mode, single-env replay, or a one-target wizard) records the read it made;
+	// a multi-environment session records the first environment's read as the
+	// representative scope, with per-environment source slices carried on the
+	// environment rows.
+	first := in.Envs[0]
+	tmpl.Scope = first.Scope
+	tmpl.Scope.FileDigest = first.FileDigest
+	if first.EnvSlug != "" {
+		tmpl.Scope.EnvSlug = first.EnvSlug
+	}
+	tmpl.Environments = nil
+	for _, e := range in.Envs {
+		target := e.EnvID
+		if e.Create {
+			target = e.EnvName
+		}
+		tmpl.Environments = append(tmpl.Environments, EnvironmentMapping{
+			Source: sourceEnvironment(e.EnvSlug),
+			Target: target,
+			Create: e.Create,
+		})
+	}
+	tmpl.Folders = folderRows(folders)
+	if tmpl.Renames == nil {
+		tmpl.Renames = renames
+	}
+	// Overwrites and trim acknowledgements are per (key, environment). The
+	// overwrite rows record what was actually admitted this run; the trim rows
+	// re-state the input template's acknowledgements for the environment they
+	// applied to. Grouped by environment (input order), sorted by key within.
+	tmpl.Overwrites = nil
+	tmpl.TrimAcknowledgements = nil
+	for i, e := range in.Envs {
+		envRef := e.EnvID
+		if e.Create {
+			envRef = e.EnvName
+		}
+		for _, name := range envs[i].Overwritten {
+			tmpl.Overwrites = append(tmpl.Overwrites, KeyEnvironment{Key: name, Environment: envRef})
+		}
+		acks := make([]string, 0)
+		for name := range templateTrimAcks(in.Template, envRef) {
+			acks = append(acks, name)
+		}
+		slices.Sort(acks)
+		for _, name := range acks {
+			tmpl.TrimAcknowledgements = append(tmpl.TrimAcknowledgements,
+				KeyEnvironment{Key: name, Environment: envRef})
+		}
+	}
+	emptySlices(&tmpl)
+	return tmpl
+}
+
+// buildManifest assembles the run manifest: the bound record of the run and the
+// phase-2 precondition. Every key a run touches in an existing environment gets
+// a server-minted occurrence row — including skipped ones, so a later overwrite
+// re-run reviews the same occurrences it was shown. Created environments are
+// tokenless: they contribute no occurrence rows and are named without an id.
+func buildManifest(in ProjectPlanInput, encodedTemplate []byte, envRows [][]mappedRecord,
+	decisions map[string]keyDecision) (Manifest, error) {
+	first := in.Envs[0]
+	m := Manifest{
+		FormatVersion:            FormatVersion,
+		ConnectorContractVersion: ConnectorContractVersion,
+		Template:                 TemplateReference{Digest: Digest(encodedTemplate)},
+		SourceIdentity:           SourceIdentity{Kind: in.Source, Context: sourceContext(first)},
+		Target:                   Target{Project: in.Project},
+		DefinitionsRevision:      in.DefinitionsRevision,
+		PhaseCompletion:          PhaseCompletion{Authored: true, Applied: false, Imported: map[string]bool{}},
+	}
+	keyID := map[string]*string{}
+	var keyOrder []string
+	var missing []string
+	for i, e := range in.Envs {
+		envRef := e.EnvID
+		if e.Create {
+			envRef = e.EnvName
+		}
+		m.Target.Environments = append(m.Target.Environments, envRef)
+		m.PhaseCompletion.Imported[envRef] = false
+		state := make(map[string]KeyState, len(e.Keys))
+		for _, k := range e.Keys {
+			state[k.Name] = k
+		}
+		for _, row := range envRows[i] {
+			key := row.target
+			if _, planned := decisions[key]; !planned {
+				continue
+			}
+			if _, seen := keyID[key]; !seen {
+				keyOrder = append(keyOrder, key)
+				keyID[key] = nil
+			}
+			if e.Create {
+				// Tokenless by construction: no presence read, so no occurrence.
+				continue
+			}
+			observed, ok := state[key]
+			if !ok {
+				missing = append(missing, quoteName(key))
+				continue
+			}
+			if observed.Declared {
+				id := observed.ID
+				keyID[key] = &id
+			}
+			m.Occurrences = append(m.Occurrences, ManifestOccurrence{
+				Key: key, Environment: e.EnvID, Token: observed.Token,
+			})
+			if row.record.Version != "" {
+				m.SourceVersions = append(m.SourceVersions, SourceVersion{
+					Key: key, Environment: e.EnvID, Version: row.record.Version,
+				})
+			}
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return Manifest{}, failure(in.Source, CodeMalformed, "",
+			"the presence read returned no occurrence for %d planned key(s): %s — phase 1 must ask about "+
+				"every key it plans", len(missing), strings.Join(missing, ", "))
+	}
+	for _, key := range keyOrder {
+		m.Target.Keys = append(m.Target.Keys, TargetKey{Name: key, ID: keyID[key]})
+	}
+	m.SourceVersions = nonNil(m.SourceVersions)
+	m.Occurrences = nonNil(m.Occurrences)
+	return m, nil
+}
+
+// mergeSkipped unions the per-environment source-skip lists, deduped and sorted.
+func mergeSkipped(envs []EnvInput) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range envs {
+		for _, name := range e.Skipped {
+			if !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sourceContext(e EnvInput) string {
+	if e.SourceIdentity != "" {
+		return e.SourceIdentity
+	}
+	return e.FileDigest
 }
 
 func desiredDeclaration(target string, classChoice map[string]string,

--- a/internal/importer/plan.go
+++ b/internal/importer/plan.go
@@ -518,6 +518,27 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Bind each environment's values file to this run by content digest, so a
+	// values file cannot be imported under a different run's manifest even when
+	// both target the same (project, environment). Only environments that write a
+	// values file get a digest; the reference is the id for existing environments
+	// and the name for created ones, matching the values file's own addressing.
+	for _, env := range plan.Envs {
+		if !env.HasValues {
+			continue
+		}
+		body, err := Encode(env.Values)
+		if err != nil {
+			return nil, err
+		}
+		ref := env.EnvID
+		if env.Create {
+			ref = env.EnvName
+		}
+		plan.Manifest.ValuesDigests = append(plan.Manifest.ValuesDigests,
+			ValuesDigest{Environment: ref, Digest: Digest(body)})
+	}
+	plan.Manifest.ValuesDigests = nonNil(plan.Manifest.ValuesDigests)
 	// Created environments are explicit, reviewable bundle lines (ADR § Targeting
 	// and hierarchy creation): `definitions apply` creates them. Deduped and
 	// sorted so the bundle is byte-stable.

--- a/internal/importer/plan_test.go
+++ b/internal/importer/plan_test.go
@@ -121,6 +121,132 @@ func planFrom(t *testing.T, fixture string, st ServerState, tmpl *Template) (*Pl
 	return BuildPlan(in)
 }
 
+// envFrom reads a k8s fixture and mints a per-name undeclared token for anything
+// the fixture state does not declare, mirroring the CLI's presence read for one
+// environment. Undeclared tokens are salted with the environment id so the two
+// environments' occurrences are distinguishable, as the server's scoped tokens
+// are.
+func envFrom(t *testing.T, fixture, envID string, keys []KeyState, tmpl *Template) EnvInput {
+	t.Helper()
+	res, err := run(t, k8sSource, fixture, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := PlanInput{Source: k8sSource, Records: res.Records, Template: tmpl}
+	candidates, err := PlannedNames(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	declared := map[string]bool{}
+	for _, k := range keys {
+		declared[k.Name] = true
+	}
+	state := append([]KeyState{}, keys...)
+	for _, name := range candidates {
+		if !declared[name] {
+			state = append(state, KeyState{Name: name, Token: "v1:undeclared-" + envID + "-" + name})
+		}
+	}
+	return EnvInput{
+		Records: res.Records, Skipped: res.Skipped, Scope: res.Scope,
+		FileDigest: "sha256:fixture", EnvID: envID, Keys: state,
+	}
+}
+
+// TestProjectPlanFansOutAcrossEnvironments: one source, two existing target
+// environments, one project-wide bundle, and per-environment buckets that differ
+// only by presence.
+func TestProjectPlanFansOutAcrossEnvironments(t *testing.T) {
+	prod := envFrom(t, "k8s-multi.yaml", "env_prod",
+		[]KeyState{declaredKey("DB_PASSWORD", "secret", true, "v1:tok-prod")}, nil)
+	staging := envFrom(t, "k8s-multi.yaml", "env_staging",
+		[]KeyState{declaredKey("DB_PASSWORD", "secret", false, "v1:tok-staging")}, nil)
+	plan, err := BuildProjectPlan(ProjectPlanInput{
+		Source: k8sSource, Project: "prj_1", DefinitionsRevision: 7,
+		Envs: []EnvInput{prod, staging},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One project-wide bundle: the three undeclared keys declared once each;
+	// DB_PASSWORD is already declared in both environments and not re-declared.
+	if len(plan.Bundle.Keys) != 3 {
+		t.Fatalf("bundle keys = %d, want one project-wide declaration per undeclared key", len(plan.Bundle.Keys))
+	}
+	if strings.Join(plan.AlreadyDeclared, ",") != "DB_PASSWORD" {
+		t.Errorf("already declared = %v, want DB_PASSWORD once project-wide", plan.AlreadyDeclared)
+	}
+
+	// Presence varies by environment: DB_PASSWORD is set in prod (skipped) and
+	// absent in staging (imported).
+	if len(plan.Envs) != 2 {
+		t.Fatalf("env plans = %d", len(plan.Envs))
+	}
+	byEnv := map[string]EnvPlan{}
+	for _, e := range plan.Envs {
+		byEnv[e.EnvID] = e
+	}
+	if strings.Join(byEnv["env_prod"].Set, ",") != "DB_PASSWORD" {
+		t.Errorf("prod set = %v, want DB_PASSWORD skipped", byEnv["env_prod"].Set)
+	}
+	for _, e := range byEnv["env_prod"].Values.Entries {
+		if e.Key == "DB_PASSWORD" {
+			t.Error("prod imported a set key without overwrite consent")
+		}
+	}
+	stagingHasPassword := false
+	for _, e := range byEnv["env_staging"].Values.Entries {
+		if e.Key == "DB_PASSWORD" {
+			stagingHasPassword = true
+		}
+	}
+	if !stagingHasPassword {
+		t.Error("staging (absent) did not import DB_PASSWORD")
+	}
+
+	// One manifest naming both environments, with occurrences per (key, env).
+	if len(plan.Manifest.Target.Environments) != 2 {
+		t.Errorf("manifest environments = %v", plan.Manifest.Target.Environments)
+	}
+	perEnv := map[string]int{}
+	for _, o := range plan.Manifest.Occurrences {
+		perEnv[o.Environment]++
+	}
+	if perEnv["env_prod"] != 4 || perEnv["env_staging"] != 4 {
+		t.Errorf("occurrence counts = %v, want 4 per environment", perEnv)
+	}
+
+	// The template records both environment rows.
+	if len(plan.Template.Environments) != 2 {
+		t.Errorf("template environments = %+v", plan.Template.Environments)
+	}
+}
+
+// TestProjectPlanRefusesFolderConflict: a key that reconciles to two different
+// folders across environments cannot be declared once (the bundle carries one
+// folder_path per key), so the run refuses. Multi-folder records defeat the k8s
+// single-Secret root collapse, so the folders are the ones the records name.
+func TestProjectPlanRefusesFolderConflict(t *testing.T) {
+	env := func(id, dbFolder string) EnvInput {
+		return EnvInput{
+			EnvID: id,
+			Records: []Record{
+				{Folder: []string{dbFolder}, SourceName: "DB_HOST", Value: "h", Type: schema.TypeString},
+				{Folder: []string{"api"}, SourceName: "API_KEY", Value: "k", Type: schema.TypeString},
+			},
+		}
+	}
+	_, err := BuildProjectPlan(ProjectPlanInput{
+		Source: k8sSource, Project: "prj_1", DefinitionsRevision: 7,
+		Envs: []EnvInput{env("env_a", "db"), env("env_b", "database")},
+	})
+	wantCode(t, err, CodeIncompatible)
+	if !strings.Contains(err.Error(), "folder") {
+		t.Errorf("refusal does not name the folder conflict: %v", err)
+	}
+}
+
 // TestBucketsAreNewAndSetOnly pins the flat-model amendment: two buckets, and a
 // `set` key is skipped by default and listed by name.
 func TestBucketsAreNewAndSetOnly(t *testing.T) {

--- a/internal/importer/plan_test.go
+++ b/internal/importer/plan_test.go
@@ -223,6 +223,48 @@ func TestProjectPlanFansOutAcrossEnvironments(t *testing.T) {
 	}
 }
 
+// TestManifestBindsEachValuesFileByDigest: the manifest records, per writing
+// environment, the digest of that environment's canonical values file — the
+// binding that stops a values file being imported under a different run's
+// manifest. The recorded digest must equal the digest the CLI recomputes from
+// the parsed values file at import.
+func TestManifestBindsEachValuesFileByDigest(t *testing.T) {
+	prod := envFrom(t, "k8s-multi.yaml", "env_prod", nil, nil)
+	staging := envFrom(t, "k8s-multi.yaml", "env_staging", nil, nil)
+	plan, err := BuildProjectPlan(ProjectPlanInput{
+		Source: k8sSource, Project: "prj_1", DefinitionsRevision: 7,
+		Envs: []EnvInput{prod, staging},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byRef := map[string]string{}
+	for _, d := range plan.Manifest.ValuesDigests {
+		byRef[d.Environment] = d.Digest
+	}
+	for _, env := range plan.Envs {
+		if !env.HasValues {
+			continue
+		}
+		body, err := Encode(env.Values)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := byRef[env.EnvID]; got != Digest(body) {
+			t.Errorf("env %s digest = %q, want %q (the values file's own digest)", env.EnvID, got, Digest(body))
+		}
+	}
+	// A tampered values file (a changed value) no longer matches — the property
+	// the CLI relies on when it refuses a mispaired file.
+	tampered := plan.Envs[0].Values
+	tampered.Entries = append([]ValuesEntry{}, tampered.Entries...)
+	tampered.Entries[0].Value += "X"
+	body, _ := Encode(tampered)
+	if Digest(body) == byRef[plan.Envs[0].EnvID] {
+		t.Error("a changed value produced the same digest")
+	}
+}
+
 // TestProjectPlanRefusesFolderConflict: a key that reconciles to two different
 // folders across environments cannot be declared once (the bundle carries one
 // folder_path per key), so the run refuses. Multi-folder records defeat the k8s

--- a/internal/importer/suggest.go
+++ b/internal/importer/suggest.go
@@ -1,0 +1,83 @@
+package importer
+
+import (
+	"encoding/json"
+
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+)
+
+// Deterministic type suggestion for the wizard (import-paths ADR § Typing).
+//
+// A suggestion NEVER applies on its own — the wizard offers it and it lands only
+// on a human accept. The conservative floor is `string`; flag mode declares
+// everything `string` and never calls this. The suggestion is computed across
+// ALL of a key's mapped values (declarations are project-scoped, so a key that
+// is `4` in staging and `auto` in prod suggests nothing but `string`): a type is
+// suggested only when EVERY value would satisfy it.
+
+// suggestBoolean and suggestInteger reuse the schema grammar so a suggestion is
+// exactly a type the declaration would then accept — an accepted suggestion that
+// failed validation would be a decorative flag, the failure this ADR refuses.
+var (
+	suggestBoolean = mustCompile(schema.TypeBoolean)
+	suggestInteger = mustCompile(schema.TypeInteger)
+)
+
+func mustCompile(t schema.Type) *schema.Compiled {
+	rule := schema.Rule{Type: t}
+	c, err := schema.Compile(schema.Declaration{Rule: &rule})
+	if err != nil {
+		// The rules are compile-time constants; a failure is a build-time bug.
+		panic("importer: compiling the " + string(t) + " suggestion rule: " + err.Error())
+	}
+	return c
+}
+
+// SuggestType returns the deterministic type suggestion for a key's values,
+// checked in the fixed order boolean → integer → json, falling back to string.
+// An empty value set suggests string: there is nothing to narrow from.
+func SuggestType(values []string) schema.Type {
+	if len(values) == 0 {
+		return schema.TypeString
+	}
+	switch {
+	case allSatisfy(values, func(v string) bool { return suggestBoolean.Validate(v, schema.Secret).Valid }):
+		return schema.TypeBoolean
+	case allSatisfy(values, func(v string) bool { return suggestInteger.Validate(v, schema.Secret).Valid }):
+		return schema.TypeInteger
+	case allSatisfy(values, isJSONObjectOrArray):
+		return schema.TypeJSON
+	default:
+		return schema.TypeString
+	}
+}
+
+func allSatisfy(values []string, ok func(string) bool) bool {
+	for _, v := range values {
+		if !ok(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// isJSONObjectOrArray reports whether a value is a single well-formed JSON
+// object or array. A scalar JSON document (`4`, `true`, `"x"`) is deliberately
+// NOT json here — those are the integer/boolean/string cases — so the suggestion
+// only fires for genuinely structured leaves, matching the ADR's wording.
+func isJSONObjectOrArray(v string) bool {
+	trimmed := schema.Normalize(v)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return false
+	}
+	var doc any
+	if err := json.Unmarshal([]byte(v), &doc); err != nil {
+		return false
+	}
+	switch doc.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/importer/suggest_test.go
+++ b/internal/importer/suggest_test.go
@@ -1,0 +1,60 @@
+package importer
+
+import (
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+)
+
+func TestSuggestType(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		want   schema.Type
+	}{
+		{"empty suggests string", nil, schema.TypeString},
+		{"canonical booleans", []string{"true", "false", "true"}, schema.TypeBoolean},
+		{"non-canonical boolean is string", []string{"TRUE"}, schema.TypeString},
+		{"integers", []string{"4", "-7", "0"}, schema.TypeInteger},
+		{"leading zero integer", []string{"01"}, schema.TypeInteger},
+		{"json object", []string{`{"a":1}`}, schema.TypeJSON},
+		{"json array", []string{"[1,2,3]"}, schema.TypeJSON},
+		{"scalar json is not json", []string{"4"}, schema.TypeInteger},
+		{"string scalar json quote is string", []string{`"x"`}, schema.TypeString},
+		// Computed across ALL mapped values: a key that disagrees across
+		// environments suggests nothing but string.
+		{"mixed integer and word", []string{"4", "auto"}, schema.TypeString},
+		{"mixed boolean and integer", []string{"true", "4"}, schema.TypeString},
+		{"mixed json shapes stays json", []string{`{"a":1}`, "[1]"}, schema.TypeJSON},
+		{"one env only", []string{"9000"}, schema.TypeInteger},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SuggestType(tc.values); got != tc.want {
+				t.Errorf("SuggestType(%v) = %s, want %s", tc.values, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSuggestionIsAlwaysAcceptedByTheDeclaration is the anti-decoration guard: a
+// suggested type must be one the declaration would then accept for every value,
+// or accepting it would fail validation later.
+func TestSuggestionIsAlwaysAcceptedByTheDeclaration(t *testing.T) {
+	sets := [][]string{
+		{"true", "false"}, {"4", "-7", "01"}, {`{"a":1}`, "[1,2]"}, {"auto", "4"},
+	}
+	for _, values := range sets {
+		typ := SuggestType(values)
+		rule := schema.Rule{Type: typ}
+		compiled, err := schema.Compile(schema.Declaration{Rule: &rule})
+		if err != nil {
+			t.Fatalf("suggested type %s does not compile: %v", typ, err)
+		}
+		for _, v := range values {
+			if verdict := compiled.Validate(v, schema.Secret); !verdict.Valid {
+				t.Errorf("suggested %s for %q but the declaration rejects it: %+v", typ, v, verdict.Errors)
+			}
+		}
+	}
+}

--- a/internal/importer/wizard.go
+++ b/internal/importer/wizard.go
@@ -94,12 +94,32 @@ func Wizard(host WizardHost, project string) (*ProjectPlan, error) {
 		return nil, err
 	}
 
+	// ONE source read, fanned across the target environments (import-paths ADR
+	// § The two-phase invariant: keys/types/classifications are project-scoped,
+	// "only presence varies by environment"). Reading one slice and mapping it
+	// onto several targets is what makes the session faithfully replayable — the
+	// template records one scope, and a replay re-reads that one source and fans
+	// it the same way.
+	sel, err := wizardSelector(host, source)
+	if err != nil {
+		return nil, err
+	}
+	read, err := host.ReadSource(source, sel)
+	if err != nil {
+		return nil, err
+	}
+	if read.Result.DecodedBytes > MaxSessionDecodedBytes {
+		return nil, failure(source, CodeBound, "",
+			"the source read totals %d decoded bytes, exceeding the %d-byte wizard-session aggregate cap",
+			read.Result.DecodedBytes, MaxSessionDecodedBytes)
+	}
+
 	existing, err := host.ExistingEnvironments()
 	if err != nil {
 		return nil, err
 	}
 
-	envs, err := wizardEnvironments(host, source, existing)
+	envs, err := wizardEnvironments(host, source, existing, read)
 	if err != nil {
 		return nil, err
 	}
@@ -108,18 +128,15 @@ func Wizard(host WizardHost, project string) (*ProjectPlan, error) {
 	}
 
 	tmpl := &Template{}
-	// Renames and folders are structural — no server contact.
-	valuesByKey, manual, err := wizardRenames(host, source, envs, tmpl)
+	// Renames are structural — no server contact.
+	valuesByKey, _, err := wizardRenames(host, source, envs, tmpl)
 	if err != nil {
 		return nil, err
 	}
-	if err := wizardFolders(host, source, envs, manual, tmpl); err != nil {
-		return nil, err
-	}
 	// A first presence read (with the default classification/type intent) learns
-	// which keys the project already declares, so classification and type review
-	// can skip them — an existing declaration governs and is not re-offered.
-	declared, err := wizardDeclaredSet(host, source, envs, tmpl)
+	// what the project already declares, so classification and type review can
+	// skip those keys and record the EXISTING declaration as the reviewed consent.
+	declared, err := wizardDeclaredSet(host, source, envs)
 	if err != nil {
 		return nil, err
 	}
@@ -174,19 +191,21 @@ func wizardSource(host WizardHost) (string, error) {
 	return sources[i], nil
 }
 
-// wizardEnvironments is states 2 and 3: for each target environment, the human
-// picks (or creates) it and provides the source slice that maps onto it. A
-// created environment is declared up front here and carries no presence read.
-func wizardEnvironments(host WizardHost, source string, existing []NamedEnv) ([]wizardEnv, error) {
+// wizardEnvironments is state 3: the human maps the one source read onto one or
+// more target environments — existing ones, or ones the session will create,
+// declared up front. Every environment shares the same source read; only
+// presence varies.
+func wizardEnvironments(host WizardHost, source string, existing []NamedEnv, read SourceRead) ([]wizardEnv, error) {
 	options := make([]string, 0, len(existing)+1)
+	existingNames := map[string]bool{}
 	for _, e := range existing {
 		options = append(options, e.Name)
+		existingNames[e.Name] = true
 	}
 	options = append(options, "+ create a new environment")
 
 	claimed := map[string]bool{}
 	var envs []wizardEnv
-	sessionDecoded := 0
 	for {
 		add := true
 		if len(envs) > 0 {
@@ -199,30 +218,22 @@ func wizardEnvironments(host WizardHost, source string, existing []NamedEnv) ([]
 				break
 			}
 		}
-		env, err := wizardOneEnvironment(host, source, existing, options, claimed)
+		env, err := wizardOneEnvironment(host, source, existing, options, existingNames, claimed)
 		if err != nil {
 			return nil, err
 		}
-		// The aggregate session bound is enforced across the fan-out, over and
-		// above each read's own per-run caps.
-		sessionDecoded += env.read.Result.DecodedBytes
-		if sessionDecoded > MaxSessionDecodedBytes {
-			return nil, failure(source, CodeBound, "",
-				"the session's reads total %d decoded bytes, exceeding the %d-byte wizard-session aggregate cap",
-				sessionDecoded, MaxSessionDecodedBytes)
-		}
+		env.read = read
 		envs = append(envs, env)
 	}
 	return envs, nil
 }
 
 func wizardOneEnvironment(host WizardHost, source string, existing []NamedEnv, options []string,
-	claimed map[string]bool) (wizardEnv, error) {
+	existingNames, claimed map[string]bool) (wizardEnv, error) {
 	choice, err := host.Choose("Target environment:", options, 0)
 	if err != nil {
 		return wizardEnv{}, err
 	}
-	var env wizardEnv
 	if choice == len(existing) {
 		name, err := host.Line("New environment name:", "")
 		if err != nil {
@@ -232,31 +243,27 @@ func wizardOneEnvironment(host WizardHost, source string, existing []NamedEnv, o
 		if name == "" {
 			return wizardEnv{}, failure(source, CodeMalformed, "", "a created environment needs a name")
 		}
+		// A created environment must not collide with one that already exists —
+		// import never modifies an environment, so `create <existing>` is a
+		// contradiction, not a target — nor with one already mapped this session.
+		if existingNames[name] {
+			return wizardEnv{}, failure(source, CodeMalformed, "",
+				"environment %s already exists; map it as an existing target rather than creating it", quoteName(name))
+		}
 		if claimed[name] {
 			return wizardEnv{}, failure(source, CodeMalformed, "",
 				"environment %s is already mapped this session", quoteName(name))
 		}
-		env = wizardEnv{ref: name, name: name, create: true}
-	} else {
-		e := existing[choice]
-		if claimed[e.ID] {
-			return wizardEnv{}, failure(source, CodeMalformed, "",
-				"environment %s is already mapped this session", quoteName(e.Name))
-		}
-		env = wizardEnv{ref: e.ID, name: e.Name}
+		claimed[name] = true
+		return wizardEnv{ref: name, name: name, create: true}, nil
 	}
-	claimed[env.ref] = true
-
-	sel, err := wizardSelector(host, source)
-	if err != nil {
-		return wizardEnv{}, err
+	e := existing[choice]
+	if claimed[e.ID] {
+		return wizardEnv{}, failure(source, CodeMalformed, "",
+			"environment %s is already mapped this session", quoteName(e.Name))
 	}
-	read, err := host.ReadSource(source, sel)
-	if err != nil {
-		return wizardEnv{}, err
-	}
-	env.read = read
-	return env, nil
+	claimed[e.ID] = true
+	return wizardEnv{ref: e.ID, name: e.Name}, nil
 }
 
 // wizardSelector is state 2: the connector selectors for one source slice,
@@ -387,39 +394,50 @@ func wizardRenames(host WizardHost, source string, envs []wizardEnv, tmpl *Templ
 }
 
 // wizardDeclaredSet performs the first presence read (default declaration
-// intent) purely to learn which keys the project already declares, so
-// classification and type review can skip them. Its tokens are not kept — the
-// second read carries the final intent.
-func wizardDeclaredSet(host WizardHost, source string, envs []wizardEnv, tmpl *Template) (map[string]bool, error) {
-	declared := map[string]bool{}
+// intent) purely to learn what the project already declares. Declared keys are
+// project-scoped, so one existing environment answers for the whole project;
+// its tokens are not kept — the second read carries the final intent. A session
+// with only created environments reads nothing (the project declares nothing an
+// import would collide with, or the collision surfaces at plan time).
+func wizardDeclaredSet(host WizardHost, source string, envs []wizardEnv) (map[string]KeyState, error) {
+	declared := map[string]KeyState{}
+	var ref string
+	var records []Record
 	for i := range envs {
-		if envs[i].create {
-			continue
+		if !envs[i].create {
+			ref = envs[i].ref
+			records = envs[i].read.Result.Records
+			break
 		}
-		candidates, err := PlannedCandidates(PlanInput{
-			Source: source, Records: envs[i].read.Result.Records, Template: tmpl,
-		})
-		if err != nil {
-			return nil, err
-		}
-		state, err := host.Presence(envs[i].ref, candidates)
-		if err != nil {
-			return nil, err
-		}
-		for _, k := range state.Keys {
-			if k.Declared {
-				declared[k.Name] = true
-			}
+	}
+	if ref == "" {
+		return declared, nil
+	}
+	candidates, err := PlannedCandidates(PlanInput{Source: source, Records: records})
+	if err != nil {
+		return nil, err
+	}
+	state, err := host.Presence(ref, candidates)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range state.Keys {
+		if k.Declared {
+			declared[k.Name] = k
 		}
 	}
 	return declared, nil
 }
 
-// wizardClassType is state 5's classification and typing half, for keys the
-// project does not already declare: classification (secret default, explicit
-// per-key downgrades) and a deterministic type suggestion (across all
-// environments' values, applied only on accept).
-func wizardClassType(host WizardHost, valuesByKey map[string][]string, declared map[string]bool,
+// wizardClassType is state 5's classification and typing half. For a key the
+// project does NOT already declare it prompts: classification (secret default,
+// explicit per-key downgrades) and a deterministic type suggestion (across the
+// key's values, applied only on accept). For a key it DOES already declare, it
+// records the EXISTING classification and type as the reviewed consent — the
+// escape hatch the ADR means by "resolved by hand" — but only when they diverge
+// from the uniform secret/string default, so a default-declared key stays
+// byte-identical to a flag run (which records nothing for it).
+func wizardClassType(host WizardHost, valuesByKey map[string][]string, declared map[string]KeyState,
 	tmpl *Template) error {
 	keys := make([]string, 0, len(valuesByKey))
 	for k := range valuesByKey {
@@ -427,7 +445,23 @@ func wizardClassType(host WizardHost, valuesByKey map[string][]string, declared 
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		if declared[key] {
+		if existing, ok := declared[key]; ok {
+			host.Notice(fmt.Sprintf("%s is already declared (%s %s); keeping the existing declaration.",
+				quoteName(key), existing.Classification, existing.Type))
+			// Record the existing classification/type as the reviewed consent, but
+			// only where the uniform secret/string default would otherwise make the
+			// planner refuse — so a default-declared key stays byte-identical to a
+			// flag run. A non-declarable existing type (an any_of the imported
+			// string does not satisfy) is left unrecorded on purpose: the planner
+			// refuses it, which is the human's to resolve.
+			if existing.Classification != "" && existing.Classification != string(schema.Secret) {
+				tmpl.Classifications = append(tmpl.Classifications,
+					ClassificationChoice{Key: key, Class: existing.Classification})
+			}
+			if existing.Type != "" && !compatibleImportedType(existing.Type, schema.TypeString) &&
+				isDeclarableType(existing.Type) {
+				tmpl.Types = append(tmpl.Types, TypeChoice{Key: key, Type: existing.Type, Accepted: true})
+			}
 			continue
 		}
 		class, downgraded, err := wizardClassification(host, key)
@@ -443,78 +477,6 @@ func wizardClassType(host WizardHost, valuesByKey map[string][]string, declared 
 		}
 		tmpl.Types = append(tmpl.Types, TypeChoice{Key: key, Type: string(typ), Accepted: true})
 	}
-	return nil
-}
-
-// wizardFolders computes each key's folder per environment and, on a conflict
-// (a key under two folders across environments — one bundle declares one folder
-// per key), asks the human to pick one; the full folder map is then recorded so
-// the replay honours it.
-func wizardFolders(host WizardHost, source string, envs []wizardEnv, manual map[string]string,
-	tmpl *Template) error {
-	// source folder -> target folder, and per key the folders seen.
-	sourceFolders := map[string]string{}
-	keyFolders := map[string]map[string]bool{}
-	keySource := map[string][]string{}
-	conflict := false
-	for i := range envs {
-		e := envs[i]
-		rootCollapse := source == k8sSource && singleSourceFolder(e.read.Result.Records)
-		for _, rec := range e.read.Result.Records {
-			target, _, err := targetName(rec.SourceName, manual)
-			if err != nil {
-				return err
-			}
-			sourceFolder := strings.Join(rec.Folder, "/")
-			tf, err := targetFolderPath(rec.Folder, rootCollapse)
-			if err != nil {
-				return err
-			}
-			sourceFolders[sourceFolder] = tf
-			if keyFolders[target] == nil {
-				keyFolders[target] = map[string]bool{}
-			}
-			if !keyFolders[target][tf] {
-				keyFolders[target][tf] = true
-				keySource[target] = append(keySource[target], sourceFolder)
-			}
-			if len(keyFolders[target]) > 1 {
-				conflict = true
-			}
-		}
-	}
-	if !conflict {
-		return nil // let the planner compute folders; matches flag mode byte-for-byte
-	}
-	// Resolve each conflicting key, then record the FULL folder map (the planner
-	// requires every source folder to be recorded once any is).
-	keys := make([]string, 0, len(keyFolders))
-	for k := range keyFolders {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		if len(keyFolders[key]) < 2 {
-			continue
-		}
-		opts := make([]string, 0, len(keyFolders[key]))
-		for f := range keyFolders[key] {
-			opts = append(opts, f)
-		}
-		sort.Strings(opts)
-		i, err := host.Choose(fmt.Sprintf("%s maps to more than one folder; keep which?",
-			quoteName(key)), opts, 0)
-		if err != nil {
-			return err
-		}
-		for _, sf := range keySource[key] {
-			sourceFolders[sf] = opts[i]
-		}
-	}
-	for sf, tf := range sourceFolders {
-		tmpl.Folders = append(tmpl.Folders, FolderMapping{SourcePath: sf, TargetPath: tf})
-	}
-	sort.Slice(tmpl.Folders, func(i, j int) bool { return tmpl.Folders[i].SourcePath < tmpl.Folders[j].SourcePath })
 	return nil
 }
 
@@ -557,6 +519,7 @@ func wizardType(host WizardHost, key string, values []string) (schema.Type, erro
 // presence read.
 func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Template) (int64, error) {
 	var revision int64
+	haveRevision := false
 	for i := range envs {
 		if envs[i].create {
 			continue
@@ -571,8 +534,19 @@ func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Temp
 		if err != nil {
 			return 0, err
 		}
-		envs[i].state = state
+		// Every environment's read must observe the SAME project catalogue
+		// revision. A definitions change committed mid-session would make the
+		// occurrence tokens across environments describe different catalogue
+		// states — an incoherent manifest. Refuse it; the human re-runs.
+		if haveRevision && state.DefinitionsRevision != revision {
+			return 0, failure(source, CodeIncompatible, "",
+				"the project's definitions revision changed during the session (%d then %d); "+
+					"re-run the import so every environment is reviewed against one catalogue",
+				revision, state.DefinitionsRevision)
+		}
 		revision = state.DefinitionsRevision
+		haveRevision = true
+		envs[i].state = state
 	}
 	return revision, nil
 }

--- a/internal/importer/wizard.go
+++ b/internal/importer/wizard.go
@@ -108,9 +108,28 @@ func Wizard(host WizardHost, project string) (*ProjectPlan, error) {
 	}
 
 	tmpl := &Template{}
-	if err := wizardKeyReview(host, source, envs, tmpl); err != nil {
+	// Renames and folders are structural — no server contact.
+	valuesByKey, manual, err := wizardRenames(host, source, envs, tmpl)
+	if err != nil {
 		return nil, err
 	}
+	if err := wizardFolders(host, source, envs, manual, tmpl); err != nil {
+		return nil, err
+	}
+	// A first presence read (with the default classification/type intent) learns
+	// which keys the project already declares, so classification and type review
+	// can skip them — an existing declaration governs and is not re-offered.
+	declared, err := wizardDeclaredSet(host, source, envs, tmpl)
+	if err != nil {
+		return nil, err
+	}
+	if err := wizardClassType(host, valuesByKey, declared, tmpl); err != nil {
+		return nil, err
+	}
+	// The second presence read carries the FINAL classification/type intent, so
+	// each undeclared key's occurrence token binds the declaration the bundle
+	// will actually apply — a first-read token minted before a downgrade or an
+	// accepted type suggestion would be stale the moment phase 2 checked it.
 	definitionsRevision, err := wizardPresence(host, source, envs, tmpl)
 	if err != nil {
 		return nil, err
@@ -295,15 +314,13 @@ func wizardSelector(host WizardHost, source string) (Selector, error) {
 	return sel, nil
 }
 
-// wizardKeyReview is states 4, 5 and 6: renames (surfaced per key, hard-stop
-// names require an explicit rename), folder reconciliation across environments,
-// classification (secret default, explicit per-key downgrades), and type
-// suggestions (deterministic, across all environments' values, applied only on
-// accept). It writes its decisions into the template.
-func wizardKeyReview(host WizardHost, source string, envs []wizardEnv, tmpl *Template) error {
-	// Renames first: every source name is surfaced, an unmappable one is prompted
-	// for an explicit rename. Renames are project-wide (a source name maps to one
-	// target across the session).
+// wizardRenames is states 4/5's rename half: every source name is surfaced, an
+// unmappable one is prompted for an explicit rename, and the choices are written
+// into the template. Renames are project-wide — a source name maps to one target
+// across the session. It returns each target key's values (across environments,
+// for the type suggestion) and the manual-rename map (for folder computation).
+func wizardRenames(host WizardHost, source string, envs []wizardEnv, tmpl *Template) (
+	map[string][]string, map[string]string, error) {
 	renames := map[string]TransformKind{} // source name -> transform, for template rows
 	manual := map[string]string{}
 	targetOf := map[string]string{} // source name -> target
@@ -321,11 +338,11 @@ func wizardKeyReview(host WizardHost, source string, envs []wizardEnv, tmpl *Tem
 				host.Notice(fmt.Sprintf("%s cannot be mapped automatically.", quoteName(rec.SourceName)))
 				entered, lerr := host.Line("Rename it to:", "")
 				if lerr != nil {
-					return lerr
+					return nil, nil, lerr
 				}
 				entered = strings.TrimSpace(entered)
 				if err := schema.CheckKeyName(entered); err != nil {
-					return failure(source, CodeUnmappableName, quoteName(rec.SourceName),
+					return nil, nil, failure(source, CodeUnmappableName, quoteName(rec.SourceName),
 						"the entered name %s is not a canonical key", quoteName(entered))
 				}
 				target = entered
@@ -335,16 +352,16 @@ func wizardKeyReview(host WizardHost, source string, envs []wizardEnv, tmpl *Tem
 				host.Notice(fmt.Sprintf("rename: %s -> %s", quoteName(rec.SourceName), quoteName(target)))
 				edit, err := host.Confirm("Edit this rename?", false)
 				if err != nil {
-					return err
+					return nil, nil, err
 				}
 				if edit {
 					entered, err := host.Line("Rename it to:", target)
 					if err != nil {
-						return err
+						return nil, nil, err
 					}
 					entered = strings.TrimSpace(entered)
 					if err := schema.CheckKeyName(entered); err != nil {
-						return failure(source, CodeUnmappableName, quoteName(rec.SourceName),
+						return nil, nil, failure(source, CodeUnmappableName, quoteName(rec.SourceName),
 							"the entered name %s is not a canonical key", quoteName(entered))
 					}
 					target = entered
@@ -366,22 +383,44 @@ func wizardKeyReview(host WizardHost, source string, envs []wizardEnv, tmpl *Tem
 		}
 	}
 	sort.Slice(tmpl.Renames, func(i, j int) bool { return tmpl.Renames[i].From < tmpl.Renames[j].From })
+	return valuesByKey, manual, nil
+}
 
-	// Folder reconciliation (state 6): a key's folder must be one project-wide.
-	if err := wizardFolders(host, source, envs, manual, tmpl); err != nil {
-		return err
-	}
-
-	// Classification and type (states 5): only for keys the project does not
-	// already declare — an existing declaration governs and is not re-offered.
+// wizardDeclaredSet performs the first presence read (default declaration
+// intent) purely to learn which keys the project already declares, so
+// classification and type review can skip them. Its tokens are not kept — the
+// second read carries the final intent.
+func wizardDeclaredSet(host WizardHost, source string, envs []wizardEnv, tmpl *Template) (map[string]bool, error) {
 	declared := map[string]bool{}
 	for i := range envs {
-		for _, k := range envs[i].state.Keys {
+		if envs[i].create {
+			continue
+		}
+		candidates, err := PlannedCandidates(PlanInput{
+			Source: source, Records: envs[i].read.Result.Records, Template: tmpl,
+		})
+		if err != nil {
+			return nil, err
+		}
+		state, err := host.Presence(envs[i].ref, candidates)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range state.Keys {
 			if k.Declared {
 				declared[k.Name] = true
 			}
 		}
 	}
+	return declared, nil
+}
+
+// wizardClassType is state 5's classification and typing half, for keys the
+// project does not already declare: classification (secret default, explicit
+// per-key downgrades) and a deterministic type suggestion (across all
+// environments' values, applied only on accept).
+func wizardClassType(host WizardHost, valuesByKey map[string][]string, declared map[string]bool,
+	tmpl *Template) error {
 	keys := make([]string, 0, len(valuesByKey))
 	for k := range valuesByKey {
 		keys = append(keys, k)

--- a/internal/importer/wizard.go
+++ b/internal/importer/wizard.go
@@ -84,9 +84,11 @@ type wizardEnv struct {
 
 // Wizard runs the whole interactive session and returns the authored project
 // plan, or an error (a refusal the human could not resolve, or an aborted
-// session). Project and DefinitionsRevision are the resolved target the CLI
-// supplies; the project must pre-exist (import never creates a project).
-func Wizard(host WizardHost, project string, definitionsRevision int64) (*ProjectPlan, error) {
+// session). The project is the resolved target the CLI supplies; it must
+// pre-exist (import never creates a project). The definitions revision the
+// manifest records is captured from the presence reads (it is project-scoped, so
+// every environment reports the same one) and is informational only.
+func Wizard(host WizardHost, project string) (*ProjectPlan, error) {
 	source, err := wizardSource(host)
 	if err != nil {
 		return nil, err
@@ -109,7 +111,8 @@ func Wizard(host WizardHost, project string, definitionsRevision int64) (*Projec
 	if err := wizardKeyReview(host, source, envs, tmpl); err != nil {
 		return nil, err
 	}
-	if err := wizardPresence(host, source, envs, tmpl); err != nil {
+	definitionsRevision, err := wizardPresence(host, source, envs, tmpl)
+	if err != nil {
 		return nil, err
 	}
 	if err := wizardCollisions(host, envs, tmpl); err != nil {
@@ -164,6 +167,7 @@ func wizardEnvironments(host WizardHost, source string, existing []NamedEnv) ([]
 
 	claimed := map[string]bool{}
 	var envs []wizardEnv
+	sessionDecoded := 0
 	for {
 		add := true
 		if len(envs) > 0 {
@@ -179,6 +183,14 @@ func wizardEnvironments(host WizardHost, source string, existing []NamedEnv) ([]
 		env, err := wizardOneEnvironment(host, source, existing, options, claimed)
 		if err != nil {
 			return nil, err
+		}
+		// The aggregate session bound is enforced across the fan-out, over and
+		// above each read's own per-run caps.
+		sessionDecoded += env.read.Result.DecodedBytes
+		if sessionDecoded > MaxSessionDecodedBytes {
+			return nil, failure(source, CodeBound, "",
+				"the session's reads total %d decoded bytes, exceeding the %d-byte wizard-session aggregate cap",
+				sessionDecoded, MaxSessionDecodedBytes)
 		}
 		envs = append(envs, env)
 	}
@@ -504,7 +516,8 @@ func wizardType(host WizardHost, key string, values []string) (schema.Type, erro
 // wizardPresence performs the per-environment presence read now that the target
 // names, classifications and types are settled. Created environments have no
 // presence read.
-func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Template) error {
+func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Template) (int64, error) {
+	var revision int64
 	for i := range envs {
 		if envs[i].create {
 			continue
@@ -513,15 +526,16 @@ func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Temp
 			Source: source, Records: envs[i].read.Result.Records, Template: tmpl,
 		})
 		if err != nil {
-			return err
+			return 0, err
 		}
 		state, err := host.Presence(envs[i].ref, candidates)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		envs[i].state = state
+		revision = state.DefinitionsRevision
 	}
-	return nil
+	return revision, nil
 }
 
 // wizardCollisions is state 7: per environment, each key already `set` is shown

--- a/internal/importer/wizard.go
+++ b/internal/importer/wizard.go
@@ -1,0 +1,613 @@
+package importer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+)
+
+// The interactive import wizard (import-paths ADR § Entry modes; spellings spec
+// § 3 wizard interaction states). The wizard is an AUTHORING FRONTEND for the
+// mapping template: it walks the source and the target mapping interactively,
+// records every choice into a Template, and then runs BuildProjectPlan — the
+// exact path replay uses. Byte-identity between a wizard session and an
+// equivalent flag/replay run (where the choices coincide) is therefore
+// structural, not tested-in: both reach the one planner.
+//
+// The engine is I/O-agnostic. Terminal reads and writes go through a Prompter;
+// source reads and the server presence read are injected callbacks the CLI
+// supplies. Nothing here contacts a network or a terminal directly, so the whole
+// nine-state walk is testable with a scripted prompter.
+
+// Prompter is the wizard's terminal surface. Confirm/Choose/Line read one answer;
+// Notice prints an informational line and reads nothing. Every method may return
+// an error (EOF on a closed stdin, a broken pipe) which aborts the session.
+type Prompter interface {
+	Notice(msg string)
+	Confirm(question string, def bool) (bool, error)
+	Choose(question string, options []string, def int) (int, error)
+	Line(question, def string) (string, error)
+}
+
+// Selector is the connector-shaped source slice the wizard gathers for one read.
+// It mirrors the flag-mode selectors so the CLI can drive Run/RunLive from it.
+type Selector struct {
+	Live      bool
+	File      string
+	Namespace string
+	Name      string
+	Context   string
+	Mount     string
+	Path      string
+	KVVersion int
+	EnvSlug   string
+}
+
+// SourceRead is one connector read the host performed for the wizard.
+type SourceRead struct {
+	Result     Result
+	FileDigest string
+	EnvSlug    string
+}
+
+// NamedEnv is one existing target environment the actor may read.
+type NamedEnv struct {
+	ID   string
+	Name string
+}
+
+// WizardHost is the impure surface the CLI supplies: the terminal, the source
+// reader, the environment list, and the server presence read. The engine calls
+// these; it never opens a file, a socket or a terminal itself.
+type WizardHost interface {
+	Prompter
+	// ReadSource performs one connector read for a gathered selector.
+	ReadSource(source string, sel Selector) (SourceRead, error)
+	// ExistingEnvironments lists the environments the actor can read (read(E)).
+	ExistingEnvironments() ([]NamedEnv, error)
+	// Presence reads server presence for one existing environment, minting an
+	// occurrence per candidate.
+	Presence(envID string, candidates []PlannedCandidate) (ServerState, error)
+}
+
+// wizardEnv is one target environment the session gathered: its identity, the
+// source read mapped onto it, and (for existing environments) the presence read.
+type wizardEnv struct {
+	ref    string // env id (existing) or env name (created)
+	name   string
+	create bool
+	read   SourceRead
+	state  ServerState // empty for a created environment
+}
+
+// Wizard runs the whole interactive session and returns the authored project
+// plan, or an error (a refusal the human could not resolve, or an aborted
+// session). Project and DefinitionsRevision are the resolved target the CLI
+// supplies; the project must pre-exist (import never creates a project).
+func Wizard(host WizardHost, project string, definitionsRevision int64) (*ProjectPlan, error) {
+	source, err := wizardSource(host)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := host.ExistingEnvironments()
+	if err != nil {
+		return nil, err
+	}
+
+	envs, err := wizardEnvironments(host, source, existing)
+	if err != nil {
+		return nil, err
+	}
+	if len(envs) == 0 {
+		return nil, failure(source, CodeMalformed, "", "the session mapped no target environment")
+	}
+
+	tmpl := &Template{}
+	if err := wizardKeyReview(host, source, envs, tmpl); err != nil {
+		return nil, err
+	}
+	if err := wizardPresence(host, source, envs, tmpl); err != nil {
+		return nil, err
+	}
+	if err := wizardCollisions(host, envs, tmpl); err != nil {
+		return nil, err
+	}
+	if err := wizardTrim(host, envs, tmpl); err != nil {
+		return nil, err
+	}
+
+	in := ProjectPlanInput{
+		Source: source, Project: project, DefinitionsRevision: definitionsRevision,
+		Template: tmpl,
+	}
+	for _, e := range envs {
+		env := EnvInput{
+			Records: e.read.Result.Records, Skipped: e.read.Result.Skipped,
+			Scope: e.read.Result.Scope, FileDigest: e.read.FileDigest, EnvSlug: e.read.EnvSlug,
+			SourceIdentity: e.read.Result.Identity, Keys: e.state.Keys,
+		}
+		if e.create {
+			env.Create = true
+			env.EnvName = e.name
+		} else {
+			env.EnvID = e.ref
+			env.EnvName = e.name
+		}
+		in.Envs = append(in.Envs, env)
+	}
+	return BuildProjectPlan(in)
+}
+
+// wizardSource is state 1: source select. Live/file mode and the credential
+// presence check ride on the connector selectors gathered per environment.
+func wizardSource(host WizardHost) (string, error) {
+	sources := Sources()
+	i, err := host.Choose("Which source are you importing from?", sources, 0)
+	if err != nil {
+		return "", err
+	}
+	return sources[i], nil
+}
+
+// wizardEnvironments is states 2 and 3: for each target environment, the human
+// picks (or creates) it and provides the source slice that maps onto it. A
+// created environment is declared up front here and carries no presence read.
+func wizardEnvironments(host WizardHost, source string, existing []NamedEnv) ([]wizardEnv, error) {
+	options := make([]string, 0, len(existing)+1)
+	for _, e := range existing {
+		options = append(options, e.Name)
+	}
+	options = append(options, "+ create a new environment")
+
+	claimed := map[string]bool{}
+	var envs []wizardEnv
+	for {
+		add := true
+		if len(envs) > 0 {
+			var err error
+			add, err = host.Confirm("Map another target environment?", false)
+			if err != nil {
+				return nil, err
+			}
+			if !add {
+				break
+			}
+		}
+		env, err := wizardOneEnvironment(host, source, existing, options, claimed)
+		if err != nil {
+			return nil, err
+		}
+		envs = append(envs, env)
+	}
+	return envs, nil
+}
+
+func wizardOneEnvironment(host WizardHost, source string, existing []NamedEnv, options []string,
+	claimed map[string]bool) (wizardEnv, error) {
+	choice, err := host.Choose("Target environment:", options, 0)
+	if err != nil {
+		return wizardEnv{}, err
+	}
+	var env wizardEnv
+	if choice == len(existing) {
+		name, err := host.Line("New environment name:", "")
+		if err != nil {
+			return wizardEnv{}, err
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return wizardEnv{}, failure(source, CodeMalformed, "", "a created environment needs a name")
+		}
+		if claimed[name] {
+			return wizardEnv{}, failure(source, CodeMalformed, "",
+				"environment %s is already mapped this session", quoteName(name))
+		}
+		env = wizardEnv{ref: name, name: name, create: true}
+	} else {
+		e := existing[choice]
+		if claimed[e.ID] {
+			return wizardEnv{}, failure(source, CodeMalformed, "",
+				"environment %s is already mapped this session", quoteName(e.Name))
+		}
+		env = wizardEnv{ref: e.ID, name: e.Name}
+	}
+	claimed[env.ref] = true
+
+	sel, err := wizardSelector(host, source)
+	if err != nil {
+		return wizardEnv{}, err
+	}
+	read, err := host.ReadSource(source, sel)
+	if err != nil {
+		return wizardEnv{}, err
+	}
+	env.read = read
+	return env, nil
+}
+
+// wizardSelector is state 2: the connector selectors for one source slice,
+// bounded per the ops catalogue by the connector itself on read.
+func wizardSelector(host WizardHost, source string) (Selector, error) {
+	var sel Selector
+	live := false
+	if source == k8sSource || source == vaultSource {
+		var err error
+		live, err = host.Confirm("Read live through the ambient client configuration?", false)
+		if err != nil {
+			return Selector{}, err
+		}
+	}
+	sel.Live = live
+	if !live {
+		file, err := host.Line("Export file path:", "")
+		if err != nil {
+			return Selector{}, err
+		}
+		sel.File = strings.TrimSpace(file)
+		if source == infisicalSource {
+			slug, err := host.Line("Source environment slug (Infisical):", "")
+			if err != nil {
+				return Selector{}, err
+			}
+			sel.EnvSlug = strings.TrimSpace(slug)
+		}
+		return sel, nil
+	}
+	switch source {
+	case k8sSource:
+		ns, err := host.Line("Kubernetes namespace:", "")
+		if err != nil {
+			return Selector{}, err
+		}
+		sel.Namespace = strings.TrimSpace(ns)
+		name, err := host.Line("One Secret name (blank for all in the namespace):", "")
+		if err != nil {
+			return Selector{}, err
+		}
+		sel.Name = strings.TrimSpace(name)
+	case vaultSource:
+		mount, err := host.Line("Vault/OpenBao KV mount:", "")
+		if err != nil {
+			return Selector{}, err
+		}
+		sel.Mount = strings.TrimSpace(mount)
+		path, err := host.Line("Path prefix (blank for the mount root):", "")
+		if err != nil {
+			return Selector{}, err
+		}
+		sel.Path = strings.TrimSpace(path)
+	}
+	return sel, nil
+}
+
+// wizardKeyReview is states 4, 5 and 6: renames (surfaced per key, hard-stop
+// names require an explicit rename), folder reconciliation across environments,
+// classification (secret default, explicit per-key downgrades), and type
+// suggestions (deterministic, across all environments' values, applied only on
+// accept). It writes its decisions into the template.
+func wizardKeyReview(host WizardHost, source string, envs []wizardEnv, tmpl *Template) error {
+	// Renames first: every source name is surfaced, an unmappable one is prompted
+	// for an explicit rename. Renames are project-wide (a source name maps to one
+	// target across the session).
+	renames := map[string]TransformKind{} // source name -> transform, for template rows
+	manual := map[string]string{}
+	targetOf := map[string]string{} // source name -> target
+	valuesByKey := map[string][]string{}
+	for i := range envs {
+		for _, rec := range envs[i].read.Result.Records {
+			if _, done := targetOf[rec.SourceName]; done {
+				valuesByKey[targetOf[rec.SourceName]] = append(valuesByKey[targetOf[rec.SourceName]], rec.Value)
+				continue
+			}
+			target, wasValid, err := TransformName(rec.SourceName)
+			if err != nil {
+				// A hard-stop name: the transform cannot resolve it, so the human
+				// must name it explicitly (ADR § Renames).
+				host.Notice(fmt.Sprintf("%s cannot be mapped automatically.", quoteName(rec.SourceName)))
+				entered, lerr := host.Line("Rename it to:", "")
+				if lerr != nil {
+					return lerr
+				}
+				entered = strings.TrimSpace(entered)
+				if err := schema.CheckKeyName(entered); err != nil {
+					return failure(source, CodeUnmappableName, quoteName(rec.SourceName),
+						"the entered name %s is not a canonical key", quoteName(entered))
+				}
+				target = entered
+				manual[rec.SourceName] = entered
+				renames[rec.SourceName] = TransformManual
+			} else if !wasValid {
+				host.Notice(fmt.Sprintf("rename: %s -> %s", quoteName(rec.SourceName), quoteName(target)))
+				edit, err := host.Confirm("Edit this rename?", false)
+				if err != nil {
+					return err
+				}
+				if edit {
+					entered, err := host.Line("Rename it to:", target)
+					if err != nil {
+						return err
+					}
+					entered = strings.TrimSpace(entered)
+					if err := schema.CheckKeyName(entered); err != nil {
+						return failure(source, CodeUnmappableName, quoteName(rec.SourceName),
+							"the entered name %s is not a canonical key", quoteName(entered))
+					}
+					target = entered
+					manual[rec.SourceName] = entered
+					renames[rec.SourceName] = TransformManual
+				} else {
+					renames[rec.SourceName] = TransformAuto
+				}
+			}
+			targetOf[rec.SourceName] = target
+			valuesByKey[target] = append(valuesByKey[target], rec.Value)
+		}
+	}
+	for from, kind := range renames {
+		if kind == TransformManual {
+			tmpl.Renames = append(tmpl.Renames, Rename{From: from, To: manual[from], Transform: TransformManual})
+		} else {
+			tmpl.Renames = append(tmpl.Renames, Rename{From: from, To: targetOf[from], Transform: TransformAuto})
+		}
+	}
+	sort.Slice(tmpl.Renames, func(i, j int) bool { return tmpl.Renames[i].From < tmpl.Renames[j].From })
+
+	// Folder reconciliation (state 6): a key's folder must be one project-wide.
+	if err := wizardFolders(host, source, envs, manual, tmpl); err != nil {
+		return err
+	}
+
+	// Classification and type (states 5): only for keys the project does not
+	// already declare — an existing declaration governs and is not re-offered.
+	declared := map[string]bool{}
+	for i := range envs {
+		for _, k := range envs[i].state.Keys {
+			if k.Declared {
+				declared[k.Name] = true
+			}
+		}
+	}
+	keys := make([]string, 0, len(valuesByKey))
+	for k := range valuesByKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if declared[key] {
+			continue
+		}
+		class, downgraded, err := wizardClassification(host, key)
+		if err != nil {
+			return err
+		}
+		tmpl.Classifications = append(tmpl.Classifications,
+			ClassificationChoice{Key: key, Class: class, Downgraded: downgraded})
+
+		typ, err := wizardType(host, key, valuesByKey[key])
+		if err != nil {
+			return err
+		}
+		tmpl.Types = append(tmpl.Types, TypeChoice{Key: key, Type: string(typ), Accepted: true})
+	}
+	return nil
+}
+
+// wizardFolders computes each key's folder per environment and, on a conflict
+// (a key under two folders across environments — one bundle declares one folder
+// per key), asks the human to pick one; the full folder map is then recorded so
+// the replay honours it.
+func wizardFolders(host WizardHost, source string, envs []wizardEnv, manual map[string]string,
+	tmpl *Template) error {
+	// source folder -> target folder, and per key the folders seen.
+	sourceFolders := map[string]string{}
+	keyFolders := map[string]map[string]bool{}
+	keySource := map[string][]string{}
+	conflict := false
+	for i := range envs {
+		e := envs[i]
+		rootCollapse := source == k8sSource && singleSourceFolder(e.read.Result.Records)
+		for _, rec := range e.read.Result.Records {
+			target, _, err := targetName(rec.SourceName, manual)
+			if err != nil {
+				return err
+			}
+			sourceFolder := strings.Join(rec.Folder, "/")
+			tf, err := targetFolderPath(rec.Folder, rootCollapse)
+			if err != nil {
+				return err
+			}
+			sourceFolders[sourceFolder] = tf
+			if keyFolders[target] == nil {
+				keyFolders[target] = map[string]bool{}
+			}
+			if !keyFolders[target][tf] {
+				keyFolders[target][tf] = true
+				keySource[target] = append(keySource[target], sourceFolder)
+			}
+			if len(keyFolders[target]) > 1 {
+				conflict = true
+			}
+		}
+	}
+	if !conflict {
+		return nil // let the planner compute folders; matches flag mode byte-for-byte
+	}
+	// Resolve each conflicting key, then record the FULL folder map (the planner
+	// requires every source folder to be recorded once any is).
+	keys := make([]string, 0, len(keyFolders))
+	for k := range keyFolders {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if len(keyFolders[key]) < 2 {
+			continue
+		}
+		opts := make([]string, 0, len(keyFolders[key]))
+		for f := range keyFolders[key] {
+			opts = append(opts, f)
+		}
+		sort.Strings(opts)
+		i, err := host.Choose(fmt.Sprintf("%s maps to more than one folder; keep which?",
+			quoteName(key)), opts, 0)
+		if err != nil {
+			return err
+		}
+		for _, sf := range keySource[key] {
+			sourceFolders[sf] = opts[i]
+		}
+	}
+	for sf, tf := range sourceFolders {
+		tmpl.Folders = append(tmpl.Folders, FolderMapping{SourcePath: sf, TargetPath: tf})
+	}
+	sort.Slice(tmpl.Folders, func(i, j int) bool { return tmpl.Folders[i].SourcePath < tmpl.Folders[j].SourcePath })
+	return nil
+}
+
+// wizardClassification is state 5's classification half: secret by default,
+// downgrade to config an explicit per-key act (hints suggest, never apply).
+func wizardClassification(host WizardHost, key string) (string, bool, error) {
+	if hint := classificationHint(key); hint != "" {
+		host.Notice(fmt.Sprintf("%s looks like it may be config (%s); it still defaults to secret.",
+			quoteName(key), hint))
+	}
+	down, err := host.Confirm(fmt.Sprintf("Downgrade %s from secret to config?", quoteName(key)), false)
+	if err != nil {
+		return "", false, err
+	}
+	if down {
+		return string(schema.Config), true, nil
+	}
+	return string(schema.Secret), false, nil
+}
+
+// wizardType is state 5's typing half: a deterministic suggestion across all
+// environments' values, applied only on accept; the floor is string.
+func wizardType(host WizardHost, key string, values []string) (schema.Type, error) {
+	suggested := SuggestType(values)
+	if suggested == schema.TypeString {
+		return schema.TypeString, nil
+	}
+	accept, err := host.Confirm(fmt.Sprintf("Declare %s as %s?", quoteName(key), suggested), true)
+	if err != nil {
+		return "", err
+	}
+	if accept {
+		return suggested, nil
+	}
+	return schema.TypeString, nil
+}
+
+// wizardPresence performs the per-environment presence read now that the target
+// names, classifications and types are settled. Created environments have no
+// presence read.
+func wizardPresence(host WizardHost, source string, envs []wizardEnv, tmpl *Template) error {
+	for i := range envs {
+		if envs[i].create {
+			continue
+		}
+		candidates, err := PlannedCandidates(PlanInput{
+			Source: source, Records: envs[i].read.Result.Records, Template: tmpl,
+		})
+		if err != nil {
+			return err
+		}
+		state, err := host.Presence(envs[i].ref, candidates)
+		if err != nil {
+			return err
+		}
+		envs[i].state = state
+	}
+	return nil
+}
+
+// wizardCollisions is state 7: per environment, each key already `set` is shown
+// and overwrite is opt-in per key (skip by default). The enumerated selection is
+// recorded in the template.
+func wizardCollisions(host WizardHost, envs []wizardEnv, tmpl *Template) error {
+	for i := range envs {
+		e := envs[i]
+		if e.create {
+			continue
+		}
+		setKeys := map[string]bool{}
+		for _, k := range e.state.Keys {
+			if k.Set {
+				setKeys[k.Name] = true
+			}
+		}
+		if len(setKeys) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(setKeys))
+		for n := range setKeys {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			ok, err := host.Confirm(fmt.Sprintf("%s is already set in %s; overwrite it?",
+				quoteName(name), quoteName(e.name)), false)
+			if err != nil {
+				return err
+			}
+			if ok {
+				tmpl.Overwrites = append(tmpl.Overwrites, KeyEnvironment{Key: name, Environment: e.ref})
+			}
+		}
+	}
+	return nil
+}
+
+// wizardTrim is state 8: a value the write-time trim would alter is refused
+// unless acknowledged; the wizard asks per (key, environment) and records the
+// acknowledgement in the template.
+func wizardTrim(host WizardHost, envs []wizardEnv, tmpl *Template) error {
+	manual := map[string]string{}
+	for _, r := range tmpl.Renames {
+		if r.Transform == TransformManual {
+			manual[r.From] = r.To
+		}
+	}
+	for i := range envs {
+		e := envs[i]
+		for _, rec := range e.read.Result.Records {
+			if schema.Normalize(rec.Value) == rec.Value {
+				continue
+			}
+			target, _, err := targetName(rec.SourceName, manual)
+			if err != nil {
+				return err
+			}
+			ack, err := host.Confirm(fmt.Sprintf(
+				"%s in %s has surrounding whitespace the store would trim; import the trimmed value?",
+				quoteName(target), quoteName(e.name)), false)
+			if err != nil {
+				return err
+			}
+			if !ack {
+				return failure(e.read.Result.Identity, CodeTrim, quoteName(target),
+					"the value would be altered by the write-time trim and was not acknowledged; fix it at the source")
+			}
+			tmpl.TrimAcknowledgements = append(tmpl.TrimAcknowledgements,
+				KeyEnvironment{Key: target, Environment: e.ref})
+		}
+	}
+	return nil
+}
+
+// classificationHint returns a short reason a key name looks like config, or "".
+// Hints suggest a downgrade; they never apply one (ADR § Classification).
+func classificationHint(key string) string {
+	for _, suffix := range []string{"_URL", "_HOST", "_PORT", "_PATH", "_DIR", "_ADDR"} {
+		if strings.HasSuffix(key, suffix) {
+			return "name ends " + suffix
+		}
+	}
+	if strings.Contains(key, "LOG_LEVEL") || strings.HasSuffix(key, "_ENV") {
+		return "name pattern"
+	}
+	return ""
+}

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -212,6 +212,68 @@ func TestWizardFansOutAcrossEnvironments(t *testing.T) {
 	}
 }
 
+// TestWizardCreatesEnvironment: a session that creates its target environment
+// declares it up front, emits a `create environment` bundle line, and authors a
+// tokenless, name-addressed values file and manifest for it.
+func TestWizardCreatesEnvironment(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	presenceCalled := false
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: "sha256:a"}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			presenceCalled = true
+			return undeclaredState(envID, c)
+		},
+		confirm: map[string]bool{
+			"Read live": false, "Map another": false, "Edit this": false,
+			"Downgrade": false, "Declare": false, "overwrite": false, "import the trim": false,
+		},
+		// index 1 is "+ create a new environment" (existing has one entry at 0).
+		choose: map[string]int{"source": 1, "Target environment": 1},
+		line:   map[string]string{"Export file path": "export.yaml", "New environment name": "staging"},
+	}
+	wiz, err := Wizard(host, "prj_1")
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if presenceCalled {
+		t.Error("a created environment triggered a presence read; it has no state to read")
+	}
+
+	// The bundle carries the create-environment line.
+	foundEnv := false
+	for _, e := range wiz.Bundle.Environments {
+		if e.Name == "staging" {
+			foundEnv = true
+		}
+	}
+	if !foundEnv {
+		t.Errorf("bundle environments = %+v, want a `staging` create line", wiz.Bundle.Environments)
+	}
+
+	// The manifest names it under created_environments, with no occurrence rows.
+	if strings.Join(wiz.Manifest.Target.CreatedEnvironments, ",") != "staging" {
+		t.Errorf("created environments = %v", wiz.Manifest.Target.CreatedEnvironments)
+	}
+	if len(wiz.Manifest.Occurrences) != 0 {
+		t.Errorf("a created environment minted %d occurrences; it is tokenless", len(wiz.Manifest.Occurrences))
+	}
+
+	// The values file is name-addressed, not id-addressed.
+	if wiz.Envs[0].Values.EnvironmentName != "staging" || wiz.Envs[0].Values.Environment != "" {
+		t.Errorf("values file = %+v, want name-addressed", wiz.Envs[0].Values)
+	}
+	encoded := string(mustEncode(t, wiz.Envs[0].Values))
+	if !strings.Contains(encoded, `"environment_name": "staging"`) || strings.Contains(encoded, `"environment":`) {
+		t.Errorf("values serialization does not carry the name alone:\n%s", encoded)
+	}
+}
+
 // mapAnotherOnce answers the "Map another?" confirm true exactly once, so the
 // fan-out loop adds a second environment and then terminates, and picks a fresh
 // existing environment on each "Target environment" choice.

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -71,7 +71,7 @@ func (h *scriptHost) Presence(envID string, cands []PlannedCandidate) (ServerSta
 // undeclaredState mints an undeclared token per candidate, mirroring the server
 // presence read for a project that declares nothing yet.
 func undeclaredState(envID string, cands []PlannedCandidate) ServerState {
-	st := ServerState{Environment: envID}
+	st := ServerState{Environment: envID, DefinitionsRevision: 7}
 	for _, c := range cands {
 		st.Keys = append(st.Keys, KeyState{Name: c.Name, Token: "v1:undeclared-" + c.Name})
 	}
@@ -125,7 +125,7 @@ func TestWizardSingleEnvMatchesFlagRun(t *testing.T) {
 		choose: map[string]int{"source": 1, "Target environment": 0},
 		line:   map[string]string{"Export file path": "export.yaml"},
 	}
-	wiz, err := Wizard(host, "prj_1", 7)
+	wiz, err := Wizard(host, "prj_1")
 	if err != nil {
 		t.Fatalf("wizard: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestWizardFansOutAcrossEnvironments(t *testing.T) {
 	host.confirm["Map another"] = true
 	callHost := &mapAnotherOnce{scriptHost: host}
 
-	wiz, err := Wizard(callHost, "prj_1", 7)
+	wiz, err := Wizard(callHost, "prj_1")
 	if err != nil {
 		t.Fatalf("wizard: %v", err)
 	}

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -326,6 +326,122 @@ func TestWizardSkipsAlreadyDeclaredKeys(t *testing.T) {
 	}
 }
 
+// TestWizardRecordsExistingNonDefaultDeclaration: a key already declared with a
+// non-default classification (config) is recorded as the reviewed consent, so
+// the planner treats it as already-declared instead of refusing it against the
+// uniform secret default.
+func TestWizardRecordsExistingNonDefaultDeclaration(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: "sha256:a"}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			st := undeclaredState(envID, c)
+			for i := range st.Keys {
+				if st.Keys[i].Name == "DB_HOST" {
+					st.Keys[i] = declaredKey("DB_HOST", "config", false, "v1:tok-host")
+				}
+			}
+			return st
+		},
+		confirm: map[string]bool{
+			"Read live": false, "Map another": false, "Edit this": false,
+			"Downgrade": false, "Declare": false, "overwrite": false, "import the trim": false,
+		},
+		choose: map[string]int{"source": 1, "Target environment": 0},
+		line:   map[string]string{"Export file path": "export.yaml"},
+	}
+	wiz, err := Wizard(host, "prj_1")
+	if err != nil {
+		t.Fatalf("wizard refused a key declared config against the secret default: %v", err)
+	}
+	found := false
+	for _, c := range wiz.Template.Classifications {
+		if c.Key == "DB_HOST" && c.Class == "config" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("existing config declaration not recorded as consent: %+v", wiz.Template.Classifications)
+	}
+	if !contains(wiz.AlreadyDeclared, "DB_HOST") {
+		t.Errorf("DB_HOST not reported already declared: %v", wiz.AlreadyDeclared)
+	}
+}
+
+// TestWizardRefusesRevisionDivergence: if the project's definitions revision
+// changes between two environments' presence reads, the manifest would bind
+// tokens against two catalogue states — refused.
+func TestWizardRefusesRevisionDivergence(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: "sha256:a"}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}, {ID: "env_staging", Name: "staging"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			st := undeclaredState(envID, c)
+			if envID == "env_staging" {
+				st.DefinitionsRevision = 8 // prod read 7; a change landed mid-session
+			}
+			return st
+		},
+		confirm: map[string]bool{
+			"Read live": false, "Edit this": false, "Downgrade": false,
+			"Declare": false, "overwrite": false, "import the trim": false,
+		},
+		choose: map[string]int{"source": 1, "Target environment": 0},
+		line:   map[string]string{"Export file path": "export.yaml"},
+	}
+	callHost := &mapAnotherOnce{scriptHost: host}
+	_, err = Wizard(callHost, "prj_1")
+	wantCode(t, err, CodeIncompatible)
+	if !strings.Contains(err.Error(), "revision") {
+		t.Errorf("refusal does not name the revision change: %v", err)
+	}
+}
+
+// TestWizardRefusesCreatingExistingEnvironment: choosing "create" and naming an
+// environment that already exists is a contradiction (import never modifies an
+// environment), refused rather than emitting a `create <existing>` bundle line.
+func TestWizardRefusesCreatingExistingEnvironment(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: "sha256:a"}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			return undeclaredState(envID, c)
+		},
+		confirm: map[string]bool{"Read live": false, "Map another": false},
+		choose:  map[string]int{"source": 1, "Target environment": 1}, // the "+ create" option
+		line:    map[string]string{"Export file path": "export.yaml", "New environment name": "prod"},
+	}
+	_, err = Wizard(host, "prj_1")
+	wantCode(t, err, CodeMalformed)
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("refusal does not explain the collision: %v", err)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
 // mapAnotherOnce answers the "Map another?" confirm true exactly once, so the
 // fan-out loop adds a second environment and then terminates, and picks a fresh
 // existing environment on each "Target environment" choice.

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -274,6 +274,58 @@ func TestWizardCreatesEnvironment(t *testing.T) {
 	}
 }
 
+// TestWizardSkipsAlreadyDeclaredKeys: a key the project already declares is
+// discovered by the first presence read and skipped in classification/type
+// review, so accepting a type suggestion cannot propose a declaration that
+// conflicts with the existing one. DB_PORT is declared `string`; its value
+// "5432" would suggest `integer`, and accepting that against the existing
+// `string` used to be a spurious incompatible refusal.
+func TestWizardSkipsAlreadyDeclaredKeys(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: "sha256:a"}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			st := undeclaredState(envID, c)
+			for i := range st.Keys {
+				if st.Keys[i].Name == "DB_PORT" {
+					st.Keys[i] = declaredKey("DB_PORT", "secret", false, "v1:tok-port")
+				}
+			}
+			return st
+		},
+		confirm: map[string]bool{
+			"Read live": false, "Map another": false, "Edit this": false,
+			"Downgrade": false, "overwrite": false, "import the trim": false,
+			"Declare": true, // accept every type suggestion
+		},
+		choose: map[string]int{"source": 1, "Target environment": 0},
+		line:   map[string]string{"Export file path": "export.yaml"},
+	}
+	wiz, err := Wizard(host, "prj_1")
+	if err != nil {
+		t.Fatalf("wizard refused an already-declared key with a divergent suggestion: %v", err)
+	}
+	for _, ty := range wiz.Template.Types {
+		if ty.Key == "DB_PORT" {
+			t.Errorf("recorded a type row for the already-declared DB_PORT: %+v", ty)
+		}
+	}
+	found := false
+	for _, k := range wiz.AlreadyDeclared {
+		if k == "DB_PORT" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("DB_PORT not reported already declared: %v", wiz.AlreadyDeclared)
+	}
+}
+
 // mapAnotherOnce answers the "Map another?" confirm true exactly once, so the
 // fan-out loop adds a second environment and then terminates, and picks a fresh
 // existing environment on each "Target environment" choice.

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -1,0 +1,242 @@
+package importer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+)
+
+// scriptHost is a scripted WizardHost: it answers prompts by matching a
+// substring of the question, so a test states its intent ("decline every
+// downgrade") without tracking prompt order.
+type scriptHost struct {
+	t        *testing.T
+	source   string
+	reads    []SourceRead
+	readAt   int
+	envs     []NamedEnv
+	presence func(envID string, cands []PlannedCandidate) ServerState
+
+	confirm map[string]bool
+	choose  map[string]int
+	line    map[string]string
+	notices []string
+}
+
+func (h *scriptHost) Notice(msg string) { h.notices = append(h.notices, msg) }
+
+func (h *scriptHost) Confirm(q string, def bool) (bool, error) {
+	for sub, v := range h.confirm {
+		if strings.Contains(q, sub) {
+			return v, nil
+		}
+	}
+	h.t.Fatalf("unscripted Confirm: %q", q)
+	return false, nil
+}
+
+func (h *scriptHost) Choose(q string, options []string, def int) (int, error) {
+	for sub, v := range h.choose {
+		if strings.Contains(q, sub) {
+			return v, nil
+		}
+	}
+	h.t.Fatalf("unscripted Choose: %q %v", q, options)
+	return 0, nil
+}
+
+func (h *scriptHost) Line(q, def string) (string, error) {
+	for sub, v := range h.line {
+		if strings.Contains(q, sub) {
+			return v, nil
+		}
+	}
+	h.t.Fatalf("unscripted Line: %q", q)
+	return "", nil
+}
+
+func (h *scriptHost) ReadSource(source string, sel Selector) (SourceRead, error) {
+	r := h.reads[h.readAt]
+	h.readAt++
+	return r, nil
+}
+
+func (h *scriptHost) ExistingEnvironments() ([]NamedEnv, error) { return h.envs, nil }
+
+func (h *scriptHost) Presence(envID string, cands []PlannedCandidate) (ServerState, error) {
+	return h.presence(envID, cands), nil
+}
+
+// undeclaredState mints an undeclared token per candidate, mirroring the server
+// presence read for a project that declares nothing yet.
+func undeclaredState(envID string, cands []PlannedCandidate) ServerState {
+	st := ServerState{Environment: envID}
+	for _, c := range cands {
+		st.Keys = append(st.Keys, KeyState{Name: c.Name, Token: "v1:undeclared-" + c.Name})
+	}
+	return st
+}
+
+// TestWizardSingleEnvMatchesFlagRun is acceptance criterion 1: a wizard session
+// whose choices coincide with a flag run authors byte-identical artifacts. It is
+// structural — both reach BuildProjectPlan — and this test pins it.
+func TestWizardSingleEnvMatchesFlagRun(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:fixture"
+
+	// Flag run: nil template, every default.
+	flagState := ServerState{Project: "prj_1", Environment: "env_prod", DefinitionsRevision: 7}
+	flagIn := PlanInput{Source: k8sSource, Records: res.Records, Skipped: res.Skipped,
+		Scope: res.Scope, FileDigest: digest, State: flagState}
+	cands, err := PlannedNames(flagIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range cands {
+		flagIn.State.Keys = append(flagIn.State.Keys, KeyState{Name: name, Token: "v1:undeclared-" + name})
+	}
+	flag, err := BuildPlan(flagIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wizard run: same read, coinciding choices — decline every downgrade and
+	// every type suggestion (flag mode declares string), never edit a rename.
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{{Result: res, FileDigest: digest}},
+		envs:  []NamedEnv{{ID: "env_prod", Name: "prod"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			return undeclaredState(envID, c)
+		},
+		confirm: map[string]bool{
+			"Read live":       false,
+			"Map another":     false,
+			"Edit this":       false,
+			"Downgrade":       false,
+			"Declare":         false,
+			"overwrite":       false,
+			"import the trim": false,
+		},
+		choose: map[string]int{"source": 1, "Target environment": 0},
+		line:   map[string]string{"Export file path": "export.yaml"},
+	}
+	wiz, err := Wizard(host, "prj_1", 7)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+
+	assertSameBytes(t, "template", mustEncode(t, flag.Template), mustEncode(t, wiz.Template))
+	assertSameBytes(t, "manifest", mustEncode(t, flag.Manifest), mustEncode(t, wiz.Manifest))
+	assertSameBytes(t, "values", mustEncode(t, flag.Values), mustEncode(t, wiz.Envs[0].Values))
+	fb, _ := definitions.Encode(flag.Bundle)
+	wb, _ := definitions.Encode(wiz.Bundle)
+	assertSameBytes(t, "bundle", fb, wb)
+}
+
+func mustEncode(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := Encode(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func assertSameBytes(t *testing.T, what string, want, got []byte) {
+	t.Helper()
+	if string(want) != string(got) {
+		t.Errorf("%s bytes differ.\n--- flag ---\n%s\n--- wizard ---\n%s", what, want, got)
+	}
+}
+
+// TestWizardFansOutAcrossEnvironments: the wizard maps one source onto two
+// existing environments, one bundle, presence differing per environment.
+func TestWizardFansOutAcrossEnvironments(t *testing.T) {
+	res, err := run(t, k8sSource, "k8s-multi.yaml", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := &scriptHost{
+		t: t, source: k8sSource,
+		reads: []SourceRead{
+			{Result: res, FileDigest: "sha256:a"},
+			{Result: res, FileDigest: "sha256:b"},
+		},
+		envs: []NamedEnv{{ID: "env_prod", Name: "prod"}, {ID: "env_staging", Name: "staging"}},
+		presence: func(envID string, c []PlannedCandidate) ServerState {
+			st := undeclaredState(envID, c)
+			if envID == "env_prod" {
+				// DB_PASSWORD already set in prod; skipped by default there.
+				for i := range st.Keys {
+					if st.Keys[i].Name == "DB_PASSWORD" {
+						st.Keys[i] = declaredKey("DB_PASSWORD", "secret", true, "v1:tok-prod")
+					}
+				}
+			}
+			return st
+		},
+		confirm: map[string]bool{
+			"Read live": false, "Edit this": false, "Downgrade": false,
+			"Declare": false, "overwrite": false, "import the trim": false,
+			"Map another": true, // add the second environment, then stop
+		},
+		choose: map[string]int{"source": 1, "Target environment": 0},
+		line:   map[string]string{"Export file path": "export.yaml"},
+	}
+	// "Map another" true would loop forever; flip it after the first extra env by
+	// tracking calls. Simpler: answer true once, then false.
+	host.confirm["Map another"] = true
+	callHost := &mapAnotherOnce{scriptHost: host}
+
+	wiz, err := Wizard(callHost, "prj_1", 7)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if len(wiz.Envs) != 2 {
+		t.Fatalf("env plans = %d, want 2", len(wiz.Envs))
+	}
+	if len(wiz.Manifest.Target.Environments) != 2 {
+		t.Errorf("manifest environments = %v", wiz.Manifest.Target.Environments)
+	}
+	byEnv := map[string]EnvPlan{}
+	for _, e := range wiz.Envs {
+		byEnv[e.EnvID] = e
+	}
+	if strings.Join(byEnv["env_prod"].Set, ",") != "DB_PASSWORD" {
+		t.Errorf("prod set = %v, want DB_PASSWORD skipped", byEnv["env_prod"].Set)
+	}
+}
+
+// mapAnotherOnce answers the "Map another?" confirm true exactly once, so the
+// fan-out loop adds a second environment and then terminates, and picks a fresh
+// existing environment on each "Target environment" choice.
+type mapAnotherOnce struct {
+	*scriptHost
+	asked   bool
+	envPick int
+}
+
+func (m *mapAnotherOnce) Confirm(q string, def bool) (bool, error) {
+	if strings.Contains(q, "Map another") {
+		if m.asked {
+			return false, nil
+		}
+		m.asked = true
+		return true, nil
+	}
+	return m.scriptHost.Confirm(q, def)
+}
+
+func (m *mapAnotherOnce) Choose(q string, options []string, def int) (int, error) {
+	if strings.Contains(q, "Target environment") {
+		pick := m.envPick
+		m.envPick++
+		return pick, nil
+	}
+	return m.scriptHost.Choose(q, options, def)
+}


### PR DESCRIPTION
Closes #112.

The interactive import wizard — the phase-1 authoring frontend for the mapping template. The wizard walks the source and the target mapping interactively, records every choice into a `Template`, then runs the **same planner replay uses** (`BuildProjectPlan`), so a single-environment wizard session and a flag run with coinciding choices author **byte-identical** artifacts (structural, pinned by `TestWizardSingleEnvMatchesFlagRun`).

## What's here

- **Multi-environment planner** (`BuildProjectPlan`): one project-wide definitions bundle, one manifest, per-environment values files/buckets/occurrences, reconciled to one identity/type/classification/folder per key. `BuildPlan` is the N=1 wrapper.
- **Wizard engine** (nine states, I/O-agnostic; scripted-prompter tests): source select → one source read fanned across target environments ("only presence varies") → renames → key review → collision review → trim acknowledgements → emit. Two-phase presence read (discover declared, then final-intent occurrence tokens). Deterministic type suggestion.
- **Created environments**, tokenless-by-design (locked decision, Fable advisor): `create environment` bundle lines, `target.created_environments` / `environment_name`, no phase-2 precondition; `values import` resolves the name post-apply and binds by name.
- **Multi-env replay** refusal lifted; routed through the planner.
- CLI TTY entry (no-TTY behaviour unchanged), terminal prompter, aggregate session bound.

## Acceptance criteria

- ✅ Wizard session ≡ flag/replay artifacts where choices coincide (byte-identical).
- ✅ Multi-environment session emits ONE reconciled project-wide bundle; conflicts refused non-interactively in replay.
- ✅ `import` on a TTY with no arguments enters the wizard; no-TTY is a hard error.
- ✅ Aggregate wizard-session bound enforced across the fan-out.

## Review

Native Codex (gpt-5.6-sol, high) adversarial pass, R1 → R2 → R3 + a confirming pass: **SOUND**. Findings fixed along the way — tokenless overwrite bypass, multi-env replay value divergence, manifest↔values run binding, and a values-file **content digest** (`values_digests`) so two runs targeting the same target cannot be mispaired.

Design + limitations: `docs/handoff/112-import-wizard.md`. Serializations: `docs/spec/api-cli-spellings.md` §3.

`go test ./...` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789834207&installation_model_id=432348&pr_number=188&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F188&signature=f6c9f476703909a0a6be42f894b95b21af7d71e88845983632e04a2ed2c6f5c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->