### PR TITLE
perf(ci): cache the Playwright browser payload for web and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,25 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
+      # verify-docs.sh installs Chromium for the docs site's own browser gates.
+      # Same payload, same cache directory as the `web` job, but keyed on the
+      # docs lockfile because that is what pins the docs site's Playwright.
+      - name: Restore Playwright browsers
+        id: playwright-browsers
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-docs-${{ runner.os }}-${{ hashFiles('docs/site/pnpm-lock.yaml') }}
       - name: Typecheck, build, and assert O4-O6 policy content
         run: ./scripts/ci/verify-docs.sh
+      - name: Save Playwright browsers
+        if: >-
+          success() && steps.playwright-browsers.outputs.cache-hit != 'true' &&
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-browsers.outputs.cache-primary-key }}
 
   compose-demo:
     needs: changes
@@ -480,9 +497,22 @@ jobs:
         # but always execute this job's tests against its fresh build.
         run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
 
+      # The browser payload is ~130 MB pulled from cdn.playwright.dev on every
+      # leg, and both matrix legs pay it. Only the apt half (`install-deps`)
+      # genuinely has to run on a fresh runner; the download half is keyed on
+      # the lockfile that pins @playwright/test, so a version bump is the only
+      # thing that re-downloads it.
+      - name: Restore Playwright browsers
+        id: playwright-browsers
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-web-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
       - name: Install Chromium
         working-directory: web
-        run: pnpm exec playwright install --with-deps chromium
+        run: |
+          pnpm exec playwright install-deps chromium
+          pnpm exec playwright install chromium
 
       # `playwright test` directly, not `pnpm run e2e`: the script rebuilds the
       # SPA so a developer cannot run the flows against a stale bundle, and the
@@ -507,6 +537,18 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ steps.web-go-cache.outputs.cache-primary-key }}
+      # Same single-writer rule as the Go cache above, and the same reason PR
+      # runs never write: this graph executes untrusted PR code, so only a main
+      # push is trusted to publish a browser payload every later run restores.
+      - name: Save Playwright browsers
+        if: >-
+          success() && steps.playwright-browsers.outputs.cache-hit != 'true' &&
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          matrix.project == 'desktop'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-browsers.outputs.cache-primary-key }}
 
   test:
     needs: changes


### PR DESCRIPTION
Chromium, its headless shell, and FFmpeg were pulled from `cdn.playwright.dev` on every `web` matrix leg and every `docs` run. Measured on job `96013877243`, the `Install Chromium` step cost 28.4s (18.1s on the desktop leg), and there was no cache behind it anywhere in the workflow. Across 53 web legs and 79 docs runs in the last usage window that is roughly 30 minutes of pure download.

The step really has two halves with different caching properties: `install-deps` is apt work a fresh runner genuinely has to redo, and `install` is the ~130 MB download that never changes until `@playwright/test` moves. Splitting them lets the download half sit behind a cache keyed on the lockfile that pins the version:

```yaml
- name: Restore Playwright browsers
  id: playwright-browsers
  uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
  with:
    path: ~/.cache/ms-playwright
    key: playwright-web-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
- name: Install Chromium
  working-directory: web
  run: |
    pnpm exec playwright install-deps chromium
    pnpm exec playwright install chromium
```

`install` still runs unconditionally rather than behind a `cache-hit` guard: it is a fast no-op once the payload is present, and that way a partially restored cache self-heals instead of failing later inside the flow suite.

Writes follow the discipline already established for the Go caches in this file. Only a main push writes, because this graph runs untrusted PR code under `pull_request_target` and a PR-writable browser payload would be a poisoning vector, and only the `desktop` leg writes so the two matrix legs do not race for the same key. `docs` gets the same treatment keyed on `docs/site/pnpm-lock.yaml`, since `verify-docs.sh` installs the same payload for the docs browser gates.

Both lockfiles pin `@playwright/test` 1.62.1 today, but the keys are kept separate so the two consumers can drift independently.

### Validation

- `actionlint` v1.7.12 (the version pinned by the `lint` job): clean
- `scripts/ci/check-trusted-ci-scripts_test.sh`: pass
- `scripts/ci/classify-changed-paths_test.sh`: pass
- `scripts/ci/check-required-jobs_test.sh`: pass
- No job names added or removed, so the `ci-required` contract in `check-required-jobs.sh` is untouched

### Note on scope

This is the one uncontroversial item from the CI cost review. The larger levers (runner SKUs, the `web` viewport sharding from #169, and the full-suite-on-main contract) each need a policy decision and are not in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->