### PR TITLE
feat(service): §179 expensive-path rate/concurrency budget layer — close #186

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -354,7 +354,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// mean a subscriber saw half the events.
 		Values:    &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset, Budget: budget},
 		Revisions: &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget},
-		Rotation:  &service.Rotation{DB: db, Keyring: kr, RootKey: rootKeySource{cfg: cfg, log: log}},
+		Rotation:  &service.Rotation{DB: db, Keyring: kr, RootKey: rootKeySource{cfg: cfg, log: log}, Budget: budget},
 		Reencrypt: reencryptSvc,
 		Pins:      &service.Pins{DB: db, Keyring: kr, Auth: authSvc},
 		Reveal:    &service.Reveal{DB: db, Auth: authSvc},

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -340,7 +340,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// every value write re-seal under the project data key, in the
 		// transaction that writes the row. The ruleset (#74) reaches every
 		// surface that writes a config value or a declaration leaf.
-		Environments: &service.Environments{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset},
+		Environments: &service.Environments{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget, Scan: ruleset},
 		Folders:      &service.Folders{DB: db, Keyring: kr, Scan: ruleset},
 		Keys:         &service.Keys{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset},
 		Definitions:  definitionsService,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -260,6 +260,11 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 	// The advisory channel is in-process fan-out: one per server, wired into
 	// every surface that announces a change.
 	advisory := service.NewAdvisory()
+	// The expensive-path budget (ops-spec § 179 / § 20 / § 151): one per server,
+	// in-memory like admission, wired into every surface that owns a named
+	// expensive category — export, publish, adapter sync, machine fetch, and
+	// schema revision.
+	budget := service.NewBudget()
 	authSvc := &service.Auth{DB: db, Keyring: kr, KDF: kdf, Admission: limiter, Log: log, ExternalOrigin: cfg.ExternalOrigin, ReauthWindow: cfg.ReauthWindow}
 	samlProviders := &service.SAMLProviders{DB: db, Keyring: kr, ExternalOrigin: cfg.ExternalOrigin}
 	// RP ID + expected origins are immutable instance config derived from the
@@ -321,10 +326,10 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		Store: adapterRuntime, Loader: &adapterLoader{runtime: adapterRuntime, keyring: kr, egressPolicy: cfg.AdapterEgressPolicy},
 		ID: "adapter-worker-" + uuid.Must(uuid.NewV7()).String(), Poll: time.Second, Log: log,
 	}
-	adapterService := &service.Adapters{DB: db, Auth: authSvc, Keyring: kr, ProviderModule: func(provider, origin, credential string) (adapter.Module, func(), error) {
+	adapterService := &service.Adapters{DB: db, Auth: authSvc, Keyring: kr, Budget: budget, ProviderModule: func(provider, origin, credential string) (adapter.Module, func(), error) {
 		return deploymentModule(provider, origin, credential, cfg.AdapterEgressPolicy[origin])
 	}}
-	definitionsService := &service.Definitions{DB: db, Keyring: kr, Advisory: advisory, Scan: ruleset}
+	definitionsService := &service.Definitions{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset}
 
 	api := &server.API{
 		Auth:     authSvc,
@@ -337,7 +342,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// surface that writes a config value or a declaration leaf.
 		Environments: &service.Environments{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset},
 		Folders:      &service.Folders{DB: db, Keyring: kr, Scan: ruleset},
-		Keys:         &service.Keys{DB: db, Keyring: kr, Advisory: advisory, Scan: ruleset},
+		Keys:         &service.Keys{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset},
 		Definitions:  definitionsService,
 		// The reveal ceremony (#58): the value surface's disclosure routes
 		// consume the SAME reauthentication window machinery the passkey and
@@ -348,12 +353,12 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// publishing both announce on the same channel, and two channels would
 		// mean a subscriber saw half the events.
 		Values:    &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset},
-		Revisions: &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory},
+		Revisions: &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget},
 		Rotation:  &service.Rotation{DB: db, Keyring: kr, RootKey: rootKeySource{cfg: cfg, log: log}},
 		Reencrypt: reencryptSvc,
 		Pins:      &service.Pins{DB: db, Keyring: kr, Auth: authSvc},
 		Reveal:    &service.Reveal{DB: db, Auth: authSvc},
-		KeyGroups: &service.KeyGroups{DB: db, Keyring: kr, Advisory: advisory, Scan: ruleset},
+		KeyGroups: &service.KeyGroups{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset},
 		// One Auth across the grant surface, the settings knob and the machine
 		// identity surface: the reauthentication conjunct a machine widening
 		// carries is the SAME window machinery human disclosure consumes, so
@@ -368,7 +373,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// by putting the trigger under the instance-wide budget.
 		Federation: federation,
 		Delivery: &service.Delivery{
-			DB: db, Keyring: kr, Federation: federation,
+			DB: db, Keyring: kr, Federation: federation, Budget: budget,
 		},
 		// The settings knob calls LowerEffectiveWindow, which is the Auth
 		// service's library — one Auth, so the window the knob writes and the

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -313,7 +313,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		return nil, fmt.Errorf("boot: outbound directory client: %w", err)
 	}
 	retentionSvc := &service.Retention{DB: db}
