### PR TITLE
fix(crypto): make reencrypt walkers retry-safe — reopen #187

### DIFF
--- a/internal/isolation/reencrypt_e2e_test.go
+++ b/internal/isolation/reencrypt_e2e_test.go
@@ -3,6 +3,7 @@ package isolation
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -12,6 +13,325 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 	"github.com/Hikyo-Org/hikyo/internal/store/keyring"
 )
+
+// injectRetryOnce returns an AfterChunk hook that fails the first chunk of each
+// named table with a retryable error, then never again — a deterministic
+// commit-time serialization retry to prove the walker publishes its cursor and
+// moved-count only after the transaction commits (#187 reopen). Firing once per
+// distinct table exercises each walker family independently.
+func injectRetryOnce(tables ...string) func(context.Context, string) error {
+	pending := map[string]bool{}
+	for _, t := range tables {
+		pending[t] = true
+	}
+	return func(_ context.Context, table string) error {
+		if pending[table] {
+			pending[table] = false
+			return store.ErrRetrySerialization
+		}
+		return nil
+	}
+}
+
+// reencCompletedRowsMoved asserts exactly one crypto.reencrypt_completed event
+// exists and its payload's rows_moved equals want (the completion audit count is
+// exact, #187 acceptance). It decodes the payload and compares numerically — a
+// substring/LIKE match would let rows_moved=2 pass against a stored 20.
+func reencCompletedRowsMoved(t *testing.T, db *store.DB, ctx context.Context, trail string, want int) {
+	t.Helper()
+	table := "audit_tenant_events"
+	if trail == "instance" {
+		table = "audit_instance_events"
+	}
+	payloads := reencQueryStrings(t, db, ctx, "SELECT payload FROM "+table+" WHERE type='crypto.reencrypt_completed'")
+	if len(payloads) != 1 {
+		t.Fatalf("crypto.reencrypt_completed events = %d, want exactly 1", len(payloads))
+	}
+	var got struct {
+		RowsMoved int64 `json:"rows_moved"`
+	}
+	if err := json.Unmarshal([]byte(payloads[0]), &got); err != nil {
+		t.Fatalf("decode reencrypt_completed payload %q: %v", payloads[0], err)
+	}
+	if got.RowsMoved != int64(want) {
+		t.Fatalf("crypto.reencrypt_completed rows_moved = %d, want %d (exact audit count)", got.RowsMoved, want)
+	}
+}
+
+// reencQueryStrings runs a single-text-column query on either engine.
+func reencQueryStrings(t *testing.T, db *store.DB, ctx context.Context, query string) []string {
+	t.Helper()
+	var out []string
+	switch db.Engine() {
+	case store.EngineSQLite:
+		rows, err := db.SQLiteRead().QueryContext(ctx, query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var s string
+			if err := rows.Scan(&s); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, s)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		rows, err := db.PG().Query(ctx, query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var s string
+			if err := rows.Scan(&s); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, s)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return out
+}
+
+// A commit-time serialization retry must not skip a page or double-count moved
+// rows. The #187 reopen found the walkers advanced their pagination cursor and
+// incremented the moved count from inside the replayable tx.Write closure, so a
+// retried chunk re-listed past the rolled-back page (stranding rows on the
+// retiring key, which the dryness gate then refuses) and counted the lost page
+// twice. AfterChunk injects one retryable failure per walker family; the run
+// must still move every row exactly once, retire v1, and report an exact count.
+func TestReencryptProjectRetrySafe(t *testing.T) {
+	t.Run("sqlite", func(t *testing.T) { reencryptProjectRetrySafe(t, openSQLite) })
+	t.Run("postgres", func(t *testing.T) { reencryptProjectRetrySafe(t, openPostgres) })
+}
+
+func reencryptProjectRetrySafe(t *testing.T, open func(*testing.T) *store.DB) {
+	// Control: no injection, to learn the exact moved count for this seed (the
+	// seeded project may carry a real draft the walk also moves).
+	control := reencProjectCycle(t, open, nil)
+	if control.err != nil {
+		t.Fatalf("control reencrypt: %v", control.err)
+	}
+	// Injected: one retryable failure on the first `value` chunk. With the bug,
+	// attempt 2 re-lists past the rolled-back row — it stays on v1, the dryness
+	// gate refuses the retire with ErrConflict, and the count double-reports.
+	got := reencProjectCycle(t, open, injectRetryOnce("value"))
+	if got.err != nil {
+		t.Fatalf("reencrypt with an injected retry: %v", got.err)
+	}
+	if got.moved != control.moved {
+		t.Fatalf("moved with a retried chunk = %d, want %d (control) — retry skipped or double-counted", got.moved, control.moved)
+	}
+	if got.v1 != "retired" {
+		t.Fatalf("DEK v1 = %q after a retried walk, want retired (a skipped page leaves it retiring)", got.v1)
+	}
+	reencCompletedRowsMoved(t, got.db, tctx(t), "project", got.moved)
+}
+
+type reencOutcome struct {
+	db    *store.DB
+	moved int
+	v1    string
+	err   error
+}
+
+// reencProjectCycle seeds one value row, rotates the project DEK, and runs
+// reencrypt with the given AfterChunk hook. With ChunkSize=1, a chunk that fails
+// retryably rolls back its row move; a walker that advanced its cursor from
+// inside that closure re-lists past the row on retry and strands it on v1, which
+// the dryness gate then refuses (the #187 skip). One row suffices to prove it.
+func reencProjectCycle(t *testing.T, open func(*testing.T) *store.DB, inject func(context.Context, string) error) reencOutcome {
+	db := seededDB(t, open)
+	kr := probeKeyring(t, db)
+	ctx := tctx(t)
+	const org, prj, env, key = "org_a", "prj_a1", "env_a1", "key_a1"
+	sealer, err := kr.ForProject(ctx, org, prj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aad := crypto.ValueAAD{OrgID: org, ProjectID: prj, EnvID: env, KeyID: key, RowID: "row_rs", FieldTag: "value"}
+	ct := reencSealValue(t, sealer.SealValue, aad, "retry-secret")
+	reencExec(t, db, ctx,
+		`INSERT INTO value_entries (id, org_id, project_id, environment_id, key_id, ciphertext, updated_at, updated_by) VALUES ('row_rs','org_a','prj_a1','env_a1','key_a1',?, '2026-01-01T00:00:00Z','usr_root')`,
+		`INSERT INTO value_entries (id, org_id, project_id, environment_id, key_id, ciphertext, updated_at, updated_by) VALUES ('row_rs','org_a','prj_a1','env_a1','key_a1',$1, '2026-01-01T00:00:00Z','usr_root')`,
+		ct)
+	rotation := &service.Rotation{DB: db, Keyring: kr, RootKey: probeRootSource{db: db}}
+	if _, err := rotation.RotateDEK(ctx, service.LocalPrincipal(root), service.DEKScope{OrgID: org, ProjectID: prj}); err != nil {
+		t.Fatalf("rotate-dek: %v", err)
+	}
+	re := &service.Reencrypt{DB: db, Keyring: kr, ChunkSize: 1, ChunkPause: -1, AfterChunk: inject}
+	res, err := re.ReencryptProject(ctx, service.LocalPrincipal(root), org, prj)
+	out := reencOutcome{db: db, moved: res.RowsMoved, err: err}
+	if err != nil {
+		return out
+	}
+	states, serr := queryTier3States(db, ctx, org, prj)
+	if serr != nil {
+		t.Fatal(serr)
+	}
+	out.v1 = states[1]
+	return out
+}
+
+// The instance walk has two more walker families than the project walk: the
+// row_version tables (password_credentials) and the blob-CAS remotes table.
+// Inject one retryable failure into each and assert the same retry-safety.
+func TestReencryptInstanceRetrySafe(t *testing.T) {
+	t.Run("sqlite", func(t *testing.T) { reencryptInstanceRetrySafe(t, openSQLite) })
+	t.Run("postgres", func(t *testing.T) { reencryptInstanceRetrySafe(t, openPostgres) })
+}
+
+func reencryptInstanceRetrySafe(t *testing.T, open func(*testing.T) *store.DB) {
+	control := reencInstanceCycle(t, open, nil)
+	if control.err != nil {
+		t.Fatalf("control reencrypt --instance: %v", control.err)
+	}
+	got := reencInstanceCycle(t, open, injectRetryOnce("password_credentials", "remotes"))
+	if got.err != nil {
+		t.Fatalf("reencrypt --instance with an injected retry: %v", got.err)
+	}
+	if got.moved != control.moved {
+		t.Fatalf("moved with retried chunks = %d, want %d (control) — retry skipped or double-counted", got.moved, control.moved)
+	}
+	if got.v1 != "retired" {
+		t.Fatalf("instance DEK v1 = %q after a retried walk, want retired", got.v1)
+	}
+	reencCompletedRowsMoved(t, got.db, tctx(t), "instance", got.moved)
+}
+
+// injectRetryOnNthChunk fails the n-th chunk of the named table once (retryable),
+// then never again — a mid-walk retry, unlike injectRetryOnce which always hits
+// the first chunk. It proves committed earlier pages are not re-counted and the
+// retried middle chunk advances exactly once (#187 validation: multi-chunk).
+func injectRetryOnNthChunk(table string, n int) func(context.Context, string) error {
+	seen, fired := 0, false
+	return func(_ context.Context, tbl string) error {
+		if tbl != table {
+			return nil
+		}
+		seen++
+		if seen == n && !fired {
+			fired = true
+			return store.ErrRetrySerialization
+		}
+		return nil
+	}
+}
+
+// The reopen's failure scenario is literally a multi-chunk walk (IDs 1–100 then
+// a later page retrying): the shared walkChunked primitive must publish the
+// cursor and moved-count only after each chunk commits, so a retry of chunk 2
+// re-counts neither chunk 1 (committed) nor itself. Three remotes with
+// ChunkSize=1 yield three chunks; inject the retry on the second.
+func TestReencryptMultiChunkRetrySafe(t *testing.T) {
+	t.Run("sqlite", func(t *testing.T) { reencryptMultiChunkRetrySafe(t, openSQLite) })
+	t.Run("postgres", func(t *testing.T) { reencryptMultiChunkRetrySafe(t, openPostgres) })
+}
+
+func reencryptMultiChunkRetrySafe(t *testing.T, open func(*testing.T) *store.DB) {
+	control := reencMultiRemoteCycle(t, open, nil)
+	if control.err != nil {
+		t.Fatalf("control reencrypt --instance: %v", control.err)
+	}
+	got := reencMultiRemoteCycle(t, open, injectRetryOnNthChunk("remotes", 2))
+	if got.err != nil {
+		t.Fatalf("reencrypt --instance with a mid-walk retry: %v", got.err)
+	}
+	if got.moved != control.moved {
+		t.Fatalf("moved with a retried middle chunk = %d, want %d (control) — retry re-counted a committed page or itself", got.moved, control.moved)
+	}
+	if got.v1 != "retired" {
+		t.Fatalf("instance DEK v1 = %q after a multi-chunk retried walk, want retired", got.v1)
+	}
+	reencCompletedRowsMoved(t, got.db, tctx(t), "instance", got.moved)
+}
+
+func reencMultiRemoteCycle(t *testing.T, open func(*testing.T) *store.DB, inject func(context.Context, string) error) reencOutcome {
+	db := seededDB(t, open)
+	kr := probeKeyring(t, db)
+	ctx := tctx(t)
+	inst := kr.ForInstance()
+	for _, rm := range []struct{ id, secret string }{{"rmt_mc1", "cred-1"}, {"rmt_mc2", "cred-2"}, {"rmt_mc3", "cred-3"}} {
+		aad := crypto.InstanceFieldAAD{OwnerTable: "remotes", OwnerRowID: rm.id, FieldTag: "credential"}
+		ct, err := inst.SealField(aad, []byte(rm.secret))
+		if err != nil {
+			t.Fatal(err)
+		}
+		reencExec(t, db, ctx,
+			`INSERT INTO remotes (id, name, url, spki_pin, credential_sealed, created_at, created_by) VALUES (?,?,'https://r','sha256-x',?, '2026-01-01T00:00:00Z','usr_root')`,
+			`INSERT INTO remotes (id, name, url, spki_pin, credential_sealed, created_at, created_by) VALUES ($1,$2,'https://r','sha256-x',$3, '2026-01-01T00:00:00Z','usr_root')`,
+			rm.id, rm.id, ct)
+	}
+	rotation := &service.Rotation{DB: db, Keyring: kr, RootKey: probeRootSource{db: db}}
+	if _, err := rotation.RotateDEK(ctx, service.LocalPrincipal(root), service.DEKScope{Instance: true}); err != nil {
+		t.Fatalf("rotate-dek --instance: %v", err)
+	}
+	re := &service.Reencrypt{DB: db, Keyring: kr, ChunkSize: 1, ChunkPause: -1, AfterChunk: inject}
+	res, err := re.ReencryptInstance(ctx, service.LocalPrincipal(root))
+	out := reencOutcome{db: db, moved: res.RowsMoved, err: err}
+	if err != nil {
+		return out
+	}
+	states, serr := queryTier3StatesPurpose(db, ctx, "instance", "", "")
+	if serr != nil {
+		t.Fatal(serr)
+	}
+	out.v1 = states[1]
+	return out
+}
+
+func reencInstanceCycle(t *testing.T, open func(*testing.T) *store.DB, inject func(context.Context, string) error) reencOutcome {
+	db := seededDB(t, open)
+	kr := probeKeyring(t, db)
+	ctx := tctx(t)
+	inst := kr.ForInstance()
+	// One password_credentials row (row_version family) and one remote (blob-CAS
+	// family). ChunkSize=1: a retried chunk that advanced its cursor strands the
+	// row on v1 and the dryness gate refuses. One row per family proves it.
+	pwAAD := crypto.InstanceFieldAAD{OwnerTable: "password_credentials", OwnerRowID: "acc_rs", FieldTag: "verifier"}
+	pwCT, err := inst.SealField(pwAAD, []byte("verifier-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reencExec(t, db, ctx,
+		`INSERT INTO accounts (id, principal_id, username, display_name, created_at) VALUES ('acc_rs','usr_root','rsuser','RS','2026-01-01T00:00:00Z')`,
+		`INSERT INTO accounts (id, principal_id, username, display_name, created_at) VALUES ('acc_rs','usr_root','rsuser','RS','2026-01-01T00:00:00Z')`)
+	reencExec(t, db, ctx,
+		`INSERT INTO password_credentials (account_id, verifier, kdf_memory_kib, kdf_time, kdf_parallelism, dek_version, credential_epoch, row_version, updated_at) VALUES ('acc_rs',?,64,3,1,1,0,0,'2026-01-01T00:00:00Z')`,
+		`INSERT INTO password_credentials (account_id, verifier, kdf_memory_kib, kdf_time, kdf_parallelism, dek_version, credential_epoch, row_version, updated_at) VALUES ('acc_rs',$1,64,3,1,1,0,0,'2026-01-01T00:00:00Z')`,
+		pwCT)
+	rmAAD := crypto.InstanceFieldAAD{OwnerTable: "remotes", OwnerRowID: "rmt_rs", FieldTag: "credential"}
+	rmCT, err := inst.SealField(rmAAD, []byte("remote-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reencExec(t, db, ctx,
+		`INSERT INTO remotes (id, name, url, spki_pin, credential_sealed, created_at, created_by) VALUES ('rmt_rs','rs-remote','https://r','sha256-x',?, '2026-01-01T00:00:00Z','usr_root')`,
+		`INSERT INTO remotes (id, name, url, spki_pin, credential_sealed, created_at, created_by) VALUES ('rmt_rs','rs-remote','https://r','sha256-x',$1, '2026-01-01T00:00:00Z','usr_root')`,
+		rmCT)
+	rotation := &service.Rotation{DB: db, Keyring: kr, RootKey: probeRootSource{db: db}}
+	if _, err := rotation.RotateDEK(ctx, service.LocalPrincipal(root), service.DEKScope{Instance: true}); err != nil {
+		t.Fatalf("rotate-dek --instance: %v", err)
+	}
+	re := &service.Reencrypt{DB: db, Keyring: kr, ChunkSize: 1, ChunkPause: -1, AfterChunk: inject}
+	res, err := re.ReencryptInstance(ctx, service.LocalPrincipal(root))
+	out := reencOutcome{db: db, moved: res.RowsMoved, err: err}
+	if err != nil {
+		return out
+	}
+	states, serr := queryTier3StatesPurpose(db, ctx, "instance", "", "")
+	if serr != nil {
+		t.Fatal(serr)
+	}
+	out.v1 = states[1]
+	return out
+}
 
 // reencExec runs a raw statement on either engine (sqlite `?` / postgres `$n`
 // placeholders), for seeding ciphertext rows the reencrypt walk then moves.

--- a/internal/service/reencrypt.go
+++ b/internal/service/reencrypt.go
@@ -40,6 +40,12 @@ type Reencrypt struct {
 	// gate. Test-only (nil in production): it lets a test interleave a rotate-dek
 	// or seed a straggler into the window the gate must refuse.
 	BeforeRetire func(context.Context) error
+	// AfterChunk, when set, runs inside each chunk transaction after its rows are
+	// processed and before commit, receiving the table being walked. Test-only
+	// (nil in production): returning a retryable error (store.ErrRetrySerialization)
+	// exercises the tx.Write replay path, proving a chunk's cursor and moved-count
+	// outputs are attempt-local and never published on a rolled-back attempt.
+	AfterChunk func(ctx context.Context, table string) error
 }
 
 // ReencryptChunkSize and ReencryptChunkPause are the ops-spec §9 (§167) bounds
@@ -318,63 +324,44 @@ func (s *Reencrypt) ReencryptInstance(ctx context.Context, actor Actor) (Reencry
 	return ReencryptResult{Scope: "instance", RowsMoved: moved}, nil
 }
 
-func (s *Reencrypt) walkInstanceVersioned(
-	ctx context.Context, actor Actor, table string, moved *int,
-	list func(store.ReencryptRepo, context.Context, authz.Proof, string, int) ([]store.ReencryptInstanceRow, error),
-	aadOf func(string) crypto.InstanceFieldAAD,
-	reseal func(store.ReencryptRepo, context.Context, authz.Proof, string, []byte, uint32, uint32) (bool, error),
-	sealer *crypto.InstanceSealer, active uint32,
+// walkChunked pages one table to completion in chunk-sized write transactions
+// with the inter-chunk pause. step processes one chunk starting at cursor and
+// returns the next cursor, how many rows it saw, and how many it moved.
+//
+// tx.Write replays step on a serialization retry (postgres 40001/40P01, sqlite
+// BUSY/LOCKED), so step MUST be a pure function of its cursor argument — it may
+// publish nothing outside its return values. walkChunked advances the outer
+// cursor and *moved only after the transaction commits, so a rolled-back attempt
+// changes neither: it neither skips the rolled-back page nor double-counts it
+// (#187 reopen).
+func (s *Reencrypt) walkChunked(
+	ctx context.Context, table string, moved *int,
+	step func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, cursor string) (next string, seen, delta int, err error),
 ) error {
 	cursor := ""
 	for {
-		var chunkLen int
+		var next string
+		var seen, delta int
 		err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, s.now())
-			if err != nil {
-				return err
+			var e error
+			// A retry re-runs step with the SAME (not-yet-published) cursor and
+			// overwrites next/seen/delta, so only the committed attempt's outputs
+			// survive to be published below.
+			next, seen, delta, e = step(ctx, r, az, cursor)
+			if e != nil {
+				return e
 			}
-			p, err := az.Authorize(ctx, caller, authz.OpReencryptInstance, domain.Scope{})
-			if err != nil {
-				return err
-			}
-			// Per-chunk fence: abort if a rotate-dek --instance demoted our target.
-			if err := fenceInstanceVersion(ctx, r, p, active); err != nil {
-				return err
-			}
-			rows, err := list(r.Reencrypt(), ctx, p, cursor, s.chunkSize())
-			if err != nil {
-				return err
-			}
-			chunkLen = len(rows)
-			for _, row := range rows {
-				cursor = row.ID
-				if row.DEKVersion == active {
-					continue
-				}
-				aad := aadOf(row.ID)
-				plain, err := sealer.OpenField(aad, row.Ciphertext)
-				if err != nil {
-					return fmt.Errorf("reencrypt: open %s %s: %w", table, row.ID, err)
-				}
-				resealed, err := sealer.SealField(aad, plain)
-				crypto.Zero(plain)
-				if err != nil {
-					return fmt.Errorf("reencrypt: reseal %s %s: %w", table, row.ID, err)
-				}
-				did, err := reseal(r.Reencrypt(), ctx, p, row.ID, resealed, active, row.RowVersion)
-				if err != nil {
-					return err
-				}
-				if did {
-					*moved++
-				}
+			if s.AfterChunk != nil {
+				return s.AfterChunk(ctx, table)
 			}
 			return nil
 		})
 		if err != nil {
 			return err
 		}
-		if chunkLen < s.chunkSize() {
+		cursor = next
+		*moved += delta
+		if seen < s.chunkSize() {
 			return nil
 		}
 		if err := s.pause(ctx); err != nil {
@@ -383,67 +370,106 @@ func (s *Reencrypt) walkInstanceVersioned(
 	}
 }
 
-func (s *Reencrypt) walkRemotes(ctx context.Context, actor Actor, moved *int, sealer *crypto.InstanceSealer, active uint32) error {
-	cursor := ""
-	for {
-		var chunkLen int
-		err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, s.now())
-			if err != nil {
-				return err
-			}
-			p, err := az.Authorize(ctx, caller, authz.OpReencryptInstance, domain.Scope{})
-			if err != nil {
-				return err
-			}
-			// Per-chunk fence: abort if a rotate-dek --instance demoted our target.
-			if err := fenceInstanceVersion(ctx, r, p, active); err != nil {
-				return err
-			}
-			rows, err := r.Reencrypt().ListRemotesForReencrypt(ctx, p, cursor, s.chunkSize())
-			if err != nil {
-				return err
-			}
-			chunkLen = len(rows)
-			for _, row := range rows {
-				cursor = row.ID
-				ver, err := crypto.RecordKeyVersion(row.Ciphertext)
-				if err != nil {
-					return fmt.Errorf("reencrypt: remote %s: %w", row.ID, err)
-				}
-				if ver == active {
-					continue
-				}
-				aad := crypto.InstanceFieldAAD{OwnerTable: "remotes", OwnerRowID: row.ID, FieldTag: "credential"}
-				plain, err := sealer.OpenField(aad, row.Ciphertext)
-				if err != nil {
-					return fmt.Errorf("reencrypt: open remote %s: %w", row.ID, err)
-				}
-				resealed, err := sealer.SealField(aad, plain)
-				crypto.Zero(plain)
-				if err != nil {
-					return fmt.Errorf("reencrypt: reseal remote %s: %w", row.ID, err)
-				}
-				did, err := r.Reencrypt().ReencryptRemote(ctx, p, row.ID, resealed, row.Ciphertext)
-				if err != nil {
-					return err
-				}
-				if did {
-					*moved++
-				}
-			}
-			return nil
-		})
+func (s *Reencrypt) walkInstanceVersioned(
+	ctx context.Context, actor Actor, table string, moved *int,
+	list func(store.ReencryptRepo, context.Context, authz.Proof, string, int) ([]store.ReencryptInstanceRow, error),
+	aadOf func(string) crypto.InstanceFieldAAD,
+	reseal func(store.ReencryptRepo, context.Context, authz.Proof, string, []byte, uint32, uint32) (bool, error),
+	sealer *crypto.InstanceSealer, active uint32,
+) error {
+	return s.walkChunked(ctx, table, moved, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, cursor string) (string, int, int, error) {
+		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
-			return err
+			return "", 0, 0, err
 		}
-		if chunkLen < s.chunkSize() {
-			return nil
+		p, err := az.Authorize(ctx, caller, authz.OpReencryptInstance, domain.Scope{})
+		if err != nil {
+			return "", 0, 0, err
 		}
-		if err := s.pause(ctx); err != nil {
-			return err
+		// Per-chunk fence: abort if a rotate-dek --instance demoted our target.
+		if err := fenceInstanceVersion(ctx, r, p, active); err != nil {
+			return "", 0, 0, err
 		}
-	}
+		rows, err := list(r.Reencrypt(), ctx, p, cursor, s.chunkSize())
+		if err != nil {
+			return "", 0, 0, err
+		}
+		next, delta := cursor, 0
+		for _, row := range rows {
+			next = row.ID // advance over skipped rows too, else a full-skip chunk re-lists forever
+			if row.DEKVersion == active {
+				continue
+			}
+			aad := aadOf(row.ID)
+			plain, err := sealer.OpenField(aad, row.Ciphertext)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: open %s %s: %w", table, row.ID, err)
+			}
+			resealed, err := sealer.SealField(aad, plain)
+			crypto.Zero(plain)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: reseal %s %s: %w", table, row.ID, err)
+			}
+			did, err := reseal(r.Reencrypt(), ctx, p, row.ID, resealed, active, row.RowVersion)
+			if err != nil {
+				return "", 0, 0, err
+			}
+			if did {
+				delta++
+			}
+		}
+		return next, len(rows), delta, nil
+	})
+}
+
+func (s *Reencrypt) walkRemotes(ctx context.Context, actor Actor, moved *int, sealer *crypto.InstanceSealer, active uint32) error {
+	return s.walkChunked(ctx, "remotes", moved, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, cursor string) (string, int, int, error) {
+		caller, err := actor.resolve(ctx, az, s.now())
+		if err != nil {
+			return "", 0, 0, err
+		}
+		p, err := az.Authorize(ctx, caller, authz.OpReencryptInstance, domain.Scope{})
+		if err != nil {
+			return "", 0, 0, err
+		}
+		// Per-chunk fence: abort if a rotate-dek --instance demoted our target.
+		if err := fenceInstanceVersion(ctx, r, p, active); err != nil {
+			return "", 0, 0, err
+		}
+		rows, err := r.Reencrypt().ListRemotesForReencrypt(ctx, p, cursor, s.chunkSize())
+		if err != nil {
+			return "", 0, 0, err
+		}
+		next, delta := cursor, 0
+		for _, row := range rows {
+			next = row.ID
+			ver, err := crypto.RecordKeyVersion(row.Ciphertext)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: remote %s: %w", row.ID, err)
+			}
+			if ver == active {
+				continue
+			}
+			aad := crypto.InstanceFieldAAD{OwnerTable: "remotes", OwnerRowID: row.ID, FieldTag: "credential"}
+			plain, err := sealer.OpenField(aad, row.Ciphertext)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: open remote %s: %w", row.ID, err)
+			}
+			resealed, err := sealer.SealField(aad, plain)
+			crypto.Zero(plain)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: reseal remote %s: %w", row.ID, err)
+			}
+			did, err := r.Reencrypt().ReencryptRemote(ctx, p, row.ID, resealed, row.Ciphertext)
+			if err != nil {
+				return "", 0, 0, err
+			}
+			if did {
+				delta++
+			}
+		}
+		return next, len(rows), delta, nil
+	})
 }
 
 func (s *Reencrypt) pause(ctx context.Context) error {
@@ -582,72 +608,59 @@ func (s *Reencrypt) walkTable(
 	cas func(context.Context, store.Repos, authz.Proof, string, []byte, []byte) (bool, error),
 	sealer *crypto.ProjectSealer, active uint32,
 ) error {
-	cursor := ""
-	for {
-		var chunkLen int
-		err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, s.now())
-			if err != nil {
-				return err
-			}
-			p, err := az.Authorize(ctx, caller, authz.OpReencryptProject, scope)
-			if err != nil {
-				return err
-			}
-			// Per-chunk fence: abort the walk if a concurrent rotate-dek demoted the
-			// version we are sealing onto. Without this the walk would keep sealing
-			// rows onto a now-retiring version, which the retire's dryness gate would
-			// then (correctly) refuse — but aborting here kills that at the source.
-			if err := fenceProject(ctx, r, p, sealer, scope); err != nil {
-				return err
-			}
-			rows, err := list(ctx, r, p, cursor)
-			if err != nil {
-				return err
-			}
-			chunkLen = len(rows)
-			for _, row := range rows {
-				cursor = row.id
-				if len(row.ciphertext) == 0 {
-					continue // an `unset` pending draft holds no ciphertext to move
-				}
-				ver, err := crypto.RecordKeyVersion(row.ciphertext)
-				if err != nil {
-					return fmt.Errorf("reencrypt: %s %s: %w", table, row.id, err)
-				}
-				if ver == active {
-					continue
-				}
-				aad := aadOf(row)
-				plain, err := sealer.Open(aad, row.ciphertext)
-				if err != nil {
-					return fmt.Errorf("reencrypt: open %s %s: %w", table, row.id, err)
-				}
-				resealed, err := sealer.Seal(aad, plain)
-				crypto.Zero(plain)
-				if err != nil {
-					return fmt.Errorf("reencrypt: reseal %s %s: %w", table, row.id, err)
-				}
-				did, err := cas(ctx, r, p, row.id, resealed, row.ciphertext)
-				if err != nil {
-					return err
-				}
-				if did {
-					*moved++
-				}
-			}
-			return nil
-		})
+	return s.walkChunked(ctx, table, moved, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, cursor string) (string, int, int, error) {
+		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
-			return err
+			return "", 0, 0, err
 		}
