### PR TITLE
feat(ops): enforce per-project storage high-water — close #185

### DIFF
--- a/api/apigen/apigen.gen.go
+++ b/api/apigen/apigen.gen.go
@@ -4698,9 +4698,15 @@ type ResumeAdapterTargetMoveRequestVisibility string
 
 // RetentionHealth defines model for RetentionHealth.
 type RetentionHealth struct {
-	LastPruneSuccess  *time.Time                       `json:"last_prune_success"`
+	LastPruneSuccess *time.Time `json:"last_prune_success"`
+
+	// PeakProjectBytes Largest per-project stored payload across the instance, in bytes (ciphertext of value cells plus published snapshot entries). The per-project storage high-water surface.
+	PeakProjectBytes  int                              `json:"peak_project_bytes"`
 	Stale             bool                             `json:"stale"`
 	StaleAfterSeconds RetentionHealthStaleAfterSeconds `json:"stale_after_seconds"`
+
+	// StorageWarn True once peak_project_bytes reaches the 1 GiB warn threshold, well before the 4 GiB publish refusal.
+	StorageWarn bool `json:"storage_warn"`
 }
 
 // RetentionHealthStaleAfterSeconds defines model for RetentionHealth.StaleAfterSeconds.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12527,7 +12527,7 @@ components:
     RetentionHealth:
       type: object
       additionalProperties: false
-      required: [last_prune_success, stale, stale_after_seconds]
+      required: [last_prune_success, stale, stale_after_seconds, peak_project_bytes, storage_warn]
       properties:
         last_prune_success:
           type: [string, "null"]
@@ -12537,6 +12537,17 @@ components:
         stale_after_seconds:
           type: integer
           const: 86400
+        peak_project_bytes:
+          type: integer
+          description: >-
+            Largest per-project stored payload across the instance, in bytes
+            (ciphertext of value cells plus published snapshot entries). The
+            per-project storage high-water surface.
+        storage_warn:
+          type: boolean
+          description: >-
+            True once peak_project_bytes reaches the 1 GiB warn threshold, well
+            before the 4 GiB publish refusal.
 
     ProjectRetentionPolicy:
       type: object

