### PR TITLE
ci: give the shared Go module cache a restore-key fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore lint Go cache
         id: lint-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -212,6 +214,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore release-snapshot Go cache
         id: release-snapshot-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -267,6 +271,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore generated-code Go cache
         id: generated-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -439,6 +445,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore web Go cache
         id: web-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -583,6 +591,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore test Go cache
         id: test-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -664,6 +674,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore k8s-e2e Go cache
         id: k8s-e2e-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -736,6 +748,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore race Go cache
         id: race-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -776,6 +790,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore fuzz Go cache
         id: fuzz-go-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -924,6 +940,8 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
       - name: Restore test Go cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:


### PR DESCRIPTION
All nine `Restore shared Go module cache` steps keyed only on the exact `go.sum` hash, with no fallback:

```yaml
- name: Restore shared Go module cache
  uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
  with:
    path: ~/go/pkg/mod
    key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
    restore-keys: |
      go-mod-${{ runner.os }}-
```

Without the fallback, any miss on that key is a *total* miss: every Go job re-downloads the entire module graph rather than restoring the 466 MB entry that differs from it by a handful of modules.

### Misses are not rare

The repo currently holds **14.39 GB of active caches against GitHub's 10 GB per-repository budget**. Each per-job GOCACHE key carries `${{ github.run_id }}-${{ github.run_attempt }}`, so every main push writes a brand-new entry instead of replacing one, and the duplicates are visible in the cache inventory:

| prefix | entries | total |
| --- | --- | --- |
| `go-race-Linux` | 2 | 2120 MB |
| `go-web-Linux` | 2 | 1223 MB |
| `codeql-dependencies-1` | 2 | 1156 MB |
| `go-k8s-e2e` | 2 | 1102 MB |
| `go-fuzz-Linux` | 1 | 1010 MB |
| `go-test-Linux` | 1 | 964 MB |
| `go-mod-Linux` | 1 | 466 MB |

Roughly 4.5 GB of fresh GOCACHE per main push against a 10 GB budget means LRU eviction runs constantly, and the single shared module cache is a frequent casualty. Run `32475020683` caught it directly, in three jobs at once:

```
Cache not found for input keys: go-mod-Linux-9ac134acf411e2e771317ef15dbd474fa3c602a55719cc9bca50f6d8d19dfb51
```

The same run restored its *per-job* GOCACHE fine, because those steps already have prefix restore-keys. The module cache was the only one without them.

### Why a stale module cache is safe

`~/go/pkg/mod` is content-addressed by `module@version` and verified against `go.sum`. Extra entries from an older generation are inert, and anything missing is fetched by the `go mod download` / build that follows. This is the same fallback `actions/setup-go` uses internally.

### The save path is unaffected

`actions/cache` reports `cache-hit == 'true'` only on an exact primary-key match. A prefix hit leaves it `false`, so the existing condition on the single trusted writer in `test` still re-seeds the new `go.sum` key:

```yaml
if: >-
  success() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
  steps.go-module-cache.outputs.cache-hit != 'true'
```

After a dependency bump the job now restores the near-complete cache, downloads only the delta, and saves a complete entry under the new key.

### Not addressed here

The 14.39 GB overrun itself is the root cause and wants a separate decision. The per-job GOCACHE split is deliberate (the comment in `test` explains the setup-go write race it avoids), so consolidating those keys is not a change I want to make unilaterally.

### Validation

- `actionlint` v1.7.12: clean
- `check-trusted-ci-scripts_test.sh`, `classify-changed-paths_test.sh`, `check-required-jobs_test.sh`: pass
- Mechanical change, 9 identical insertions, no job or key renamed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->