### PR TITLE
Give every SQLite restore uniquely owned staging

### DIFF
--- a/docs/handoff/219-sqlite-restore-staging.md
+++ b/docs/handoff/219-sqlite-restore-staging.md
@@ -1,0 +1,51 @@
+# Handoff: #219 uniquely owned SQLite restore staging
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/219 (parent #204; programme
+#203; audit ID `DB02-B`).
+
+## What changed
+
+- `store.RestoreSQLite` creates its staging database with `os.CreateTemp` in
+  the destination directory. Every concurrent attempt therefore owns a unique
+  path while preserving same-filesystem publication.
+- `sqliteRestoreStaging` owns the open file plus the exact database, WAL, and
+  SHM paths. It closes the file before SQLite opens the snapshot and removes
+  only those owned paths during unwind.
+- Cleanup errors join the restore error instead of disappearing. A cleanup
+  failure after publication is therefore explicit even though the destination
+  hard link already exists.
+- Publication remains `os.Link`: the destination is never overwritten if it
+  appears while a restore is running. `os.CreateTemp`'s `0600` mode carries to
+  the published hard link.
+
+## Regression evidence
+
+- A mutation barrier holds one restore open while a second reaches the same
+  phase. Their staging paths must differ; exactly one publication succeeds and
+  the other returns `ErrTargetNotEmpty`.
+- The cleanup table injects failures at staging creation, archive extraction,
+  staging close, database open, mutation, database close, fsync, publication,
+  and cleanup. Every created staging artifact is absent afterward.
+- The publication-conflict row proves pre-existing target bytes remain
+  unchanged. The permission test proves the published database is `0600`.
+
+## Validation
+
+```text
+go test -count=1 ./internal/store -run 'TestRestoreSQLite'        13 passed
+go test -count=1 ./internal/store/...                            61 passed
+go test -race -count=1 ./internal/store/...                      61 passed
+go test -count=1 ./internal/isolation -run '^TestBackupRestoreDrillSQLite$'
+                                                                 11 passed
+go test -count=1 ./...                                           2916 passed
+```
+
+The first full-suite run passed 2802 tests but three unrelated tests timed out
+under package-level contention. Both isolation failures passed together (2/2),
+the lint package passed alone (28/28), and the unchanged full command then
+passed all 2916 tests.
+
+Docs build, Astro diagnostics, OSS/PWA static policy, live-docs, and fallback
+checks passed. The offline Playwright check could not launch Chromium in this
+macOS agent (`MachPortRendezvousServer`, error 141) on two attempts; no page or
+application code ran.

--- a/docs/handoff/76-backup-restore-drill.md
+++ b/docs/handoff/76-backup-restore-drill.md
@@ -118,9 +118,9 @@ The adversarial pass found five things; all fixed in this PR:
   (`os.CreateTemp`), no-replace publication (`os.Link`) with suffix retry.
 - **Empty-target TOCTOU closed**: sqlite publishes the restored file with
   `os.Link` (fails if a database appeared since the check) under a
-  pid-unique staging name; postgres re-verifies emptiness-modulo-migration-
-  seeds under `LOCK TABLE ... ACCESS EXCLUSIVE` inside the restore
-  transaction, before the truncate.
+  per-attempt, exclusively created staging name in the destination directory;
+  postgres re-verifies emptiness-modulo-migration-seeds under `LOCK TABLE ...
+  ACCESS EXCLUSIVE` inside the restore transaction, before the truncate.
 - **Drill honesty**: survival counts captured before the export (on postgres
   `db` and `restored` are the same database, so post-restore reads compared
   the restore with itself); the restore's own `restore.completed` event is

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -435,7 +435,7 @@ func openArchive(archive io.Reader) (*tar.Reader, Manifest, error) {
 
 // RestoreSQLite writes the archive's snapshot to path, which must not exist.
 // The file is fully written and fsynced under a temporary name and then
-// renamed into place, so a crash mid-restore cannot leave a half-written
+// linked into place, so a crash mid-restore cannot leave a half-written
 // database where a complete one is expected.
 //
 // mutate runs against the restored file BEFORE it is published, which is
@@ -443,6 +443,32 @@ func openArchive(archive io.Reader) (*tar.Reader, Manifest, error) {
 // reachable, even for an instant, in a state where its pre-restore bearer
 // credentials still authenticate.
 func RestoreSQLite(ctx context.Context, archive io.Reader, path string, mutate func(ctx context.Context, db *DB) error) (Manifest, error) {
+	return restoreSQLite(ctx, archive, path, mutate, defaultSQLiteRestoreOperations())
+}
+
+type sqliteRestoreOperations struct {
+	createTemp    func(string, string) (*os.File, error)
+	closeFile     func(*os.File) error
+	openDatabase  func(context.Context, Config) (*DB, error)
+	closeDatabase func(*DB) error
+	fsyncFile     func(string) error
+	link          func(string, string) error
+	remove        func(string) error
+}
+
+func defaultSQLiteRestoreOperations() sqliteRestoreOperations {
+	return sqliteRestoreOperations{
+		createTemp:    os.CreateTemp,
+		closeFile:     func(file *os.File) error { return file.Close() },
+		openDatabase:  Open,
+		closeDatabase: func(db *DB) error { return db.Close() },
+		fsyncFile:     fsyncFile,
+		link:          os.Link,
+		remove:        os.Remove,
+	}
+}
+
+func restoreSQLite(ctx context.Context, archive io.Reader, path string, mutate func(ctx context.Context, db *DB) error, operations sqliteRestoreOperations) (manifest Manifest, restoreErr error) {
 	tr, m, err := openArchive(archive)
 	if err != nil {
 		return Manifest{}, err
@@ -456,32 +482,29 @@ func RestoreSQLite(ctx context.Context, archive io.Reader, path string, mutate f
 		return Manifest{}, fmt.Errorf("store: check restore target: %w", err)
 	}
 
-	// The staging name is unique per restore attempt: a fixed `<path>.restoring`
-	// would let two concurrent restores write the same file and publish each
-	// other's bytes.
-	staging := fmt.Sprintf("%s.restoring-%d", path, os.Getpid())
-	if err := os.Remove(staging); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return Manifest{}, fmt.Errorf("store: clear restore staging file: %w", err)
-	}
-	if err := extractMemberTo(tr, sqliteMember, staging); err != nil {
+	staging, err := createSQLiteRestoreStaging(path, operations)
+	if err != nil {
 		return Manifest{}, err
 	}
-	// sqlite checkpoints and deletes the -wal on last close, but a crash can
-	// leave the sidecars behind, and a stale one beside the staging name would
-	// outlive the restore.
 	defer func() {
-		for _, suffix := range []string{"", "-wal", "-shm"} {
-			os.Remove(staging + suffix)
+		if cleanupErr := staging.cleanup(); cleanupErr != nil {
+			restoreErr = errors.Join(restoreErr, cleanupErr)
 		}
 	}()
+	if err := extractMemberTo(tr, sqliteMember, staging.file, staging.database); err != nil {
+		return Manifest{}, err
+	}
+	if err := staging.close(); err != nil {
+		return Manifest{}, fmt.Errorf("store: write %s: %w", staging.database, err)
+	}
 
 	if mutate != nil {
-		db, err := Open(ctx, Config{Engine: EngineSQLite, Path: staging})
+		db, err := operations.openDatabase(ctx, Config{Engine: EngineSQLite, Path: staging.database})
 		if err != nil {
 			return Manifest{}, fmt.Errorf("store: open restored snapshot: %w", err)
 		}
 		mutateErr := mutate(ctx, db)
-		closeErr := db.Close()
+		closeErr := operations.closeDatabase(db)
 		if mutateErr != nil {
 			return Manifest{}, mutateErr
 		}
@@ -489,7 +512,7 @@ func RestoreSQLite(ctx context.Context, archive io.Reader, path string, mutate f
 			return Manifest{}, fmt.Errorf("store: close restored snapshot: %w", closeErr)
 		}
 	}
-	if err := fsyncFile(staging); err != nil {
+	if err := operations.fsyncFile(staging.database); err != nil {
 		return Manifest{}, err
 	}
 	// link(2), not rename(2): the not-exists check above raced everything that
@@ -497,7 +520,7 @@ func RestoreSQLite(ctx context.Context, archive io.Reader, path string, mutate f
 	// in the meantime. Link fails on an existing target, which re-asserts
 	// "must not exist" at the moment of publication. The staging name is
 	// removed by the deferred cleanup.
-	if err := os.Link(staging, path); err != nil {
+	if err := operations.link(staging.database, path); err != nil {
 		if errors.Is(err, os.ErrExist) {
 			return Manifest{}, fmt.Errorf("%w: %s appeared during the restore", ErrTargetNotEmpty, path)
 		}
@@ -506,9 +529,67 @@ func RestoreSQLite(ctx context.Context, archive io.Reader, path string, mutate f
 	return m, nil
 }
 
+// sqliteRestoreStaging is one restore attempt's exclusively owned resource.
+// Keeping the database and its SQLite sidecars together prevents cleanup from
+// ever deriving or deleting another attempt's paths.
+type sqliteRestoreStaging struct {
+	database  string
+	wal       string
+	shm       string
+	file      *os.File
+	closeFile func(*os.File) error
+	remove    func(string) error
+}
+
+func createSQLiteRestoreStaging(target string, operations sqliteRestoreOperations) (*sqliteRestoreStaging, error) {
+	directory := filepath.Dir(target)
+	pattern := filepath.Base(target) + ".restoring-*"
+	f, err := operations.createTemp(directory, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("store: create restore staging file: %w", err)
+	}
+	staging := &sqliteRestoreStaging{
+		database:  f.Name(),
+		wal:       f.Name() + "-wal",
+		shm:       f.Name() + "-shm",
+		file:      f,
+		closeFile: operations.closeFile,
+		remove:    operations.remove,
+	}
+	return staging, nil
+}
+
+func (s *sqliteRestoreStaging) close() error {
+	if s.file == nil {
+		return nil
+	}
+	file := s.file
+	s.file = nil
+	return s.closeFile(file)
+}
+
+// cleanup removes only paths derived from the exact file CreateTemp returned.
+// SQLite normally checkpoints and removes its sidecars on close; explicit
+// removal also covers failed opens and interrupted mutation attempts.
+func (s *sqliteRestoreStaging) cleanup() error {
+	var cleanupErrors []error
+	if err := s.close(); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("close %s: %w", s.database, err))
+	}
+	for _, path := range []string{s.database, s.wal, s.shm} {
+		if err := s.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+	if err := errors.Join(cleanupErrors...); err != nil {
+		return fmt.Errorf("store: clean restore staging: %w", err)
+	}
+	return nil
+}
+
 // extractMemberTo walks the archive (already positioned past the manifest)
 // to the named member and writes it out.
-func extractMemberTo(tr *tar.Reader, member, path string) error {
+func extractMemberTo(tr *tar.Reader, member string, destination io.Writer, destinationPath string) error {
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
@@ -520,17 +601,8 @@ func extractMemberTo(tr *tar.Reader, member, path string) error {
 		if hdr.Name != member {
 			continue
 		}
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-		if err != nil {
-			return fmt.Errorf("store: create %s: %w", path, err)
-		}
-		_, copyErr := io.Copy(f, tr)
-		closeErr := f.Close()
-		if copyErr != nil {
-			return fmt.Errorf("store: write %s: %w", path, copyErr)
-		}
-		if closeErr != nil {
-			return fmt.Errorf("store: write %s: %w", path, closeErr)
+		if _, err := io.Copy(destination, tr); err != nil {
+			return fmt.Errorf("store: write %s: %w", destinationPath, err)
 		}
 		return nil
 	}

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -1,0 +1,342 @@
+package store
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRestoreSQLiteConcurrentAttemptsOwnDistinctStaging(t *testing.T) {
+	archive := sqliteRestoreArchive(t, nil)
+	target := filepath.Join(t.TempDir(), "restored.db")
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	results := make(chan error, 2)
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	restore := func() {
+		_, err := RestoreSQLite(t.Context(), bytes.NewReader(archive), target, func(ctx context.Context, db *DB) error {
+			staging, err := sqliteDatabasePath(ctx, db)
+			if err != nil {
+				return err
+			}
+			entered <- staging
+			<-release
+			return nil
+		})
+		results <- err
+	}
+
+	go restore()
+	first := receiveBefore(t, entered, 10*time.Second, "first restore did not reach mutation barrier")
+	go restore()
+	second := receiveBefore(t, entered, 10*time.Second, "second restore did not reach mutation barrier")
+
+	close(release)
+	released = true
+	firstErr := receiveBefore(t, results, 10*time.Second, "first restore did not finish")
+	secondErr := receiveBefore(t, results, 10*time.Second, "second restore did not finish")
+
+	if first == second {
+		t.Fatalf("concurrent restores shared staging path %q", first)
+	}
+	for _, staging := range []string{first, second} {
+		sameDirectory, err := pathsShareDirectory(staging, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sameDirectory {
+			t.Errorf("staging path %q is outside destination directory %q", staging, filepath.Dir(target))
+		}
+	}
+
+	successes := 0
+	conflicts := 0
+	for _, err := range []error{firstErr, secondErr} {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrTargetNotEmpty):
+			conflicts++
+		default:
+			t.Errorf("concurrent restore returned unexpected error: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent restore results: successes=%d target conflicts=%d; want 1 each", successes, conflicts)
+	}
+	assertNoRestoreStaging(t, target)
+}
+
+func TestRestoreSQLiteCleansOwnedStagingOnFailure(t *testing.T) {
+	stagingCreationFailure := errors.New("injected staging creation failure")
+	stagingCloseFailure := errors.New("injected staging close failure")
+	mutationFailure := errors.New("injected mutation failure")
+	databaseCloseFailure := errors.New("injected database close failure")
+	fsyncFailure := errors.New("injected fsync failure")
+	publicationFailure := errors.New("injected publication failure")
+	cleanupFailure := errors.New("injected cleanup failure")
+	tests := []struct {
+		name              string
+		payload           []byte
+		archive           func(t *testing.T, payload []byte) []byte
+		configure         func(*sqliteRestoreOperations)
+		mutate            func(target string) func(context.Context, *DB) error
+		wantError         error
+		wantErrorText     string
+		wantTargetContent []byte
+	}{
+		{
+			name: "staging creation",
+			configure: func(operations *sqliteRestoreOperations) {
+				operations.createTemp = func(string, string) (*os.File, error) {
+					return nil, stagingCreationFailure
+				}
+			},
+			wantError: stagingCreationFailure,
+		},
+		{
+			name:          "payload extraction",
+			payload:       bytes.Repeat([]byte("x"), 1024),
+			archive:       truncatedSQLiteRestoreArchive,
+			wantErrorText: "unexpected EOF",
+		},
+		{
+			name: "staging close",
+			configure: func(operations *sqliteRestoreOperations) {
+				operations.closeFile = func(file *os.File) error {
+					return errors.Join(file.Close(), stagingCloseFailure)
+				}
+			},
+			wantError: stagingCloseFailure,
+		},
+		{
+			name:    "database open",
+			payload: []byte("not a sqlite database"),
+			mutate: func(string) func(context.Context, *DB) error {
+				return func(context.Context, *DB) error { return nil }
+			},
+			wantErrorText: "open restored snapshot",
+		},
+		{
+			name: "mutation",
+			mutate: func(string) func(context.Context, *DB) error {
+				return func(context.Context, *DB) error { return mutationFailure }
+			},
+			wantError: mutationFailure,
+		},
+		{
+			name: "database close",
+			configure: func(operations *sqliteRestoreOperations) {
+				operations.closeDatabase = func(db *DB) error {
+					return errors.Join(db.Close(), databaseCloseFailure)
+				}
+			},
+			mutate: func(string) func(context.Context, *DB) error {
+				return func(context.Context, *DB) error { return nil }
+			},
+			wantError: databaseCloseFailure,
+		},
+		{
+			name: "fsync",
+			configure: func(operations *sqliteRestoreOperations) {
+				operations.fsyncFile = func(string) error { return fsyncFailure }
+			},
+			wantError: fsyncFailure,
+		},
+		{
+			name: "publication conflict",
+			mutate: func(target string) func(context.Context, *DB) error {
+				return func(context.Context, *DB) error {
+					return os.WriteFile(target, []byte("existing database"), 0o600)
+				}
+			},
+			wantError:         ErrTargetNotEmpty,
+			wantTargetContent: []byte("existing database"),
+		},
+		{
+			name: "publication failure",
+			configure: func(operations *sqliteRestoreOperations) {
+				operations.link = func(string, string) error { return publicationFailure }
+			},
+			wantError: publicationFailure,
+		},
+		{
+			name: "cleanup",
+			configure: func(operations *sqliteRestoreOperations) {
+				injected := false
+				operations.remove = func(path string) error {
+					err := os.Remove(path)
+					if !injected && !errors.Is(err, os.ErrNotExist) {
+						injected = true
+						return errors.Join(err, cleanupFailure)
+					}
+					return err
+				}
+			},
+			wantError: cleanupFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "restored.db")
+			archiveBuilder := tt.archive
+			if archiveBuilder == nil {
+				archiveBuilder = sqliteRestoreArchive
+			}
+			archive := archiveBuilder(t, tt.payload)
+			operations := defaultSQLiteRestoreOperations()
+			if tt.configure != nil {
+				tt.configure(&operations)
+			}
+			var mutate func(context.Context, *DB) error
+			if tt.mutate != nil {
+				mutate = tt.mutate(target)
+			}
+
+			_, err := restoreSQLite(t.Context(), bytes.NewReader(archive), target, mutate, operations)
+			if err == nil {
+				t.Fatal("restoreSQLite() returned nil error")
+			}
+			if tt.wantError != nil && !errors.Is(err, tt.wantError) {
+				t.Errorf("restoreSQLite() error = %v, want matching %v", err, tt.wantError)
+			}
+			if tt.wantErrorText != "" && !strings.Contains(err.Error(), tt.wantErrorText) {
+				t.Errorf("restoreSQLite() error = %v, want containing %q", err, tt.wantErrorText)
+			}
+			if tt.wantTargetContent != nil {
+				got, readErr := os.ReadFile(target)
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if !bytes.Equal(got, tt.wantTargetContent) {
+					t.Errorf("restore target content = %q, want %q", got, tt.wantTargetContent)
+				}
+			}
+			assertNoRestoreStaging(t, target)
+		})
+	}
+}
+
+func TestRestoreSQLitePublishesPrivateDatabase(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "restored.db")
+	if _, err := RestoreSQLite(t.Context(), bytes.NewReader(sqliteRestoreArchive(t, nil)), target, nil); err != nil {
+		t.Fatalf("RestoreSQLite() error = %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("restored database permissions = %04o, want 0600", got)
+	}
+	assertNoRestoreStaging(t, target)
+}
+
+func pathsShareDirectory(first, second string) (bool, error) {
+	firstDirectory, err := os.Stat(filepath.Dir(first))
+	if err != nil {
+		return false, fmt.Errorf("stat first directory: %w", err)
+	}
+	secondDirectory, err := os.Stat(filepath.Dir(second))
+	if err != nil {
+		return false, fmt.Errorf("stat second directory: %w", err)
+	}
+	return os.SameFile(firstDirectory, secondDirectory), nil
+}
+
+func sqliteDatabasePath(ctx context.Context, db *DB) (string, error) {
+	var sequence int
+	var name string
+	var path string
+	if err := db.sqRead.QueryRowContext(ctx, "PRAGMA database_list").Scan(&sequence, &name, &path); err != nil {
+		return "", fmt.Errorf("read sqlite database path: %w", err)
+	}
+	return path, nil
+}
+
+func sqliteRestoreArchive(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	writeTarMember(t, tw, manifestMember, sqliteRestoreManifest(t))
+	writeTarMember(t, tw, sqliteMember, payload)
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return archive.Bytes()
+}
+
+func truncatedSQLiteRestoreArchive(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	writeTarMember(t, tw, manifestMember, sqliteRestoreManifest(t))
+	if err := tw.WriteHeader(&tar.Header{Name: sqliteMember, Mode: 0o600, Size: int64(len(payload))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload[:len(payload)/2]); err != nil {
+		t.Fatal(err)
+	}
+	return archive.Bytes()
+}
+
+func sqliteRestoreManifest(t *testing.T) []byte {
+	t.Helper()
+	manifest, err := json.Marshal(Manifest{
+		Format:    ArchiveFormat,
+		Engine:    EngineSQLite,
+		CreatedAt: time.Unix(0, 0).UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func writeTarMember(t *testing.T, tw *tar.Writer, name string, body []byte) {
+	t.Helper()
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(body))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertNoRestoreStaging(t *testing.T, target string) {
+	t.Helper()
+	matches, err := filepath.Glob(target + ".restoring-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("restore left staging artifacts: %v", matches)
+	}
+}
+
+func receiveBefore[T any](t *testing.T, ch <-chan T, timeout time.Duration, message string) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(timeout):
+		t.Fatal(message)
+		var zero T
+		return zero
+	}
+}


### PR DESCRIPTION
Closes #219

## Contract and migration

- `store.RestoreSQLite` now creates one unpredictable staging database with `os.CreateTemp` in the destination directory, preserving same-filesystem publication.
- The staging database, `-wal`, `-shm`, and open handle are carried as one owned resource. Every failure path cleans only those exact paths, and cleanup failures are joined into the returned error.
- Staging is closed before SQLite opens it and before publication. The published database remains mode `0600`.
- Publication still uses `os.Link`, preserving atomic no-overwrite behavior when the requested destination already exists.
- No public API, backup format, database schema, or CLI migration is required.

## Generated outputs

None.

## Validation

- `go test -count=1 ./internal/store/...` — 61 passed
- `go test -race -count=1 ./internal/store/...` — 61 passed
- SQLite restore drill — 11 passed
- `go test -count=1 ./...` — 2,916 passed across 56 packages
- Exact-head CI for `36592b873b7733a9b179b3bc6d9221bfb5ba42ff` — 17 passed, 0 failed; desktop flow and both required aggregate gates passed on the unchanged-head rerun after one unrelated admission-budget HTTP 429 flake

## Review

- Implemented test-first at the public `store.RestoreSQLite` seam, including barrier concurrency and injected failures through creation, extraction, close, SQLite mutation, sync, publication, and cleanup.
- Standards and specification reviews completed in two rounds. Final verdicts: `CLEAN`.
- DCO sign-off present on commit `36592b873b7733a9b179b3bc6d9221bfb5ba42ff`. Implementation handoff: `docs/handoff/219-sqlite-restore-staging.md`.