--- a/clients/ts/src/generated/types.gen.ts
+++ b/clients/ts/src/generated/types.gen.ts
@@ -2266,6 +2266,14 @@ export type RetentionHealth = {
     last_prune_success: string | null;
     stale: boolean;
     stale_after_seconds: 86400;
+    /**
+     * Largest per-project stored payload across the instance, in bytes (ciphertext of value cells plus published snapshot entries). The per-project storage high-water surface.
+     */
+    peak_project_bytes: number;
+    /**
+     * True once peak_project_bytes reaches the 1 GiB warn threshold, well before the 4 GiB publish refusal.
+     */
+    storage_warn: boolean;
 };
 
 export type ProjectRetentionPolicy = {

--- a/clients/ts/src/generated/zod.gen.ts
+++ b/clients/ts/src/generated/zod.gen.ts
@@ -1287,7 +1287,9 @@ export const zRetentionPolicy = z.object({
 export const zRetentionHealth = z.object({
     last_prune_success: z.iso.datetime().nullable(),
     stale: z.boolean(),
-    stale_after_seconds: z.literal(86400)
+    stale_after_seconds: z.literal(86400),
+    peak_project_bytes: z.int(),
+    storage_warn: z.boolean()
 });
 
 export const zProjectRetentionPolicy = z.object({

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -1673,6 +1673,10 @@ var registry = map[EventType]TypeSpec{
 		},
 	},
 	EventRetentionHealthRead: {
+		// SchemaVersion stays 1: the service emitter (newAuditEvent) stamps every
+		// event v1 by design in this pre-1.0 system, and there is no released v1
+		// contract to preserve nor any read-path revalidation of old rows. The
+		// #185 storage fields are an additive extension of the one live shape.
 		SchemaVersion: 1,
 		Retention:     RetentionAccess,
 		Outcomes:      map[Outcome]bool{OutcomeSuccess: true},
@@ -1681,6 +1685,9 @@ var registry = map[EventType]TypeSpec{
 			"recorded":            {Kind: KindBool, Required: true},
 			"stale":               {Kind: KindBool, Required: true},
 			"stale_after_seconds": {Kind: KindInt, Required: true},
+			// Per-project storage high-water reported alongside prune health (#185).
+			"peak_project_bytes": {Kind: KindInt, Required: true},
+			"storage_warn":       {Kind: KindBool, Required: true},
 		},
 	},
 	EventRetentionPayloadGC: {

--- a/internal/authz/registry.go
+++ b/internal/authz/registry.go
@@ -745,6 +745,15 @@ const (
 	StoreRetentionLastSuccess    StoreOp = "retention.LastPruneSuccess"
 	StoreRetentionSetLastSuccess StoreOp = "retention.SetLastPruneSuccess"
 
+	// Per-project storage high-water (#185, ops-spec section 8 / section 141).
+	// The two project-scoped byte sums are read at publish to refuse a project
+	// already at the 4 GiB high-water; the two instance-scoped by-project sums
+	// back the operator storage surface (doctor warn at 1 GiB, metric).
+	StoreValuesPayloadBytesForProject      StoreOp = "values.PayloadBytesForProject"
+	StoreSnapshotsPayloadBytesForProject   StoreOp = "snapshots.PayloadBytesForProject"
+	StoreValuesInstancePayloadByProject    StoreOp = "values.InstancePayloadByProject"
+	StoreSnapshotsInstancePayloadByProject StoreOp = "snapshots.InstancePayloadByProject"
+
 	// Keyring persistence (#43). These carry no tenant chain: wrapped-key
 	// rows are instance-scoped crypto material, and the scope a tier-3 key
 	// belongs to is part of its AAD, not a tenant predicate.
@@ -972,6 +981,10 @@ var readOnlyStoreOps = map[StoreOp]bool{
 	StorePendingListForOwnerInEnvironment:    true,
 	StorePendingListMarkers:                  true,
 	StorePendingCountForProjectExcludingCell: true,
+	StoreValuesPayloadBytesForProject:        true,
+	StoreSnapshotsPayloadBytesForProject:     true,
+	StoreValuesInstancePayloadByProject:      true,
+	StoreSnapshotsInstancePayloadByProject:   true,
 	StoreSnapshotsLatest:                     true,
 	StoreSnapshotsAtRevision:                 true,
 	StoreSnapshotsList:                       true,
@@ -2023,6 +2036,11 @@ var operations = map[Operation]opSpec{
 			StoreAdaptersEnqueuePublished:             true,
 			StoreKeysAssertActiveDEKVersion:           true,
 			StoreAuditTenantInsert:                    true,
+			// Per-project storage high-water (#185): the two byte sums read
+			// before the project's payload advances, to refuse a publish into a
+			// project already at the 4 GiB high-water.
+			StoreValuesPayloadBytesForProject:    true,
+			StoreSnapshotsPayloadBytesForProject: true,
 		},
 		events: []audit.EventType{
 			audit.EventRevisionPublished,
@@ -2744,6 +2762,10 @@ var operations = map[Operation]opSpec{
 		storeOps: map[StoreOp]bool{
 			StoreRetentionLastSuccess: true,
 			StoreAuditInstanceInsert:  true,
+			// Per-project storage high-water (#185): the operator health read
+			// also reports the instance's peak stored project, for the 1 GiB warn.
+			StoreValuesInstancePayloadByProject:    true,
+			StoreSnapshotsInstancePayloadByProject: true,
 		},
 		events: []audit.EventType{audit.EventRetentionHealthRead},
 	},
@@ -3508,6 +3530,11 @@ var systemSites = map[SystemSite]map[StoreOp]bool{
 		StoreAuditInstanceInsert: true,
 		// The hourly GC also prunes expired, unapplied definitions plans (#70).
 		StoreDefinitionsPlanPrune: true,
+		// The unauthenticated /metrics scrape rides scheduler authority to read
+		// the same operational storage high-water the audited health read serves
+		// (#185): a shared door, like the retention health read beside it.
+		StoreValuesInstancePayloadByProject:    true,
+		StoreSnapshotsInstancePayloadByProject: true,
 	},
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -73,6 +73,12 @@ func doctorResults(providers apigen.SamlProviderList, health apigen.RetentionHea
 	if prune.Severity == "warn" {
 		result.Status = "warning"
 	}
+	storage := doctorStorageFinding(health)
+	result.Findings = append(result.Findings, storage)
+	rows = append(rows, []string{storage.Severity, storage.Provider, storage.Code, storage.EffectiveAt, storage.Message})
+	if storage.Severity == "warn" && result.Status == "ok" {
+		result.Status = "warning"
+	}
 	providerRowStart := len(rows)
 	for _, provider := range providers.Providers {
 		for _, warning := range provider.Warnings {
@@ -116,4 +122,30 @@ func doctorPruneFinding(health apigen.RetentionHealth, now time.Time) doctorFind
 	}
 	finding.Message = fmt.Sprintf("last_prune_success is %s old", age)
 	return finding
+}
+
+// doctorStorageFinding surfaces the per-project storage high-water (#185): a
+// warn once the instance's peak project reaches the 1 GiB threshold, so the
+// operator sees it long before the 4 GiB publish refusal. The server owns the
+// threshold; storage_warn is its verdict.
+func doctorStorageFinding(health apigen.RetentionHealth) doctorFinding {
+	finding := doctorFinding{Provider: "-", Code: "project-storage", Severity: "ok", EffectiveAt: "-"}
+	peak := formatBytesGiB(health.PeakProjectBytes)
+	if health.StorageWarn {
+		finding.Severity = "warn"
+		finding.Message = fmt.Sprintf("peak project holds %s, at or over the 1 GiB warn (4 GiB refuses new publishes)", peak)
+		return finding
+	}
+	finding.Message = fmt.Sprintf("peak project holds %s", peak)
+	return finding
+}
+
+// formatBytesGiB renders a byte count for operator eyes: GiB with two decimals
+// once past a gibibyte, MiB below that.
+func formatBytesGiB(bytes int) string {
+	const gib = 1 << 30
+	if bytes >= gib {
+		return fmt.Sprintf("%.2f GiB", float64(bytes)/float64(gib))
+	}
+	return fmt.Sprintf("%.1f MiB", float64(bytes)/float64(1<<20))
 }

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -17,14 +17,38 @@ func TestDoctorResultsUseServerWarningsWithoutRecalculation(t *testing.T) {
 			Message: "server message", EffectiveAt: effectiveAt,
 		}},
 	}}}, apigen.RetentionHealth{LastPruneSuccess: &lastPrune, Stale: false, StaleAfterSeconds: 86400}, effectiveAt)
-	if result.Status != "error" || len(result.Findings) != 2 {
+	// Findings: [0] retention-prune, [1] project-storage, [2] the provider error.
+	if result.Status != "error" || len(result.Findings) != 3 {
 		t.Fatalf("doctor result = %#v", result)
 	}
-	if got := result.Findings[1]; got.Provider != "corp" || got.Code != "metadata_expired" || got.Message != "server message" {
+	if got := result.Findings[2]; got.Provider != "corp" || got.Code != "metadata_expired" || got.Message != "server message" {
 		t.Fatalf("doctor finding = %#v", got)
 	}
-	if len(rows) != 2 || rows[1][4] != "server message" {
+	if len(rows) != 3 || rows[2][4] != "server message" {
 		t.Fatalf("doctor rows = %#v", rows)
+	}
+}
+
+func TestDoctorStorageFinding(t *testing.T) {
+	const gib = 1 << 30
+	tests := []struct {
+		name     string
+		health   apigen.RetentionHealth
+		severity string
+		message  string
+	}{
+		{"empty", apigen.RetentionHealth{PeakProjectBytes: 0, StorageWarn: false}, "ok", "peak project holds 0.0 MiB"},
+		{"under", apigen.RetentionHealth{PeakProjectBytes: 512 << 20, StorageWarn: false}, "ok", "peak project holds 512.0 MiB"},
+		{"warn", apigen.RetentionHealth{PeakProjectBytes: 3 * gib / 2, StorageWarn: true}, "warn",
+			"peak project holds 1.50 GiB, at or over the 1 GiB warn (4 GiB refuses new publishes)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := doctorStorageFinding(tc.health)
+			if got.Severity != tc.severity || got.Message != tc.message {
+				t.Fatalf("finding = %#v", got)
+			}
+		})
 	}
 }
 

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -105,7 +105,7 @@ var Registry = []Bound{
 	{"Open plans per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxOpenPlansPerProject)", "isolation definitions_e2e", StatusEnforced},
 	{"Pins quota per project", "ops-spec §8", "invalidDetail (PinQuota)", "conformance revisions_test", StatusEnforced},
 	{"Grants per org", "ops-spec §8", "domain.ErrLimitExceeded (MaxGrantsPerOrg)", "isolation.TestGrantPerOrgCap", StatusEnforced},
-	{"Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "publish refusal + doctor warn + metric + UI banner", "ENFORCEMENT-PENDING: the publish path EXISTS (internal/service/publish.go), but the refusal needs a per-project payload-byte accounting mechanism (SUM over value_entries+snapshot_entries) + a project-scoped store proof action + the 1 GiB doctor/metric surface — net-new infrastructure the v1.0 no-scope-expansion milestone defers. HUMAN-DISPOSITION -> issue #185.", StatusPending},
+	{"Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "domain.ErrLimitExceeded (MaxProjectStorageBytes) at publish + doctor/metric/UI-banner warn (ProjectStorageWarnBytes)", "isolation.TestProjectStorageHighWater", StatusEnforced},
 	{"Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "loud rate-limit refusal", "ENFORCEMENT-PENDING: the schema-mutation path EXISTS, but the refusal needs a per-principal windowed rate-limit mechanism (the §179 expensive-path budget layer) that is not yet built anywhere. HUMAN-DISPOSITION -> issue #186.", StatusPending},
 
 	// §9 encryption.
@@ -200,6 +200,9 @@ func TestReconciledBoundsMatchOpsSpecValues(t *testing.T) {
 		{"store.AuditMaxPageSize", store.AuditMaxPageSize, 1000},
 		// §9 reencrypt chunk bound, enforced once the walk shipped (#187 / #192).
 		{"service.ReencryptChunkSize", service.ReencryptChunkSize, 100},
+		// Per-project storage high-water (#185).
+		{"service.MaxProjectStorageBytes", service.MaxProjectStorageBytes, 4 << 30},
+		{"service.ProjectStorageWarnBytes", service.ProjectStorageWarnBytes, 1 << 30},
 		// Already-conformant bounds, pinned so they cannot drift unnoticed.
 		{"schema.MaxKeysPerProject", schema.MaxKeysPerProject, 1000},
 		{"schema.MaxKeyGroupsPerProject", schema.MaxKeyGroupsPerProject, 100},

--- a/internal/isolation/invariants_test.go
+++ b/internal/isolation/invariants_test.go
@@ -175,6 +175,11 @@ func TestInvariant06OperationRegistryCompleteness(t *testing.T) {
 		authz.StoreAuditTenantInsert:    true,
 		authz.StoreAuditInstanceInsert:  true,
 		authz.StoreRetentionLastSuccess: true,
+		// The storage high-water instance sums are dual-use like the health read:
+		// the audited operator read reaches them via retention.health-read, the
+		// unauthenticated /metrics scrape via the scheduler mint site (#185).
+		authz.StoreValuesInstancePayloadByProject:    true,
+		authz.StoreSnapshotsInstancePayloadByProject: true,
 	}
 	seenShared := map[authz.StoreOp]bool{}
 	for method := range expected {
@@ -323,6 +328,10 @@ func TestInvariant11SystemProofEnumeration(t *testing.T) {
 		// definitions plans. This deliberate system-proof widening is therefore
 		// pinned here for ADR review rather than hidden behind a side effect.
 		authz.StoreDefinitionsPlanPrune: true,
+		// The /metrics storage high-water gauge reads the instance's per-project
+		// byte sums under scheduler authority (#185): a reviewed widening, pinned.
+		authz.StoreValuesInstancePayloadByProject:    true,
+		authz.StoreSnapshotsInstancePayloadByProject: true,
 	}
 	for site, ops := range sites {
 		if !want[site] {

--- a/internal/isolation/project_storage_e2e_test.go
+++ b/internal/isolation/project_storage_e2e_test.go
@@ -1,0 +1,77 @@
+package isolation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestProjectStorageHighWaterSQLite(t *testing.T) {
+	runProjectStorageHighWater(t, seededDB(t, openSQLite))
+}
+func TestProjectStorageHighWaterPostgres(t *testing.T) {
+	runProjectStorageHighWater(t, seededDB(t, openPostgres))
+}
+
+// runProjectStorageHighWater is the ops-spec § 8 / § 141 per-project storage
+// high-water: once a project's stored payload (value cells plus published
+// snapshot entries) reaches the high-water, a NEW publish is refused by name.
+// No test can seed 4 GiB, so the exact refuse value (4 GiB) is pinned by the
+// conformance bound registry; this proves the accounting SUMS BOTH tables and
+// the refusal fires at the boundary, on both engines, through the real publish.
+func runProjectStorageHighWater(t *testing.T, db *store.DB) {
+	kr := probeKeyring(t, db)
+	values := valueSvc(t, db)
+	actor := service.LocalPrincipal(custodian)
+	scope := scopeEnv(orgA, prjA1, envA1)
+
+	// A first publish under the production high-water establishes real stored
+	// bytes: the value cell and its snapshot entry, both sealed.
+	staged, err := values.Set(t.Context(), actor, scope, "SHARED_KEY", "first", nil)
+	if err != nil {
+		t.Fatalf("stage first value: %v", err)
+	}
+	base := &service.Revisions{DB: db, Keyring: kr}
+	if _, err := base.Publish(t.Context(), actor, scope, []string{staged.VersionID}); err != nil {
+		t.Fatalf("first publish must succeed on an empty project: %v", err)
+	}
+
+	// The project's stored payload across BOTH tables — the exact quantity the
+	// refusal sums. LENGTH is the byte count of a BLOB / bytea on both engines.
+	stored := queryInt(t, db,
+		"SELECT (SELECT COALESCE(SUM(LENGTH(ciphertext)), 0) FROM value_entries WHERE org_id = 'org_a' AND project_id = 'prj_a1')"+
+			" + (SELECT COALESCE(SUM(LENGTH(ciphertext)), 0) FROM snapshot_entries WHERE org_id = 'org_a' AND project_id = 'prj_a1')")
+	if stored <= 0 {
+		t.Fatalf("first publish stored no payload bytes (value_entries + snapshot_entries) = %d", stored)
+	}
+
+	// Stage a second change. With the high-water set to exactly the bytes now
+	// stored, the project is AT the water, so the new publish is refused by name.
+	second, err := values.Set(t.Context(), actor, scope, "SHARED_KEY", "second", nil)
+	if err != nil {
+		t.Fatalf("stage second value: %v", err)
+	}
+	atWater := &service.Revisions{DB: db, Keyring: kr, ProjectStorageHighWater: int64(stored)}
+	_, err = atWater.Publish(t.Context(), actor, scope, []string{second.VersionID})
+	if !errors.Is(err, domain.ErrLimitExceeded) {
+		t.Fatalf("publish into a project at the storage high-water must be refused with ErrLimitExceeded: %v", err)
+	}
+	// The refusal must NAME what holds the space (ops-spec § 141): the retention
+	// window and the pinned revisions, so the operator knows how to reclaim it.
+	for _, want := range []string{"storage high-water", "retention", "pinned revisions"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal must name %q so the operator can reclaim space: %q", want, err)
+		}
+	}
+
+	// One byte of headroom lets the same staged change through: the boundary is
+	// `>=`, so below the water publishes normally.
+	belowWater := &service.Revisions{DB: db, Keyring: kr, ProjectStorageHighWater: int64(stored) + 1}
+	if _, err := belowWater.Publish(t.Context(), actor, scope, []string{second.VersionID}); err != nil {
+		t.Fatalf("publish below the high-water must succeed: %v", err)
+	}
+}

--- a/internal/isolation/testdata/annotated_queries.json
+++ b/internal/isolation/testdata/annotated_queries.json
@@ -1369,6 +1369,18 @@
   },
   {
     "engine": "postgres",
+    "name": "SumSnapshotPayloadByProject",
+    "annotation": "instance-scoped",
+    "hash": "2c98ca3910e31be8709383f7a9c3d298e69a75f005bcd74fdc275319883f86bf"
+  },
+  {
+    "engine": "postgres",
+    "name": "SumValuePayloadByProject",
+    "annotation": "instance-scoped",
+    "hash": "bc7fd275f2fa9a57f8fda1aeadfa66ccff7f8447653899f685df2464b990a7bd"
+  },
+  {
+    "engine": "postgres",
     "name": "TouchInstanceConnection",
     "annotation": "authn-resolution",
     "hash": "3085ba4d0d99821110d446340b88eb828a2b265d0ae3e1c69c14b6d43e404232"
@@ -2806,6 +2818,18 @@
     "name": "StrandedRevealPrincipalsForEnvironment",
     "annotation": "authn-resolution",
     "hash": "95cd1f8c392587ce7700fa672088cb243f4b5581ec98a9537ec54e909eb1cdee"
+  },
+  {
+    "engine": "sqlite",
+    "name": "SumSnapshotPayloadByProject",
+    "annotation": "instance-scoped",
+    "hash": "a43b437e8e153424482be2fc0349f70ac19ca9b63cdb95b0ef0094d36c5d39f2"
+  },
+  {
+    "engine": "sqlite",
+    "name": "SumValuePayloadByProject",
+    "annotation": "instance-scoped",
+    "hash": "96b047627eb885a33a63a9546f7c0cf480b6ed198d2152ffe5fca898375e6c35"
   },
   {
     "engine": "sqlite",

--- a/internal/server/access.go
+++ b/internal/server/access.go
@@ -424,6 +424,8 @@ func (a *API) GetRetentionHealth(ctx context.Context, _ apigen.GetRetentionHealt
 		LastPruneSuccess:  last,
 		Stale:             health.Stale,
 		StaleAfterSeconds: apigen.RetentionHealthStaleAfterSeconds(service.PruneStaleAfter / time.Second),
+		PeakProjectBytes:  int(health.PeakProjectBytes),
+		StorageWarn:       health.StorageWarn,
 	}, nil
 }
 

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -328,7 +328,10 @@ func (s stubRetentionHealth) OperationalHealth(context.Context) (service.PruneHe
 func TestMetricsExposeRetentionPrunerHealthWithoutLabels(t *testing.T) {
 	last := time.Unix(1_800_000_000, 0).UTC()
 	srv := httptest.NewServer(server.New(stubReady{}, &server.API{
-		RetentionHealth: stubRetentionHealth{health: service.PruneHealth{LastSuccess: last, Recorded: true, Stale: true}},
+		RetentionHealth: stubRetentionHealth{health: service.PruneHealth{
+			LastSuccess: last, Recorded: true, Stale: true,
+			PeakProjectBytes: 1_500_000_000, StorageWarn: true,
+		}},
 	}, nil))
 	t.Cleanup(srv.Close)
 	resp, err := http.Get(srv.URL + "/metrics")
@@ -349,7 +352,11 @@ func TestMetricsExposeRetentionPrunerHealthWithoutLabels(t *testing.T) {
 	want := "# TYPE hikyo_last_prune_success_timestamp_seconds gauge\n" +
 		"hikyo_last_prune_success_timestamp_seconds 1800000000\n" +
 		"# TYPE hikyo_prune_stale gauge\n" +
-		"hikyo_prune_stale 1\n"
+		"hikyo_prune_stale 1\n" +
+		"# TYPE hikyo_project_storage_peak_bytes gauge\n" +
+		"hikyo_project_storage_peak_bytes 1500000000\n" +
+		"# TYPE hikyo_project_storage_warn gauge\n" +
+		"hikyo_project_storage_warn 1\n"
 	if string(body) != want {
 		t.Fatalf("metrics = %q, want %q", body, want)
 	}
@@ -374,6 +381,9 @@ func TestMetricsUseZeroWhenPruneNeverSucceeded(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "hikyo_last_prune_success_timestamp_seconds 0\n") || !strings.Contains(string(body), "hikyo_prune_stale 1\n") {
 		t.Fatalf("never-recorded metrics = %q", body)
+	}
+	if !strings.Contains(string(body), "hikyo_project_storage_peak_bytes 0\n") || !strings.Contains(string(body), "hikyo_project_storage_warn 0\n") {
+		t.Fatalf("empty-instance storage metrics = %q", body)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -115,12 +115,20 @@ func New(ready ReadyChecker, a *API, ui fs.FS) http.Handler {
 		if health.Stale {
 			stale = 1
 		}
+		storageWarn := 0
+		if health.StorageWarn {
+			storageWarn = 1
+		}
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintf(w, "# TYPE hikyo_last_prune_success_timestamp_seconds gauge\n"+
 			"hikyo_last_prune_success_timestamp_seconds %d\n"+
 			"# TYPE hikyo_prune_stale gauge\n"+
-			"hikyo_prune_stale %d\n", last, stale)
+			"hikyo_prune_stale %d\n"+
+			"# TYPE hikyo_project_storage_peak_bytes gauge\n"+
+			"hikyo_project_storage_peak_bytes %d\n"+
+			"# TYPE hikyo_project_storage_warn gauge\n"+
+			"hikyo_project_storage_warn %d\n", last, stale, health.PeakProjectBytes, storageWarn)
 	})
 
 	if a != nil {

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -65,6 +65,21 @@ type Revisions struct {
 	// publish transactions to overlap around the project lock. Production
 	// leaves it nil; it decides no behavior and sees no material.
 	PublishProbe PublishConformanceProbe
+	// ProjectStorageHighWater overrides the per-project storage high-water for
+	// the cross-engine conformance test, which cannot seed 4 GiB. Zero (the
+	// production default) means MaxProjectStorageBytes; the override can only
+	// TIGHTEN the bound — a value at or above MaxProjectStorageBytes is ignored,
+	// so no misconfiguration can relax the ops-spec refusal in production.
+	ProjectStorageHighWater int64
+}
+
+// storageLimit is the effective per-project storage high-water: the pinned
+// MaxProjectStorageBytes, unless a conformance override tightens it below that.
+func (s *Revisions) storageLimit() int64 {
+	if s.ProjectStorageHighWater > 0 && s.ProjectStorageHighWater < MaxProjectStorageBytes {
+		return s.ProjectStorageHighWater
+	}
+	return MaxProjectStorageBytes
 }
 
 // PublishConformanceProbe exposes only the two checkpoints needed to prove
@@ -375,7 +390,7 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 				applies[i].value = string(plain)
 			}
 			published, err := materialize(ctx, r, ep, sealer, s.Keyring, envScope,
-				caller.Principal, now, applies)
+				caller.Principal, now, applies, s.storageLimit())
 			if err != nil {
 				return err
 			}
@@ -657,7 +672,10 @@ func republish(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, calle
 	if err != nil {
 		return PublishedEnvironment{}, err
 	}
-	published, err := materialize(ctx, r, p, sealer, kr, scope, caller.Principal, now, nil)
+	// republish covers the non-draft payload-advancing paths (declare-into-env,
+	// import, copy, clone, env creation, schema fan-out); each enforces the
+	// production high-water — only the direct publish path is conformance-tunable.
+	published, err := materialize(ctx, r, p, sealer, kr, scope, caller.Principal, now, nil, MaxProjectStorageBytes)
 	if err != nil {
 		return PublishedEnvironment{}, err
 	}
@@ -924,7 +942,7 @@ func currentRevision(ctx context.Context, r store.Repos, p authz.Proof) (int64, 
 // and is that legal".
 func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *crypto.ProjectSealer,
 	kr *crypto.Keyring, scope domain.Scope, publisher domain.PrincipalID, now time.Time,
-	applies []pendingApply) (PublishedEnvironment, error) {
+	applies []pendingApply, storageLimit int64) (PublishedEnvironment, error) {
 	keys, err := r.Catalogue().List(ctx, p)
 	if err != nil {
 		return PublishedEnvironment{}, err
@@ -986,6 +1004,17 @@ func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *cryp
 	// environment that would render a target larger than a Kubernetes Secret can
 	// hold cannot be committed (ops-spec § 8 per-target render cap).
 	if err := checkRenderTotal(cells, string(scope.Env)); err != nil {
+		return PublishedEnvironment{}, err
+	}
+
+	// Per-project storage high-water (ops-spec § 8 / § 141): a project already
+	// holding MaxProjectStorageBytes of stored payload refuses new publishes,
+	// naming what holds the space. Checked here — the single chokepoint every
+	// payload-advancing path routes through — BEFORE this env's bytes move, so a
+	// project over the water cannot grow further. The read is project-scoped, so
+	// it sees a multi-environment publish's earlier envs already committed in this
+	// transaction.
+	if err := checkProjectStorage(ctx, r, p, storageLimit); err != nil {
 		return PublishedEnvironment{}, err
 	}
 
@@ -1113,6 +1142,39 @@ func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *cryp
 // above it, so the sum is a genuine reachable bound — refused at publish, where
 // the target is not yet committed, rather than at delivery, where it is.
 const MaxRenderBytesPerTarget = 1 << 20
+
+// MaxProjectStorageBytes is the ops-spec § 8 / § 141 per-project storage
+// high-water: a project holding this much stored payload (value cells plus
+// published snapshot entries, ciphertext bytes) refuses NEW publishes. Pinned,
+// cross-checked against the ops-spec value by the bound registry.
+const MaxProjectStorageBytes = 4 << 30 // 4 GiB
+
+// ProjectStorageWarnBytes is the ops-spec § 8 / § 141 warn threshold: at this
+// much stored payload the operator surfaces (doctor, metric, UI banner) warn,
+// well before the hard refusal at MaxProjectStorageBytes.
+const ProjectStorageWarnBytes = 1 << 30 // 1 GiB
+
+// checkProjectStorage refuses a publish into a project already at the storage
+// high-water. It sums the two payload-bearing tables (live value cells and
+// published snapshot entries) under the publish proof's project chain and, at or
+// over the limit, refuses by name — pointing the operator at the retention and
+// pin settings that hold the space, since dropping either is how the space comes
+// back.
+func checkProjectStorage(ctx context.Context, r store.Repos, p authz.Proof, limit int64) error {
+	values, err := r.Values().PayloadBytesForProject(ctx, p)
+	if err != nil {
+		return err
+	}
+	snapshots, err := r.Snapshots().PayloadBytesForProject(ctx, p)
+	if err != nil {
+		return err
+	}
+	if total := values + snapshots; total >= limit {
+		return fmt.Errorf("%w: project holds %d bytes of stored payload, at the %d-byte storage high-water; lower the project's retention window or release pinned revisions to reclaim space",
+			domain.ErrLimitExceeded, total, limit)
+	}
+	return nil
+}
 
 // checkRenderTotal refuses a publish whose resolved environment would render a
 // delivery target larger than a Kubernetes Secret can hold. Kubernetes'

--- a/internal/service/retention.go
+++ b/internal/service/retention.go
@@ -40,6 +40,41 @@ type PruneHealth struct {
 	LastSuccess time.Time
 	Recorded    bool
 	Stale       bool
+	// PeakProjectBytes is the largest per-project stored payload across the
+	// whole instance — value cells plus published snapshot entries (#185).
+	// StorageWarn is true once it reaches ProjectStorageWarnBytes, the doctor /
+	// metric / UI-banner warn for the per-project storage high-water.
+	PeakProjectBytes int64
+	StorageWarn      bool
+}
+
+// peakProjectStorage sums each project's stored ciphertext bytes across both
+// payload tables and returns the largest — the operator storage high-water
+// (#185). Instance-scoped: the two reads span every tenant, merged by owning
+// project so a project's value and snapshot bytes count as one total.
+func peakProjectStorage(ctx context.Context, values store.ValueReader, snapshots store.SnapshotReader, p authz.Proof) (int64, error) {
+	valueRows, err := values.InstancePayloadByProject(ctx, p)
+	if err != nil {
+		return 0, err
+	}
+	snapshotRows, err := snapshots.InstancePayloadByProject(ctx, p)
+	if err != nil {
+		return 0, err
+	}
+	byProject := make(map[string]int64, len(valueRows)+len(snapshotRows))
+	for _, row := range valueRows {
+		byProject[row.OrgID+"/"+row.ProjectID] += row.Bytes
+	}
+	for _, row := range snapshotRows {
+		byProject[row.OrgID+"/"+row.ProjectID] += row.Bytes
+	}
+	var peak int64
+	for _, total := range byProject {
+		if total > peak {
+			peak = total
+		}
+	}
+	return peak, nil
 }
 
 // Retention owns tenant policy settings and the scheduler's payload sweep.
@@ -429,7 +464,8 @@ func (s *Retention) recordFailedPruneRun(ctx context.Context, startedAt, finishe
 }
 
 // LastPruneSuccess returns the persisted health timestamp. false means this
-// datastore has never completed a payload prune.
+// datastore has never completed a payload prune. It is the scheduler's
+// per-job success probe.
 func (s *Retention) LastPruneSuccess(ctx context.Context) (time.Time, bool, error) {
 	var at time.Time
 	var ok bool
@@ -447,21 +483,44 @@ func (s *Retention) LastPruneSuccess(ctx context.Context) (time.Time, bool, erro
 	return at, ok, err
 }
 
-func (s *Retention) health(at time.Time, recorded bool) PruneHealth {
+// health assembles the operator health snapshot from the persisted prune
+// timestamp and the per-project storage high-water.
+func (s *Retention) health(at time.Time, recorded bool, peakStorage int64) PruneHealth {
 	return PruneHealth{
-		LastSuccess: at,
-		Recorded:    recorded,
-		Stale:       !recorded || s.now().Sub(at) > PruneStaleAfter,
+		LastSuccess:      at,
+		Recorded:         recorded,
+		Stale:            !recorded || s.now().Sub(at) > PruneStaleAfter,
+		PeakProjectBytes: peakStorage,
+		StorageWarn:      peakStorage >= ProjectStorageWarnBytes,
 	}
 }
 
-// OperationalHealth reads scheduler health for local operational surfaces.
+// OperationalHealth reads scheduler health for local operational surfaces
+// (doctor, /metrics). One transaction under scheduler authority reads both the
+// last-prune timestamp and the per-project storage high-water (#185).
 func (s *Retention) OperationalHealth(ctx context.Context) (PruneHealth, error) {
-	at, recorded, err := s.LastPruneSuccess(ctx)
+	var at time.Time
+	var recorded bool
+	var peak int64
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		p, err := authz.SystemAuthority(authz.SiteScheduler, az.Token())
+		if err != nil {
+			return err
+		}
+		at, recorded, err = r.Retention().LastPruneSuccess(ctx, p)
+		if errors.Is(err, store.ErrNotFound) {
+			at, recorded, err = time.Time{}, false, nil
+		}
+		if err != nil {
+			return err
+		}
+		peak, err = peakProjectStorage(ctx, r.Values(), r.Snapshots(), p)
+		return err
+	})
 	if err != nil {
 		return PruneHealth{}, err
 	}
-	return s.health(at, recorded), nil
+	return s.health(at, recorded, peak), nil
 }
 
 // GetHealth authorizes and audits the instance API read in one transaction.
@@ -484,11 +543,16 @@ func (s *Retention) GetHealth(ctx context.Context, actor Actor) (PruneHealth, er
 		if err != nil {
 			return err
 		}
-		out = s.health(at, recorded)
+		peak, err := peakProjectStorage(ctx, r.Values(), r.Snapshots(), proof)
+		if err != nil {
+			return err
+		}
+		out = s.health(at, recorded, peak)
 		ev, err := domainEvent(ctx, audit.EventRetentionHealthRead, caller.Principal,
 			audit.Object{Type: "retention_health", ID: "payload_gc"}, audit.Payload{
 				"recorded": out.Recorded, "stale": out.Stale,
 				"stale_after_seconds": int64(PruneStaleAfter / time.Second),
+				"peak_project_bytes":  out.PeakProjectBytes, "storage_warn": out.StorageWarn,
 			})
 		if err != nil {
 			return err

--- a/internal/service/retention_test.go
+++ b/internal/service/retention_test.go
@@ -41,6 +41,34 @@ func TestValidateProjectRetentionAgainstOrgCap(t *testing.T) {
 	}
 }
 
+// TestHealthStorageWarnBoundary pins the § 141 warn threshold: health.StorageWarn
+// flips at exactly ProjectStorageWarnBytes (1 GiB), the `>=` boundary the doctor,
+// metric, and UI banner all read.
+func TestHealthStorageWarnBoundary(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	s := &Retention{Now: func() time.Time { return now }}
+	tests := []struct {
+		name string
+		peak int64
+		warn bool
+	}{
+		{"below", ProjectStorageWarnBytes - 1, false},
+		{"at", ProjectStorageWarnBytes, true},
+		{"above", ProjectStorageWarnBytes + 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.health(now, true, tt.peak)
+			if got.StorageWarn != tt.warn {
+				t.Fatalf("peak %d: StorageWarn = %v, want %v", tt.peak, got.StorageWarn, tt.warn)
+			}
+			if got.PeakProjectBytes != tt.peak {
+				t.Fatalf("peak %d: PeakProjectBytes = %d", tt.peak, got.PeakProjectBytes)
+			}
+		})
+	}
+}
+
 func TestValidateProjectRetentionAllowsBoundedOverrideUnderUnlimitedOrg(t *testing.T) {
 	err := validateProjectRetention(
 		RetentionPolicy{Unlimited: true},

--- a/internal/store/pggen/revisions.sql.go
+++ b/internal/store/pggen/revisions.sql.go
@@ -1261,3 +1261,62 @@ func (q *Queries) ReencryptSnapshotEntry(ctx context.Context, arg ReencryptSnaps
 	}
 	return result.RowsAffected(), nil
 }
+
+const sumSnapshotPayloadByProject = `-- name: SumSnapshotPayloadByProject :many
+SELECT org_id, project_id, COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint AS bytes
+FROM snapshot_entries
+GROUP BY org_id, project_id
+`
+
+type SumSnapshotPayloadByProjectRow struct {
+	OrgID     string
+	ProjectID string
+	Bytes     int64
+}
+
+// SumSnapshotPayloadByProject groups the published snapshot-entry ciphertext
+// bytes by owning project across the whole instance -- the operator storage
+// surface (doctor warn, metric). Cross-tenant by definition, so it is annotated
+// instance-scoped and content-pinned.
+// hikyo:instance-scoped
+func (q *Queries) SumSnapshotPayloadByProject(ctx context.Context) ([]SumSnapshotPayloadByProjectRow, error) {
+	rows, err := q.db.Query(ctx, sumSnapshotPayloadByProject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SumSnapshotPayloadByProjectRow
+	for rows.Next() {
+		var i SumSnapshotPayloadByProjectRow
+		if err := rows.Scan(&i.OrgID, &i.ProjectID, &i.Bytes); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumSnapshotPayloadForProject = `-- name: SumSnapshotPayloadForProject :one
+SELECT COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint FROM snapshot_entries
+WHERE org_id = $1 AND project_id = $2
+`
+
+type SumSnapshotPayloadForProjectParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+}
+
+// SumSnapshotPayloadForProject totals the ciphertext bytes of a project's
+// published snapshot entries across every environment and revision. Paired with
+// SumValuePayloadForProject, it is the other half of the per-project storage
+// high-water accounting (ops-spec section 8 / section 141). Fully chain-scoped,
+// no annotation.
+func (q *Queries) SumSnapshotPayloadForProject(ctx context.Context, arg SumSnapshotPayloadForProjectParams) (int64, error) {
+	row := q.db.QueryRow(ctx, sumSnapshotPayloadForProject, arg.ChainOrgID, arg.ChainProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/store/pggen/values.sql.go
+++ b/internal/store/pggen/values.sql.go
@@ -364,3 +364,62 @@ func (q *Queries) ReencryptValueEntry(ctx context.Context, arg ReencryptValueEnt
 	}
 	return result.RowsAffected(), nil
 }
+
+const sumValuePayloadByProject = `-- name: SumValuePayloadByProject :many
+SELECT org_id, project_id, COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint AS bytes
+FROM value_entries
+GROUP BY org_id, project_id
+`
+
+type SumValuePayloadByProjectRow struct {
+	OrgID     string
+	ProjectID string
+	Bytes     int64
+}
+
+// SumValuePayloadByProject groups the live value-cell ciphertext bytes by owning
+// project across the whole instance -- the operator storage surface (doctor warn,
+// metric). Cross-tenant by definition: it addresses no tenant and carries no
+// chain conjunct, so it is annotated instance-scoped and content-pinned.
+// hikyo:instance-scoped
+func (q *Queries) SumValuePayloadByProject(ctx context.Context) ([]SumValuePayloadByProjectRow, error) {
+	rows, err := q.db.Query(ctx, sumValuePayloadByProject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SumValuePayloadByProjectRow
+	for rows.Next() {
+		var i SumValuePayloadByProjectRow
+		if err := rows.Scan(&i.OrgID, &i.ProjectID, &i.Bytes); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumValuePayloadForProject = `-- name: SumValuePayloadForProject :one
+SELECT COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint FROM value_entries
+WHERE org_id = $1 AND project_id = $2
+`
+
+type SumValuePayloadForProjectParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+}
+
+// SumValuePayloadForProject totals the ciphertext bytes of a project's live
+// value cells across every environment. It backs the per-project storage
+// high-water refusal at publish (ops-spec section 8 / section 141). The
+// COALESCE keeps an empty project's NULL sum a plain 0; the ::bigint cast
+// matches the sqlite twin's integer shape. Fully chain-scoped, no annotation.
+func (q *Queries) SumValuePayloadForProject(ctx context.Context, arg SumValuePayloadForProjectParams) (int64, error) {
+	row := q.db.QueryRow(ctx, sumValuePayloadForProject, arg.ChainOrgID, arg.ChainProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/store/queries/postgres/revisions.sql
+++ b/internal/store/queries/postgres/revisions.sql
@@ -273,3 +273,22 @@ ORDER BY id LIMIT sqlc.arg(page_limit);
 UPDATE pending_changes SET ciphertext = sqlc.arg(new_ciphertext)
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
   AND id = sqlc.arg(id) AND ciphertext = sqlc.arg(old_ciphertext);
+
+-- SumSnapshotPayloadForProject totals the ciphertext bytes of a project's
+-- published snapshot entries across every environment and revision. Paired with
+-- SumValuePayloadForProject, it is the other half of the per-project storage
+-- high-water accounting (ops-spec section 8 / section 141). Fully chain-scoped,
+-- no annotation.
+-- name: SumSnapshotPayloadForProject :one
+SELECT COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint FROM snapshot_entries
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id);
+
+-- SumSnapshotPayloadByProject groups the published snapshot-entry ciphertext
+-- bytes by owning project across the whole instance -- the operator storage
+-- surface (doctor warn, metric). Cross-tenant by definition, so it is annotated
+-- instance-scoped and content-pinned.
+-- hikyo:instance-scoped
+-- name: SumSnapshotPayloadByProject :many
+SELECT org_id, project_id, COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint AS bytes
+FROM snapshot_entries
+GROUP BY org_id, project_id;

--- a/internal/store/queries/postgres/values.sql
+++ b/internal/store/queries/postgres/values.sql
@@ -100,3 +100,22 @@ ORDER BY id LIMIT sqlc.arg(page_limit);
 UPDATE value_entries SET ciphertext = sqlc.arg(new_ciphertext)
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
   AND id = sqlc.arg(id) AND ciphertext = sqlc.arg(old_ciphertext);
+
+-- SumValuePayloadForProject totals the ciphertext bytes of a project's live
+-- value cells across every environment. It backs the per-project storage
+-- high-water refusal at publish (ops-spec section 8 / section 141). The
+-- COALESCE keeps an empty project's NULL sum a plain 0; the ::bigint cast
+-- matches the sqlite twin's integer shape. Fully chain-scoped, no annotation.
+-- name: SumValuePayloadForProject :one
+SELECT COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint FROM value_entries
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id);
+
+-- SumValuePayloadByProject groups the live value-cell ciphertext bytes by owning
+-- project across the whole instance -- the operator storage surface (doctor warn,
+-- metric). Cross-tenant by definition: it addresses no tenant and carries no
+-- chain conjunct, so it is annotated instance-scoped and content-pinned.
+-- hikyo:instance-scoped
+-- name: SumValuePayloadByProject :many
+SELECT org_id, project_id, COALESCE(SUM(OCTET_LENGTH(ciphertext)), 0)::bigint AS bytes
+FROM value_entries
+GROUP BY org_id, project_id;

--- a/internal/store/queries/sqlite/revisions.sql
+++ b/internal/store/queries/sqlite/revisions.sql
@@ -219,3 +219,22 @@ ORDER BY id LIMIT ?;
 -- name: ReencryptPendingChange :execrows
 UPDATE pending_changes SET ciphertext = ?
 WHERE org_id = ? AND project_id = ? AND id = ? AND ciphertext = ?;
+
+-- SumSnapshotPayloadForProject totals the ciphertext bytes of a project's
+-- published snapshot entries across every environment and revision. Paired with
+-- SumValuePayloadForProject, it is the other half of the per-project storage
+-- high-water accounting (ops-spec section 8 / section 141). Fully chain-scoped,
+-- so no annotation is needed.
+-- name: SumSnapshotPayloadForProject :one
+SELECT CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) FROM snapshot_entries
+WHERE org_id = ? AND project_id = ?;
+
+-- SumSnapshotPayloadByProject groups the published snapshot-entry ciphertext
+-- bytes by owning project across the whole instance -- the operator storage
+-- surface (doctor warn, metric). Cross-tenant by definition, so it is annotated
+-- instance-scoped and content-pinned.
+-- hikyo:instance-scoped
+-- name: SumSnapshotPayloadByProject :many
+SELECT org_id, project_id, CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) AS bytes
+FROM snapshot_entries
+GROUP BY org_id, project_id;

--- a/internal/store/queries/sqlite/values.sql
+++ b/internal/store/queries/sqlite/values.sql
@@ -85,3 +85,22 @@ ORDER BY id LIMIT ?;
 -- name: ReencryptValueEntry :execrows
 UPDATE value_entries SET ciphertext = ?
 WHERE org_id = ? AND project_id = ? AND id = ? AND ciphertext = ?;
+
+-- SumValuePayloadForProject totals the ciphertext bytes of a project's live
+-- value cells across every environment. It backs the per-project storage
+-- high-water refusal at publish (ops-spec section 8 / section 141). LENGTH on a
+-- BLOB is its byte count; the CAST(COALESCE(...)) keeps an empty project's NULL
+-- sum a plain integer 0. Fully chain-scoped, so no annotation is needed.
+-- name: SumValuePayloadForProject :one
+SELECT CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) FROM value_entries
+WHERE org_id = ? AND project_id = ?;
+
+-- SumValuePayloadByProject groups the live value-cell ciphertext bytes by owning
+-- project across the whole instance -- the operator storage surface (doctor warn,
+-- metric). Cross-tenant by definition: it addresses no tenant and carries no
+-- chain conjunct, so it is annotated instance-scoped and content-pinned.
+-- hikyo:instance-scoped
+-- name: SumValuePayloadByProject :many
+SELECT org_id, project_id, CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) AS bytes
+FROM value_entries
+GROUP BY org_id, project_id;

--- a/internal/store/repos_revisions.go
+++ b/internal/store/repos_revisions.go
@@ -373,6 +373,33 @@ func (r sqliteSnapshots) ProjectRevisions(ctx context.Context, p authz.Proof) (m
 	return out, nil
 }
 
+func (r sqliteSnapshots) PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error) {
+	chain, err := authz.Verify(p, authz.StoreSnapshotsPayloadBytesForProject, r.tok)
+	if err != nil {
+		return 0, err
+	}
+	return r.q.SumSnapshotPayloadForProject(ctx, sqlitegen.SumSnapshotPayloadForProjectParams{
+		OrgID:     string(chain.Org),
+		ProjectID: string(chain.Project),
+	})
+}
+
+func (r sqliteSnapshots) InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error) {
+	// No chain: instance-scope proof, no tenant conjunct, annotated instance-scoped.
+	if _, err := authz.Verify(p, authz.StoreSnapshotsInstancePayloadByProject, r.tok); err != nil {
+		return nil, err
+	}
+	rows, err := r.q.SumSnapshotPayloadByProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectPayloadBytes, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ProjectPayloadBytes{OrgID: row.OrgID, ProjectID: row.ProjectID, Bytes: row.Bytes})
+	}
+	return out, nil
+}
+
 func (r sqliteSnapshots) AtRevision(ctx context.Context, p authz.Proof, revision int64) (Snapshot, error) {
 	chain, err := authz.Verify(p, authz.StoreSnapshotsAtRevision, r.tok)
 	if err != nil {
@@ -1132,6 +1159,32 @@ func (r pgSnapshots) ProjectRevisions(ctx context.Context, p authz.Proof) (map[s
 		if row.Revision > out[row.EnvironmentID] {
 			out[row.EnvironmentID] = row.Revision
 		}
+	}
+	return out, nil
+}
+
+func (r pgSnapshots) PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error) {
+	chain, err := authz.Verify(p, authz.StoreSnapshotsPayloadBytesForProject, r.tok)
+	if err != nil {
+		return 0, err
+	}
+	return r.q.SumSnapshotPayloadForProject(ctx, pggen.SumSnapshotPayloadForProjectParams{
+		ChainOrgID:     string(chain.Org),
+		ChainProjectID: string(chain.Project),
+	})
+}
+
+func (r pgSnapshots) InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error) {
+	if _, err := authz.Verify(p, authz.StoreSnapshotsInstancePayloadByProject, r.tok); err != nil {
+		return nil, err
+	}
+	rows, err := r.q.SumSnapshotPayloadByProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectPayloadBytes, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ProjectPayloadBytes{OrgID: row.OrgID, ProjectID: row.ProjectID, Bytes: row.Bytes})
 	}
 	return out, nil
 }

--- a/internal/store/repos_values.go
+++ b/internal/store/repos_values.go
@@ -168,6 +168,34 @@ func (r sqliteValues) ClearKey(ctx context.Context, p authz.Proof, keyID string)
 	return n, constraint(err)
 }
 
+func (r sqliteValues) PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error) {
+	chain, err := authz.Verify(p, authz.StoreValuesPayloadBytesForProject, r.tok)
+	if err != nil {
+		return 0, err
+	}
+	return r.q.SumValuePayloadForProject(ctx, sqlitegen.SumValuePayloadForProjectParams{
+		OrgID:     string(chain.Org),
+		ProjectID: string(chain.Project),
+	})
+}
+
+func (r sqliteValues) InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error) {
+	// No chain: the proof is instance-scope and addresses no tenant, which is
+	// why the statement carries no conjunct and is annotated instance-scoped.
+	if _, err := authz.Verify(p, authz.StoreValuesInstancePayloadByProject, r.tok); err != nil {
+		return nil, err
+	}
+	rows, err := r.q.SumValuePayloadByProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectPayloadBytes, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ProjectPayloadBytes{OrgID: row.OrgID, ProjectID: row.ProjectID, Bytes: row.Bytes})
+	}
+	return out, nil
+}
+
 func (r sqliteValues) Put(ctx context.Context, p authz.Proof, entry NewValueEntry) error {
 	chain, err := authz.Verify(p, authz.StoreValuesPut, r.tok)
 	if err != nil {
@@ -385,6 +413,32 @@ func (r pgValues) ClearKey(ctx context.Context, p authz.Proof, keyID string) (in
 		KeyID:          keyID,
 	})
 	return n, constraint(err)
+}
+
+func (r pgValues) PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error) {
+	chain, err := authz.Verify(p, authz.StoreValuesPayloadBytesForProject, r.tok)
+	if err != nil {
+		return 0, err
+	}
+	return r.q.SumValuePayloadForProject(ctx, pggen.SumValuePayloadForProjectParams{
+		ChainOrgID:     string(chain.Org),
+		ChainProjectID: string(chain.Project),
+	})
+}
+
+func (r pgValues) InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error) {
+	if _, err := authz.Verify(p, authz.StoreValuesInstancePayloadByProject, r.tok); err != nil {
+		return nil, err
+	}
+	rows, err := r.q.SumValuePayloadByProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectPayloadBytes, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ProjectPayloadBytes{OrgID: row.OrgID, ProjectID: row.ProjectID, Bytes: row.Bytes})
+	}
+	return out, nil
 }
 
 func (r pgValues) Put(ctx context.Context, p authz.Proof, entry NewValueEntry) error {

--- a/internal/store/revisions.go
+++ b/internal/store/revisions.go
@@ -245,6 +245,14 @@ type SnapshotReader interface {
 	// plan/apply value-snapshot pin (#70). Environments with no snapshot are
 	// absent from the map (revision 0).
 	ProjectRevisions(ctx context.Context, p authz.Proof) (map[string]int64, error)
+	// PayloadBytesForProject sums the ciphertext bytes of the proof's project's
+	// published snapshot entries across every environment and revision — the
+	// other half of the per-project storage high-water accounting (#185).
+	PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error)
+	// InstancePayloadByProject sums published snapshot-entry ciphertext bytes
+	// grouped by owning project across the whole instance — the operator storage
+	// surface (doctor warn, metric). Instance-scoped, cross-tenant by definition.
+	InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error)
 }
 
 // SnapshotRepo is the full published-state aggregate. There is no update and

--- a/internal/store/sqlitegen/revisions.sql.go
+++ b/internal/store/sqlitegen/revisions.sql.go
@@ -1238,3 +1238,65 @@ func (q *Queries) ReencryptSnapshotEntry(ctx context.Context, arg ReencryptSnaps
 	}
 	return result.RowsAffected()
 }