-		if chunkLen < s.chunkSize() {
-			return nil
+		p, err := az.Authorize(ctx, caller, authz.OpReencryptProject, scope)
+		if err != nil {
+			return "", 0, 0, err
 		}
-		if err := s.pause(ctx); err != nil {
-			return err
+		// Per-chunk fence: abort the walk if a concurrent rotate-dek demoted the
+		// version we are sealing onto. Without this the walk would keep sealing
+		// rows onto a now-retiring version, which the retire's dryness gate would
+		// then (correctly) refuse — but aborting here kills that at the source.
+		if err := fenceProject(ctx, r, p, sealer, scope); err != nil {
+			return "", 0, 0, err
 		}
-	}
+		rows, err := list(ctx, r, p, cursor)
+		if err != nil {
+			return "", 0, 0, err
+		}
+		next, delta := cursor, 0
+		for _, row := range rows {
+			next = row.id // advance over skipped rows too, else a full-skip chunk re-lists forever
+			if len(row.ciphertext) == 0 {
+				continue // an `unset` pending draft holds no ciphertext to move
+			}
+			ver, err := crypto.RecordKeyVersion(row.ciphertext)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: %s %s: %w", table, row.id, err)
+			}
+			if ver == active {
+				continue
+			}
+			aad := aadOf(row)
+			plain, err := sealer.Open(aad, row.ciphertext)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: open %s %s: %w", table, row.id, err)
+			}
+			resealed, err := sealer.Seal(aad, plain)
+			crypto.Zero(plain)
+			if err != nil {
+				return "", 0, 0, fmt.Errorf("reencrypt: reseal %s %s: %w", table, row.id, err)
+			}
+			did, err := cas(ctx, r, p, row.id, resealed, row.ciphertext)
+			if err != nil {
+				return "", 0, 0, err
+			}
+			if did {
+				delta++
+			}
+		}
+		return next, len(rows), delta, nil
+	})
 }
 
 // retireAndRecord retires the scope's now-unreferenced retiring DEK versions and

