### PR TITLE
ci: pilot a Blacksmith arm64 runner for the test job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Blacksmith runner labels are custom self-hosted labels, so actionlint cannot
+# infer them from GitHub's hosted-label list. Declare every label used by
+# `runs-on:` in .github/workflows so the runner-label rule stays enforced.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,15 +549,18 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      # GOCACHE entries are keyed internally by GOARCH, so a cross-architecture
+      # restore is a few hundred megabytes downloaded to hit on nothing. The
+      # module cache above is exempt: it holds module source, not objects.
       - name: Restore test Go cache
         id: test-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build
-          key: go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: go-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-
-            go-test-${{ runner.os }}-
+            go-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}-
+            go-test-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Populate shared Go module cache
         run: go mod download
@@ -890,14 +893,19 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
-      - name: Restore test Go cache
+      # This job used to read `test`'s GOCACHE. `test` is now the arm64 runner
+      # pilot, and a GOCACHE built for another GOARCH hits on nothing, so this
+      # job keeps its own amd64 lineage under its own prefix rather than paying
+      # to download one it cannot use.
+      - name: Restore headline-guarantee Go cache
+        id: headline-guarantee-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build
-          key: go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: go-headline-guarantee-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            go-test-${{ runner.os }}-${{ hashFiles('go.sum') }}-
-            go-test-${{ runner.os }}-
+            go-headline-guarantee-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}-
+            go-headline-guarantee-${{ runner.os }}-${{ runner.arch }}-
       - name: Container round-trip, stanza exclusivity and truncation refusal
         run: go test -count=1 ./internal/crypto/backup/
       - name: Planted-plaintext scan of dump and backup, and credential replay refusal
@@ -908,6 +916,12 @@ jobs:
           -run 'TestBackupRestoreDrill|TestNoBulkAcceptInTheAPISurface'
       - name: Automatic pre-migration export, with recipients and without
         run: go test -count=1 ./internal/app/ -run TestPreMigrationExport
+      - name: Save headline-guarantee Go cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.headline-guarantee-go-cache.outputs.cache-primary-key }}
 
   # The permanent required context. Every validation job is named here so a
   # future job split cannot accidentally weaken branch protection.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,15 @@ jobs:
   test:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).test }}
-    runs-on: ubuntu-latest
+    # Metered-runner pilot, and deliberately the only job on one. GitHub-hosted
+    # minutes are free on a public repository, so a Blacksmith runner only earns
+    # its keep where wall clock is on the critical path: this job is ~420s of
+    # mostly CPU-bound `go test`, second only to the flow suite. Same vCPU count
+    # as the hosted runner it replaces, so the measured delta is attributable to
+    # the runner and not to a tier change. arm64 is safe here specifically:
+    # modernc.org/sqlite is pure Go, nothing carries an amd64 build constraint,
+    # and the pinned postgres index publishes linux/arm64/v8.
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     services:
       postgres:
         image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a


### PR DESCRIPTION
Hikyo is a public repository, so GitHub-hosted minutes are free and effectively unlimited. That makes a metered Blacksmith runner worth paying for only where wall clock sits on the PR critical path, and it makes "move everything" the wrong shape. This moves exactly one job.

Measured from the last four green `trusted-ci` runs on hosted runners, the critical path is a four-way cluster:

| job | hosted duration |
| --- | --- |
| `web (desktop)` | 412-442s |
| `race` | 431-453s |
| `test` | 417-421s |
| `fuzz` | 348-357s |

`test` is the best first candidate: it is nearly all CPU-bound `go test`, and unlike `web` it is arm64-eligible, so it gets the 0.625x ARM rate.

```yaml
  test:
    needs: changes
    if: ${{ fromJSON(needs.changes.outputs.plan).test }}
    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
```

The tier stays at 4 vCPU deliberately. It matches the hosted runner it replaces, so whatever the run history shows is attributable to the runner rather than confounded by a simultaneous tier change.

### Why arm64 is safe for this job specifically

- `modernc.org/sqlite` is a pure-Go driver, so there is no cgo to cross-build
- no package in the tree carries an `amd64` build constraint
- the pinned `postgres:18@sha256:3a82e1f5…` digest is an OCI image index that publishes `linux/arm64/v8` alongside amd64, so the service container resolves normally

This does not generalise. `web` and `docs` **cannot** move to arm64: Chrome for Testing publishes no `linux-arm64` build (`chrome-linux-arm64.zip` is a 404 in the Chrome for Testing bucket) and Playwright 1.62.1 resolves chromium from exactly that bucket. `release-snapshot` is also a poor ARM candidate, since `scripts/release/snapshot-manifest_test.sh` matches on `Linux:x86_64 | Linux:amd64` when picking the native archive.

### Budget

At roughly 15-16 runs/day this projects to about 4,100 billing minutes/month, near half of the 8,000/month cap, with nothing else metered. Worth re-reading the actual burn with `blacksmith usage --repo Hikyo-Org/Hikyo --since 7d` after a day or two and dropping to 2 vCPU if the wall-clock win does not justify the tier.

Reverting is a one-line change back to `ubuntu-latest`.

### Validation

- `actionlint` v1.7.12, the version pinned by the `lint` job: clean. Confirmed it fails without the restored config, which is why `.github/actionlint.yaml` comes back here after being deleted in #170
- `scripts/ci/check-trusted-ci-scripts_test.sh`, `classify-changed-paths_test.sh`, `check-required-jobs_test.sh`: all pass
- No job added or removed, so the `ci-required` contract is untouched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->