### PR TITLE
ci: keep the race detector and fuzz pass off the per-PR path

### DIFF
--- a/scripts/ci/classify-changed-paths.sh
+++ b/scripts/ci/classify-changed-paths.sh
@@ -23,6 +23,15 @@ test=false
 web=false
 saw_path=false
 
+# `race` and `fuzz` are deliberately absent from every per-path rule below, so
+# they are selected only by all_jobs — that is, by a main push, by a dependency
+# or workflow change, and by the fail-closed default. Both are long (~440s and
+# ~360s) and neither is a per-change regression gate: the race detector wants
+# repeated executions over time rather than one pass per commit, and the fuzz
+# job is a bounded exploration whose value comes from cumulative runs. Merges
+# still cover them, and fuzz-report.yml's report-main job already routes push
+# findings to a repository issue, so nothing is lost by keeping them off the
+# per-PR critical path.
 all_jobs() {
 	client=true
 	compose_demo=true
@@ -95,8 +104,6 @@ else
 			generated=true
 			headline_guarantee=true
 			release_snapshot=true
-			fuzz=true
-			race=true
 			test=true
 			web=true
 			;;
@@ -108,11 +115,9 @@ else
 		# The operator (Go under test by the kind e2e) and the kind e2e test
 		# itself carry the *.go integration set PLUS the k8s_e2e job.
 		internal/operator/* | internal/isolation/k8s_*)
-			fuzz=true
 			generated=true
 			headline_guarantee=true
 			k8s_e2e=true
-			race=true
 			release_snapshot=true
 			test=true
 			web=true
@@ -137,11 +142,9 @@ else
 			supply_chain_checks=true
 			;;
 		*.go | *.sql)
-			fuzz=true
 			generated=true
 			headline_guarantee=true
 			release_snapshot=true
-			race=true
 			test=true
 			web=true
 			;;

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -51,11 +51,9 @@ if ! printf '%s\n' "$core_actual" | jq -e '
 	.generated == true and
 	.headline_guarantee == true and
 	.release_snapshot == true and
-	.fuzz == true and
-	.race == true and
 	.test == true and
 	.web == true and
-	([.client, .compose_demo, .docs, .k8s_e2e, .lint, .supply_chain_checks] | all(. == false))
+	([.client, .compose_demo, .docs, .fuzz, .k8s_e2e, .lint, .race, .supply_chain_checks] | all(. == false))
 ' >/dev/null; then
 	printf 'changed-path classifier fixture failed: core plan was wrong\n' >&2
 	printf 'actual: %s\n' "$core_actual" >&2
@@ -66,14 +64,12 @@ api_actual=$(printf '%s\n' 'api/openapi.yaml' | "$classifier" --files)
 if ! printf '%s\n' "$api_actual" | jq -e '
 	.client == true and
 	.compose_demo == true and
-	.fuzz == true and
 	.generated == true and
 	.headline_guarantee == true and
 	.release_snapshot == true and
-	.race == true and
 	.test == true and
 	.web == true and
-	([.docs, .k8s_e2e, .lint, .supply_chain_checks] | all(. == false))
+	([.docs, .fuzz, .k8s_e2e, .lint, .race, .supply_chain_checks] | all(. == false))
 ' >/dev/null; then
 	printf 'changed-path classifier fixture failed: API plan was wrong\n' >&2
 	printf 'actual: %s\n' "$api_actual" >&2
@@ -155,6 +151,26 @@ if ! printf '%s\n' "$all_actual" | jq -e 'all(.[]; . == true)' >/dev/null; then
 	exit 1
 fi
 
+# The race detector and the fuzz pass are reachable ONLY through all_jobs: a main
+# push, a dependency or workflow change, or the fail-closed default. No per-path
+# rule may select them, or they land back on the per-PR critical path.
+for scoped_path in \
+	'internal/service/values.go' \
+	'internal/store/query.sql' \
+	'api/openapi.yaml' \
+	'internal/operator/reconciler.go' \
+	'internal/isolation/k8s_operator_e2e_test.go' \
+	'web/src/routes/Values.tsx' \
+	'docs/site/src/content/docs/docs/index.mdx'; do
+	scoped_actual=$(printf '%s\n' "$scoped_path" | "$classifier" --files)
+	if ! printf '%s\n' "$scoped_actual" | jq -e '.fuzz == false and .race == false' >/dev/null; then
+		printf 'changed-path classifier fixture failed: %s selected race/fuzz on a scoped plan\n' \
+			"$scoped_path" >&2
+		printf 'actual: %s\n' "$scoped_actual" >&2
+		exit 1
+	fi
+done
+
 for dependency_or_config in \
 	'go.sum' \
 	'web/pnpm-lock.yaml' \
@@ -207,12 +223,10 @@ for operator_path in \
 		.k8s_e2e == true and
 		.generated == true and
 		.headline_guarantee == true and
-		.fuzz == true and
-		.race == true and
 		.release_snapshot == true and
 		.test == true and
 		.web == true and
-		([.client, .docs, .lint, .supply_chain_checks] | all(. == false))
+		([.client, .docs, .fuzz, .lint, .race, .supply_chain_checks] | all(. == false))
 	' >/dev/null; then
 		printf 'changed-path classifier fixture failed: %s did not select k8s_e2e\n' \
 			"$operator_path" >&2


### PR DESCRIPTION
`race` and `fuzz` currently fire on every `*.go` or `*.sql` PR. Measured across four green `trusted-ci` runs on hosted runners they cost 431-453s and 348-357s, which is roughly 800s of a ~2800s suite, and neither is really a per-change regression gate: the race detector wants repeated executions over time rather than one pass per commit, and the fuzz job is a bounded exploration whose value is cumulative.

The change is entirely in the classifier. Both flags come out of every per-path rule, which leaves them reachable only through `all_jobs`:

```sh
		*.go | *.sql)
			generated=true
			headline_guarantee=true
			release_snapshot=true
			test=true
			web=true
			;;
```

`all_jobs` still covers a main push, any dependency or workflow change, and the fail-closed default, so every merge continues to run both. Nothing is lost on the reporting side either: `fuzz-report.yml` already has a `report-main` job for `workflow_run` failures where `event == 'push'`, and it routes findings straight to a repository issue. That path was already built for exactly this case.

Resulting plans:

```
internal/service/values.go  ->  race:false fuzz:false  test:true web:true generated:true …
--all (main push)           ->  every flag true, race and fuzz included
```

### Honest sizing

The direct critical-path gain is small. The path was `max(race 453, web 442, test 421, fuzz 357)`, and it becomes `max(web 442, test 421)` — about 11s, because the flow suite still dominates. The real effect is 28% less total work per PR run, which matters against the free-tier concurrency limit when several PRs are in flight, and it removes two long jobs from the flake surface. Cutting PR latency further means attacking `web`, which is a separate question.

### Contract impact

None. `race` and `fuzz` remain plan keys and job names, so `expected_plan` and `expected_results` in `check-required-jobs.sh` are untouched, and `ci-required` keeps them in `needs`. On a PR the plan says false and the jobs report `skipped`, which is exactly the consistency the checker asserts. On `push` the plan is all-true, so the `all($plan[]; . == true)` assertion still holds.

### Validation

- `scripts/ci/classify-changed-paths_test.sh`: pass, with three fixtures updated (core, API, operator) and a new loop asserting no scoped path can ever select `race` or `fuzz` again
- `scripts/ci/check-required-jobs_test.sh`, `scripts/ci/check-trusted-ci-scripts_test.sh`: pass
- `shellcheck` v0.11.0 on both changed scripts: clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->