### PR TITLE
fix(deps): patch js-yaml denial of service

### DIFF
--- a/clients/ts/pnpm-lock.yaml
+++ b/clients/ts/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@<4.3.1: 4.3.1
+
 importers:
 
   .:
@@ -156,8 +159,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   ohash@2.0.12:
@@ -246,7 +249,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
 
   '@hey-api/openapi-ts@0.97.3(typescript@5.9.3)':
     dependencies:
@@ -371,7 +374,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/clients/ts/pnpm-workspace.yaml
+++ b/clients/ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  js-yaml@<4.3.1: 4.3.1

--- a/docs/handoff/dependabot-5-js-yaml.md
+++ b/docs/handoff/dependabot-5-js-yaml.md
@@ -1,0 +1,40 @@
+# Handoff: Dependabot #5 js-yaml CPU denial of service
+
+## Scope
+
+Dependabot [#5](https://github.com/Hikyo-Org/Hikyo/security/dependabot/5)
+reports `GHSA-52cp-r559-cp3m` / `CVE-2026-59869` against the TypeScript
+client's transitive development dependency on `js-yaml@4.1.1`.
+
+## Decision
+
+- Keep `@hey-api/openapi-ts@0.97.3`; upgrading it cannot close the finding
+  because its latest transitive parser still pins a vulnerable `js-yaml`.
+- Override vulnerable `js-yaml` 4.x versions to `4.3.1`. This is the smallest
+  patched version that closes both the reported merge-key-chain finding and the
+  newer `GHSA-5p4m-2wfm-xmqj` ordered-map CPU denial of service.
+- Treat `clients/ts/pnpm-workspace.yaml` as build configuration in the changed-
+  path classifier so override-only changes select the full CI suite.
+
+## Changed surfaces
+
+- `clients/ts/pnpm-workspace.yaml`: declares the narrow transitive override.
+- `clients/ts/pnpm-lock.yaml`: resolves the sole `js-yaml` copy to `4.3.1`.
+- `scripts/ci/classify-changed-paths.sh`: classifies the pnpm workspace config
+  as a full-suite dependency/config change.
+- `scripts/ci/classify-changed-paths_test.sh`: locks that classification in.
+
+## Verification
+
+- `pnpm --dir clients/ts audit --json`: zero vulnerabilities.
+- `pnpm --dir clients/ts verify`: generated client stayed fresh; TypeScript and
+  all 4 contract tests passed.
+- Changed-path classifier fixture, ShellCheck 0.11.0, and actionlint 1.7.12
+  passed.
+- 14 independent supply-chain fixtures passed.
+- Web TypeScript, 240 unit tests, and production build passed.
+- Docs verification passed with 0 Astro diagnostics and 34 pages built.
+- `go test -count=1 ./...` passed 3,971 tests across 56 packages against a
+  disposable PostgreSQL 18 instance.
+- Local `scripts/release/test-fixtures.sh` remains unverified because `cosign`
+  is not installed; GitHub CI installs pinned cosign 3.1.3 before this gate.

--- a/scripts/ci/classify-changed-paths.sh
+++ b/scripts/ci/classify-changed-paths.sh
@@ -59,7 +59,7 @@ else
 		# their owning directory, so keep them on the full integration backstop.
 		go.mod | go.sum | sqlc.yaml | .goreleaser.yaml | \
 			web/package.json | web/pnpm-lock.yaml | web/tsconfig*.json | web/*.config.* | \
-			clients/ts/package.json | clients/ts/pnpm-lock.yaml | clients/ts/tsconfig*.json | clients/ts/*.config.* | \
+			clients/ts/package.json | clients/ts/pnpm-lock.yaml | clients/ts/pnpm-workspace.yaml | clients/ts/tsconfig*.json | clients/ts/*.config.* | \
 			docs/site/package.json | docs/site/pnpm-lock.yaml | docs/site/tsconfig*.json | docs/site/*.config.*)
 			all_jobs
 			;;

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -159,6 +159,7 @@ for dependency_or_config in \
 	'go.sum' \
 	'web/pnpm-lock.yaml' \
 	'clients/ts/package.json' \
+	'clients/ts/pnpm-workspace.yaml' \
 	'docs/site/package.json' \
 	'.goreleaser.yaml'; do
 	dependency_actual=$(printf '%s\n' "$dependency_or_config" | "$classifier" --files)


### PR DESCRIPTION
## Summary

- override vulnerable transitive js-yaml versions with patched 4.3.1
- make the TypeScript pnpm workspace config select the full CI suite
- document remediation and verification in the finding handoff

Addresses Dependabot alert https://github.com/Hikyo-Org/Hikyo/security/dependabot/5 and also closes the newer GHSA-5p4m-2wfm-xmqj exposure found by pnpm audit.

## Verification

- pnpm audit: 0 vulnerabilities
- TypeScript client generation, typecheck, and 4 contract tests passed
- web typecheck, 240 unit tests, and production build passed
- Go suite: 3,971 tests across 56 packages passed with PostgreSQL 18
- docs verification: 0 Astro diagnostics, 34 pages built, PWA and policy gates passed
- ShellCheck 0.11.0, actionlint 1.7.12, and 14 independent supply-chain fixtures passed
- Standards review: CLEAN
- Spec review: CLEAN

Local scripts/release/test-fixtures.sh was not run because cosign is absent locally; CI installs pinned cosign 3.1.3 before this gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hikyo-Org/codesmith/Hikyo/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789909840&installation_model_id=432348&pr_number=264&repository=Hikyo-Org%2FHikyo&return_to=https%3A%2F%2Fgithub.com%2FHikyo-Org%2FHikyo%2Fpull%2F264&signature=a3908288ebab6b2f429e42b4cc138bbbb9ab6663c886a9618a05058c1604e4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->