### PR TITLE
fix(ci): split fuzz reporting to workflow_run, unblock trusted-ci (#189)

### DIFF
--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -1,6 +1,8 @@
 # Pull-request orchestration must come from the base branch. This workflow
-# never executes PR-controlled workflow YAML or receives secrets. Validation
-# stays read-only; reporting writes are isolated in a base-controlled job.
+# never executes PR-controlled workflow YAML or receives secrets, and grants no
+# issue/PR write anywhere: validation stays read-only. Fuzz findings are
+# classified and posted out-of-band by fuzz-report.yml (workflow_run), so no
+# write request here can startup-fail the run or reach untrusted PR code (#189).
 name: trusted-ci
 
 on:
@@ -18,94 +20,6 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
-
-  # Re-run each minimized input against trusted base code without write
-  # authority. Base failure = pre-existing issue; base pass/new target = PR.
-  classify-fuzz-findings:
-    if: ${{ always() && needs.validation.result == 'failure' }}
-    needs: validation
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    outputs:
-      classification: ${{ steps.classify.outputs.classification }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Restore shared Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
-      - name: Download minimized fuzz reproducers
-        id: artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          ARTIFACT_NAME: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          artifact_id=
-          attempt=1
-          while [ "$attempt" -le 5 ]; do
-            artifact_id=$(gh api \
-              "repos/$GH_REPO/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
-              --jq ".artifacts | map(select(.name == \"$ARTIFACT_NAME\" and .expired == false))[0].id // empty")
-            [ -z "$artifact_id" ] || break
-            [ "$attempt" -eq 5 ] || sleep 2
-            attempt=$((attempt + 1))
-          done
-          if [ -z "$artifact_id" ]; then
-            echo 'found=false' >>"$GITHUB_OUTPUT"
-            exit 0
-          fi
-          archive="$RUNNER_TEMP/fuzz-reproducers.zip"
-          gh api "repos/$GH_REPO/actions/artifacts/$artifact_id/zip" >"$archive"
-          echo 'found=true' >>"$GITHUB_OUTPUT"
-          echo "archive=$archive" >>"$GITHUB_OUTPUT"
-      - name: Classify findings against trusted base
-        id: classify
-        if: steps.artifact.outputs.found == 'true'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          classification=$(./scripts/ci/classify-fuzz-findings.sh \
-            "${{ steps.artifact.outputs.archive }}" "$BASE_SHA" "$GITHUB_WORKSPACE")
-          echo "classification=$classification" >>"$GITHUB_OUTPUT"
-
-  # Validation executes the untrusted PR head without write authority. Only
-  # this base-controlled job receives issue/PR permission, and its reporter
-  # accepts strict Go corpus paths from the fuzz artifact before publishing.
-  report-fuzz-failure:
-    if: ${{ always() && needs.validation.result == 'failure' }}
-    needs: [validation, classify-fuzz-findings]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-      - name: Route fuzz findings to PR or issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          FUZZ_CLASSIFICATION: ${{ needs.classify-fuzz-findings.outputs.classification }}
-        run: >-
-          ./scripts/ci/report-fuzz-finding.sh "PR #${{ github.event.pull_request.number }}"
-          "${{ github.event.pull_request.head.sha }}" "$RUN_URL"
-          "${{ github.run_id }}" "${{ github.run_attempt }}"
 
   # Permanent required context. This job and its success criteria are loaded
   # from the base branch, so a PR cannot redefine its own merge gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,31 +834,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ steps.fuzz-go-cache.outputs.cache-primary-key }}
 
-  # Main executes this workflow directly. Keep issue write authority out of the
-  # fuzz job, then consume its untrusted artifact through the validating
-  # reporter script in a separate trusted job.
-  report-main-fuzz-failure:
-    needs: fuzz
-    if: >-
-      ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-      needs.fuzz.result == 'failure' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Create or update fuzz finding issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: >-
-          ./scripts/ci/report-fuzz-finding.sh main "${{ github.sha }}" "$RUN_URL"
-          "${{ github.run_id }}" "${{ github.run_attempt }}"
+  # Fuzz findings are reported out-of-band by fuzz-report.yml (workflow_run), so
+  # no job here requests issue/PR write. That keeps this reusable workflow's
+  # permission surface at contents:read, which is all its caller (trusted-ci)
+  # grants — a write request here would startup-fail every PR's trusted-ci run.
 
   # The headline guarantee, as its own named context (#76, mvp-boundary K3):
   # a stolen database and a stolen backup, without the root key, yield no

--- a/.github/workflows/fuzz-report.yml
+++ b/.github/workflows/fuzz-report.yml
@@ -1,0 +1,184 @@
+# Out-of-band fuzz reporting (#189). The validation graphs (ci.yml, ci-control.yml)
+# execute untrusted PR code and therefore hold no issue/PR write authority — a
+# write request inside the reusable ci.yml is capped by trusted-ci's contents:read
+# grant and startup-fails every PR run. This workflow runs in the trusted base
+# context on workflow_run completion, where write can be granted safely.
+#
+# Trust model: the fuzz-reproducers artifact is produced by untrusted PR jobs, so
+# its contents are re-validated (corpus-path shape and count) by both the classify
+# and report scripts. PR identity (number, base SHA, head SHA) is taken ONLY from
+# GitHub-owned workflow_run metadata, never from an artifact a PR job could forge.
+# Classification runs in a read-only job; only the posting job holds write.
+name: fuzz-report
+
+on:
+  workflow_run:
+    workflows: [trusted-ci, ci]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  # Read-only: replay the untrusted reproducers against the PR's trusted base to
+  # decide PR-related vs pre-existing. No write authority, so executing base test
+  # code against attacker-influenced corpus input cannot reach the issue/PR token.
+  classify:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      found: ${{ steps.classify.outputs.found }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      classification: ${{ steps.classify.outputs.classification }}
+    steps:
+      - name: Resolve PR identity from trigger metadata
+        id: pr
+        env:
+          TRIGGER_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+        run: |
+          set -eu
+          if [ "$(printf '%s' "$TRIGGER_PRS" | jq 'length')" -eq 0 ]; then
+            # No GitHub-attributed PR (e.g. a fork); we cannot safely bind the
+            # findings to a PR, so skip. The base-branch author still sees the
+            # failing validation run.
+            echo 'attributed=false' >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_number=$(printf '%s' "$TRIGGER_PRS" | jq -r '.[0].number')
+          base_sha=$(printf '%s' "$TRIGGER_PRS" | jq -r '.[0].base.sha')
+          head_sha=$(printf '%s' "$TRIGGER_PRS" | jq -r '.[0].head.sha')
+          {
+            echo 'attributed=true'
+            echo "pr_number=$pr_number"
+            echo "base_sha=$base_sha"
+            echo "head_sha=$head_sha"
+          } >>"$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.pr.outputs.attributed == 'true'
+        with:
+          ref: ${{ steps.pr.outputs.base_sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: steps.pr.outputs.attributed == 'true'
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        if: steps.pr.outputs.attributed == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Download minimized fuzz reproducers
+        id: artifact
+        if: steps.pr.outputs.attributed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ARTIFACT_NAME: fuzz-reproducers-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -eu
+          artifact_id=
+          attempt=1
+          while [ "$attempt" -le 5 ]; do
+            artifact_id=$(gh api \
+              "repos/$GH_REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
+              --jq ".artifacts | map(select(.name == \"$ARTIFACT_NAME\" and .expired == false))[0].id // empty")
+            [ -z "$artifact_id" ] || break
+            [ "$attempt" -eq 5 ] || sleep 2
+            attempt=$((attempt + 1))
+          done
+          if [ -z "$artifact_id" ]; then
+            echo 'found=false' >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          archive="$RUNNER_TEMP/fuzz-reproducers.zip"
+          gh api "repos/$GH_REPO/actions/artifacts/$artifact_id/zip" >"$archive"
+          echo 'found=true' >>"$GITHUB_OUTPUT"
+          echo "archive=$archive" >>"$GITHUB_OUTPUT"
+      - name: Classify findings against trusted base
+        id: classify
+        if: steps.artifact.outputs.found == 'true'
+        env:
+          ARCHIVE: ${{ steps.artifact.outputs.archive }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+        run: |
+          set -eu
+          # Attribution failure must not drop the finding: report-fuzz-finding.sh
+          # treats an empty classification as PR-related, keeping it off any
+          # repository-wide issue until a clean base replay can classify it.
+          if classification=$(./scripts/ci/classify-fuzz-findings.sh \
+            "$ARCHIVE" "$BASE_SHA" "$GITHUB_WORKSPACE"); then
+            echo "classification=$classification" >>"$GITHUB_OUTPUT"
+          else
+            echo 'fuzz report: base replay failed; findings will post as PR-related' >&2
+            echo 'classification=' >>"$GITHUB_OUTPUT"
+          fi
+          echo 'found=true' >>"$GITHUB_OUTPUT"
+
+  # Only this job holds issue/PR write. It re-validates the classification schema,
+  # the PR-number shape, and every corpus path before publishing.
+  report-pr:
+    needs: classify
+    if: ${{ needs.classify.outputs.found == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Route fuzz findings to PR or issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          PR_NUMBER: ${{ needs.classify.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.classify.outputs.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          FUZZ_CLASSIFICATION: ${{ needs.classify.outputs.classification }}
+        run: >-
+          ./scripts/ci/report-fuzz-finding.sh "PR #$PR_NUMBER" "$HEAD_SHA"
+          "$RUN_URL" "$RUN_ID" "$RUN_ATTEMPT"
+
+  # Main push runs ci.yml directly. Its fuzz findings are independently actionable
+  # (no PR base to replay against), so they go straight to a repository issue.
+  report-main:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Create or update fuzz finding issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: >-
+          ./scripts/ci/report-fuzz-finding.sh main "$HEAD_SHA"
+          "$RUN_URL" "$RUN_ID" "$RUN_ATTEMPT"


### PR DESCRIPTION
Fixes #189.

## Root cause
Every PR's `trusted-ci` run has startup-failed (0–1s) since #181. `ci-control.yml`'s `validation` job calls the reusable `ci.yml` with a `contents: read` grant, but `ci.yml`'s `report-main-fuzz-failure` job requests `issues: write`. GitHub validates a **called** workflow's job permissions against the caller's grant at graph-construction time, **ignoring `if:` conditions** — the nested write request exceeds the cap and rejects the whole run.

Decisive evidence it's the nested cap, not the repo's `default_workflow_permissions: read`: **main push CI is green** while running that same `report-main-fuzz-failure` (issues:write) directly — read-default is not a hard cap; the failure is specific to the capped reusable call. `ci-control.yml`'s own `report-fuzz-failure` also held issue/PR write under `pull_request_target`.

#181's own PR didn't catch it because `pull_request_target` resolves the graph from the base branch; the new jobs first executed on the *next* PR.

## Fix
Move all fuzz reporting out of both validation graphs into a new `fuzz-report.yml` on `workflow_run` (trusted base context, where write is grantable safely). Neither `ci.yml` nor `ci-control.yml` now requests any issue/PR write, so the reusable-call cap is satisfied.

- **ci.yml**: drop `report-main-fuzz-failure`.
- **ci-control.yml**: drop the classify/report jobs — now validation + `ci-required` gate only.
- **fuzz-report.yml** (new): dispatch by the triggering run's event.
  - PR identity (number, base SHA, head SHA) comes **only** from GitHub-owned `github.event.workflow_run.pull_requests` — never an artifact a PR job could forge. Unattributed (fork) → skip.
  - Read-only `classify` job replays the untrusted reproducers against the trusted PR base (base test code never runs with a write token); write-only `report-pr` posts. Main-push findings go straight to a repo issue via `report-main`.
  - The unchanged `report-fuzz-finding.sh` re-validates the classification schema, PR-number shape, and every corpus path.

## Security review
Adversarial Codex (gpt-5.6-sol, high effort) R1→R2. R1 flagged the first design's forgeable same-run request artifact (PR jobs can exfil `ACTIONS_RUNTIME_TOKEN` and win v4's immutable-name race); redesigned to compute classification in the trusted `workflow_run` with privilege separation. **R2: CLEAN.**

## Verification
- actionlint clean (pinned v1.7.12) on all workflows; both fuzz script tests pass (scripts untouched).
- **Only activates once merged to main** — both `pull_request_target` and `workflow_run` resolve from the default branch, so this PR's own trusted-ci still runs the base (broken) copy. Post-merge: verify with a fresh trivial PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789838027&installation_model_id=432348&pr_number=191&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F191&signature=c4332b79e08c04601684bc075999c5a4008e463321cab91d1c23fd9d0f0bb912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->