### PR TITLE
fix(docs): stop landing-page fallback

### DIFF
--- a/docs/site/scripts/build-pwa.mjs
+++ b/docs/site/scripts/build-pwa.mjs
@@ -10,8 +10,6 @@ const { count, size, warnings } = await generateSW({
   globPatterns: ['**/*.{css,html,js,json,png,svg,txt,webmanifest,woff,woff2}'],
   ignoreURLParametersMatching: [/^deployment$/, /^utm_/, /^fbclid$/],
   inlineWorkboxRuntime: true,
-  navigateFallback: '/index.html',
-  navigateFallbackDenylist: [/^\/api\//, /^\/prototypes(?:\/|$)/],
   skipWaiting: true,
   sourcemap: false,
   swDest: fileURLToPath(new URL('../dist/sw.js', import.meta.url)),

--- a/docs/site/scripts/test-pwa-offline.mjs
+++ b/docs/site/scripts/test-pwa-offline.mjs
@@ -22,6 +22,22 @@ const contentTypes = new Map([
 const server = createServer(async (request, response) => {
   try {
     const pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://localhost').pathname);
+    if (!pathname.endsWith('/') && extname(pathname) === '') {
+      const directoryIndexPath = resolve(dist, `.${pathname}/index.html`);
+      if (!directoryIndexPath.startsWith(`${dist}${sep}`)) {
+        response.writeHead(403).end('Forbidden');
+        return;
+      }
+      try {
+        await readFile(directoryIndexPath);
+        response.writeHead(301, { Location: `${pathname}/` }).end();
+        return;
+      } catch (error) {
+        const code = error instanceof Error && 'code' in error ? error.code : undefined;
+        if (code !== 'ENOENT') throw error;
+      }
+    }
+
     const assetPath = pathname.endsWith('/') ? `${pathname}index.html` : pathname;
     const filePath = resolve(dist, `.${assetPath}`);
     if (!filePath.startsWith(`${dist}${sep}`)) {
@@ -93,6 +109,16 @@ try {
       }, { once: true });
     });
   });
+
+  const slashlessDocsResponse = await page.goto(`${origin}/docs/getting-started`, {
+    waitUntil: 'networkidle',
+  });
+  assert.ok(slashlessDocsResponse?.ok(), 'slashless docs route did not load successfully');
+  assert.equal(
+    await page.title(),
+    'Getting started — Hikyo',
+    'service worker navigation fallback replaced the slashless docs route',
+  );
 
   const prototypeResponse = await page.goto(`${origin}/prototypes/`, {
     waitUntil: 'networkidle',


### PR DESCRIPTION
## Summary

- remove SPA-only Workbox navigation fallback from Astro multi-page docs
- preserve GitHub Pages canonical slash redirects under service-worker control
- add Playwright regression coverage for slashless docs navigation

## Verification

- `./scripts/ci/verify-docs.sh`
- Standards review: CLEAN
- Spec review: CLEAN

Fixes the reported `/docs/getting-started` landing-page redirect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789899427&installation_model_id=432348&pr_number=258&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F258&signature=5987cdb880b510a8c06b569bc2c13a1dd93c4608f93e9db76d5967a18336d589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->