--- a/internal/service/retention.go
+++ b/internal/service/retention.go
@@ -336,19 +336,24 @@ func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 		now := store.CanonTime(s.now())
 		var candidates int
 		var collected int64
+		var prunedThisChunk bool
 		err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			candidates, collected = 0, 0
+			candidates, collected, prunedThisChunk = 0, 0, false
 			p, err := authz.SystemAuthority(authz.SiteScheduler, az.Token())
 			if err != nil {
 				return err
 			}
 			// Expired definitions plans share the hourly GC lifecycle. Run once per
 			// sweep, including startup catch-up, before payload batching begins.
+			// tx.Write can replay this closure on a serialization retry, so the
+			// once-per-sweep flag is published only after the chunk commits (below):
+			// setting it inside the closure would strand the prune if the pruning
+			// chunk rolled back and retried.
 			if !plansPruned {
 				if _, err := r.Definitions().PruneExpiredPlans(ctx, p, now); err != nil {
 					return err
 				}
-				plansPruned = true
+				prunedThisChunk = true
 			}
 			rows, err := r.Retention().Eligible(ctx, p, now, RetentionBatchSize)
 			if err != nil {
@@ -406,6 +411,9 @@ func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 		if err != nil {
 			return total, s.recordFailedPruneRun(ctx, startedAt, store.CanonTime(s.now()),
 				totalCandidates+int64(candidates), total, err)
+		}
+		if prunedThisChunk {
+			plansPruned = true
 		}
 		total += collected
 		totalCandidates += int64(candidates)


### PR DESCRIPTION
## Reopen #187 — retry-safe reencrypt walkers

The DEK-rotation reencrypt walkers advanced their pagination cursor and incremented the moved-count from **inside** the replayable `tx.Write` closure. A serialization/deadlock retry (postgres 40001/40P01, sqlite BUSY/LOCKED) re-ran the closure in a fresh transaction, but the outer cursor had already advanced past the rolled-back page and the moved-count already included it — so a retried chunk **skipped a page** (stranding rows on the retiring DEK, which the dryness gate then refuses with `ErrConflict`) and **double-counted** the lost work.

### Fix
- **`internal/service/reencrypt.go`** — extract one retry-safe `walkChunked` primitive. The per-chunk `step` is a pure function of its cursor argument, returning next-cursor / rows-seen / moved-delta as **values**; `walkChunked` publishes the outer cursor and `*moved` **only after `tx.Write` returns nil**. A rolled-back attempt now changes neither. All three walker families (project tables, instance `row_version` tables, remotes) route through it — collapsing ~150 lines of triplicated tx boilerplate.
- **`internal/service/retention.go`** (campsite) — `Retention.Sweep`'s once-per-sweep `plansPruned` flag was the same bug class: set inside the replayable closure, so a pruning chunk that rolled back and retried stranded the plan prune. Now `prunedThisChunk` is attempt-local and `plansPruned` is published post-commit.

### Tests (`internal/isolation/reencrypt_e2e_test.go`)
Deterministic commit-time retry injection via an `AfterChunk(ctx, table)` seam returning `store.ErrRetrySerialization` once per walker family. **Red-first proven** against the old walkers (dryness `ErrConflict`), green after.
- Per-family single-row injection (skip proof): project `value`, instance `password_credentials`, `remotes`.
- `TestReencryptMultiChunkRetrySafe` — 3 remotes, retry on chunk 2 → committed chunk 1 not re-counted, retried chunk advances exactly once.
- Exact completion-audit count (decoded numerically, not `LIKE`).

Meets all four acceptance criteria: failed attempt changes no outer state; retried chunk counts exactly once; deterministic commit-time retry test across all families; completion audit exact + retirement succeeds after one run.

### Verification
- Full suite **exit 0 on both engines** (sqlite + postgres).
- Cross-model review (Codex gpt-5.6-sol, high): R1 clean-for-production + 1 LOW test-matcher → **R2 CLEAN**. Claude Standards + Spec axes: no blocking items.
- Bound registry stays `StatusEnforced`; `ReencryptChunkSize`/`ReencryptChunkPause` (100 / 100 ms) untouched.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789896925&installation_model_id=432348&pr_number=208&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F208&signature=cfde2ee6f234730a0cf85ae8cfbe03c403cfa5e596c42478b4e8f3e072cb9427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->