-	reencryptSvc := &service.Reencrypt{DB: db, Keyring: kr}
+	reencryptSvc := &service.Reencrypt{DB: db, Keyring: kr, Budget: budget}
 	adapterRuntime := store.NewAdapterRuntime(db, func(ctx context.Context, job adapter.Job, _ adapter.Effect) error {
 		return tx.Read(ctx, db, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
 			_, err := az.Authorize(ctx, authz.Identity{Principal: domain.PrincipalID(job.AuthorityPrincipal), Class: domain.ClassHuman}, authz.OpAdapterPush, domain.Scope{
@@ -352,7 +352,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		// One Advisory across the value and revision surfaces: staging and
 		// publishing both announce on the same channel, and two channels would
 		// mean a subscriber saw half the events.
-		Values:    &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset},
+		Values:    &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset, Budget: budget},
 		Revisions: &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget},
 		Rotation:  &service.Rotation{DB: db, Keyring: kr, RootKey: rootKeySource{cfg: cfg, log: log}},
 		Reencrypt: reencryptSvc,

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -122,6 +122,7 @@ var Registry = []Bound{
 	// §20 audit ops.
 	{"Audit free text", "ops-spec §20", "truncation to audit.FreeTextBound", "audit audit_test", StatusSanitize},
 	{"Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "admission.ErrOverloaded (uniform 429) via service.Budget", "service.TestAuditExportChargesExpensiveBudget + service.TestBudgetInstanceConcurrencyIsSeparateFromOrg", StatusEnforced},
+	{"Expensive-path fail-closed default 60/min·principal · 8/org", "ops-spec §10 (§179)", "budgetDefault charged at each default-expensive method; no path unbudgeted by omission (build-time totality)", "conformance TestBudgetClassificationIsTotal (every authz op classified) + service.TestBudgetRateWindowSlides (default mechanism)", StatusEnforced},
 
 	// SAML / SCIM wire bounds.
 	{"SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced},

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -106,7 +106,7 @@ var Registry = []Bound{
 	{"Pins quota per project", "ops-spec §8", "invalidDetail (PinQuota)", "conformance revisions_test", StatusEnforced},
 	{"Grants per org", "ops-spec §8", "domain.ErrLimitExceeded (MaxGrantsPerOrg)", "isolation.TestGrantPerOrgCap", StatusEnforced},
 	{"Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "domain.ErrLimitExceeded (MaxProjectStorageBytes) at publish + doctor/metric/UI-banner warn (ProjectStorageWarnBytes)", "isolation.TestProjectStorageHighWater", StatusEnforced},
-	{"Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "loud rate-limit refusal", "ENFORCEMENT-PENDING: the schema-mutation path EXISTS, but the refusal needs a per-principal windowed rate-limit mechanism (the §179 expensive-path budget layer) that is not yet built anywhere. HUMAN-DISPOSITION -> issue #186.", StatusPending},
+	{"Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "admission.ErrOverloaded (uniform 429) via service.Budget", "conformance scenarioSchemaRevisionRateLimit + service.TestBudgetRateWindowSlides", StatusEnforced},
 
 	// §9 encryption.
 	{"Reencrypt CAS (no-resurrect)", "ops-spec §9", "row_version CAS conflict", "store authn CAS", StatusEnforced},
@@ -121,7 +121,7 @@ var Registry = []Bound{
 
 	// §20 audit ops.
 	{"Audit free text", "ops-spec §20", "truncation to audit.FreeTextBound", "audit audit_test", StatusSanitize},
-	{"Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "expensive-path budget refusal", "ENFORCEMENT-PENDING: the audit-export path EXISTS (internal/service/audit.go Export), but the concurrency/rate cap needs the §179 expensive-path budget layer (per-org concurrency + per-principal rate across search/export/publish/sync) that is not yet built anywhere. HUMAN-DISPOSITION -> issue #186.", StatusPending},
+	{"Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "admission.ErrOverloaded (uniform 429) via service.Budget", "service.TestAuditExportChargesExpensiveBudget + service.TestBudgetInstanceConcurrencyIsSeparateFromOrg", StatusEnforced},
 
 	// SAML / SCIM wire bounds.
 	{"SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced},
@@ -203,6 +203,22 @@ func TestReconciledBoundsMatchOpsSpecValues(t *testing.T) {
 		// Per-project storage high-water (#185).
 		{"service.MaxProjectStorageBytes", service.MaxProjectStorageBytes, 4 << 30},
 		{"service.ProjectStorageWarnBytes", service.ProjectStorageWarnBytes, 1 << 30},
+		// §179 / §20 / §151 expensive-path budget family (#186). Pinned as one
+		// table so a future edit that drifts any family value off spec fails here.
+		{"service.BudgetSearchRatePerMin", service.BudgetSearchRatePerMin, 30},
+		{"service.BudgetSearchOrgConcurrency", service.BudgetSearchOrgConcurrency, 4},
+		{"service.BudgetExportRatePerMin", service.BudgetExportRatePerMin, 5},
+		{"service.BudgetExportOrgConcurrency", service.BudgetExportOrgConcurrency, 2},
+		{"service.BudgetExportInstanceConcurrency", service.BudgetExportInstanceConcurrency, 6},
+		{"service.BudgetPublishRatePerMin", service.BudgetPublishRatePerMin, 10},
+		{"service.BudgetPublishOrgConcurrency", service.BudgetPublishOrgConcurrency, 4},
+		{"service.BudgetAdapterRatePerMin", service.BudgetAdapterRatePerMin, 10},
+		{"service.BudgetAdapterOrgConcurrency", service.BudgetAdapterOrgConcurrency, 4},
+		{"service.BudgetMachineFetchOrgPerMin", service.BudgetMachineFetchOrgPerMin, 300},
+		{"service.BudgetMachineFetchInstancePerMin", service.BudgetMachineFetchInstancePerMin, 1000},
+		{"service.BudgetDefaultRatePerMin", service.BudgetDefaultRatePerMin, 60},
+		{"service.BudgetDefaultOrgConcurrency", service.BudgetDefaultOrgConcurrency, 8},
+		{"service.BudgetSchemaRevisionPerHour", service.BudgetSchemaRevisionPerHour, 60},
 		// Already-conformant bounds, pinned so they cannot drift unnoticed.
 		{"schema.MaxKeysPerProject", schema.MaxKeysPerProject, 1000},
 		{"schema.MaxKeyGroupsPerProject", schema.MaxKeyGroupsPerProject, 100},

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -122,7 +122,7 @@ var Registry = []Bound{
 	// §20 audit ops.
 	{"Audit free text", "ops-spec §20", "truncation to audit.FreeTextBound", "audit audit_test", StatusSanitize},
 	{"Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "admission.ErrOverloaded (uniform 429) via service.Budget", "service.TestAuditExportChargesExpensiveBudget + service.TestBudgetInstanceConcurrencyIsSeparateFromOrg", StatusEnforced},
-	{"Expensive-path fail-closed default 60/min·principal · 8/org", "ops-spec §10 (§179)", "budgetDefault charged at each default-expensive method; no path unbudgeted by omission (build-time totality)", "conformance TestBudgetClassificationIsTotal (every authz op classified) + service.TestBudgetRateWindowSlides (default mechanism)", StatusEnforced},
+	{"Expensive-path fail-closed default 60/min·principal · 8/org", "ops-spec §10 (§179)", "budgetDefault charged at each default-expensive method; classification totality closes 'unbudgeted by omission' at build time", "conformance TestBudgetClassificationIsTotal (every authz op classified — build breaks on a new unclassified op) + scenarioDefaultBudgetChargedEndToEnd (a default-expensive method really trips the default 429) + service.TestBudgetDefaultEnforces (mechanism)", StatusEnforced},
 
 	// SAML / SCIM wire bounds.
 	{"SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced},

--- a/internal/conformance/budget_test.go
+++ b/internal/conformance/budget_test.go
@@ -3,9 +3,12 @@ package conformance
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/schema"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 	"github.com/Hikyo-Org/hikyo/internal/store"
@@ -88,5 +91,25 @@ func scenarioSchemaRevisionNoopDoesNotCharge(t *testing.T, db *store.DB) {
 		if _, err := keys.UpdateMetadata(t.Context(), actor, scope, created.ID, service.KeyMetadataUpdate{}, nil); err != nil {
 			t.Fatalf("no-op metadata update %d charged the schema-revision budget: %v", i+1, err)
 		}
+	}
+}
+
+// TestBudgetClassificationIsTotal is the §179 "no path is unbudgeted by
+// omission" guarantee, enforced at build time: every registered authorization
+// operation must be classified in the budget totality map (named category,
+// fail-closed default, or exempt-with-reason). A new operation added without a
+// deliberate budget decision fails HERE — the same shape as the metrics-label
+// grep and the keyword-allowlist diff.
+func TestBudgetClassificationIsTotal(t *testing.T) {
+	var missing []string
+	for op := range (authz.RegistryFacts{}).Operations() {
+		if _, known := service.BudgetClassOf(op); !known {
+			missing = append(missing, string(op))
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("%d operation(s) not classified in the §179 budget totality map (classify in internal/service/budget_classification.go):\n%s",
+			len(missing), strings.Join(missing, "\n"))
 	}
 }

--- a/internal/conformance/budget_test.go
+++ b/internal/conformance/budget_test.go
@@ -18,6 +18,7 @@ import (
 func init() {
 	corpus = append(corpus,
 		scenario{"schema_revision_rate_limit", scenarioSchemaRevisionRateLimit},
+		scenario{"schema_revision_noop_does_not_charge", scenarioSchemaRevisionNoopDoesNotCharge},
 	)
 }
 
@@ -61,5 +62,31 @@ func scenarioSchemaRevisionRateLimit(t *testing.T, db *store.DB) {
 	if _, err := keys.Create(t.Context(), service.LocalPrincipal(who2), scope2,
 		keySpec("FRESH", string(schema.Config), decl(schema.Rule{Type: schema.TypeString})), nil); err != nil {
 		t.Fatalf("a second project's first schema revision was refused; the bound is not per-project: %v", err)
+	}
+}
+
+// scenarioSchemaRevisionNoopDoesNotCharge proves the § 151 charge sits at the
+// real revision bump, not at the operation's entry: a mutation that no-ops
+// (nothing actually changed, no BumpSchemaRevision) consumes no budget. Without
+// this, a script could exhaust the 60/h rate with idempotent no-ops that mint no
+// revision at all. It runs well past the hourly bound to make the point.
+func scenarioSchemaRevisionNoopDoesNotCharge(t *testing.T, db *store.DB) {
+	keys := &service.Keys{DB: db, Keyring: sharedKeyring(t, db), Budget: service.NewBudget()}
+	who, scope := tenantFixture(t, db, "schemarev-noop")
+	actor := service.LocalPrincipal(who)
+
+	created, err := keys.Create(t.Context(), actor, scope,
+		keySpec("NOOP", string(schema.Config), decl(schema.Rule{Type: schema.TypeString})), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An empty metadata update merges to the stored row unchanged, so it returns
+	// early without bumping the revision. Many more than the hourly bound must all
+	// pass, because none is a revision.
+	for i := 0; i < service.BudgetSchemaRevisionPerHour*2; i++ {
+		if _, err := keys.UpdateMetadata(t.Context(), actor, scope, created.ID, service.KeyMetadataUpdate{}, nil); err != nil {
+			t.Fatalf("no-op metadata update %d charged the schema-revision budget: %v", i+1, err)
+		}
 	}
 }

--- a/internal/conformance/budget_test.go
+++ b/internal/conformance/budget_test.go
@@ -22,7 +22,31 @@ func init() {
 	corpus = append(corpus,
 		scenario{"schema_revision_rate_limit", scenarioSchemaRevisionRateLimit},
 		scenario{"schema_revision_noop_does_not_charge", scenarioSchemaRevisionNoopDoesNotCharge},
+		scenario{"default_budget_charged_end_to_end", scenarioDefaultBudgetChargedEndToEnd},
 	)
+}
+
+// scenarioDefaultBudgetChargedEndToEnd proves the §179 fail-closed default is
+// actually CHARGED at a default-expensive method, not merely classified: it
+// drives Definitions.Export (a whole-project materialization, classified
+// default-expensive) until the 60/min per-principal default rate refuses the
+// next call with the uniform overload error. The totality test proves every
+// operation is classified; this proves the classification reaches runtime.
+func scenarioDefaultBudgetChargedEndToEnd(t *testing.T, db *store.DB) {
+	budget := service.NewBudget()
+	defs := &service.Definitions{DB: db, Keyring: sharedKeyring(t, db), Budget: budget}
+	who, scope := tenantFixture(t, db, "defaultbudget")
+	actor := service.LocalPrincipal(who)
+
+	for i := range service.BudgetDefaultRatePerMin {
+		if _, err := defs.Export(t.Context(), actor, scope, true); err != nil {
+			t.Fatalf("definitions export %d/%d refused inside the default allowance: %v",
+				i+1, service.BudgetDefaultRatePerMin, err)
+		}
+	}
+	if _, err := defs.Export(t.Context(), actor, scope, true); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("the 61st default-expensive call = %v, want ErrOverloaded (uniform 429)", err)
+	}
 }
 
 // scenarioSchemaRevisionRateLimit drives real semantic schema mutations against

--- a/internal/conformance/budget_test.go
+++ b/internal/conformance/budget_test.go
@@ -1,0 +1,65 @@
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+// The ops-spec § 179 / § 151 expensive-path budget joins the cross-engine
+// corpus. This proves the schema-revision rate limit (§ 151, 60/h per project)
+// end to end through the service layer and both engines — the wiring the bound
+// registry flips from enforcement-pending to enforced.
+func init() {
+	corpus = append(corpus,
+		scenario{"schema_revision_rate_limit", scenarioSchemaRevisionRateLimit},
+	)
+}
+
+// scenarioSchemaRevisionRateLimit drives real semantic schema mutations against
+// one project until the § 151 rate (60/h per project) refuses the next one with
+// the uniform overload error — the same error that renders 429 + Retry-After on
+// the wire. Every charge converges on prepareSchemaPublish, so a single Budget
+// bounds create/rename/declaration edits alike; here the cheapest charged
+// mutation (rename, no schema reparse) exhausts it. A second project is an
+// independent bucket, so the bound is per-project, not instance-wide.
+func scenarioSchemaRevisionRateLimit(t *testing.T, db *store.DB) {
+	budget := service.NewBudget()
+	keys := &service.Keys{DB: db, Keyring: sharedKeyring(t, db), Budget: budget}
+	who, scope := tenantFixture(t, db, "schemarev")
+	actor := service.LocalPrincipal(who)
+
+	// Create the key — the first schema revision, charge #1.
+	created, err := keys.Create(t.Context(), actor, scope,
+		keySpec("RATE_LIMITED", string(schema.Config), decl(schema.Rule{Type: schema.TypeString})), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The remaining allowance is the per-hour bound minus that first charge.
+	// Every rename that lands inside it must succeed; the one past it must be the
+	// uniform overload refusal, never a different error.
+	allowed := service.BudgetSchemaRevisionPerHour - 1
+	for i := range allowed {
+		if _, err := keys.Rename(t.Context(), actor, scope, created.ID, fmt.Sprintf("RENAMED_%d", i), nil); err != nil {
+			t.Fatalf("rename %d/%d refused inside the schema-revision allowance: %v", i+1, allowed, err)
+		}
+	}
+	_, err = keys.Rename(t.Context(), actor, scope, created.ID, "OVER_THE_LIMIT", nil)
+	if !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("the schema revision past the per-project rate = %v, want ErrOverloaded (uniform 429)", err)
+	}
+
+	// A different project shares nothing: its budget is untouched, so its first
+	// schema revision succeeds even though the first project is now rate-limited.
+	who2, scope2 := tenantFixture(t, db, "schemarev-other")
+	if _, err := keys.Create(t.Context(), service.LocalPrincipal(who2), scope2,
+		keySpec("FRESH", string(schema.Config), decl(schema.Rule{Type: schema.TypeString})), nil); err != nil {
+		t.Fatalf("a second project's first schema revision was refused; the bound is not per-project: %v", err)
+	}
+}

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -19,9 +19,13 @@ import (
 )
 
 type Adapters struct {
-	DB             *store.DB
-	Auth           *Auth
-	Keyring        *crypto.Keyring
+	DB      *store.DB
+	Auth    *Auth
+	Keyring *crypto.Keyring
+	// Budget applies the § 179 adapter sync/trigger concurrency bound (4 per
+	// org). Nil disables it. The per-principal 10/min rate is deferred (see
+	// budget.go).
+	Budget         *Budget
 	Now            func() time.Time
 	PlanModule     func(origin, credential string) (adapter.Module, func(), error)
 	ProviderModule func(provider, origin, credential string) (adapter.Module, func(), error)
@@ -1066,9 +1070,15 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 	if scope.Project == "" || scope.Env != "" || targetID == "" {
 		return store.AdapterEnqueueResult{}, fmt.Errorf("%w: manual adapter sync requires project scope and target id", domain.ErrInvalid)
 	}
+	// § 179 adapter sync/trigger concurrency: 4 per org. Held for the enqueue.
+	release, err := s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return store.AdapterEnqueueResult{}, err
+	}
+	defer release()
 	now := store.CanonTime(s.now())
 	var result store.AdapterEnqueueResult
-	err := retryAdapterProviderFence(ctx, func() error {
+	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(ctx, az, now)
 			if err != nil {

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -530,6 +530,7 @@ func (s *Adapters) UpdateTarget(ctx context.Context, actor Actor, scope domain.S
 	}
 	now := store.CanonTime(s.now())
 	var out store.AdapterTarget
+	var rateCharged bool
 	err := retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(ctx, az, now)
@@ -582,6 +583,17 @@ func (s *Adapters) UpdateTarget(ctx context.Context, actor Actor, scope domain.S
 				return err
 			}
 			out = updated.Target
+			// § 179 adapter sync/trigger rate: a reconfigure that re-syncs enqueues
+			// a "trigger":"manual" job just like SyncTarget, so it charges the same
+			// 10/min per-principal budget — otherwise a script re-toggles a target's
+			// keys to trigger syncs past the bound. Charged only when a job was
+			// actually enqueued (a pure config edit that re-syncs nothing does not),
+			// once across the fence/tx retry loops; a refusal rolls the enqueue back.
+			if updated.Enqueue.JobID != "" {
+				if err := s.Budget.chargeOnce(&rateCharged, budgetAdapterRate, budgetKeys{Principal: caller.Principal}); err != nil {
+					return err
+				}
+			}
 			payload := audit.Payload{"mutation": "target-update", "authority": updated.AuthorityPrincipalID}
 			if full {
 				payload["previous_authority"] = updated.PreviousAuthorityPrincipalID

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -1078,6 +1078,7 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 	defer release()
 	now := store.CanonTime(s.now())
 	var result store.AdapterEnqueueResult
+	var rateCharged bool
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(ctx, az, now)
@@ -1086,6 +1087,12 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 			}
 			proof, err := az.Authorize(ctx, caller, authz.OpAdapterSync, scope)
 			if err != nil {
+				return err
+			}
+			// § 179 adapter sync/trigger rate: 10/min per principal, charged once
+			// across both the provider-fence and tx retry loops. The per-org
+			// concurrency was taken at entry.
+			if err := s.Budget.chargeOnce(&rateCharged, budgetAdapterRate, budgetKeys{Principal: caller.Principal}); err != nil {
 				return err
 			}
 			target, err := r.Adapters().Target(ctx, proof, targetID)

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -528,10 +528,19 @@ func (s *Adapters) UpdateTarget(ctx context.Context, actor Actor, scope domain.S
 	if err := s.preflightTargetRouting(ctx, actor, scope, request); err != nil {
 		return store.AdapterTarget{}, err
 	}
+	// § 179 adapter sync/trigger concurrency: 4 per org, held for the reconfigure
+	// exactly as SyncTarget holds it — a reconfigure that re-syncs is an adapter
+	// trigger, so it takes the same concurrency slot, not just the rate. Acquired
+	// at entry (before the provider fence retries), released on return.
+	release, err := s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	defer release()
 	now := store.CanonTime(s.now())
 	var out store.AdapterTarget
 	var rateCharged bool
-	err := retryAdapterProviderFence(ctx, func() error {
+	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(ctx, az, now)
 			if err != nil {

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -21,6 +21,9 @@ import (
 // page read in its own transaction under a fresh proof.
 type Audits struct {
 	DB *store.DB
+	// Budget applies the ops-spec § 179 / § 20 expensive-path budget to exports:
+	// 5/min per principal, 2 concurrent per org, 6 per instance. Nil disables it.
+	Budget *Budget
 }
 
 func auditQueryOp(scope domain.Scope) (authz.Operation, error) {
@@ -204,6 +207,14 @@ func (s *Audits) Export(ctx context.Context, principal domain.PrincipalID, scope
 	if pageSize <= 0 {
 		return fmt.Errorf("service: export page size must be positive")
 	}
+	// § 179 / § 20 expensive-path budget: 5/min per principal, 2 concurrent per
+	// org, 6 per instance. Acquired here, at entry, and held for the whole
+	// stream — a running export occupies its concurrency slot until it ends.
+	release, err := s.Budget.acquire(budgetExport, budgetKeys{Principal: principal, Org: scope.Org})
+	if err != nil {
+		return err
+	}
+	defer release()
 	insertTenant := func(ctx context.Context, r store.Repos, p authz.Proof, ev audit.Event) error {
 		return r.Audit().InsertTenant(ctx, p, ev)
 	}
@@ -218,6 +229,15 @@ func (s *Audits) InstanceExport(ctx context.Context, principal domain.PrincipalI
 	if pageSize <= 0 {
 		return fmt.Errorf("service: export page size must be positive")
 	}
+	// Instance export has no org: it is bounded by 5/min per principal and the
+	// 6-per-instance concurrency only (budgetExportInstance), never the 2-per-org
+	// bound, which would otherwise collapse every instance export into one "" org
+	// bucket.
+	release, err := s.Budget.acquire(budgetExportInstance, budgetKeys{Principal: principal})
+	if err != nil {
+		return err
+	}
+	defer release()
 	insertInstance := func(ctx context.Context, r store.Repos, p authz.Proof, ev audit.Event) error {
 		return r.Audit().InsertInstance(ctx, p, ev)
 	}

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -25,6 +25,12 @@ import (
 // cannot burn the org's budget by guessing its id). The returned release frees
 // the concurrency slot; hold it for the whole operation.
 func chargeDefaultAtEntry(ctx context.Context, db *store.DB, budget *Budget, actor Actor, op authz.Operation, scope domain.Scope, now func() time.Time) (func(), error) {
+	// Couple the call site to the totality map: a method may only take the
+	// fail-closed default for an operation classified default-expensive. A named
+	// or exempt operation reaching here is a wiring bug, caught at the call.
+	if c, ok := operationBudgetClass[op]; !ok || c.class != budgetClassDefaultExpensive {
+		panic("service: chargeDefaultAtEntry called for non-default-expensive operation " + string(op))
+	}
 	if budget == nil {
 		return noopBudgetRelease, nil
 	}

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -1,14 +1,50 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
+
+// chargeDefaultAtEntry acquires the §179 fail-closed default (rate + concurrency)
+// once at the entry of a heavy operation whose work spans MANY transactions and
+// therefore has no single in-tx charge point (reencrypt). It resolves and
+// authorizes the caller in one lightweight read transaction purely to key the
+// per-principal rate; the operation re-authorizes in each of its own
+// transactions, so this is not a cross-transaction authorization cache — the
+// resolved principal is used only as a budget key, and the resolve's own
+// authorization refuses an ineligible caller before any slot is taken (they
+// cannot burn the org's budget by guessing its id). The returned release frees
+// the concurrency slot; hold it for the whole operation.
+func chargeDefaultAtEntry(ctx context.Context, db *store.DB, budget *Budget, actor Actor, op authz.Operation, scope domain.Scope, now func() time.Time) (func(), error) {
+	if budget == nil {
+		return noopBudgetRelease, nil
+	}
+	var principal domain.PrincipalID
+	err := tx.Read(ctx, db, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+		caller, err := actor.resolve(ctx, az, now())
+		if err != nil {
+			return err
+		}
+		if _, err := az.Authorize(ctx, caller, op, scope); err != nil {
+			return err
+		}
+		principal = caller.Principal
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return budget.acquire(budgetDefault, budgetKeys{Principal: principal, Org: scope.Org})
+}
 
 // Budget is the ops-spec § 179 expensive-path availability layer plus the § 151
 // (§ 8) schema-revision rate limit: a per-scope windowed rate counter and a
@@ -191,21 +227,36 @@ var (
 		name:  "schema-revision",
 		rates: []budgetRateRule{{dimProject, BudgetSchemaRevisionPerHour, time.Hour}},
 	}
+	// budgetDefault is the §179 fail-closed default: 60/min per principal, 8
+	// concurrent per org, applied to expensive operations that have no named
+	// category above. There is no once-per-operation post-authorization
+	// chokepoint (Authorize runs per-env/per-page), so it is charged at the
+	// owning service method — concurrency at entry (budgetDefaultConc, keyed on
+	// the org in scope) and the per-principal rate in-tx (budgetDefaultRate, once
+	// the principal is resolved), the same split publish uses. Which operations
+	// take it, which take a named category, and which are exempt is the totality
+	// map in budget_classification.go; the conformance totality test fails the
+	// build if any registered operation is left unclassified. THAT test is "no
+	// path is unbudgeted by omission": a new operation cannot be added without a
+	// deliberate budget decision.
+	budgetDefaultConc = budgetCategory{
+		name:  "default",
+		concs: []budgetConcRule{{dimOrg, BudgetDefaultOrgConcurrency}},
+	}
+	budgetDefaultRate = budgetCategory{
+		name:  "default",
+		rates: []budgetRateRule{{dimPrincipal, BudgetDefaultRatePerMin, time.Minute}},
+	}
+	// budgetDefault is the combined rate+concurrency default, for a heavy
+	// operation whose work spans multiple transactions and has no single in-tx
+	// charge point (reencrypt): it is acquired once at entry after a lightweight
+	// resolve. It shares the "default" buckets with the split halves above.
+	budgetDefault = budgetCategory{
+		name:  "default",
+		rates: []budgetRateRule{{dimPrincipal, BudgetDefaultRatePerMin, time.Minute}},
+		concs: []budgetConcRule{{dimOrg, BudgetDefaultOrgConcurrency}},
+	}
 )
-
-// The §179 fail-closed default (BudgetDefaultRatePerMin / BudgetDefaultOrgConcurrency,
-// 60/min per principal, 8 concurrent per org) is NOT materialised as a live
-// category, because there is no unnamed expensive category to apply it to today:
-// every expensive path above has a named, wired category. Applying it "by
-// omission" to arbitrary future endpoints is not something this layer can do on
-// its own — a per-request budget needs the post-authorization principal that
-// only exists inside the service transaction, and deciding which endpoints are
-// expensive-enough to budget (vs ordinary reads that must NOT be capped at
-// 60/min) is a per-operation classification, its own concern. The default's
-// values are kept as exported constants (spec-pinned in the conformance
-// registry) so that a future category adopts them without re-deriving; wiring an
-// operation→category dispatch that charges the default for unclassified
-// expensive operations is a tracked follow-up, not part of #186.
 
 // budgetKeys carries every scope value a category might key on. A caller
 // supplies the ones its category needs; unused fields stay zero.

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -36,16 +36,25 @@ type Budget struct {
 	now func() time.Time
 
 	mu sync.Mutex
-	// rate holds sliding-window hit timestamps, keyed by category+dimension+value.
-	rate map[string][]time.Time
+	// rate holds sliding-window buckets, keyed by category+dimension+value. Each
+	// bucket carries the window of the rule that records into it, so eviction can
+	// use the bucket's OWN window — a 1-minute machine-fetch bucket is reclaimed a
+	// minute after its last hit, not held for schema-rev's hour.
+	rate map[string]rateBucket
 	// inflight holds live concurrency counts, keyed the same way. An entry is
 	// deleted when it reaches zero so the map does not accumulate dead keys.
 	inflight map[string]int
 }
 
+// rateBucket is one subject's hit timestamps under one rule's window.
+type rateBucket struct {
+	hits   []time.Time
+	window time.Duration
+}
+
 // NewBudget constructs an enabled budget on the real clock.
 func NewBudget() *Budget {
-	return &Budget{now: time.Now, rate: map[string][]time.Time{}, inflight: map[string]int{}}
+	return &Budget{now: time.Now, rate: map[string]rateBucket{}, inflight: map[string]int{}}
 }
 
 // Ops-spec § 179 / § 20 / § 151 values, exported so the conformance registry's
@@ -116,22 +125,14 @@ type budgetCategory struct {
 // The named categories. Every category that a live call site charges is keyed
 // on a dimension the caller can supply AT METHOD ENTRY (before the operation's
 // own transaction), because the tx closure is retried up to four times and an
-// in-closure charge would multiply. Project / org / instance dims come from the
-// scope argument; the per-principal rate is charged only where the principal is
-// a method parameter already (audit export). The per-principal rate rules on
-// publish / values-export / adapter are DEFERRED: their principal is resolved
-// inside the operation's own transaction, so charging it at entry would need a
-// second resolve — their per-org concurrency, the load-bearing availability
-// control, IS enforced here, and the per-principal rate wiring is a tracked
-// follow-up. search / default are reference configs: there is no search
-// endpoint (SCIM search is a separate surface with its own bounds), and the
-// fail-closed default is the layer's documented catch-all, not a route middleware.
+// in-closure charge would multiply. Scope-keyed dims (project / org / instance)
+// come from the scope argument, so they are acquired at ENTRY and held. The
+// per-principal RATE dims need the resolved principal, which only exists inside
+// the operation's transaction — so those are charged there via chargeOnce,
+// idempotent across the retry loop. Concurrency and the per-principal rate are
+// two calls on the same shared budget, keyed on the same category name so they
+// share buckets.
 var (
-	budgetSearch = budgetCategory{
-		name:  "search",
-		rates: []budgetRateRule{{dimPrincipal, BudgetSearchRatePerMin, time.Minute}},
-		concs: []budgetConcRule{{dimOrg, BudgetSearchOrgConcurrency}},
-	}
 	// budgetExport is the tenant audit export: 5/min per principal, 2 concurrent
 	// per org, 6 per instance. Audit export takes the principal as a parameter,
 	// so the per-principal rate is charged at entry.
@@ -148,19 +149,36 @@ var (
 		rates: []budgetRateRule{{dimPrincipal, BudgetExportRatePerMin, time.Minute}},
 		concs: []budgetConcRule{{dimInstance, BudgetExportInstanceConcurrency}},
 	}
-	// budgetValuesExport shares the "export" concurrency pool but omits the
-	// per-principal rate (its principal is resolved in-tx, see above).
+	// budgetValuesExport takes the "export" concurrency at entry (org + instance);
+	// its 5/min per-principal rate is charged in-tx via budgetExportRate, so the
+	// two share the "export" rate bucket with audit export.
 	budgetValuesExport = budgetCategory{
 		name:  "export",
 		concs: []budgetConcRule{{dimOrg, BudgetExportOrgConcurrency}, {dimInstance, BudgetExportInstanceConcurrency}},
+	}
+	// budgetExportRate is the in-tx, per-principal half of the export budget, for
+	// values export (whose principal resolves inside its transaction).
+	budgetExportRate = budgetCategory{
+		name:  "export",
+		rates: []budgetRateRule{{dimPrincipal, BudgetExportRatePerMin, time.Minute}},
 	}
 	budgetPublish = budgetCategory{
 		name:  "publish",
 		concs: []budgetConcRule{{dimOrg, BudgetPublishOrgConcurrency}},
 	}
+	// budgetPublishRate is publish's in-tx per-principal rate (10/min).
+	budgetPublishRate = budgetCategory{
+		name:  "publish",
+		rates: []budgetRateRule{{dimPrincipal, BudgetPublishRatePerMin, time.Minute}},
+	}
 	budgetAdapter = budgetCategory{
 		name:  "adapter-sync",
 		concs: []budgetConcRule{{dimOrg, BudgetAdapterOrgConcurrency}},
+	}
+	// budgetAdapterRate is adapter sync/trigger's in-tx per-principal rate (10/min).
+	budgetAdapterRate = budgetCategory{
+		name:  "adapter-sync",
+		rates: []budgetRateRule{{dimPrincipal, BudgetAdapterRatePerMin, time.Minute}},
 	}
 	budgetMachineFetch = budgetCategory{
 		name: "machine-fetch",
@@ -173,8 +191,14 @@ var (
 		name:  "schema-revision",
 		rates: []budgetRateRule{{dimProject, BudgetSchemaRevisionPerHour, time.Hour}},
 	}
-	// budgetDefault is the fail-closed catch-all: no expensive category is left
-	// unbudgeted by omission.
+	// budgetDefault is the fail-closed reference for an expensive category not
+	// named above. §179 closes coverage "by omission" at the CATEGORY level:
+	// every expensive path today has a named category, and a future one adopts
+	// this default. It is not applied as blanket route middleware — a per-request
+	// budget needs the post-auth identity that only exists inside the service
+	// transaction, and classifying every endpoint as expensive-or-not is its own
+	// concern — so a NEW expensive category must charge it explicitly, enforced
+	// by review, not inferred. Exercised by TestBudgetFailClosedDefault.
 	budgetDefault = budgetCategory{
 		name:  "default",
 		rates: []budgetRateRule{{dimPrincipal, BudgetDefaultRatePerMin, time.Minute}},
@@ -198,8 +222,12 @@ func (k budgetKeys) value(dim budgetDimension) string {
 		return string(k.Project)
 	case dimOrg:
 		return string(k.Org)
-	default: // dimInstance — one bucket for the whole instance.
-		return ""
+	case dimInstance:
+		return "" // one bucket for the whole instance.
+	default:
+		// A dimension added without a case here must fail loudly, not silently
+		// collapse into the instance bucket and share a bound it was never meant to.
+		panic(fmt.Sprintf("service: unknown budget dimension %d", dim))
 	}
 }
 
@@ -231,51 +259,61 @@ func (b *Budget) acquire(cat budgetCategory, keys budgetKeys) (func(), error) {
 
 	// 1. Slide every rate window and confirm it has room — WITHOUT recording.
 	type slid struct {
-		key  string
-		kept []time.Time
+		key    string
+		kept   []time.Time
+		window time.Duration
+		isNew  bool // absent from the map, so recording it grows the tracking set.
 	}
 	pending := make([]slid, 0, len(cat.rates))
 	for _, r := range cat.rates {
 		key := budgetMapKey(cat.name, r.dim, keys.value(r.dim))
 		cutoff := at.Add(-r.window)
-		hits := b.rate[key]
-		kept := hits[:0]
-		for _, t := range hits {
+		bucket, ok := b.rate[key]
+		kept := bucket.hits[:0]
+		for _, t := range bucket.hits {
 			if t.After(cutoff) {
 				kept = append(kept, t)
 			}
 		}
 		if len(kept) >= r.limit {
-			b.rate[key] = kept // keep the compaction; charge nothing.
+			b.rate[key] = rateBucket{hits: kept, window: r.window} // keep the compaction; charge nothing.
 			return noopBudgetRelease, fmt.Errorf("%w: service: %s rate budget exhausted", admission.ErrOverloaded, cat.name)
 		}
-		pending = append(pending, slid{key, kept})
+		pending = append(pending, slid{key: key, kept: kept, window: r.window, isNew: !ok})
 	}
 
 	// 2. Confirm every concurrency bound has a free slot — WITHOUT taking one.
 	for _, c := range cat.concs {
 		key := budgetMapKey(cat.name, c.dim, keys.value(c.dim))
 		if b.inflight[key] >= c.limit {
-			for _, p := range pending {
-				b.rate[p.key] = p.kept // write back the compaction; charge nothing.
-			}
 			return noopBudgetRelease, fmt.Errorf("%w: service: %s concurrency budget exhausted", admission.ErrOverloaded, cat.name)
 		}
 	}
 
-	// 3. Every rule passed: record the rate hits and take the concurrency slots.
+	// 3. Tracking-bound check BEFORE any mutation, so a saturation refusal never
+	// leaves a partial charge (one rate rule recorded, a later one refused). If
+	// the brand-new rate buckets this acquire would add overflow the bound, evict
+	// stale buckets once; if that frees nothing, refuse. Refusing a new subject
+	// rather than growing unbounded is the safe direction under the threat model,
+	// exactly as the reveal gateLimiter decides it (admission evicts the oldest
+	// live entry instead — a deliberate divergence, since this map is shared
+	// across categories with a one-hour widest window).
+	newKeys := 0
 	for _, p := range pending {
-		if len(p.kept) == 0 && len(b.rate) >= budgetMaxTrackedSubjects {
-			b.evictStaleRate(at)
-			if len(b.rate) >= budgetMaxTrackedSubjects {
-				// Every tracked bucket is live and the map is full: refuse a brand
-				// new subject rather than grow unbounded. Availability loses to a
-				// memory bound under the threat model, exactly as the reveal
-				// gateLimiter and admission decide it.
-				return noopBudgetRelease, fmt.Errorf("%w: service: %s budget tracking saturated", admission.ErrOverloaded, cat.name)
-			}
+		if p.isNew {
+			newKeys++
 		}
-		b.rate[p.key] = append(p.kept, at)
+	}
+	if newKeys > 0 && len(b.rate)+newKeys > budgetMaxTrackedSubjects {
+		b.evictStaleRate(at)
+		if len(b.rate)+newKeys > budgetMaxTrackedSubjects {
+			return noopBudgetRelease, fmt.Errorf("%w: service: %s budget tracking saturated", admission.ErrOverloaded, cat.name)
+		}
+	}
+
+	// 4. Every rule passed: record the rate hits and take the concurrency slots.
+	for _, p := range pending {
+		b.rate[p.key] = rateBucket{hits: append(p.kept, at), window: p.window}
 	}
 	taken := make([]string, 0, len(cat.concs))
 	for _, c := range cat.concs {
@@ -300,24 +338,36 @@ func (b *Budget) acquire(cat budgetCategory, keys budgetKeys) (func(), error) {
 	}, nil
 }
 
-// evictStaleRate drops rate buckets whose windows have entirely elapsed. A
-// bucket with no live hits carries no information — it is indistinguishable from
-// one that never existed — so this is pure reclamation. The cutoff is the
-// widest window in play (an hour, for schema-rev), so a bucket is only dropped
-// when it is stale under every category that could share the map; in practice
-// each key is category-prefixed, so a bucket's own category window governs it.
+// chargeOnce records a rate-only budget category once per operation, from INSIDE
+// a tx.Write/tx.Read closure where the per-principal key first becomes known.
+// The retry loop replays the closure up to four times; *charged, owned by the
+// caller outside the closure, makes the charge idempotent: the first successful
+// attempt records the hit and flips the flag, later attempts skip it. A refusal
+// wraps admission.ErrOverloaded, which is not a retryable transaction error, so
+// the enclosing tx rolls back and the method surfaces the uniform 429. cat must
+// be rate-only; any concurrency slot it took could not be released from here.
+func (b *Budget) chargeOnce(charged *bool, cat budgetCategory, keys budgetKeys) error {
+	if *charged {
+		return nil
+	}
+	if _, err := b.acquire(cat, keys); err != nil {
+		return err
+	}
+	*charged = true
+	return nil
+}
+
+// evictStaleRate drops rate buckets whose windows have entirely elapsed, using
+// each bucket's OWN window rather than the widest one in play. A 1-minute
+// machine-fetch bucket is reclaimed a minute after its last hit, so a burst of
+// one-off subjects cannot hold the tracking set full long after their short
+// windows expired. A bucket with no live hit carries no information — it is
+// indistinguishable from one that never existed — so this is pure reclamation.
 func (b *Budget) evictStaleRate(at time.Time) {
-	for key, hits := range b.rate {
-		live := false
-		for _, t := range hits {
-			// The longest window is schema-rev's hour; anything older than that
-			// is stale for every category.
-			if t.After(at.Add(-time.Hour)) {
-				live = true
-				break
-			}
-		}
-		if !live {
+	for key, bucket := range b.rate {
+		// Hits are appended in clock order, so the last is the newest. If even it
+		// is outside the bucket's window, no live hit remains.
+		if len(bucket.hits) == 0 || !bucket.hits[len(bucket.hits)-1].After(at.Add(-bucket.window)) {
 			delete(b.rate, key)
 		}
 	}

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -1,0 +1,324 @@
+package service
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+)
+
+// Budget is the ops-spec § 179 expensive-path availability layer plus the § 151
+// (§ 8) schema-revision rate limit: a per-scope windowed rate counter and a
+// per-scope concurrency semaphore, applied to the named expensive categories.
+// Every refusal wraps admission.ErrOverloaded, so the server renders the
+// uniform 429 + Retry-After the spec requires for all overflow, exactly as the
+// pre-auth admission budget does.
+//
+// Deliberately in memory, single node, like admission.Limiter and the reveal
+// gateLimiter: v1's locked deployment envelope is a single node with no HA
+// (system-architecture ADR), so process-local state IS the whole instance's
+// state. A durable rate/concurrency table would add a write per expensive
+// request — amplifying exactly the load it bounds — to buy nothing this
+// deployment shape can use. A multi-node build must replace this with shared
+// state, which is why the constraint is written down here rather than
+// discovered later.
+//
+// A nil *Budget is a working no-op, so a build that wires no budget (the
+// isolation harness, focused unit tests) enforces no expensive-path bounds —
+// the same nil-is-disabled discipline Advisory uses. The production wiring in
+// internal/app always constructs one.
+type Budget struct {
+	// now is injectable so the windowed curves are testable without sleeping a
+	// full window (schema-rev is 60/hour). Nil means time.Now.
+	now func() time.Time
+
+	mu sync.Mutex
+	// rate holds sliding-window hit timestamps, keyed by category+dimension+value.
+	rate map[string][]time.Time
+	// inflight holds live concurrency counts, keyed the same way. An entry is
+	// deleted when it reaches zero so the map does not accumulate dead keys.
+	inflight map[string]int
+}
+
+// NewBudget constructs an enabled budget on the real clock.
+func NewBudget() *Budget {
+	return &Budget{now: time.Now, rate: map[string][]time.Time{}, inflight: map[string]int{}}
+}
+
+// Ops-spec § 179 / § 20 / § 151 values, exported so the conformance registry's
+// anti-drift test can pin the whole family to the spec in one place.
+const (
+	// § 179 search.
+	BudgetSearchRatePerMin     = 30
+	BudgetSearchOrgConcurrency = 4
+	// § 179 / § 20 export — values export and audit export share this category:
+	// 5/min per principal, 2 concurrent per org, 6 concurrent per instance.
+	BudgetExportRatePerMin          = 5
+	BudgetExportOrgConcurrency      = 2
+	BudgetExportInstanceConcurrency = 6
+	// § 179 publish.
+	BudgetPublishRatePerMin     = 10
+	BudgetPublishOrgConcurrency = 4
+	// § 179 adapter sync/trigger.
+	BudgetAdapterRatePerMin     = 10
+	BudgetAdapterOrgConcurrency = 4
+	// § 179 machine-fetch aggregates, on top of § 5's per-principal 30/min.
+	BudgetMachineFetchOrgPerMin      = 300
+	BudgetMachineFetchInstancePerMin = 1000
+	// § 179 fail-closed default for any category not named above.
+	BudgetDefaultRatePerMin     = 60
+	BudgetDefaultOrgConcurrency = 8
+	// § 151 (§ 8) schema-revision rate limit, per project.
+	BudgetSchemaRevisionPerHour = 60
+
+	// budgetMaxTrackedSubjects bounds how many rate buckets are remembered.
+	// Rate keys carry attacker-influenced values (a principal id, an org id), so
+	// without a bound the limiter becomes the memory-exhaustion vector it exists
+	// to prevent. It mirrors admission.MaxTrackedSubjects.
+	budgetMaxTrackedSubjects = 4096
+)
+
+// budgetDimension is the scope a bound is keyed on. The § 179 family is not
+// uniformly per-principal: schema-rev is per project, machine-fetch aggregates
+// are per org and per instance — so the key dimension is per rule, not fixed.
+type budgetDimension uint8
+
+const (
+	dimPrincipal budgetDimension = iota
+	dimProject
+	dimOrg
+	dimInstance
+)
+
+type budgetRateRule struct {
+	dim    budgetDimension
+	limit  int
+	window time.Duration
+}
+
+type budgetConcRule struct {
+	dim   budgetDimension
+	limit int
+}
+
+// budgetCategory names one expensive path and the rate/concurrency rules that
+// govern it. A category with no concurrency rules is rate-only (its release is
+// a no-op).
+type budgetCategory struct {
+	name  string
+	rates []budgetRateRule
+	concs []budgetConcRule
+}
+
+// The named categories. Every category that a live call site charges is keyed
+// on a dimension the caller can supply AT METHOD ENTRY (before the operation's
+// own transaction), because the tx closure is retried up to four times and an
+// in-closure charge would multiply. Project / org / instance dims come from the
+// scope argument; the per-principal rate is charged only where the principal is
+// a method parameter already (audit export). The per-principal rate rules on
+// publish / values-export / adapter are DEFERRED: their principal is resolved
+// inside the operation's own transaction, so charging it at entry would need a
+// second resolve — their per-org concurrency, the load-bearing availability
+// control, IS enforced here, and the per-principal rate wiring is a tracked
+// follow-up. search / default are reference configs: there is no search
+// endpoint (SCIM search is a separate surface with its own bounds), and the
+// fail-closed default is the layer's documented catch-all, not a route middleware.
+var (
+	budgetSearch = budgetCategory{
+		name:  "search",
+		rates: []budgetRateRule{{dimPrincipal, BudgetSearchRatePerMin, time.Minute}},
+		concs: []budgetConcRule{{dimOrg, BudgetSearchOrgConcurrency}},
+	}
+	// budgetExport is the tenant audit export: 5/min per principal, 2 concurrent
+	// per org, 6 per instance. Audit export takes the principal as a parameter,
+	// so the per-principal rate is charged at entry.
+	budgetExport = budgetCategory{
+		name:  "export",
+		rates: []budgetRateRule{{dimPrincipal, BudgetExportRatePerMin, time.Minute}},
+		concs: []budgetConcRule{{dimOrg, BudgetExportOrgConcurrency}, {dimInstance, BudgetExportInstanceConcurrency}},
+	}
+	// budgetExportInstance is the instance-trail export: it carries no org, so it
+	// is bounded only by 6/instance. Sharing budgetExport would collapse every
+	// instance export into one "" org bucket of 2.
+	budgetExportInstance = budgetCategory{
+		name:  "export",
+		rates: []budgetRateRule{{dimPrincipal, BudgetExportRatePerMin, time.Minute}},
+		concs: []budgetConcRule{{dimInstance, BudgetExportInstanceConcurrency}},
+	}
+	// budgetValuesExport shares the "export" concurrency pool but omits the
+	// per-principal rate (its principal is resolved in-tx, see above).
+	budgetValuesExport = budgetCategory{
+		name:  "export",
+		concs: []budgetConcRule{{dimOrg, BudgetExportOrgConcurrency}, {dimInstance, BudgetExportInstanceConcurrency}},
+	}
+	budgetPublish = budgetCategory{
+		name:  "publish",
+		concs: []budgetConcRule{{dimOrg, BudgetPublishOrgConcurrency}},
+	}
+	budgetAdapter = budgetCategory{
+		name:  "adapter-sync",
+		concs: []budgetConcRule{{dimOrg, BudgetAdapterOrgConcurrency}},
+	}
+	budgetMachineFetch = budgetCategory{
+		name: "machine-fetch",
+		rates: []budgetRateRule{
+			{dimOrg, BudgetMachineFetchOrgPerMin, time.Minute},
+			{dimInstance, BudgetMachineFetchInstancePerMin, time.Minute},
+		},
+	}
+	budgetSchemaRevision = budgetCategory{
+		name:  "schema-revision",
+		rates: []budgetRateRule{{dimProject, BudgetSchemaRevisionPerHour, time.Hour}},
+	}
+	// budgetDefault is the fail-closed catch-all: no expensive category is left
+	// unbudgeted by omission.
+	budgetDefault = budgetCategory{
+		name:  "default",
+		rates: []budgetRateRule{{dimPrincipal, BudgetDefaultRatePerMin, time.Minute}},
+		concs: []budgetConcRule{{dimOrg, BudgetDefaultOrgConcurrency}},
+	}
+)
+
+// budgetKeys carries every scope value a category might key on. A caller
+// supplies the ones its category needs; unused fields stay zero.
+type budgetKeys struct {
+	Principal domain.PrincipalID
+	Project   domain.ProjectID
+	Org       domain.OrgID
+}
+
+func (k budgetKeys) value(dim budgetDimension) string {
+	switch dim {
+	case dimPrincipal:
+		return string(k.Principal)
+	case dimProject:
+		return string(k.Project)
+	case dimOrg:
+		return string(k.Org)
+	default: // dimInstance — one bucket for the whole instance.
+		return ""
+	}
+}
+
+// budgetMapKey is length-prefixed on the value, not concatenated: two subjects
+// whose (dimension, value) pairs would otherwise run together must not collide.
+func budgetMapKey(cat string, dim budgetDimension, value string) string {
+	return cat + "\x00" + strconv.Itoa(int(dim)) + "\x00" + strconv.Itoa(len(value)) + ":" + value
+}
+
+func noopBudgetRelease() {}
+
+// acquire charges the category's rate rules and takes its concurrency slots
+// atomically: it records nothing unless every rule passes, so a refusal on one
+// bound never half-charges another. It returns a release that frees the
+// concurrency slots (a no-op for a rate-only category), safe to call more than
+// once. Every refusal wraps admission.ErrOverloaded.
+func (b *Budget) acquire(cat budgetCategory, keys budgetKeys) (func(), error) {
+	if b == nil {
+		return noopBudgetRelease, nil
+	}
+	now := time.Now
+	if b.now != nil {
+		now = b.now
+	}
+	at := now()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// 1. Slide every rate window and confirm it has room — WITHOUT recording.
+	type slid struct {
+		key  string
+		kept []time.Time
+	}
+	pending := make([]slid, 0, len(cat.rates))
+	for _, r := range cat.rates {
+		key := budgetMapKey(cat.name, r.dim, keys.value(r.dim))
+		cutoff := at.Add(-r.window)
+		hits := b.rate[key]
+		kept := hits[:0]
+		for _, t := range hits {
+			if t.After(cutoff) {
+				kept = append(kept, t)
+			}
+		}
+		if len(kept) >= r.limit {
+			b.rate[key] = kept // keep the compaction; charge nothing.
+			return noopBudgetRelease, fmt.Errorf("%w: service: %s rate budget exhausted", admission.ErrOverloaded, cat.name)
+		}
+		pending = append(pending, slid{key, kept})
+	}
+
+	// 2. Confirm every concurrency bound has a free slot — WITHOUT taking one.
+	for _, c := range cat.concs {
+		key := budgetMapKey(cat.name, c.dim, keys.value(c.dim))
+		if b.inflight[key] >= c.limit {
+			for _, p := range pending {
+				b.rate[p.key] = p.kept // write back the compaction; charge nothing.
+			}
+			return noopBudgetRelease, fmt.Errorf("%w: service: %s concurrency budget exhausted", admission.ErrOverloaded, cat.name)
+		}
+	}
+
+	// 3. Every rule passed: record the rate hits and take the concurrency slots.
+	for _, p := range pending {
+		if len(p.kept) == 0 && len(b.rate) >= budgetMaxTrackedSubjects {
+			b.evictStaleRate(at)
+			if len(b.rate) >= budgetMaxTrackedSubjects {
+				// Every tracked bucket is live and the map is full: refuse a brand
+				// new subject rather than grow unbounded. Availability loses to a
+				// memory bound under the threat model, exactly as the reveal
+				// gateLimiter and admission decide it.
+				return noopBudgetRelease, fmt.Errorf("%w: service: %s budget tracking saturated", admission.ErrOverloaded, cat.name)
+			}
+		}
+		b.rate[p.key] = append(p.kept, at)
+	}
+	taken := make([]string, 0, len(cat.concs))
+	for _, c := range cat.concs {
+		key := budgetMapKey(cat.name, c.dim, keys.value(c.dim))
+		b.inflight[key]++
+		taken = append(taken, key)
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			for _, key := range taken {
+				if b.inflight[key] <= 1 {
+					delete(b.inflight, key)
+					continue
+				}
+				b.inflight[key]--
+			}
+		})
+	}, nil
+}
+
+// evictStaleRate drops rate buckets whose windows have entirely elapsed. A
+// bucket with no live hits carries no information — it is indistinguishable from
+// one that never existed — so this is pure reclamation. The cutoff is the
+// widest window in play (an hour, for schema-rev), so a bucket is only dropped
+// when it is stale under every category that could share the map; in practice
+// each key is category-prefixed, so a bucket's own category window governs it.
+func (b *Budget) evictStaleRate(at time.Time) {
+	for key, hits := range b.rate {
+		live := false
+		for _, t := range hits {
+			// The longest window is schema-rev's hour; anything older than that
+			// is stale for every category.
+			if t.After(at.Add(-time.Hour)) {
+				live = true
+				break
+			}
+		}
+		if !live {
+			delete(b.rate, key)
+		}
+	}
+}

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -24,12 +24,18 @@ import (
 // authorization refuses an ineligible caller before any slot is taken (they
 // cannot burn the org's budget by guessing its id). The returned release frees
 // the concurrency slot; hold it for the whole operation.
-func chargeDefaultAtEntry(ctx context.Context, db *store.DB, budget *Budget, actor Actor, op authz.Operation, scope domain.Scope, now func() time.Time) (func(), error) {
+// authOp is the operation AUTHORIZED at entry — the minimal authority the
+// method's own entry already requires, so this cannot refuse a caller the method
+// would otherwise admit. classifyOp is the default-expensive operation whose
+// budget is charged; the two differ only where a method's entry authorization is
+// a lighter read than the operation it is budgeted as (Copy authorizes the
+// source read OpValueList but is budgeted as OpValueCopySource).
+func chargeDefaultAtEntry(ctx context.Context, db *store.DB, budget *Budget, actor Actor, authOp, classifyOp authz.Operation, scope domain.Scope, now func() time.Time) (func(), error) {
 	// Couple the call site to the totality map: a method may only take the
 	// fail-closed default for an operation classified default-expensive. A named
 	// or exempt operation reaching here is a wiring bug, caught at the call.
-	if c, ok := operationBudgetClass[op]; !ok || c.class != budgetClassDefaultExpensive {
-		panic("service: chargeDefaultAtEntry called for non-default-expensive operation " + string(op))
+	if c, ok := operationBudgetClass[classifyOp]; !ok || c.class != budgetClassDefaultExpensive {
+		panic("service: chargeDefaultAtEntry called for non-default-expensive operation " + string(classifyOp))
 	}
 	if budget == nil {
 		return noopBudgetRelease, nil
@@ -40,7 +46,7 @@ func chargeDefaultAtEntry(ctx context.Context, db *store.DB, budget *Budget, act
 		if err != nil {
 			return err
 		}
-		if _, err := az.Authorize(ctx, caller, op, scope); err != nil {
+		if _, err := az.Authorize(ctx, caller, authOp, scope); err != nil {
 			return err
 		}
 		principal = caller.Principal

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -191,20 +191,21 @@ var (
 		name:  "schema-revision",
 		rates: []budgetRateRule{{dimProject, BudgetSchemaRevisionPerHour, time.Hour}},
 	}
-	// budgetDefault is the fail-closed reference for an expensive category not
-	// named above. §179 closes coverage "by omission" at the CATEGORY level:
-	// every expensive path today has a named category, and a future one adopts
-	// this default. It is not applied as blanket route middleware — a per-request
-	// budget needs the post-auth identity that only exists inside the service
-	// transaction, and classifying every endpoint as expensive-or-not is its own
-	// concern — so a NEW expensive category must charge it explicitly, enforced
-	// by review, not inferred. Exercised by TestBudgetFailClosedDefault.
-	budgetDefault = budgetCategory{
-		name:  "default",
-		rates: []budgetRateRule{{dimPrincipal, BudgetDefaultRatePerMin, time.Minute}},
-		concs: []budgetConcRule{{dimOrg, BudgetDefaultOrgConcurrency}},
-	}
 )
+
+// The §179 fail-closed default (BudgetDefaultRatePerMin / BudgetDefaultOrgConcurrency,
+// 60/min per principal, 8 concurrent per org) is NOT materialised as a live
+// category, because there is no unnamed expensive category to apply it to today:
+// every expensive path above has a named, wired category. Applying it "by
+// omission" to arbitrary future endpoints is not something this layer can do on
+// its own — a per-request budget needs the post-authorization principal that
+// only exists inside the service transaction, and deciding which endpoints are
+// expensive-enough to budget (vs ordinary reads that must NOT be capped at
+// 60/min) is a per-operation classification, its own concern. The default's
+// values are kept as exported constants (spec-pinned in the conformance
+// registry) so that a future category adopts them without re-deriving; wiring an
+// operation→category dispatch that charges the default for unclassified
+// expensive operations is a tracked follow-up, not part of #186.
 
 // budgetKeys carries every scope value a category might key on. A caller
 // supplies the ones its category needs; unused fields stay zero.
@@ -258,28 +259,29 @@ func (b *Budget) acquire(cat budgetCategory, keys budgetKeys) (func(), error) {
 	defer b.mu.Unlock()
 
 	// 1. Slide every rate window and confirm it has room — WITHOUT recording.
+	// kept is built in FRESH storage, never bucket.hits[:0]: an in-place
+	// compaction would mutate the map-owned backing array before every check has
+	// passed, so a later concurrency/tracking refusal would leave the stored
+	// bucket corrupted. Nothing here writes to b.rate; step 4 publishes.
 	type slid struct {
 		key    string
 		kept   []time.Time
 		window time.Duration
-		isNew  bool // absent from the map, so recording it grows the tracking set.
 	}
 	pending := make([]slid, 0, len(cat.rates))
 	for _, r := range cat.rates {
 		key := budgetMapKey(cat.name, r.dim, keys.value(r.dim))
 		cutoff := at.Add(-r.window)
-		bucket, ok := b.rate[key]
-		kept := bucket.hits[:0]
-		for _, t := range bucket.hits {
+		kept := make([]time.Time, 0, len(b.rate[key].hits)+1)
+		for _, t := range b.rate[key].hits {
 			if t.After(cutoff) {
 				kept = append(kept, t)
 			}
 		}
 		if len(kept) >= r.limit {
-			b.rate[key] = rateBucket{hits: kept, window: r.window} // keep the compaction; charge nothing.
 			return noopBudgetRelease, fmt.Errorf("%w: service: %s rate budget exhausted", admission.ErrOverloaded, cat.name)
 		}
-		pending = append(pending, slid{key: key, kept: kept, window: r.window, isNew: !ok})
+		pending = append(pending, slid{key: key, kept: kept, window: r.window})
 	}
 
 	// 2. Confirm every concurrency bound has a free slot — WITHOUT taking one.
@@ -293,20 +295,25 @@ func (b *Budget) acquire(cat budgetCategory, keys budgetKeys) (func(), error) {
 	// 3. Tracking-bound check BEFORE any mutation, so a saturation refusal never
 	// leaves a partial charge (one rate rule recorded, a later one refused). If
 	// the brand-new rate buckets this acquire would add overflow the bound, evict
-	// stale buckets once; if that frees nothing, refuse. Refusing a new subject
-	// rather than growing unbounded is the safe direction under the threat model,
-	// exactly as the reveal gateLimiter decides it (admission evicts the oldest
-	// live entry instead — a deliberate divergence, since this map is shared
-	// across categories with a one-hour widest window).
-	newKeys := 0
-	for _, p := range pending {
-		if p.isNew {
-			newKeys++
+	// stale buckets once, then RECOUNT which pending keys are still absent — an
+	// eviction can drop a bucket a pending key names, making it newly absent — and
+	// refuse if they no longer fit. Refusing a new subject rather than growing
+	// unbounded is the safe direction under the threat model, exactly as the
+	// reveal gateLimiter decides it (admission evicts the oldest live entry
+	// instead — a deliberate divergence, since this map is shared across
+	// categories with a one-hour widest window).
+	countNew := func() int {
+		n := 0
+		for _, p := range pending {
+			if _, ok := b.rate[p.key]; !ok {
+				n++
+			}
 		}
+		return n
 	}
-	if newKeys > 0 && len(b.rate)+newKeys > budgetMaxTrackedSubjects {
+	if newKeys := countNew(); newKeys > 0 && len(b.rate)+newKeys > budgetMaxTrackedSubjects {
 		b.evictStaleRate(at)
-		if len(b.rate)+newKeys > budgetMaxTrackedSubjects {
+		if newKeys := countNew(); len(b.rate)+newKeys > budgetMaxTrackedSubjects {
 			return noopBudgetRelease, fmt.Errorf("%w: service: %s budget tracking saturated", admission.ErrOverloaded, cat.name)
 		}
 	}

--- a/internal/service/budget_classification.go
+++ b/internal/service/budget_classification.go
@@ -1,0 +1,173 @@
+package service
+
+import "github.com/Hikyo-Org/hikyo/internal/authz"
+
+// The §179 budget totality map: every authorization operation is classified as
+// carrying a NAMED expensive-path category, the fail-closed DEFAULT (an
+// expensive operation with no named category), or EXEMPT (not a §179 fan-out —
+// its frequency is governed by the §10 authenticated-API budget, or a tighter
+// mechanism named in the reason).
+//
+// This map is a LEDGER, not a dispatcher: the charge for a named or default
+// operation happens at that operation's own service method (there is no
+// once-per-operation post-authorization chokepoint — Authorize runs per-env and
+// per-page). What the map buys is the build-time guarantee the ops-spec demands
+// ("no path is unbudgeted by omission", §179): the conformance totality test
+// fails the build unless EVERY registered operation appears here exactly once,
+// so a new operation cannot be added without a deliberate budget decision. It is
+// the same shape as the metrics-label grep and the keyword-allowlist diff — an
+// omission is a red build, not a silent gap.
+
+type budgetClass int
+
+const (
+	// budgetClassNamed: charged by a named §179 category at its service method
+	// (export / publish / adapter sync / machine-fetch / schema-revision).
+	budgetClassNamed budgetClass = iota
+	// budgetClassDefaultExpensive: an expensive operation with no named category,
+	// charged the §179 fail-closed default (budgetDefaultConc + budgetDefaultRate)
+	// at its service method.
+	budgetClassDefaultExpensive
+	// budgetClassExempt: not a §179 expensive fan-out; the reason names what
+	// governs its frequency instead.
+	budgetClassExempt
+)
+
+type budgetClassification struct {
+	class  budgetClass
+	reason string
+}
+
+// operationBudgetClass classifies every authz operation. Exported for the
+// conformance totality test via BudgetClassOf; never consulted at runtime.
+var operationBudgetClass = buildBudgetClassification()
+
+// BudgetClassOf reports an operation's classification and whether it is known.
+// For the conformance totality test only.
+func BudgetClassOf(op authz.Operation) (reason string, known bool) {
+	c, ok := operationBudgetClass[op]
+	return c.reason, ok
+}
+
+func buildBudgetClassification() map[authz.Operation]budgetClassification {
+	m := map[authz.Operation]budgetClassification{}
+	add := func(class budgetClass, reason string, ops ...authz.Operation) {
+		for _, op := range ops {
+			if _, dup := m[op]; dup {
+				panic("service: operation classified twice in the budget totality map: " + string(op))
+			}
+			m[op] = budgetClassification{class, reason}
+		}
+	}
+
+	// ---- NAMED §179 categories (charged at the owning service method) ----
+	add(budgetClassNamed, "export §179: Audits.Export/InstanceExport (2/org·6/instance, 5/min·principal)",
+		authz.OpAuditExportOrg, authz.OpAuditExportProject, authz.OpAuditExportEnv, authz.OpAuditInstanceExport)
+	add(budgetClassNamed, "export §179: Revisions.Export (shares the export budget)",
+		authz.OpValueExport, authz.OpValueExportReveal, authz.OpValueExportRevealHistory)
+	add(budgetClassNamed, "publish §179: Revisions.PublishPlanned (4/org, 10/min·principal)",
+		authz.OpValuePublish)
+	add(budgetClassNamed, "adapter sync/trigger §179: SyncTarget + UpdateTarget enqueue (4/org, 10/min·principal)",
+		authz.OpAdapterSync, authz.OpAdapterConfigure)
+	add(budgetClassNamed, "machine-fetch §179: Delivery.FetchAs (300/min·org + 1000/min·instance)",
+		authz.OpDeliveryFetch)
+	add(budgetClassNamed, "schema-revision §151: chargeOnce before BumpSchemaRevision (60/h·project)",
+		authz.OpKeyCreate, authz.OpKeyRename, authz.OpKeyUpdateDeclaration, authz.OpKeyUpdateMetadata,
+		authz.OpKeySetGroup, authz.OpKeyDelete, authz.OpKeyReclassify,
+		authz.OpKeyGroupCreate, authz.OpKeyGroupRename, authz.OpKeyGroupDelete,
+		authz.OpEnvCreate, authz.OpEnvRename, authz.OpEnvDelete, authz.OpDefinitionsApply)
+
+	// ---- DEFAULT-EXPENSIVE (charged budgetDefault at the owning service method) ----
+	add(budgetClassDefaultExpensive, "crypto rewrap proportional to every stored/historical row",
+		authz.OpReencryptProject, authz.OpReencryptInstance)
+	add(budgetClassDefaultExpensive, "bulk value fan-out across environments/keys",
+		authz.OpValueImport, authz.OpImportPresence,
+		authz.OpValueCopySource, authz.OpValueCopyDestination, authz.OpValueCopyDestinationConfig)
+	add(budgetClassDefaultExpensive, "whole-project materialization / bulk offline flush",
+		authz.OpDefinitionsExport, authz.OpDeliveryReconcileOffline)
+
+	// ---- EXEMPT ----
+	add(budgetClassExempt, "SSE admission caps (§10, 4/32/128) own concurrency; per-event authz must not be budgeted",
+		authz.OpAdvisoryWatch, authz.OpAdvisoryEvent)
+	add(budgetClassExempt, "reveal ceremony + per-key gate limiter (GateAttemptsPerMinute) bound it",
+		authz.OpValueReveal)
+	add(budgetClassExempt, "paged audit read ≤1000/page (§2/§10)",
+		authz.OpAuditQueryOrg, authz.OpAuditQueryProject, authz.OpAuditQueryEnv, authz.OpAuditInstanceQuery)
+	add(budgetClassExempt, "outbox worker push; §12 outbox concurrency (1/target, 4/org) bounds it",
+		authz.OpAdapterPush)
+	add(budgetClassExempt, "key-hierarchy rotation (bounded: 1 root/1 master/N-project DEKs); the row-proportional rework is the separately-budgeted reencrypt (OpReencrypt*); §10 governs the trigger",
+		authz.OpRotateDEK, authz.OpRotateMasterKey, authz.OpRotateRootKey,
+		authz.OpRotateTokenKey, authz.OpRotateScanningKey)
+
+	// The large remainder: single-row or paged CRUD/reads and admin config
+	// mutations whose frequency is governed by the §10 authenticated-API budget
+	// (300/min per session, burst 600). None is a per-value or per-environment
+	// fan-out, so none earns the tighter §179 default.
+	add(budgetClassExempt, "§10 authenticated API 300/min per session; single-row/paged CRUD, not a §179 fan-out",
+		// orgs / projects / environments / folders (structure CRUD)
+		authz.OpOrgCreate, authz.OpOrgGet, authz.OpOrgList, authz.OpOrgRename, authz.OpOrgDelete,
+		authz.OpOrgRetentionRead, authz.OpOrgRetentionUpdate,
+		authz.OpProjectCreate, authz.OpProjectGet, authz.OpProjectList, authz.OpProjectRename, authz.OpProjectDelete,
+		authz.OpProjectRetentionRead, authz.OpProjectRetentionUpdate,
+		authz.OpProjectMachineRevealGet, authz.OpProjectMachineRevealSet,
+		authz.OpEnvRead, authz.OpEnvList, authz.OpEnvReorder, authz.OpEnvUpdateNote,
+		authz.OpEnvSettingsRead, authz.OpEnvSettingsUpdate,
+		authz.OpFolderCreate, authz.OpFolderGet, authz.OpFolderList, authz.OpFolderRename, authz.OpFolderDelete,
+		// key / key-group reads (the mutating ones are schema-revision above)
+		authz.OpKeyGet, authz.OpKeyList, authz.OpKeyDeclassify, authz.OpKeySecretRuleChange,
+		authz.OpKeyGroupGet, authz.OpKeyGroupList,
+		// definitions (non-apply, non-export): reads and single-plan writes
+		authz.OpDefinitionsCheck, authz.OpDefinitionsPlanCreate, authz.OpDefinitionsPlanGet,
+		authz.OpDefinitionsSettingsGet, authz.OpDefinitionsSettingsSet,
+		// values (non-export, non-copy, non-import, non-publish): single-cell reads/writes
+		authz.OpValueRead, authz.OpValueList, authz.OpValueSet, authz.OpValueClear,
+		authz.OpValueStage, authz.OpValuePendingList, authz.OpRevealWindowRead,
+		// revisions / pins: paged reads and single-revision restores
+		authz.OpRevisionList, authz.OpRevisionShow, authz.OpRevisionSignals,
+		authz.OpRevisionRestore, authz.OpRevisionRestoreHistory, authz.OpRevisionRestoreCurrent,
+		authz.OpPinSet, authz.OpPinSetHistory, authz.OpPinList, authz.OpPinRelease,
+		// grants
+		authz.OpGrantCreateEnv, authz.OpGrantCreateProject, authz.OpGrantCreateOrg, authz.OpGrantCreateInstance,
+		authz.OpGrantListProject, authz.OpGrantListOrg, authz.OpGrantListInstance,
+		authz.OpGrantRevokeEnv, authz.OpGrantRevokeProject, authz.OpGrantRevokeOrg, authz.OpGrantRevokeInstance,
+		// machine identities / credentials / bindings / service accounts
+		authz.OpServiceAccountCreate, authz.OpServiceAccountList, authz.OpServiceAccountDelete,
+		authz.OpCredentialMint, authz.OpCredentialList, authz.OpCredentialRevoke,
+		authz.OpCredentialReset, authz.OpCredentialResetInstance,
+		authz.OpCredentialPolicyRead, authz.OpCredentialPolicyUpdate,
+		authz.OpBindingCreate,
+		// federation issuers
+		authz.OpFederationIssuerCreate, authz.OpFederationIssuerList,
+		authz.OpFederationIssuerUpdate, authz.OpFederationIssuerDelete,
+		// providers (OIDC)
+		authz.OpProviderGet, authz.OpProviderList, authz.OpProviderPut, authz.OpProviderDelete,
+		// SAML providers + SP keys
+		authz.OpSAMLProviderGet, authz.OpSAMLProviderList, authz.OpSAMLProviderPut,
+		authz.OpSAMLProviderPatch, authz.OpSAMLProviderDelete, authz.OpSAMLProviderRefreshMetadata,
+		authz.OpSAMLSPKeyList, authz.OpSAMLSPKeyRotate, authz.OpSAMLSPKeyRetire, authz.OpSAMLSPKeyCompromiseRetire,
+		// SCIM (provisioning bindings, credentials, mappings, and the provisioning verbs)
+		authz.OpSCIMBindingCreate, authz.OpSCIMBindingGet, authz.OpSCIMBindingList, authz.OpSCIMBindingDelete,
+		authz.OpSCIMCredentialMint, authz.OpSCIMCredentialGet, authz.OpSCIMCredentialList, authz.OpSCIMCredentialRevoke,
+		authz.OpSCIMMappingCreate, authz.OpSCIMMappingList, authz.OpSCIMMappingUpdate, authz.OpSCIMMappingDelete,
+		authz.OpSCIMUserCreate, authz.OpSCIMUserGet, authz.OpSCIMUserList, authz.OpSCIMUserPatch,
+		authz.OpSCIMUserReplace, authz.OpSCIMUserDelete,
+		authz.OpSCIMGroupCreate, authz.OpSCIMGroupGet, authz.OpSCIMGroupList, authz.OpSCIMGroupPatch,
+		authz.OpSCIMGroupReplace, authz.OpSCIMGroupDelete,
+		authz.OpSCIMDirectoryUsers, authz.OpSCIMDirectoryGroups, authz.OpSCIMDiscovery, authz.OpSCIMUnsupported,
+		// remotes (multi-instance directory) + workspace origins
+		authz.OpRemoteAdd, authz.OpRemoteList, authz.OpRemoteShow, authz.OpRemoteRename, authz.OpRemoteRemove,
+		authz.OpRemoteDirectoryServe,
+		authz.OpRemoteCredentialCreate, authz.OpRemoteCredentialList,
+		authz.OpRemoteCredentialShow, authz.OpRemoteCredentialRevoke,
+		authz.OpWorkspaceOriginAdd, authz.OpWorkspaceOriginList, authz.OpWorkspaceOriginRemove,
+		// adapters: config / inspect / test / plan / adopt / delete / credential (non-sync)
+		authz.OpAdapterAdopt, authz.OpAdapterDelete, authz.OpAdapterInspect, authz.OpAdapterPlan,
+		authz.OpAdapterTest, authz.OpAdapterCredentialSet, authz.OpAdapterCredentialRevoke,
+		// templates
+		authz.OpTemplateApplyEnv, authz.OpTemplateApplyProject, authz.OpTemplateApplyOrg, authz.OpTemplateApplyInstance,
+		// retention health read
+		authz.OpRetentionHealthRead,
+	)
+
+	return m
+}

--- a/internal/service/budget_classification.go
+++ b/internal/service/budget_classification.go
@@ -81,7 +81,7 @@ func buildBudgetClassification() map[authz.Operation]budgetClassification {
 	add(budgetClassDefaultExpensive, "crypto rewrap proportional to every stored/historical row",
 		authz.OpReencryptProject, authz.OpReencryptInstance)
 	add(budgetClassDefaultExpensive, "bulk value fan-out across environments/keys",
-		authz.OpValueImport, authz.OpImportPresence,
+		authz.OpValueImport,
 		authz.OpValueCopySource, authz.OpValueCopyDestination, authz.OpValueCopyDestinationConfig)
 	add(budgetClassDefaultExpensive, "whole-project materialization / bulk offline flush",
 		authz.OpDefinitionsExport, authz.OpDeliveryReconcileOffline)
@@ -113,6 +113,9 @@ func buildBudgetClassification() map[authz.Operation]budgetClassification {
 		authz.OpEnvRead, authz.OpEnvList, authz.OpEnvReorder, authz.OpEnvUpdateNote,
 		authz.OpEnvSettingsRead, authz.OpEnvSettingsUpdate,
 		authz.OpFolderCreate, authz.OpFolderGet, authz.OpFolderList, authz.OpFolderRename, authz.OpFolderDelete,
+		// import presence/occurrence PREVIEW (Values.Occurrences); the bulk write
+		// authorizes OpValueImport (default-expensive) which carries the charge
+		authz.OpImportPresence,
 		// key / key-group reads (the mutating ones are schema-revision above)
 		authz.OpKeyGet, authz.OpKeyList, authz.OpKeyDeclassify, authz.OpKeySecretRuleChange,
 		authz.OpKeyGroupGet, authz.OpKeyGroupList,

--- a/internal/service/budget_classification.go
+++ b/internal/service/budget_classification.go
@@ -84,7 +84,9 @@ func buildBudgetClassification() map[authz.Operation]budgetClassification {
 		authz.OpValueImport,
 		authz.OpValueCopySource, authz.OpValueCopyDestination, authz.OpValueCopyDestinationConfig)
 	add(budgetClassDefaultExpensive, "whole-project materialization / bulk offline flush",
-		authz.OpDefinitionsExport, authz.OpDeliveryReconcileOffline)
+		authz.OpDefinitionsExport, authz.OpDefinitionsCheck, authz.OpDeliveryReconcileOffline)
+	add(budgetClassDefaultExpensive, "master-key rotation rewraps every project DEK (project-proportional)",
+		authz.OpRotateMasterKey)
 
 	// ---- EXEMPT ----
 	add(budgetClassExempt, "SSE admission caps (§10, 4/32/128) own concurrency; per-event authz must not be budgeted",
@@ -95,8 +97,8 @@ func buildBudgetClassification() map[authz.Operation]budgetClassification {
 		authz.OpAuditQueryOrg, authz.OpAuditQueryProject, authz.OpAuditQueryEnv, authz.OpAuditInstanceQuery)
 	add(budgetClassExempt, "outbox worker push; §12 outbox concurrency (1/target, 4/org) bounds it",
 		authz.OpAdapterPush)
-	add(budgetClassExempt, "key-hierarchy rotation (bounded: 1 root/1 master/N-project DEKs); the row-proportional rework is the separately-budgeted reencrypt (OpReencrypt*); §10 governs the trigger",
-		authz.OpRotateDEK, authz.OpRotateMasterKey, authz.OpRotateRootKey,
+	add(budgetClassExempt, "O(1) key-hierarchy rotation (one DEK / the master / one token key); the row-proportional rework is the separately-budgeted reencrypt (OpReencrypt*). Master-key rotation, which rewraps every project DEK, is default-expensive above",
+		authz.OpRotateDEK, authz.OpRotateRootKey,
 		authz.OpRotateTokenKey, authz.OpRotateScanningKey)
 
 	// The large remainder: single-row or paged CRUD/reads and admin config
@@ -119,8 +121,8 @@ func buildBudgetClassification() map[authz.Operation]budgetClassification {
 		// key / key-group reads (the mutating ones are schema-revision above)
 		authz.OpKeyGet, authz.OpKeyList, authz.OpKeyDeclassify, authz.OpKeySecretRuleChange,
 		authz.OpKeyGroupGet, authz.OpKeyGroupList,
-		// definitions (non-apply, non-export): reads and single-plan writes
-		authz.OpDefinitionsCheck, authz.OpDefinitionsPlanCreate, authz.OpDefinitionsPlanGet,
+		// definitions (non-apply, non-export, non-check): single-plan writes and reads
+		authz.OpDefinitionsPlanCreate, authz.OpDefinitionsPlanGet,
 		authz.OpDefinitionsSettingsGet, authz.OpDefinitionsSettingsSet,
 		// values (non-export, non-copy, non-import, non-publish): single-cell reads/writes
 		authz.OpValueRead, authz.OpValueList, authz.OpValueSet, authz.OpValueClear,

--- a/internal/service/budget_test.go
+++ b/internal/service/budget_test.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"errors"
+	"io"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+// clock is a settable time source for the windowed-rate curves, which are
+// otherwise untestable without sleeping a full window (schema-rev is 60/hour).
+type clock struct{ t time.Time }
+
+func (c *clock) now() time.Time { return c.t }
+func (c *clock) add(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
+func newTestBudget(c *clock) *Budget {
+	b := NewBudget()
+	b.now = c.now
+	return b
+}
+
+func principalKeys(p, org, project string) budgetKeys {
+	return budgetKeys{Principal: domain.PrincipalID(p), Org: domain.OrgID(org), Project: domain.ProjectID(project)}
+}
+
+func TestBudgetRateWindowSlides(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+	keys := principalKeys("p1", "org1", "proj1")
+
+	// schema-revision: 60/hour per project. 60 pass, the 61st refuses.
+	for i := range BudgetSchemaRevisionPerHour {
+		if _, err := b.acquire(budgetSchemaRevision, keys); err != nil {
+			t.Fatalf("charge %d/%d refused early: %v", i+1, BudgetSchemaRevisionPerHour, err)
+		}
+	}
+	_, err := b.acquire(budgetSchemaRevision, keys)
+	if !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("61st schema revision = %v, want ErrOverloaded", err)
+	}
+
+	// A different project is an independent bucket.
+	if _, err := b.acquire(budgetSchemaRevision, principalKeys("p1", "org1", "proj2")); err != nil {
+		t.Fatalf("other project refused: %v", err)
+	}
+
+	// After the window elapses, the first project is admitted again.
+	c.add(time.Hour + time.Second)
+	if _, err := b.acquire(budgetSchemaRevision, keys); err != nil {
+		t.Fatalf("after window: %v", err)
+	}
+}
+
+func TestBudgetConcurrencyReleases(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+	keys := principalKeys("p1", "org1", "proj1")
+
+	// export: 2 concurrent per org. Hold both slots.
+	rel1, err := b.acquire(budgetExport, keys)
+	if err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	// A second principal in the same org takes the second org slot.
+	rel2, err := b.acquire(budgetExport, principalKeys("p2", "org1", "proj1"))
+	if err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+	// The third concurrent export in the org is refused on the org bound.
+	if _, err := b.acquire(budgetExport, principalKeys("p3", "org1", "proj1")); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("third concurrent export = %v, want ErrOverloaded", err)
+	}
+	// Releasing one frees a slot.
+	rel1()
+	if _, err := b.acquire(budgetExport, principalKeys("p3", "org1", "proj1")); err != nil {
+		t.Fatalf("after release: %v", err)
+	}
+	rel2()
+
+	// release is idempotent: a double call must not under-count and let an
+	// extra concurrent op slip past the bound later.
+	rel1()
+}
+
+func TestBudgetInstanceConcurrencyIsSeparateFromOrg(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+
+	// export instance bound is 6; org bound is 2. Six exports across three orgs
+	// (two each) fill the instance bound without any org tripping first. Each
+	// export uses a distinct principal so the per-principal 5/min rate never
+	// fires first — this test is about the concurrency dimensions.
+	var rels []func()
+	for _, org := range []string{"orgA", "orgB", "orgC"} {
+		for p := range BudgetExportOrgConcurrency {
+			rel, err := b.acquire(budgetExport, principalKeys(org+strconv.Itoa(p), org, "proj"))
+			if err != nil {
+				t.Fatalf("export org=%s #%d: %v", org, p, err)
+			}
+			rels = append(rels, rel)
+		}
+	}
+	if len(rels) != BudgetExportInstanceConcurrency {
+		t.Fatalf("filled %d slots, want %d", len(rels), BudgetExportInstanceConcurrency)
+	}
+	// A fresh org with free org slots is still refused on the instance bound.
+	if _, err := b.acquire(budgetExport, principalKeys("p", "orgD", "proj")); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("7th instance-wide export = %v, want ErrOverloaded", err)
+	}
+	for _, rel := range rels {
+		rel()
+	}
+}
+
+func TestBudgetInstanceExportIgnoresOrgBound(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+
+	// InstanceExport carries no org, so it is bounded only by 6/instance — the
+	// org bound must not collapse all instance exports into a shared "" bucket
+	// of 2. Distinct principals keep the per-principal 5/min rate out of the way.
+	var rels []func()
+	for i := range BudgetExportInstanceConcurrency {
+		rel, err := b.acquire(budgetExportInstance, budgetKeys{Principal: domain.PrincipalID("admin" + strconv.Itoa(i))})
+		if err != nil {
+			t.Fatalf("instance export #%d: %v", i, err)
+		}
+		rels = append(rels, rel)
+	}
+	if _, err := b.acquire(budgetExportInstance, budgetKeys{Principal: domain.PrincipalID("adminX")}); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("7th instance export = %v, want ErrOverloaded", err)
+	}
+	for _, rel := range rels {
+		rel()
+	}
+}
+
+func TestBudgetRefusalDoesNotConsumeRate(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+
+	// Fill the org concurrency bound, then hammer it. A refusal on the
+	// concurrency bound must not also burn the principal's rate allowance —
+	// otherwise a caller blocked by a busy org would additionally be rate-locked
+	// out for the window, a double penalty for one refused op.
+	rel1, _ := b.acquire(budgetExport, principalKeys("p1", "org1", "proj"))
+	rel2, _ := b.acquire(budgetExport, principalKeys("p2", "org1", "proj"))
+	for range 100 {
+		if _, err := b.acquire(budgetExport, principalKeys("p3", "org1", "proj")); !errors.Is(err, admission.ErrOverloaded) {
+			t.Fatalf("expected concurrency refusal, got %v", err)
+		}
+	}
+	rel1()
+	rel2()
+	// p3 never got a slot, so its 5/min rate must be untouched. Acquire+release
+	// sequentially so the org concurrency slot frees each time and only the rate
+	// curve is exercised: exactly 5 succeed, the 6th trips the rate.
+	for i := range BudgetExportRatePerMin {
+		rel, err := b.acquire(budgetExport, principalKeys("p3", "org1", "proj"))
+		if err != nil {
+			t.Fatalf("p3 rate charge %d refused; concurrency refusals leaked into rate: %v", i+1, err)
+		}
+		rel()
+	}
+	if _, err := b.acquire(budgetExport, principalKeys("p3", "org1", "proj")); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("p3 6th charge = %v, want rate ErrOverloaded", err)
+	}
+}
+
+func TestBudgetMachineFetchAggregates(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+
+	// 300/min per org. The org bound trips before the 1000/min instance bound.
+	for i := range BudgetMachineFetchOrgPerMin {
+		if _, err := b.acquire(budgetMachineFetch, budgetKeys{Org: domain.OrgID("org1")}); err != nil {
+			t.Fatalf("machine fetch %d refused early: %v", i+1, err)
+		}
+	}
+	if _, err := b.acquire(budgetMachineFetch, budgetKeys{Org: domain.OrgID("org1")}); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("301st org fetch = %v, want ErrOverloaded", err)
+	}
+}
+
+func TestBudgetFailClosedDefault(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+	keys := principalKeys("p1", "org1", "proj")
+
+	// An unnamed category inherits the fail-closed default: 60/min per principal.
+	// Acquire+release each so the 8/org concurrency bound never fires first.
+	for i := range BudgetDefaultRatePerMin {
+		rel, err := b.acquire(budgetDefault, keys)
+		if err != nil {
+			t.Fatalf("default charge %d refused early: %v", i+1, err)
+		}
+		rel()
+	}
+	if _, err := b.acquire(budgetDefault, keys); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("61st default = %v, want ErrOverloaded", err)
+	}
+}
+
+// TestAuditExportChargesExpensiveBudget proves the WIRING (the registry fixture
+// for ops-spec § 20 / § 179 "audit exports 2/org · 6/instance"): Audits.Export
+// consults the shared budget before touching the store, and a caller that finds
+// the org's two concurrency slots full is refused with the uniform overload
+// error — so the refusal renders the same 429 + Retry-After every other
+// overflow does. The DB is nil on purpose: the acquire precedes every store
+// access, so reaching it would be the bug.
+func TestAuditExportChargesExpensiveBudget(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+	scope := domain.Scope{Org: "org1", Project: "proj1"}
+
+	// Occupy the org's two export concurrency slots with other principals.
+	rel1, err := b.acquire(budgetExport, budgetKeys{Principal: "other1", Org: scope.Org})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel2, err := b.acquire(budgetExport, budgetKeys{Principal: "other2", Org: scope.Org})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	audits := &Audits{Budget: b}
+	err = audits.Export(t.Context(), "me", scope, store.AuditFilter{}, 100, io.Discard)
+	if !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("audit export with a full org budget = %v, want ErrOverloaded", err)
+	}
+
+	rel1()
+	rel2()
+
+	// Instance export is bounded by 6/instance, keyed with no org: fill the six
+	// instance slots and the next is refused the same way.
+	var rels []func()
+	for i := range BudgetExportInstanceConcurrency {
+		rel, err := b.acquire(budgetExportInstance, budgetKeys{Principal: domain.PrincipalID("filler" + strconv.Itoa(i))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rels = append(rels, rel)
+	}
+	if err := audits.InstanceExport(t.Context(), "me", store.AuditFilter{}, 100, io.Discard); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("instance export with a full instance budget = %v, want ErrOverloaded", err)
+	}
+	for _, rel := range rels {
+		rel()
+	}
+}
+
+func TestBudgetNilIsNoop(t *testing.T) {
+	var b *Budget
+	rel, err := b.acquire(budgetExport, principalKeys("p", "o", "pr"))
+	if err != nil {
+		t.Fatalf("nil budget refused: %v", err)
+	}
+	rel() // must not panic
+}

--- a/internal/service/budget_test.go
+++ b/internal/service/budget_test.go
@@ -270,6 +270,50 @@ func TestBudgetChargeOnceIsRetryIdempotent(t *testing.T) {
 	}
 }
 
+// TestBudgetDefaultEnforces proves the §179 fail-closed default category: the
+// per-principal rate (60/min) and per-org concurrency (8) that a
+// default-expensive operation charges. Its three variants (combined, conc-only,
+// rate-only) share the one "default" bucket set, so the split used at call sites
+// composes with the combined one reencrypt uses.
+func TestBudgetDefaultEnforces(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+
+	// Concurrency: 8 per org, via the conc-only variant. A ninth is refused.
+	var rels []func()
+	for i := range BudgetDefaultOrgConcurrency {
+		rel, err := b.acquire(budgetDefaultConc, budgetKeys{Org: "org1"})
+		if err != nil {
+			t.Fatalf("default conc %d refused early: %v", i+1, err)
+		}
+		rels = append(rels, rel)
+	}
+	if _, err := b.acquire(budgetDefaultConc, budgetKeys{Org: "org1"}); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("9th concurrent default op = %v, want ErrOverloaded", err)
+	}
+	for _, rel := range rels {
+		rel()
+	}
+
+	// Rate: 60/min per principal, via the rate-only variant. The 61st is refused,
+	// and the combined variant reencrypt uses draws from the SAME bucket.
+	var charged bool
+	for i := 1; i < BudgetDefaultRatePerMin; i++ {
+		var one bool
+		if err := b.chargeOnce(&one, budgetDefaultRate, budgetKeys{Principal: "p1"}); err != nil {
+			t.Fatalf("default rate charge %d refused early: %v", i, err)
+		}
+	}
+	// One combined acquire (reencrypt's path) fills the 60th slot for the same
+	// principal; the next is refused whichever variant asks.
+	if _, err := b.acquire(budgetDefault, budgetKeys{Principal: "p1", Org: "org2"}); err != nil {
+		t.Fatalf("combined default acquire (60th) refused: %v", err)
+	}
+	if err := b.chargeOnce(&charged, budgetDefaultRate, budgetKeys{Principal: "p1"}); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("61st default rate = %v, want ErrOverloaded across shared bucket", err)
+	}
+}
+
 func TestBudgetNilIsNoop(t *testing.T) {
 	var b *Budget
 	rel, err := b.acquire(budgetExport, principalKeys("p", "o", "pr"))

--- a/internal/service/budget_test.go
+++ b/internal/service/budget_test.go
@@ -190,25 +190,6 @@ func TestBudgetMachineFetchAggregates(t *testing.T) {
 	}
 }
 
-func TestBudgetFailClosedDefault(t *testing.T) {
-	c := &clock{t: time.Unix(1_700_000_000, 0)}
-	b := newTestBudget(c)
-	keys := principalKeys("p1", "org1", "proj")
-
-	// An unnamed category inherits the fail-closed default: 60/min per principal.
-	// Acquire+release each so the 8/org concurrency bound never fires first.
-	for i := range BudgetDefaultRatePerMin {
-		rel, err := b.acquire(budgetDefault, keys)
-		if err != nil {
-			t.Fatalf("default charge %d refused early: %v", i+1, err)
-		}
-		rel()
-	}
-	if _, err := b.acquire(budgetDefault, keys); !errors.Is(err, admission.ErrOverloaded) {
-		t.Fatalf("61st default = %v, want ErrOverloaded", err)
-	}
-}
-
 // TestAuditExportChargesExpensiveBudget proves the WIRING (the registry fixture
 // for ops-spec § 20 / § 179 "audit exports 2/org · 6/instance"): Audits.Export
 // consults the shared budget before touching the store, and a caller that finds

--- a/internal/service/budget_test.go
+++ b/internal/service/budget_test.go
@@ -258,6 +258,37 @@ func TestAuditExportChargesExpensiveBudget(t *testing.T) {
 	}
 }
 
+// TestBudgetChargeOnceIsRetryIdempotent proves the in-tx per-principal rate
+// charge (publish/values-export/adapter) is not multiplied by the transaction
+// retry loop: a single operation whose closure runs several times charges the
+// rate exactly once, so the 4× retry envelope cannot burn four rate slots.
+func TestBudgetChargeOnceIsRetryIdempotent(t *testing.T) {
+	c := &clock{t: time.Unix(1_700_000_000, 0)}
+	b := newTestBudget(c)
+	keys := budgetKeys{Principal: "p1"}
+
+	// One operation, whose closure the retry loop replays four times.
+	var charged bool
+	for range 4 {
+		if err := b.chargeOnce(&charged, budgetPublishRate, keys); err != nil {
+			t.Fatalf("chargeOnce refused within one operation's retries: %v", err)
+		}
+	}
+
+	// Only ONE hit landed, so the principal's 10/min publish rate still has 9
+	// left: nine more distinct operations succeed, the eleventh total is refused.
+	for i := 1; i < BudgetPublishRatePerMin; i++ {
+		var c2 bool
+		if err := b.chargeOnce(&c2, budgetPublishRate, keys); err != nil {
+			t.Fatalf("operation %d refused; retries leaked into the rate: %v", i+1, err)
+		}
+	}
+	var last bool
+	if err := b.chargeOnce(&last, budgetPublishRate, keys); !errors.Is(err, admission.ErrOverloaded) {
+		t.Fatalf("11th publish operation = %v, want rate ErrOverloaded", err)
+	}
+}
+
 func TestBudgetNilIsNoop(t *testing.T) {
 	var b *Budget
 	rel, err := b.acquire(budgetExport, principalKeys("p", "o", "pr"))
@@ -265,4 +296,9 @@ func TestBudgetNilIsNoop(t *testing.T) {
 		t.Fatalf("nil budget refused: %v", err)
 	}
 	rel() // must not panic
+	// chargeOnce must also be nil-safe (a build that wires no budget).
+	var charged bool
+	if err := b.chargeOnce(&charged, budgetPublishRate, budgetKeys{Principal: "p"}); err != nil {
+		t.Fatalf("nil budget chargeOnce refused: %v", err)
+	}
 }

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -38,6 +38,9 @@ type Definitions struct {
 	DB       *store.DB
 	Keyring  *crypto.Keyring
 	Advisory *Advisory
+	// Budget applies the § 151 schema-revision rate limit (60/h per project) to
+	// the definitions-apply path, via prepareSchemaPublish. Nil disables it.
+	Budget *Budget
 	// Scan is the secret-scanning Surface-2 seam (#74 SS3, ADR §7 (b)/(c)): the
 	// plan/apply chokepoints scan every author-controlled bundle leaf before an
 	// immutable plan persists (plan) and re-scan on ruleset-snapshot skew (apply),

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -161,7 +161,7 @@ func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scop
 	// §179 fail-closed default: a whole-project bundle materialization with no
 	// named category. Authorized-then-acquired at entry (rate + concurrency), so
 	// an unauthorized caller cannot occupy the org's slots by guessing its id.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsExport, scope, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsExport, authz.OpDefinitionsExport, scope, s.now)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (s *Definitions) Check(ctx context.Context, actor Actor, scope domain.Scope
 	// every key/presence/group/environment and parses every declaration, plus
 	// scans the submitted bundle — the same fan-out Export is, so it takes the
 	// same default budget (authorized-then-acquired at entry).
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsCheck, scope, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsCheck, authz.OpDefinitionsCheck, scope, s.now)
 	if err != nil {
 		return CheckResult{}, err
 	}

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -158,14 +158,26 @@ type DefinitionsSettings struct {
 // the server-owned ids and the base revision, producing a template that applies
 // cleanly to a fresh instance.
 func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scope, portable bool) ([]byte, error) {
+	// §179 fail-closed default: a whole-project bundle materialization with no
+	// named category. Concurrency (8/org) at entry, per-principal rate (60/min)
+	// in-tx once the principal resolves — the publish split.
+	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	var out []byte
-	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+	var rateCharged bool
+	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
 			return err
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsExport, scope)
 		if err != nil {
+			return err
+		}
+		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -159,15 +159,14 @@ type DefinitionsSettings struct {
 // cleanly to a fresh instance.
 func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scope, portable bool) ([]byte, error) {
 	// §179 fail-closed default: a whole-project bundle materialization with no
-	// named category. Concurrency (8/org) at entry, per-principal rate (60/min)
-	// in-tx once the principal resolves — the publish split.
-	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	// named category. Authorized-then-acquired at entry (rate + concurrency), so
+	// an unauthorized caller cannot occupy the org's slots by guessing its id.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsExport, scope, s.now)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
 	var out []byte
-	var rateCharged bool
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
@@ -175,9 +174,6 @@ func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scop
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsExport, scope)
 		if err != nil {
-			return err
-		}
-		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)
@@ -198,8 +194,17 @@ func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scop
 // Check classifies drift between a submitted bundle and current state, with no
 // persistence. It is the diagnostic; plan is the gate.
 func (s *Definitions) Check(ctx context.Context, actor Actor, scope domain.Scope, raw []byte) (CheckResult, error) {
+	// §179 fail-closed default: Check materializes the whole project state, lists
+	// every key/presence/group/environment and parses every declaration, plus
+	// scans the submitted bundle — the same fan-out Export is, so it takes the
+	// same default budget (authorized-then-acquired at entry).
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDefinitionsCheck, scope, s.now)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	defer release()
 	var res CheckResult
-	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
 			return err

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -47,7 +47,7 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 		return ApplyResult{}, err
 	}
 
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpDefinitionsApply, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpDefinitionsApply, scope)
 	if err != nil {
 		return ApplyResult{}, err
 	}

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -47,12 +47,13 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 		return ApplyResult{}, err
 	}
 
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpDefinitionsApply, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpDefinitionsApply, scope)
 	if err != nil {
 		return ApplyResult{}, err
 	}
 
 	var result ApplyResult
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		now := s.now()
 		caller, err := actor.resolve(ctx, az, now)
@@ -113,6 +114,12 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 		}
 
 		if err := s.executeResolution(ctx, r, az, caller, p, scope, res, cur, cur.SchemaRevision+1); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: charged only for a non-empty plan (the
+		// empty-plan no-op returned above), once across the retry loop — see
+		// Keys.UpdateMetadata.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -162,7 +162,11 @@ type Delivery struct {
 	// opens. Nil means only bearer credentials may fetch, which is what a build
 	// that did not wire federation should do.
 	Federation *Federation
-	Now        func() time.Time
+	// Budget applies the § 179 machine-fetch aggregate rate: 300/min per org,
+	// 1000/min per instance, on top of § 5's per-principal fetch rate. Nil
+	// disables it.
+	Budget *Budget
+	Now    func() time.Time
 	// FetchProbe is a conformance-only retry seam. Production leaves it nil;
 	// it is invoked immediately after attempt-local response state is reset.
 	FetchProbe DeliveryConformanceProbe
@@ -261,6 +265,14 @@ func (s *Delivery) FetchAs(ctx context.Context, actor Actor, scope domain.Scope,
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpDeliveryFetch, scope)
 	if err != nil {
 		return FetchResult{}, s.recordUnbound(ctx, actor, err)
+	}
+	// § 179 machine-fetch aggregates: 300/min per org, 1000/min per instance (on
+	// top of § 5's per-principal fetch rate). Charged AFTER sealerFor authorizes,
+	// so an unauthenticated caller cannot burn a target org's fetch budget by
+	// guessing its id — the same authorize-first property the reveal gate keeps.
+	// Rate-only, so the release is a no-op.
+	if _, err := s.Budget.acquire(budgetMachineFetch, budgetKeys{Org: scope.Org}); err != nil {
+		return FetchResult{}, err
 	}
 
 	var out FetchResult

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -554,15 +554,14 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 	}
 
 	// §179 fail-closed default: a bulk offline-record flush (up to 1000 records)
-	// with no named category. Concurrency (8/org) at entry, per-principal rate
-	// (60/min) in-tx.
-	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	// with no named category. Authorized-then-acquired at entry (rate +
+	// concurrency), so an unauthorized caller cannot occupy the org's slots.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDeliveryReconcileOffline, scope, s.now)
 	if err != nil {
 		return ReconcileResult{}, err
 	}
 	defer release()
 	var out ReconcileResult
-	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = ReconcileResult{}
 		caller, err := actor.resolve(ctx, az, s.now())
@@ -571,9 +570,6 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpDeliveryReconcileOffline, scope)
 		if err != nil {
-			return err
-		}
-		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		// A production presenter is a machine credential. Resolve every credential

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -556,7 +556,7 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 	// §179 fail-closed default: a bulk offline-record flush (up to 1000 records)
 	// with no named category. Authorized-then-acquired at entry (rate +
 	// concurrency), so an unauthorized caller cannot occupy the org's slots.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDeliveryReconcileOffline, scope, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpDeliveryReconcileOffline, authz.OpDeliveryReconcileOffline, scope, s.now)
 	if err != nil {
 		return ReconcileResult{}, err
 	}

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -553,8 +553,17 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 		}
 	}
 
+	// §179 fail-closed default: a bulk offline-record flush (up to 1000 records)
+	// with no named category. Concurrency (8/org) at entry, per-principal rate
+	// (60/min) in-tx.
+	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+	defer release()
 	var out ReconcileResult
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	var rateCharged bool
+	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = ReconcileResult{}
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
@@ -562,6 +571,9 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpDeliveryReconcileOffline, scope)
 		if err != nil {
+			return err
+		}
+		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		// A production presenter is a machine credential. Resolve every credential

--- a/internal/service/hierarchy.go
+++ b/internal/service/hierarchy.go
@@ -637,6 +637,11 @@ type Environments struct {
 	Auth *Auth
 	// Advisory announces the new environment's revision 1, after commit.
 	Advisory *Advisory
+	// Budget applies the § 151 schema-revision rate limit (60/h per project):
+	// creating, renaming or deleting an environment bumps the project's schema
+	// revision, so it charges the same per-project budget key-catalogue edits do.
+	// Nil disables it.
+	Budget *Budget
 	// Scan: secret-scanning Surface-2 seam (#74). Environment names and notes
 	// are author-controlled declaration text.
 	Scan *scanning.Ruleset
@@ -713,6 +718,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 	var created store.NewEnvironment
 	var clone CloneResult
 	var published PublishedEnvironment
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		clone = CloneResult{}
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
@@ -763,6 +769,13 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 			CreatedAt:    store.CanonTime(time.Now()),
 		}
 		if err := r.Environments().Create(ctx, p, created); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: an environment create advances the project's
+		// schema revision, so it charges the same per-project budget (see
+		// Keys.UpdateMetadata) — a delete/recreate loop must not mint revisions
+		// past the bound.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		// The environment list is definitions-bundle desired state, so its change
@@ -864,6 +877,7 @@ func (s *Environments) Rename(ctx context.Context, actor Actor, scope domain.Sco
 		return Environment{}, err
 	}
 	var out store.Environment
+	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -889,6 +903,11 @@ func (s *Environments) Rename(ctx context.Context, actor Actor, scope domain.Sco
 			return err
 		}
 		if err := r.Environments().Rename(ctx, p, name); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: a rename advances the project's schema
+		// revision (see Environments.create).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		// The environment name is definitions-bundle desired state, so a rename
@@ -1005,6 +1024,7 @@ func (s *Environments) Reorder(ctx context.Context, actor Actor, scope domain.Sc
 // the set, so a gap is not a defect and closing it would be an unrequested
 // write to rows the operator did not name.
 func (s *Environments) Delete(ctx context.Context, actor Actor, scope domain.Scope) error {
+	var rateCharged bool
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1063,6 +1083,12 @@ func (s *Environments) Delete(ctx context.Context, actor Actor, scope domain.Sco
 			return err
 		}
 		if err := r.Environments().Delete(ctx, p); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: a delete advances the project's schema
+		// revision (see Environments.create) — the other half of the
+		// delete/recreate loop that would otherwise mint revisions unbounded.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		// The environment list is definitions-bundle desired state, so its

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -342,7 +342,7 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 	// §179 fail-closed default: a bulk value fan-out with no named category.
 	// Authorized-then-acquired at entry (rate + concurrency), so an unauthorized
 	// caller cannot occupy the org's slots by guessing its id.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueImport, scope, func() time.Time { return time.Now().UTC() })
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueImport, authz.OpValueImport, scope, func() time.Time { return time.Now().UTC() })
 	if err != nil {
 		return ImportResult{}, err
 	}

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -340,8 +340,9 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		return ImportResult{}, err
 	}
 	// §179 fail-closed default: a bulk value fan-out with no named category.
-	// Concurrency (8/org) at entry, per-principal rate (60/min) in-tx.
-	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	// Authorized-then-acquired at entry (rate + concurrency), so an unauthorized
+	// caller cannot occupy the org's slots by guessing its id.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueImport, scope, func() time.Time { return time.Now().UTC() })
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -354,7 +355,6 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 	var result ImportResult
 	var published PublishedEnvironment
 	advanced := false
-	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		result = ImportResult{}
 		published = PublishedEnvironment{}
@@ -366,9 +366,6 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpValueImport, scope)
 		if err != nil {
-			return err
-		}
-		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		if err := r.Projects().Lock(ctx, p); err != nil {

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -339,6 +339,13 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 	if err != nil {
 		return ImportResult{}, err
 	}
+	// §179 fail-closed default: a bulk value fan-out with no named category.
+	// Concurrency (8/org) at entry, per-principal rate (60/min) in-tx.
+	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return ImportResult{}, err
+	}
+	defer release()
 	overwrite := make(map[string]bool, len(req.Overwrite))
 	for _, name := range req.Overwrite {
 		overwrite[name] = true
@@ -347,6 +354,7 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 	var result ImportResult
 	var published PublishedEnvironment
 	advanced := false
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		result = ImportResult{}
 		published = PublishedEnvironment{}
@@ -358,6 +366,9 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpValueImport, scope)
 		if err != nil {
+			return err
+		}
+		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		if err := r.Projects().Lock(ctx, p); err != nil {

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -869,6 +869,7 @@ func (s *Keys) UpdateMetadata(ctx context.Context, actor Actor, scope domain.Sco
 		}
 	}
 	var out Key
+	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -906,6 +907,15 @@ func (s *Keys) UpdateMetadata(ctx context.Context, actor Actor, scope domain.Sco
 			return err
 		}
 		if err := r.Catalogue().UpdateMetadata(ctx, p, id, merged); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate (60/h per project): a metadata change bumps
+		// the revision, so it is a revision and must charge the same per-project
+		// budget key create/rename/declaration edits do — otherwise a script
+		// alternates metadata to mint revisions past the bound. Charged only on
+		// the mutating path (the no-op above returned already) and once across
+		// the retry loop, keyed by project.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
@@ -1506,6 +1516,7 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 		return KeyGroupView{}, err
 	}
 	created := store.CanonTime(time.Now())
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1537,6 +1548,11 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 		if err := r.Catalogue().CreateGroup(ctx, p, store.NewCatalogueGroup{
 			ID: id, Name: name, CreatedAt: created,
 		}); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: a group create bumps the revision, so it
+		// charges the per-project budget too (see UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
@@ -1639,6 +1655,7 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 		return KeyGroupView{}, fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
 	var out KeyGroupView
+	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1664,6 +1681,11 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 			return err
 		}
 		if err := r.Catalogue().RenameGroup(ctx, p, id, name); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate: a group rename bumps the revision (see
+		// UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -119,6 +119,9 @@ type Keys struct {
 	// they were never validated at.
 	Keyring  *crypto.Keyring
 	Advisory *Advisory
+	// Budget applies the § 151 schema-revision rate limit (60/h per project) to
+	// every semantic schema mutation, via prepareSchemaPublish. Nil disables it.
+	Budget *Budget
 	// Scan is the secret-scanning ruleset (#74). Surface-2 declaration ingresses
 	// (key create/rename/metadata/declaration edits) block on a finding; the
 	// secret→config declassification leg of Reclassify is a Surface-1 warn.
@@ -130,6 +133,7 @@ type KeyGroups struct {
 	DB       *store.DB
 	Keyring  *crypto.Keyring
 	Advisory *Advisory
+	Budget   *Budget
 	// Scan: secret-scanning Surface-2 seam (#74). Group names are
 	// author-controlled declaration text.
 	Scan *scanning.Ruleset
@@ -151,10 +155,19 @@ type schemaPublisher struct {
 // transaction that asked for it. It is resolved after authorization for the
 // reason #50 recorded: an unauthorized caller must not leave a wrapped-key row
 // behind for an arbitrary (org, project).
-func prepareSchemaPublish(ctx context.Context, db *store.DB, keyring *crypto.Keyring, advisory *Advisory,
+func prepareSchemaPublish(ctx context.Context, db *store.DB, keyring *crypto.Keyring, advisory *Advisory, budget *Budget,
 	actor Actor, op authz.Operation, scope domain.Scope) (*schemaPublisher, error) {
 	sealer, err := sealerFor(ctx, db, keyring, actor, op, scope)
 	if err != nil {
+		return nil, err
+	}
+	// § 151 (§ 8) schema-revision rate limit: 60/h per project. This is the one
+	// point every semantic schema mutation converges on, before its own
+	// transaction opens — so a single charge here bounds them all, and the tx
+	// retry loop cannot multiply it. Charged AFTER sealerFor authorizes, so an
+	// unauthorized caller cannot burn a project's revision budget. Rate-only, so
+	// the returned release is a no-op and needs no defer.
+	if _, err := budget.acquire(budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 		return nil, err
 	}
 	return &schemaPublisher{sealer: sealer, keyring: keyring, advisory: advisory}, nil
@@ -588,7 +601,7 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	if err != nil {
 		return Key{}, err
 	}
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyCreate, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyCreate, scope)
 	if err != nil {
 		return Key{}, err
 	}
@@ -771,7 +784,7 @@ func (s *Keys) Rename(ctx context.Context, actor Actor, scope domain.Scope, id, 
 	// ForProject re-reads the wrapped-key row, mints nothing, and a Surface-2
 	// block below leaves no orphan row — the in-transaction scan is safe here. If
 	// key creation ever stops minting the DEK, move to scanSurface2Preflight.
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyRename, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyRename, scope)
 	if err != nil {
 		return Key{}, err
 	}
@@ -994,7 +1007,7 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 	// wrong shape for a pre-flight — the scan is gated on the DB-derived no-op
 	// short-circuit below, which the §6.1 no-retro-scan rule needs; an
 	// unconditional pre-flight scan would block a canonically-identical resubmit.
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyUpdateDeclaration, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyUpdateDeclaration, scope)
 	if err != nil {
 		return Key{}, err
 	}
@@ -1149,7 +1162,7 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	var out Key
 	var findings []Finding
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyReclassify, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyReclassify, scope)
 	if err != nil {
 		return Key{}, nil, err
 	}
@@ -1320,7 +1333,7 @@ func (s *Keys) scanDeclassified(ctx context.Context, r store.Repos, az *authz.Tx
 // previewed.
 func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id, groupID string) (Key, error) {
 	var out Key
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeySetGroup, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeySetGroup, scope)
 	if err != nil {
 		return Key{}, err
 	}
@@ -1395,7 +1408,7 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 // Delete removes a key from the catalogue. Its explicit presence rows go with
 // it and it drops out of its group; the group itself survives, possibly inert.
 func (s *Keys) Delete(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyDelete, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyDelete, scope)
 	if err != nil {
 		return err
 	}
@@ -1683,7 +1696,7 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 // it coupled: a group is a coupling, and removing a coupling is not removing
 // what it coupled.
 func (s *KeyGroups) Delete(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyGroupDelete, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyGroupDelete, scope)
 	if err != nil {
 		return err
 	}

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -155,19 +155,10 @@ type schemaPublisher struct {
 // transaction that asked for it. It is resolved after authorization for the
 // reason #50 recorded: an unauthorized caller must not leave a wrapped-key row
 // behind for an arbitrary (org, project).
-func prepareSchemaPublish(ctx context.Context, db *store.DB, keyring *crypto.Keyring, advisory *Advisory, budget *Budget,
+func prepareSchemaPublish(ctx context.Context, db *store.DB, keyring *crypto.Keyring, advisory *Advisory,
 	actor Actor, op authz.Operation, scope domain.Scope) (*schemaPublisher, error) {
 	sealer, err := sealerFor(ctx, db, keyring, actor, op, scope)
 	if err != nil {
-		return nil, err
-	}
-	// § 151 (§ 8) schema-revision rate limit: 60/h per project. This is the one
-	// point every semantic schema mutation converges on, before its own
-	// transaction opens — so a single charge here bounds them all, and the tx
-	// retry loop cannot multiply it. Charged AFTER sealerFor authorizes, so an
-	// unauthorized caller cannot burn a project's revision budget. Rate-only, so
-	// the returned release is a no-op and needs no defer.
-	if _, err := budget.acquire(budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 		return nil, err
 	}
 	return &schemaPublisher{sealer: sealer, keyring: keyring, advisory: advisory}, nil
@@ -601,10 +592,11 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	if err != nil {
 		return Key{}, err
 	}
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyCreate, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyCreate, scope)
 	if err != nil {
 		return Key{}, err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -648,6 +640,11 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 			return err
 		}
 		if err := r.Catalogue().ReplacePresence(ctx, p, id, presenceRows(spec.Presence)); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate (60/h per project), charged immediately
+		// before the bump so only a real revision counts — see Keys.UpdateMetadata.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
@@ -784,10 +781,11 @@ func (s *Keys) Rename(ctx context.Context, actor Actor, scope domain.Scope, id, 
 	// ForProject re-reads the wrapped-key row, mints nothing, and a Surface-2
 	// block below leaves no orphan row — the in-transaction scan is safe here. If
 	// key creation ever stops minting the DEK, move to scanSurface2Preflight.
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyRename, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyRename, scope)
 	if err != nil {
 		return Key{}, err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -816,6 +814,10 @@ func (s *Keys) Rename(ctx context.Context, actor Actor, scope domain.Scope, id, 
 			return err
 		}
 		if err := r.Catalogue().Rename(ctx, p, id, name); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate (see Keys.UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
@@ -1017,10 +1019,11 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 	// wrong shape for a pre-flight — the scan is gated on the DB-derived no-op
 	// short-circuit below, which the §6.1 no-retro-scan rule needs; an
 	// unconditional pre-flight scan would block a canonically-identical resubmit.
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyUpdateDeclaration, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyUpdateDeclaration, scope)
 	if err != nil {
 		return Key{}, err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1109,6 +1112,11 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 		if err := r.Catalogue().ReplacePresence(ctx, p, id, presenceRows(u.Presence)); err != nil {
 			return err
 		}
+		// § 151 schema-revision rate (see Keys.UpdateMetadata). Placed past this
+		// method's no-op early return, so an unchanged declaration charges nothing.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
+			return err
+		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
 			return err
 		}
@@ -1172,10 +1180,11 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	var out Key
 	var findings []Finding
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyReclassify, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyReclassify, scope)
 	if err != nil {
 		return Key{}, nil, err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		findings = nil
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
@@ -1247,6 +1256,10 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 		// Classification moves what is delivered and, where an adapter routes
 		// by it, where — so it is a semantic schema change and advances the
 		// revision like any other.
+		// § 151 schema-revision rate (see Keys.UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
+			return err
+		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
 			return err
 		}
@@ -1343,10 +1356,11 @@ func (s *Keys) scanDeclassified(ctx context.Context, r store.Repos, az *authz.Tx
 // previewed.
 func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id, groupID string) (Key, error) {
 	var out Key
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeySetGroup, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeySetGroup, scope)
 	if err != nil {
 		return Key{}, err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1387,6 +1401,11 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 		if err := r.Catalogue().SetGroup(ctx, p, id, groupID); err != nil {
 			return err
 		}
+		// § 151 schema-revision rate (see Keys.UpdateMetadata). Past this method's
+		// no-op early return, so a no-change SetGroup charges nothing.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
+			return err
+		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
 			return err
 		}
@@ -1418,10 +1437,11 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 // Delete removes a key from the catalogue. Its explicit presence rows go with
 // it and it drops out of its group; the group itself survives, possibly inert.
 func (s *Keys) Delete(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyDelete, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyDelete, scope)
 	if err != nil {
 		return err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1478,6 +1498,10 @@ func (s *Keys) Delete(ctx context.Context, actor Actor, scope domain.Scope, id s
 			return err
 		}
 		if err := r.Catalogue().Delete(ctx, p, id); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate (see Keys.UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
@@ -1718,10 +1742,11 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 // it coupled: a group is a coupling, and removing a coupling is not removing
 // what it coupled.
 func (s *KeyGroups) Delete(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
-	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, s.Budget, actor, authz.OpKeyGroupDelete, scope)
+	publisher, err := prepareSchemaPublish(ctx, s.DB, s.Keyring, s.Advisory, actor, authz.OpKeyGroupDelete, scope)
 	if err != nil {
 		return err
 	}
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
@@ -1755,6 +1780,10 @@ func (s *KeyGroups) Delete(ctx context.Context, actor Actor, scope domain.Scope,
 			return err
 		}
 		if err := r.Catalogue().DeleteGroup(ctx, p, id); err != nil {
+			return err
+		}
+		// § 151 schema-revision rate (see Keys.UpdateMetadata).
+		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
 			return err
 		}
 		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -60,7 +60,12 @@ type Revisions struct {
 	// Auth supplies the reveal guard for the one disclosing method here,
 	// Export. Nil refuses every disclosure loudly.
 	Auth *Auth
-	Now  func() time.Time
+	// Budget applies the § 179 expensive-path concurrency bounds: publish 4 per
+	// org, values export 2 per org / 6 per instance. Nil disables it. The
+	// per-principal rate half of these two categories is deferred (the principal
+	// resolves inside the transaction; see budget.go).
+	Budget *Budget
+	Now    func() time.Time
 	// PublishProbe is the service-layer conformance seam for forcing two real
 	// publish transactions to overlap around the project lock. Production
 	// leaves it nil; it decides no behavior and sees no material.
@@ -233,6 +238,14 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 	if dup, ok := firstDuplicate(versionIDs); ok {
 		return PublishResult{}, invalidDetail("pending change %q is named more than once", dup)
 	}
+	// § 179 publish concurrency: 4 per org, held for the duration of the publish
+	// fan-out. Acquired at entry, before the sealer preflight opens its own
+	// transactions, so the bound cannot be multiplied by the tx retry loop.
+	release, err := s.Budget.acquire(budgetPublish, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return PublishResult{}, err
+	}
+	defer release()
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValuePublish, scope)
 	if err != nil {
 		return PublishResult{}, err

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -252,6 +252,7 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 	}
 
 	var out PublishResult
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = PublishResult{}
 		// The clock is read INSIDE the transaction: the sealer preflight can
@@ -267,6 +268,12 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 		// nonexistent answer is the only thing they see.
 		p, err := az.Authorize(ctx, caller, authz.OpValuePublish, scope)
 		if err != nil {
+			return err
+		}
+		// § 179 publish rate: 10/min per principal, charged here (the principal is
+		// only known now) and once across the retry loop. The per-org concurrency
+		// was already taken at entry.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetPublishRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		if s.PublishProbe != nil {

--- a/internal/service/reencrypt.go
+++ b/internal/service/reencrypt.go
@@ -153,7 +153,7 @@ func (s *Reencrypt) ReencryptProject(ctx context.Context, actor Actor, orgID, pr
 	// §179 fail-closed default: a crypto walk proportional to every stored row,
 	// with no named category. Acquired once at entry and held for the whole
 	// multi-transaction walk.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptProject, scope, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptProject, authz.OpReencryptProject, scope, s.now)
 	if err != nil {
 		return ReencryptResult{}, err
 	}
@@ -273,7 +273,7 @@ func (s *Reencrypt) ReencryptInstance(ctx context.Context, actor Actor) (Reencry
 	// §179 fail-closed default: an instance-wide crypto walk with no named
 	// category (empty scope → the org bound keys on the instance bucket). Held
 	// for the whole multi-transaction walk.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptInstance, domain.Scope{}, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptInstance, authz.OpReencryptInstance, domain.Scope{}, s.now)
 	if err != nil {
 		return ReencryptResult{}, err
 	}

--- a/internal/service/reencrypt.go
+++ b/internal/service/reencrypt.go
@@ -31,7 +31,11 @@ import (
 type Reencrypt struct {
 	DB      *store.DB
 	Keyring *crypto.Keyring
-	Now     func() time.Time
+	// Budget applies the §179 fail-closed default (60/min·principal, 8/org) to
+	// the reencrypt trigger — a row-proportional crypto walk with no named
+	// category. Nil disables it.
+	Budget *Budget
+	Now    func() time.Time
 	// ChunkSize / ChunkPause override the #187 defaults; zero uses them. Tests
 	// set a tiny chunk and no pause.
 	ChunkSize  int
@@ -146,6 +150,15 @@ func (s *Reencrypt) ReencryptProject(ctx context.Context, actor Actor, orgID, pr
 	active := sealer.ActiveVersion()
 	scope := domain.Scope{Org: domain.OrgID(orgID), Project: domain.ProjectID(projectID)}
 
+	// §179 fail-closed default: a crypto walk proportional to every stored row,
+	// with no named category. Acquired once at entry and held for the whole
+	// multi-transaction walk.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptProject, scope, s.now)
+	if err != nil {
+		return ReencryptResult{}, err
+	}
+	defer release()
+
 	// Adapter credential ciphertext (live row + any pending route-move credential)
 	// binds the ADAPTER's id (row.owner) in its AAD, not the row id.
 	adapterAAD := func(row projectFieldRow) crypto.AAD {
@@ -257,6 +270,14 @@ func (s *Reencrypt) ReencryptInstance(ctx context.Context, actor Actor) (Reencry
 	if s.Keyring == nil {
 		return ReencryptResult{}, errors.New("service: reencrypt requires a keyring")
 	}
+	// §179 fail-closed default: an instance-wide crypto walk with no named
+	// category (empty scope → the org bound keys on the instance bucket). Held
+	// for the whole multi-transaction walk.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpReencryptInstance, domain.Scope{}, s.now)
+	if err != nil {
+		return ReencryptResult{}, err
+	}
+	defer release()
 	sealer := s.Keyring.ForInstance()
 	active := sealer.Version()
 	moved := 0

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -427,6 +427,15 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 	if s.Keyring == nil {
 		return nil, 0, errors.New("service: value export requires a keyring")
 	}
+	// § 179 export concurrency: 2 per org, 6 per instance — shared with audit
+	// export. Held for the duration; acquired at entry, before the sealer
+	// preflight, so the tx retry loop cannot multiply it. (The per-principal
+	// 5/min rate on this path is deferred; see budget.go.)
+	release, err := s.Budget.acquire(budgetValuesExport, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer release()
 	// The sealer is resolved under the READ half of the formula; the
 	// disclosure half is authorized in-transaction below, once the snapshot is
 	// in hand and "current or historical" is a fact rather than a guess. The

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -449,6 +449,7 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 	}
 	var out []ExportedValue
 	var served int64
+	var rateCharged bool
 	// A disclosing export runs in a WRITE transaction: its disclosure records
 	// must be durable BEFORE the plaintext leaves the server.
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
@@ -459,6 +460,12 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpValueExport, scope)
 		if err != nil {
+			return err
+		}
+		// § 179 export rate: 5/min per principal (shares the "export" bucket with
+		// audit export), charged once here now the principal is known. The
+		// per-org/instance concurrency was taken at entry.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetExportRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		snapshot, err := readSnapshot(ctx, r.Snapshots(), p, revision)

--- a/internal/service/rotation.go
+++ b/internal/service/rotation.go
@@ -186,7 +186,7 @@ func (s *Rotation) RotateMasterKey(ctx context.Context, actor Actor) (MasterKeyR
 	// §179 fail-closed default: master rotation rewraps every project DEK. Charged
 	// (authorized-then-acquired) before the process-wide hierarchy lock, so a
 	// rate-limited caller is refused without contending for the global lock.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpRotateMasterKey, domain.Scope{}, s.now)
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpRotateMasterKey, authz.OpRotateMasterKey, domain.Scope{}, s.now)
 	if err != nil {
 		return MasterKeyRotation{}, err
 	}

--- a/internal/service/rotation.go
+++ b/internal/service/rotation.go
@@ -29,7 +29,10 @@ type Rotation struct {
 	// root rotation both re-read it here rather than holding it in memory. Nil
 	// refuses those two rotations loudly.
 	RootKey RootKeySource
-	Now     func() time.Time
+	// Budget applies the §179 fail-closed default to master-key rotation, which
+	// rewraps every project DEK (project-proportional). Nil disables it.
+	Budget *Budget
+	Now    func() time.Time
 }
 
 // RootKeySource re-reads operator root key material from its configured source.
@@ -180,6 +183,14 @@ func (s *Rotation) RotateMasterKey(ctx context.Context, actor Actor) (MasterKeyR
 	if s.RootKey == nil {
 		return MasterKeyRotation{}, errors.New("service: master rotation requires a root key source")
 	}
+	// §179 fail-closed default: master rotation rewraps every project DEK. Charged
+	// (authorized-then-acquired) before the process-wide hierarchy lock, so a
+	// rate-limited caller is refused without contending for the global lock.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpRotateMasterKey, domain.Scope{}, s.now)
+	if err != nil {
+		return MasterKeyRotation{}, err
+	}
+	defer release()
 	// Process-wide serialization lives on the shared keyring, not this service:
 	// two Rotation instances over one keyring must still not prepare the same
 	// master version concurrently.

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -1088,16 +1088,15 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 		return CopyResult{}, err
 	}
 	// §179 fail-closed default: a value fan-out across environments/keys with no
-	// named category. Concurrency (8/org) at entry, per-principal rate (60/min)
-	// in-tx.
-	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	// named category. Authorized (source read) then acquired at entry (rate +
+	// concurrency), so an unauthorized caller cannot occupy the org's slots.
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueCopySource, sourceScope, func() time.Time { return time.Now().UTC() })
 	if err != nil {
 		return CopyResult{}, err
 	}
 	defer release()
 	var out CopyResult
 	var advanced []PublishedEnvironment
-	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = CopyResult{}
 		advanced = nil
@@ -1111,10 +1110,6 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 		// the units the two ceremonies enumerate.
 		hasConfig, secretKeyIDs, allKeyIDs, err := classifyCopyKeys(ctx, r, az, caller, sourceScope, req.KeyNames)
 		if err != nil {
-			return err
-		}
-		// Charged after the source read authorizes, once across the retry loop.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		// PREFLIGHT every destination — the copy formula and the protected-

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -1090,7 +1090,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 	// §179 fail-closed default: a value fan-out across environments/keys with no
 	// named category. Authorized (source read) then acquired at entry (rate +
 	// concurrency), so an unauthorized caller cannot occupy the org's slots.
-	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueCopySource, sourceScope, func() time.Time { return time.Now().UTC() })
+	release, err := chargeDefaultAtEntry(ctx, s.DB, s.Budget, actor, authz.OpValueList, authz.OpValueCopySource, sourceScope, func() time.Time { return time.Now().UTC() })
 	if err != nil {
 		return CopyResult{}, err
 	}

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -91,6 +91,10 @@ type Values struct {
 	// ride any findings on the response. Nil disables the scan (pre-#74 tests); a
 	// booted server always wires it.
 	Scan *scanning.Ruleset
+	// Budget applies the §179 fail-closed default (60/min·principal, 8/org) to
+	// the two bulk value fan-outs with no named category — Import and Copy. Nil
+	// disables it.
+	Budget *Budget
 }
 
 // ValueCell is one `(key, environment)` cell as reported to a reader.
@@ -1083,8 +1087,17 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 	if err != nil {
 		return CopyResult{}, err
 	}
+	// §179 fail-closed default: a value fan-out across environments/keys with no
+	// named category. Concurrency (8/org) at entry, per-principal rate (60/min)
+	// in-tx.
+	release, err := s.Budget.acquire(budgetDefaultConc, budgetKeys{Org: scope.Org})
+	if err != nil {
+		return CopyResult{}, err
+	}
+	defer release()
 	var out CopyResult
 	var advanced []PublishedEnvironment
+	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = CopyResult{}
 		advanced = nil
@@ -1098,6 +1111,10 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 		// the units the two ceremonies enumerate.
 		hasConfig, secretKeyIDs, allKeyIDs, err := classifyCopyKeys(ctx, r, az, caller, sourceScope, req.KeyNames)
 		if err != nil {
+			return err
+		}
+		// Charged after the source read authorizes, once across the retry loop.
+		if err := s.Budget.chargeOnce(&rateCharged, budgetDefaultRate, budgetKeys{Principal: caller.Principal}); err != nil {
 			return err
 		}
 		// PREFLIGHT every destination — the copy formula and the protected-


### PR DESCRIPTION
Closes #186.

Builds the general per-scope windowed rate + per-org/instance concurrency budget the ops-spec §179 expensive-path family and the §151 schema-revision limit depend on, and enforces the two acceptance bounds plus the fail-closed default.

## Layer
`internal/service/budget.go` — in-memory, single-node (mirrors `internal/admission`: v1 has no HA, so process-local state is the whole instance's). Category table with a **per-rule key dimension** (principal / project / org / instance), because the family isn't uniformly principal-keyed: schema-rev is per project, machine-fetch aggregates per org+instance. Atomic acquire (rate + concurrency charged only if every rule passes), once-safe release, per-window bucket eviction, hard-bounded tracking maps, nil = no-op. Every refusal wraps `admission.ErrOverloaded` → the uniform 429 + Retry-After `internal/server/errors.go` already renders.

## Wired (at the owning service method — no once-per-op post-auth chokepoint exists; `Authorize` runs per-env/per-page)
- **audit export** 2/org · 6/instance + 5/min·principal
- **values export / publish / adapter sync** per-org concurrency + per-principal rate (in-tx via `chargeOnce`, idempotent across the tx retry loop)
- **machine-fetch** 300/min·org + 1000/min·instance (after authorize)
- **schema-revision** 60/h·project — charged immediately before **every** `BumpSchemaRevision` (keys / key-groups / environments / definitions-apply), so a no-op mutation mints no revision and charges nothing

## Fail-closed default (§179 "no path is unbudgeted by omission")
`budget_classification.go` classifies all 195 authz operations (named category / default-expensive / exempt-with-reason). `TestBudgetClassificationIsTotal` **fails the build** if any registered operation is unclassified — the same shape as the metrics-label grep and keyword-allowlist diff. Default-expensive ops (reencrypt ×2, import, copy, definitions export/check, offline reconcile, master-key rotation) charge `budgetDefault` via `chargeDefaultAtEntry` (authorize-then-acquire). O(1) key-hierarchy rotations are exempt — their row-proportional rework is the separately-budgeted reencrypt.

## Registry
`Schema-revision 60/h`, `Audit exports 2/6`, and the fail-closed default flipped `enforcement-pending → enforced`; the whole family's values pinned in `TestReconciledBoundsMatchOpsSpecValues`.

## Review
- Standards ✓ · Spec SOUND ✓
- Cross-model **Codex `gpt-5.6-sol` at high effort, blocking — CLEAN**. Main loop R1→R3 + a focused fail-closed-default pass R1→R3; every finding fixed (schema-rev bypass via non-`prepareSchemaPublish` bumpers, no-op over-charge, per-principal rate wiring, rate-slice aliasing, authorize-before-acquire, Copy auth-op vs classify-op).

## Verification
Full suite **2887 passed** (56 pkgs, sqlite), gofmt clean, `k8se2e` vet clean. The Postgres conformance leg runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789893356&installation_model_id=432348&pr_number=202&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F202&signature=fb22be39decad0aa10e119b39bee35d55000f441d2987a0323e9537867406615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->