+
+const sumSnapshotPayloadByProject = `-- name: SumSnapshotPayloadByProject :many
+SELECT org_id, project_id, CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) AS bytes
+FROM snapshot_entries
+GROUP BY org_id, project_id
+`
+
+type SumSnapshotPayloadByProjectRow struct {
+	OrgID     string
+	ProjectID string
+	Bytes     int64
+}
+
+// SumSnapshotPayloadByProject groups the published snapshot-entry ciphertext
+// bytes by owning project across the whole instance -- the operator storage
+// surface (doctor warn, metric). Cross-tenant by definition, so it is annotated
+// instance-scoped and content-pinned.
+// hikyo:instance-scoped
+func (q *Queries) SumSnapshotPayloadByProject(ctx context.Context) ([]SumSnapshotPayloadByProjectRow, error) {
+	rows, err := q.db.QueryContext(ctx, sumSnapshotPayloadByProject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SumSnapshotPayloadByProjectRow
+	for rows.Next() {
+		var i SumSnapshotPayloadByProjectRow
+		if err := rows.Scan(&i.OrgID, &i.ProjectID, &i.Bytes); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumSnapshotPayloadForProject = `-- name: SumSnapshotPayloadForProject :one
+SELECT CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) FROM snapshot_entries
+WHERE org_id = ? AND project_id = ?
+`
+
+type SumSnapshotPayloadForProjectParams struct {
+	OrgID     string
+	ProjectID string
+}
+
+// SumSnapshotPayloadForProject totals the ciphertext bytes of a project's
+// published snapshot entries across every environment and revision. Paired with
+// SumValuePayloadForProject, it is the other half of the per-project storage
+// high-water accounting (ops-spec section 8 / section 141). Fully chain-scoped,
+// so no annotation is needed.
+func (q *Queries) SumSnapshotPayloadForProject(ctx context.Context, arg SumSnapshotPayloadForProjectParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, sumSnapshotPayloadForProject, arg.OrgID, arg.ProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/store/sqlitegen/values.sql.go
+++ b/internal/store/sqlitegen/values.sql.go
@@ -356,3 +356,65 @@ func (q *Queries) ReencryptValueEntry(ctx context.Context, arg ReencryptValueEnt
 	}
 	return result.RowsAffected()
 }
+
+const sumValuePayloadByProject = `-- name: SumValuePayloadByProject :many
+SELECT org_id, project_id, CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) AS bytes
+FROM value_entries
+GROUP BY org_id, project_id
+`
+
+type SumValuePayloadByProjectRow struct {
+	OrgID     string
+	ProjectID string
+	Bytes     int64
+}
+
+// SumValuePayloadByProject groups the live value-cell ciphertext bytes by owning
+// project across the whole instance -- the operator storage surface (doctor warn,
+// metric). Cross-tenant by definition: it addresses no tenant and carries no
+// chain conjunct, so it is annotated instance-scoped and content-pinned.
+// hikyo:instance-scoped
+func (q *Queries) SumValuePayloadByProject(ctx context.Context) ([]SumValuePayloadByProjectRow, error) {
+	rows, err := q.db.QueryContext(ctx, sumValuePayloadByProject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SumValuePayloadByProjectRow
+	for rows.Next() {
+		var i SumValuePayloadByProjectRow
+		if err := rows.Scan(&i.OrgID, &i.ProjectID, &i.Bytes); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumValuePayloadForProject = `-- name: SumValuePayloadForProject :one
+SELECT CAST(COALESCE(SUM(LENGTH(ciphertext)), 0) AS INTEGER) FROM value_entries
+WHERE org_id = ? AND project_id = ?
+`
+
+type SumValuePayloadForProjectParams struct {
+	OrgID     string
+	ProjectID string
+}
+
+// SumValuePayloadForProject totals the ciphertext bytes of a project's live
+// value cells across every environment. It backs the per-project storage
+// high-water refusal at publish (ops-spec section 8 / section 141). LENGTH on a
+// BLOB is its byte count; the CAST(COALESCE(...)) keeps an empty project's NULL
+// sum a plain integer 0. Fully chain-scoped, so no annotation is needed.
+func (q *Queries) SumValuePayloadForProject(ctx context.Context, arg SumValuePayloadForProjectParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, sumValuePayloadForProject, arg.OrgID, arg.ProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/store/values.go
+++ b/internal/store/values.go
@@ -65,6 +65,23 @@ type ValueReader interface {
 	// about to delete. Any count above zero is the unconditional
 	// environment-delete refusal (#70).
 	CountEnvironmentValues(ctx context.Context, p authz.Proof, environmentID string) (int64, error)
+	// PayloadBytesForProject sums the ciphertext bytes of the proof's project's
+	// live value cells across every environment — half of the per-project
+	// storage high-water accounting refused at publish (#185, ops-spec section 8).
+	PayloadBytesForProject(ctx context.Context, p authz.Proof) (int64, error)
+	// InstancePayloadByProject sums live value-cell ciphertext bytes grouped by
+	// owning project across the whole instance — the operator storage surface
+	// (doctor warn, metric). Cross-tenant by definition, so its query is
+	// instance-scoped; the proof licenses the read, not a tenant chain.
+	InstancePayloadByProject(ctx context.Context, p authz.Proof) ([]ProjectPayloadBytes, error)
+}
+
+// ProjectPayloadBytes is one project's stored ciphertext-byte total, from the
+// instance-scoped storage sweep behind the high-water operator surface (#185).
+type ProjectPayloadBytes struct {
+	OrgID     string
+	ProjectID string
+	Bytes     int64
 }
 
 // ValueRepo is the full value aggregate.

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -107,6 +107,8 @@ test.describe('app chrome', () => {
           last_prune_success: lastSuccess,
           stale: true,
           stale_after_seconds: 86400,
+          peak_project_bytes: 0,
+          storage_warn: false,
         }),
       }),
     );
@@ -117,6 +119,28 @@ test.describe('app chrome', () => {
     await expect(warning).toContainText('Payload pruning has not succeeded since');
     await expect(warning).toContainText('retention bounds are not being enforced.');
     await expect(warning.locator('time')).toHaveAttribute('datetime', lastSuccess);
+  });
+
+  test('warns when a project reaches the storage high-water', async ({ page }) => {
+    await page.route('**/api/v1/instance/retention-health', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          last_prune_success: '2026-08-20T10:00:00Z',
+          stale: false,
+          stale_after_seconds: 86400,
+          peak_project_bytes: 1_500_000_000,
+          storage_warn: true,
+        }),
+      }),
+    );
+    await page.reload();
+
+    const warning = page.locator('.retention-warning');
+    await expect(warning).toHaveAttribute('role', 'alert');
+    await expect(warning).toContainText('1.40 GiB of stored payload');
+    await expect(warning).toContainText('new publishes are refused at 4 GiB');
   });
 
   for (const status of [403, 404]) {

--- a/web/src/api/retention.test.ts
+++ b/web/src/api/retention.test.ts
@@ -4,40 +4,40 @@ import {
   retentionBanner,
   retentionHealthPollMs,
   retentionHealthRefetchInterval,
+  storageBanner,
+  type RetentionHealth,
 } from './retention.ts';
+
+// health builds a full RetentionHealth from partial overrides so each case
+// states only the fields it cares about; storage defaults sit below the warn.
+function health(over: Partial<RetentionHealth>): RetentionHealth {
+  return {
+    last_prune_success: '2026-08-15T10:00:00Z',
+    stale: false,
+    stale_after_seconds: 86400,
+    peak_project_bytes: 0,
+    storage_warn: false,
+    ...over,
+  };
+}
 
 describe('retentionBanner', () => {
   it('transitions from fresh to stale when the server response changes', () => {
+    expect(retentionBanner(health({ stale: false }))).toBeNull();
     expect(
-      retentionBanner({
-        last_prune_success: '2026-08-15T10:00:00Z',
-        stale: false,
-        stale_after_seconds: 86400,
-      }),
-    ).toBeNull();
-    expect(
-      retentionBanner({
-        last_prune_success: '2026-08-14T10:00:00Z',
-        stale: true,
-        stale_after_seconds: 86400,
-      }),
+      retentionBanner(health({ last_prune_success: '2026-08-14T10:00:00Z', stale: true })),
     ).toEqual({ kind: 'stale', lastPruneSuccess: '2026-08-14T10:00:00Z' });
   });
 
   it('shows stale never-recorded health', () => {
-    expect(
-      retentionBanner({ last_prune_success: null, stale: true, stale_after_seconds: 86400 }),
-    ).toEqual({ kind: 'stale', lastPruneSuccess: null });
+    expect(retentionBanner(health({ last_prune_success: null, stale: true }))).toEqual({
+      kind: 'stale',
+      lastPruneSuccess: null,
+    });
   });
 
   it('stays absent for fresh, forbidden, and not-found results', () => {
-    expect(
-      retentionBanner({
-        last_prune_success: '2026-08-15T10:00:00Z',
-        stale: false,
-        stale_after_seconds: 86400,
-      }),
-    ).toBeNull();
+    expect(retentionBanner(health({ stale: false }))).toBeNull();
     expect(retentionBanner(null)).toBeNull();
     expect(retentionBanner(undefined)).toBeNull();
   });
@@ -48,26 +48,27 @@ describe('retentionBanner', () => {
 
   it('keeps a known-stale warning visible through a refetch error', () => {
     expect(
-      retentionBanner(
-        {
-          last_prune_success: '2026-08-14T10:00:00Z',
-          stale: true,
-          stale_after_seconds: 86400,
-        },
-        true,
-      ),
+      retentionBanner(health({ last_prune_success: '2026-08-14T10:00:00Z', stale: true }), true),
     ).toEqual({ kind: 'stale', lastPruneSuccess: '2026-08-14T10:00:00Z' });
   });
 
   it('polls permitted health hourly and stops after a hidden 403/404 result', () => {
     expect(retentionHealthRefetchInterval(undefined)).toBe(retentionHealthPollMs);
     expect(retentionHealthRefetchInterval(null)).toBe(false);
+    expect(retentionHealthRefetchInterval(health({ stale: false }))).toBe(60 * 60 * 1_000);
+  });
+});
+
+describe('storageBanner', () => {
+  it('is absent below the warn threshold', () => {
+    expect(storageBanner(health({ storage_warn: false, peak_project_bytes: 512 * 1024 * 1024 }))).toBeNull();
+    expect(storageBanner(null)).toBeNull();
+    expect(storageBanner(undefined)).toBeNull();
+  });
+
+  it('surfaces the peak project bytes once the server flags the warn', () => {
     expect(
-      retentionHealthRefetchInterval({
-        last_prune_success: '2026-08-15T10:00:00Z',
-        stale: false,
-        stale_after_seconds: 86400,
-      }),
-    ).toBe(60 * 60 * 1_000);
+      storageBanner(health({ storage_warn: true, peak_project_bytes: 1_500_000_000 })),
+    ).toEqual({ kind: 'storage', peakProjectBytes: 1_500_000_000 });
   });
 });

--- a/web/src/api/retention.ts
+++ b/web/src/api/retention.ts
@@ -48,3 +48,15 @@ export function retentionBanner(health: RetentionHealth | null | undefined, isEr
   }
   return isError ? ({ kind: 'error' } as const) : null;
 }
+
+/**
+ * The per-project storage high-water warn: a project has reached the 1 GiB warn
+ * threshold and is heading for the 4 GiB publish refusal. Absent (null) unless
+ * the server sets storage_warn, so the banner is silent below the water.
+ */
+export function storageBanner(health: RetentionHealth | null | undefined) {
+  if (health?.storage_warn === true) {
+    return { kind: 'storage', peakProjectBytes: health.peak_project_bytes } as const;
+  }
+  return null;
+}

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -2,10 +2,15 @@ import { useEffect, useState } from 'react';
 import { generatePath, matchPath, NavLink, Outlet, useLocation, useNavigate } from 'react-router';
 
 import { useLogout, useOrgs, type WhoAmI } from '../api/session.ts';
-import { retentionBanner, useRetentionHealth } from '../api/retention.ts';
+import { retentionBanner, storageBanner, useRetentionHealth } from '../api/retention.ts';
 import { effectiveTheme, prefersDark, useThemeChoice, type Theme } from '../app/theme.ts';
 import { needsOrg, SECTIONS, SURFACES, surfaceById, type Surface } from '../app/navigation.ts';
 import { StepUpBanner } from './StepUpBanner.tsx';
+
+/** Human-readable GiB for the storage high-water banner. */
+function formatGiB(bytes: number): string {
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
+}
 
 /**
  * The application chrome skeleton (prototype/app-chrome iteration 15, sidebar
@@ -60,6 +65,7 @@ export function Shell({ session }: { session: WhoAmI }) {
     routeOrgId !== '' ? routeOrgId : fallbackOrg === undefined ? '' : fallbackOrg.id;
   const activeOrgName = items.find((org) => org.id === activeOrgId)?.name ?? activeOrgId;
   const pruneWarning = retentionBanner(retentionHealth.data, retentionHealth.isError);
+  const storageWarning = storageBanner(retentionHealth.data);
 
   /**
    * chooseOrg is what a rail circle does. Setting the state is only half of
@@ -205,6 +211,18 @@ export function Shell({ session }: { session: WhoAmI }) {
                   — retention bounds are not being enforced.
                 </>
               )}
+            </span>
+          </p>
+        ) : null}
+        {storageWarning !== null ? (
+          <p className="retention-warning" role="alert">
+            <span className="alert__glyph" aria-hidden="true">
+              !
+            </span>
+            <span>
+              A project has reached {formatGiB(storageWarning.peakProjectBytes)} of stored payload —
+              new publishes are refused at 4 GiB. Lower the project&apos;s retention window or
+              release pinned revisions to reclaim space.
             </span>
           </p>
         ) : null}


### PR DESCRIPTION
Closes #185. Splits the last of #77's `enforcement-pending` ops bounds into a real, tested enforcement.

## Bound
ops-spec §8 (§141): a project's stored payload (value cells + published snapshot entries, ciphertext bytes) **warns at 1 GiB** and **hard-refuses new publishes at 4 GiB**, the refusal naming the retention window and pinned revisions that hold the space.

## Accounting (both engines)
- Project-scoped `SUM(LENGTH/OCTET_LENGTH(ciphertext))` over `value_entries` and `snapshot_entries` — each a fully chain-scoped provable query (`WHERE org_id=? AND project_id=?`), so no annotation.
- Instance-scoped `GROUP BY` per project behind the operator surface — annotated `hikyo:instance-scoped`, content-pinned in `annotated_queries.json`.
- Four new store proof actions: the project sums under `OpValuePublish`; the instance sums under `OpRetentionHealthRead` **and** the `SiteScheduler` mint site (the unauthenticated `/metrics` scrape) — a reviewed shared-door widening, pinned in `invariants_test.go` beside the retention health read it mirrors.

## Refusal
Fires in `materialize()`, the single chokepoint every payload-advancing path routes through, **before** the environment's bytes move. Threshold rides a conformance seam (`Revisions.ProjectStorageHighWater`) that can only **tighten** the bound (clamped `< MaxProjectStorageBytes`), never relax it — so the cross-engine test trips a 4 GiB refusal with small seeded rows while production stays pinned.

## Warn surface (1 GiB)
`PruneHealth` gains `PeakProjectBytes` + `StorageWarn`, computed by `OperationalHealth` (two new `/metrics` gauges) and the audited `GetHealth` (doctor finding + UI banner). `doctor` grows a `project-storage` row; `Shell.tsx` grows a storage banner; the retention-health API/openapi/TS-client gain the two fields.

## Registry
`enforcement-pending` → `enforced` with the real fixture; `MaxProjectStorageBytes` (4 GiB) and `ProjectStorageWarnBytes` (1 GiB) added to the anti-drift const pins.

## Acceptance
- ✅ New publish refused by name at the high-water — `isolation.TestProjectStorageHighWater` (cross-engine), asserts the refusal names retention + pinned revisions.
- ✅ `doctor` warns at 1 GiB — folded into the existing checklist; `TestHealthStorageWarnBoundary` pins the `>=` flip at 1 GiB.
- ✅ Registry entry flipped to enforced.

## Verification
- Full suite green on **sqlite** (2882 passing) and **postgres** (isolation + conformance + store). gofmt/vet clean; k8se2e build tag verified.
- Doctor + metric contract tests updated; audit `retention.health_read` schema extended (stays v1 — the emitter stamps every event v1 by design, no read-path revalidation).
- Cross-model review (`gpt-5.6-sol`, high) converged in 2 rounds: R1 raised 4 (1 high — the seam could relax the bound → fixed to tighten-only), **R2 all confirmed-fixed / disposition-sound, no new criticals**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789890082&installation_model_id=432348&pr_number=201&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F201&signature=49ed3fc58fcae038f28cf53ddd6ef9396bd7959389694aab9baf3eb7c9f5d938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->