### PR TITLE
Define one total HTTP error wire policy

### DIFF
--- a/docs/handoff/212-http-error-wire-policy.md
+++ b/docs/handoff/212-http-error-wire-policy.md
@@ -1,0 +1,45 @@
+# #212 — Total HTTP error wire policy
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/212 (parent #204; programme
+#203).
+
+## Contract
+
+Hikyo's JSON error envelope is governed by one server-layer `WireError`
+policy. Each public error code has exactly one HTTP status, fixed message, and
+detail rule. `bad_request` and `conflict` alone may carry an explicitly safe
+detail; every other class redacts it.
+
+Unknown internal errors, wrapped unknown errors, and unrecognized public codes
+all collapse to the same `500 internal` response. Domain errors remain free of
+HTTP types. Handler authentication, authorization, validation, and
+non-enumeration ordering is unchanged; only classification and rendering move
+behind the policy.
+
+One contextual override is explicit: an unusable workspace handoff remains
+`403 forbidden` for approval/redemption, while authenticated transaction lookup
+collapses unknown, stale, consumed, and non-owned state to `404 not_found`.
+
+## Enforcement
+
+- `internal/server/errors.go` owns the complete public-code table and the
+  wrapped-error classifier.
+- `writeHandlerError` consumes one policy for status, code, message, and detail
+  handling instead of choosing those values independently.
+- `internal/server/errors_internal_test.go` compares the policy table with the
+  OpenAPI `ErrorCode` enum, so a new public code without a complete mapping
+  fails tests.
+- `internal/server/contract_test.go` proves plain, wrapped, and detail-carrying
+  unknown handler errors expose only the uniform internal response.
+
+## Validation
+
+```sh
+go test -count=1 ./internal/server/...   # 183 passed
+go test -count=1 ./internal/isolation/  # 1084 passed
+go test -count=1 ./...                  # 2933 passed in 56 packages
+```
+
+Standards review was CLEAN. Spec review reached CLEAN in three rounds after
+fixing partial handler-family migration and preserving the workspace handoff
+403/404 context split.

--- a/internal/server/accounts.go
+++ b/internal/server/accounts.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -22,17 +21,9 @@ func (a *API) ResetCredential(ctx context.Context, req apigen.ResetCredentialReq
 	// holder, who transmits it to the target out of band.
 	result, err := a.Auth.ResetCredential(ctx, service.Bearer(bearer(ctx)), string(req.Principal), "response")
 	if err != nil {
-		// An unknown or non-human target — and an instance-capability target with
-		// no network path — answer the SAME uniform 401 as an unauthorized one, so
-		// the response cannot distinguish "exists but is not reachable here" from
-		// "you may not reach it" (classify would otherwise fault it to 500 — a
-		// status-code oracle on an enumeration-uniform route).
-		if errors.Is(err, service.ErrNoResetTarget) {
-			return apigen.ResetCredential401JSONResponse{
-				UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, "")),
-			}, nil
-		}
-		switch classify(err) {
+		// Every recognized refusal collapses to the same 401 on this
+		// enumeration-uniform route; only overload and faults remain distinct.
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.ResetCredential429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
 		case apigen.ErrorCodeInternal:

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -254,7 +254,7 @@ func (a *API) EstablishCredential(ctx context.Context, req apigen.EstablishCrede
 	switch {
 	case err == nil:
 		return apigen.EstablishCredential204Response{}, nil
-	case errors.Is(err, service.ErrWeakPassword), errors.Is(err, service.ErrCommonPassword):
+	case passwordPrecondition(err):
 		// The one loud refusal on this path: it is the caller's own input,
 		// evaluated before anything is looked up, so naming the rule helps
 		// the human and reveals nothing.
@@ -314,17 +314,6 @@ func (a *API) Logout(ctx context.Context, _ apigen.LogoutRequestObject) (apigen.
 // mutations reissue the acting session and step-up rotates it, so each returns
 // a fresh token the client must persist in place of the old one.
 
-// factorPrecondition reports a loud structural refusal — a caller acting on
-// their OWN authenticated account, so the state (already enrolled, nothing to
-// confirm, no factor) is theirs to know and 400 names it. A bad code or
-// password stays the uniform 401.
-func factorPrecondition(err error) bool {
-	return errors.Is(err, service.ErrTOTPAlreadyEnrolled) ||
-		errors.Is(err, service.ErrNoPendingTOTP) ||
-		errors.Is(err, service.ErrNoTOTPFactor) ||
-		errors.Is(err, service.ErrNoProofCredential)
-}
-
 func (a *API) EnrolTotpStart(ctx context.Context, req apigen.EnrolTotpStartRequestObject) (apigen.EnrolTotpStartResponseObject, error) {
 	uri, err := a.Auth.EnrolTOTPStart(ctx, bearer(ctx), req.Body.Password)
 	if err != nil {
@@ -382,7 +371,7 @@ func (a *API) RemoveTotp(ctx context.Context, req apigen.RemoveTotpRequestObject
 func (a *API) GetTotpStatus(ctx context.Context, _ apigen.GetTotpStatusRequestObject) (apigen.GetTotpStatusResponseObject, error) {
 	status, err := a.Auth.TOTPStatus(ctx, bearer(ctx))
 	if err != nil {
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.GetTotpStatus401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -425,7 +414,7 @@ func (a *API) BeginRecovery(ctx context.Context, req apigen.BeginRecoveryRequest
 		// passwordless account is refused loudly. Only a caller holding a VALID
 		// code reaches it, so naming the structural state reveals nothing an
 		// enumerator could not already learn — and the refusal is non-destructive.
-		if errors.Is(err, service.ErrPasskeyOnlyViolation) {
+		if recoveryPrecondition(err) {
 			return apigen.BeginRecovery400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
 		return nil, err
@@ -498,7 +487,7 @@ func (a *API) CreateOrg(ctx context.Context, req apigen.CreateOrgRequestObject) 
 func (a *API) ListMyOrgs(ctx context.Context, _ apigen.ListMyOrgsRequestObject) (apigen.ListMyOrgsResponseObject, error) {
 	orgs, err := a.Orgs.ListMine(ctx, service.Bearer(bearer(ctx)))
 	if err != nil {
-		if classify(err) == apigen.ErrorCodeUnauthenticated {
+		if wireErrorFor(err).code == apigen.ErrorCodeUnauthenticated {
 			return apigen.ListMyOrgs401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		}
 		return nil, err
@@ -727,21 +716,21 @@ func (a *API) validateAgainstContract(next http.Handler) http.Handler {
 		case err == nil:
 			ctx, ok := api.WithRequestOperation(r.Context(), r)
 			if !ok {
-				writeError(w, apigen.ErrorCodeInternal, "")
+				writeError(w, wirePolicyForCode(apigen.ErrorCodeInternal), "")
 				return
 			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 		case errors.Is(err, api.ErrNoRoute):
 			// A path the contract does not describe. 404, like any other
 			// thing that is not there.
-			writeError(w, apigen.ErrorCodeNotFound, "")
+			writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		default:
 			var verr *api.ValidationError
 			detail := ""
 			if errors.As(err, &verr) {
 				detail = verr.Member
 			}
-			writeError(w, apigen.ErrorCodeBadRequest, detail)
+			writeError(w, wirePolicyForCode(apigen.ErrorCodeBadRequest), detail)
 		}
 	})
 }

--- a/internal/server/cli_reauth.go
+++ b/internal/server/cli_reauth.go
@@ -2,10 +2,8 @@ package server
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
-	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 )
 
@@ -30,7 +28,7 @@ func (a *API) StartCLIReauth(ctx context.Context, req apigen.StartCLIReauthReque
 func (a *API) ShowCLIReauthTransaction(ctx context.Context, req apigen.ShowCLIReauthTransactionRequestObject) (apigen.ShowCLIReauthTransactionResponseObject, error) {
 	result, err := a.Auth.CLIReauthTransaction(ctx, service.Bearer(bearer(ctx)), req.State)
 	if err != nil {
-		if errors.Is(err, service.ErrCLIReauthInvalid) || errors.Is(err, service.ErrReauthRequired) {
+		if wireErrorFor(err).code == apigen.ErrorCodeConflict {
 			return apigen.ShowCLIReauthTransaction409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
 		}
 		return nil, err
@@ -49,7 +47,7 @@ func (a *API) ShowCLIReauthTransaction(ctx context.Context, req apigen.ShowCLIRe
 func (a *API) ApproveCLIReauth(ctx context.Context, req apigen.ApproveCLIReauthRequestObject) (apigen.ApproveCLIReauthResponseObject, error) {
 	approved, err := a.Auth.ApproveCLIReauth(ctx, service.Bearer(bearer(ctx)), req.Body.State)
 	if err != nil {
-		if errors.Is(err, service.ErrReauthRequired) || errors.Is(err, service.ErrCLIReauthInvalid) {
+		if wireErrorFor(err).code == apigen.ErrorCodeConflict {
 			return apigen.ApproveCLIReauth409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
 		}
 		return nil, err
@@ -60,10 +58,10 @@ func (a *API) ApproveCLIReauth(ctx context.Context, req apigen.ApproveCLIReauthR
 func (a *API) RedeemCLIReauth(ctx context.Context, req apigen.RedeemCLIReauthRequestObject) (apigen.RedeemCLIReauthResponseObject, error) {
 	result, err := a.Auth.RedeemCLIReauth(ctx, req.Body.Code, req.Body.PkceVerifier)
 	if err != nil {
-		if errors.Is(err, service.ErrCLIReauthInvalid) {
+		switch wireErrorFor(err).code {
+		case apigen.ErrorCodeConflict:
 			return apigen.RedeemCLIReauth409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-		}
-		if errors.Is(err, domain.ErrUnauthenticated) {
+		case apigen.ErrorCodeUnauthenticated:
 			return apigen.RedeemCLIReauth401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		}
 		return nil, err

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -258,6 +258,20 @@ func (stubProviders) Delete(context.Context, service.Actor, string) error {
 	return domain.ErrUnauthorized
 }
 
+type stubWorkspace struct {
+	server.WorkspaceService
+	show   func(context.Context, service.Actor, string) (service.HandoffView, error)
+	redeem func(context.Context, string, string, string) (service.WorkspaceSession, error)
+}
+
+func (s stubWorkspace) ShowHandoff(ctx context.Context, actor service.Actor, state string) (service.HandoffView, error) {
+	return s.show(ctx, actor, state)
+}
+
+func (s stubWorkspace) RedeemHandoff(ctx context.Context, code, verifier, origin string) (service.WorkspaceSession, error) {
+	return s.redeem(ctx, code, verifier, origin)
+}
+
 type stubOrgs struct {
 	create func(ctx context.Context, a service.Actor, name string, active bool, meta json.RawMessage) (service.Org, error)
 	get    func(ctx context.Context, a service.Actor, org domain.OrgID) (service.Org, error)
@@ -1556,6 +1570,74 @@ func TestConflictAndLimitRenderUniformly(t *testing.T) {
 				t.Errorf("the limit refusal does not name its bound: %q", body.Error.Message)
 			}
 		})
+	}
+}
+
+type unknownSafeDetailError struct {
+	cause error
+}
+
+func (e unknownSafeDetailError) Error() string      { return "private storage failure: must not escape" }
+func (e unknownSafeDetailError) Unwrap() error      { return e.cause }
+func (e unknownSafeDetailError) SafeDetail() string { return "private row tenant-secret-7c31" }
+
+func TestUnknownHandlerErrorsFailClosedOnTheWire(t *testing.T) {
+	unknown := errors.New("private storage failure")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"plain", unknown},
+		{"wrapped", fmt.Errorf("query project: %w", unknown)},
+		{"safe detail carrier", unknownSafeDetailError{cause: unknown}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := hierarchyServer(t, tc.err)
+			resp, payload := call(t, srv, http.MethodPost,
+				api.PathPrefix+"/orgs/"+testOrgID+"/projects", "hik_1_cli_x",
+				apigen.CreateProjectRequest{Name: "p"})
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("status %d, want 500", resp.StatusCode)
+			}
+			body := decodeError(t, payload)
+			if body.Error.Code != apigen.ErrorCodeInternal || body.Error.Message != "internal error" {
+				t.Fatalf("body = %+v, want uniform internal refusal", body)
+			}
+			if body.Error.Detail != nil || bytes.Contains(payload, []byte("storage")) || bytes.Contains(payload, []byte("tenant-secret")) {
+				t.Fatalf("internal refusal leaked cause or detail: %s", payload)
+			}
+		})
+	}
+}
+
+func TestWorkspaceHandoffInvalidPreservesContextualRefusals(t *testing.T) {
+	workspace := stubWorkspace{
+		show: func(context.Context, service.Actor, string) (service.HandoffView, error) {
+			return service.HandoffView{}, fmt.Errorf("lookup: %w", service.ErrHandoffInvalid)
+		},
+		redeem: func(context.Context, string, string, string) (service.WorkspaceSession, error) {
+			return service.WorkspaceSession{}, fmt.Errorf("redeem: %w", service.ErrHandoffInvalid)
+		},
+	}
+	srv := httptest.NewServer(server.New(stubReady{}, &server.API{
+		Auth: stubAuth{identity: liveIdentityFn}, Orgs: stubOrgs{}, Providers: stubProviders{},
+		Projects: stubHierarchy{}, Environments: stubEnvs{}, Values: stubValues{}, Folders: stubFolders{},
+		Workspace: workspace, Version: "test",
+	}, nil))
+	t.Cleanup(srv.Close)
+
+	showResp, showPayload := call(t, srv, http.MethodGet,
+		api.PathPrefix+"/auth/workspace/transactions/stale-state", "hik_1_cli_x", nil)
+	if showResp.StatusCode != http.StatusNotFound || decodeError(t, showPayload).Error.Code != apigen.ErrorCodeNotFound {
+		t.Fatalf("show refusal = %d %s, want 404 not_found", showResp.StatusCode, showPayload)
+	}
+
+	redeemResp, redeemPayload := call(t, srv, http.MethodPost,
+		api.PathPrefix+"/auth/workspace/redeem", "", apigen.RedeemWorkspaceHandoffRequest{
+			Code: "spent-code", PkceVerifier: strings.Repeat("a", 43), Origin: "https://shell.example",
+		})
+	if redeemResp.StatusCode != http.StatusForbidden || decodeError(t, redeemPayload).Error.Code != apigen.ErrorCodeForbidden {
+		t.Fatalf("redeem refusal = %d %s, want 403 forbidden", redeemResp.StatusCode, redeemPayload)
 	}
 }
 

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -45,26 +45,44 @@ var limitExceededMessage = fmt.Sprintf(
 		"declares at most %d keys, and declares at most %d key groups",
 	service.MaxEnvironmentsPerProject, schema.MaxKeysPerProject, schema.MaxKeyGroupsPerProject)
 
-var messages = map[apigen.ErrorCode]string{
-	apigen.ErrorCodeBadRequest:      "the request does not satisfy the API contract",
-	apigen.ErrorCodeUnauthenticated: "authentication required",
-	apigen.ErrorCodeForbidden:       "not permitted",
-	apigen.ErrorCodeNotFound:        "not found",
-	apigen.ErrorCodeConflict:        "the current state of this resource refuses the request",
-	apigen.ErrorCodeLimitExceeded:   limitExceededMessage,
-	apigen.ErrorCodeTooManyRequests: "too many requests",
-	apigen.ErrorCodeInternal:        "internal error",
+type detailPolicy uint8
+
+const (
+	redactDetail detailPolicy = iota
+	allowSafeDetail
+)
+
+// WireError is the closed server-layer policy for one public error class.
+// Its fields stay private so handlers cannot assemble status, code, message,
+// and detail handling independently.
+type WireError struct {
+	status       int
+	code         apigen.ErrorCode
+	message      string
+	detailPolicy detailPolicy
 }
 
-var statuses = map[apigen.ErrorCode]int{
-	apigen.ErrorCodeBadRequest:      http.StatusBadRequest,
-	apigen.ErrorCodeUnauthenticated: http.StatusUnauthorized,
-	apigen.ErrorCodeForbidden:       http.StatusForbidden,
-	apigen.ErrorCodeNotFound:        http.StatusNotFound,
-	apigen.ErrorCodeConflict:        http.StatusConflict,
-	apigen.ErrorCodeLimitExceeded:   http.StatusConflict,
-	apigen.ErrorCodeTooManyRequests: http.StatusTooManyRequests,
-	apigen.ErrorCodeInternal:        http.StatusInternalServerError,
+// wirePolicies is the one total public-code policy. A contract test compares
+// this table with the OpenAPI enum, so adding a public code without deciding
+// all four fields fails the suite.
+var wirePolicies = map[apigen.ErrorCode]WireError{
+	apigen.ErrorCodeBadRequest:      {status: http.StatusBadRequest, code: apigen.ErrorCodeBadRequest, message: "the request does not satisfy the API contract", detailPolicy: allowSafeDetail},
+	apigen.ErrorCodeUnauthenticated: {status: http.StatusUnauthorized, code: apigen.ErrorCodeUnauthenticated, message: "authentication required", detailPolicy: redactDetail},
+	apigen.ErrorCodeForbidden:       {status: http.StatusForbidden, code: apigen.ErrorCodeForbidden, message: "not permitted", detailPolicy: redactDetail},
+	apigen.ErrorCodeNotFound:        {status: http.StatusNotFound, code: apigen.ErrorCodeNotFound, message: "not found", detailPolicy: redactDetail},
+	apigen.ErrorCodeConflict:        {status: http.StatusConflict, code: apigen.ErrorCodeConflict, message: "the current state of this resource refuses the request", detailPolicy: allowSafeDetail},
+	apigen.ErrorCodeLimitExceeded:   {status: http.StatusConflict, code: apigen.ErrorCodeLimitExceeded, message: limitExceededMessage, detailPolicy: redactDetail},
+	apigen.ErrorCodeTooManyRequests: {status: http.StatusTooManyRequests, code: apigen.ErrorCodeTooManyRequests, message: "too many requests", detailPolicy: redactDetail},
+	apigen.ErrorCodeInternal:        {status: http.StatusInternalServerError, code: apigen.ErrorCodeInternal, message: "internal error", detailPolicy: redactDetail},
+}
+
+// wirePolicyForCode fails closed for an unrecognized public code. Callers that
+// receive a future or invalid code can never render an empty status or body.
+func wirePolicyForCode(code apigen.ErrorCode) WireError {
+	if policy, ok := wirePolicies[code]; ok {
+		return policy
+	}
+	return wirePolicies[apigen.ErrorCodeInternal]
 }
 
 // errorBody builds the wire body for a code. detail is honoured only for
@@ -78,10 +96,18 @@ var statuses = map[apigen.ErrorCode]int{
 // refusal, whose detail is the caller's OWN destination id (post-authorization,
 // so naming it discloses nothing).
 func errorBody(code apigen.ErrorCode, detail string) apigen.Error {
+	return wirePolicyForCode(code).bodyWithDetail(detail)
+}
+
+func (policy WireError) body(err error) apigen.Error {
+	return policy.bodyWithDetail(safeDetailOf(err))
+}
+
+func (policy WireError) bodyWithDetail(detail string) apigen.Error {
 	var body apigen.Error
-	body.Error.Code = code
-	body.Error.Message = messages[code]
-	if (code == apigen.ErrorCodeBadRequest || code == apigen.ErrorCodeConflict) && detail != "" {
+	body.Error.Code = policy.code
+	body.Error.Message = policy.message
+	if policy.detailPolicy == allowSafeDetail && detail != "" {
 		body.Error.Detail = &detail
 	}
 	return body
@@ -124,18 +150,84 @@ func safeDetailOf(err error) string {
 
 // writeError renders a refusal. It never writes anything derived from the
 // cause beyond the code itself; the cause is the process log's business.
-func writeError(w http.ResponseWriter, code apigen.ErrorCode, detail string) {
-	if code == apigen.ErrorCodeTooManyRequests {
+func writeError(w http.ResponseWriter, policy WireError, detail string) {
+	if policy.code == apigen.ErrorCodeTooManyRequests {
 		w.Header().Set("Retry-After", strconv.Itoa(int(admission.RetryAfter.Seconds())))
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statuses[code])
-	_ = json.NewEncoder(w).Encode(errorBody(code, detail))
+	w.WriteHeader(policy.status)
+	_ = json.NewEncoder(w).Encode(policy.bodyWithDetail(detail))
 }
 
-// classify maps a domain outcome onto a wire code. It is the single place
-// that decision is made, so a handler cannot invent a status that leaks what
-// the sentinels are built to hide.
+// wireErrorRules is the single mapping from recognized Hikyo error classes to
+// public policies. Protocol-specific SCIM errors are intentionally excluded:
+// that wire uses RFC 7644 envelopes and owns its closed policy in scim_wire.go.
+var wireErrorRules = []struct {
+	match error
+	code  apigen.ErrorCode
+}{
+	// Reveal and account-security refusals.
+	{service.ErrNoReauthWindow, apigen.ErrorCodeForbidden},
+	{service.ErrReauthWindowExpired, apigen.ErrorCodeForbidden},
+	{service.ErrReauthUnitMismatch, apigen.ErrorCodeForbidden},
+	{service.ErrReauthWindowSpent, apigen.ErrorCodeForbidden},
+	{service.ErrReauthWindowClosed, apigen.ErrorCodeConflict},
+	{service.ErrTOTPCodeAlreadyUsed, apigen.ErrorCodeConflict},
+	{service.ErrCLIReauthInvalid, apigen.ErrorCodeConflict},
+	{service.ErrReauthRequired, apigen.ErrorCodeConflict},
+	{service.ErrWeakPassword, apigen.ErrorCodeBadRequest},
+	{service.ErrCommonPassword, apigen.ErrorCodeBadRequest},
+	{service.ErrTOTPAlreadyEnrolled, apigen.ErrorCodeBadRequest},
+	{service.ErrNoPendingTOTP, apigen.ErrorCodeBadRequest},
+	{service.ErrNoTOTPFactor, apigen.ErrorCodeBadRequest},
+	{service.ErrNoProofCredential, apigen.ErrorCodeBadRequest},
+	{service.ErrWebAuthnUnavailable, apigen.ErrorCodeBadRequest},
+	{service.ErrNoWebAuthnCeremony, apigen.ErrorCodeBadRequest},
+	{service.ErrNoPasskey, apigen.ErrorCodeBadRequest},
+	{service.ErrPasskeyOnlyViolation, apigen.ErrorCodeBadRequest},
+
+	// OIDC and SAML provider administration.
+	{service.ErrProviderNotFound, apigen.ErrorCodeNotFound},
+	{service.ErrBadPurpose, apigen.ErrorCodeBadRequest},
+	{service.ErrReauthNoPolicy, apigen.ErrorCodeBadRequest},
+	{service.ErrReauthNoEnvironment, apigen.ErrorCodeBadRequest},
+	{service.ErrIdentityNotFound, apigen.ErrorCodeBadRequest},
+	{service.ErrLastCredential, apigen.ErrorCodeBadRequest},
+	{service.ErrIssuerImmutable, apigen.ErrorCodeBadRequest},
+	{service.ErrProviderDiscovery, apigen.ErrorCodeBadRequest},
+	{service.ErrProviderExists, apigen.ErrorCodeBadRequest},
+	{service.ErrProviderRace, apigen.ErrorCodeConflict},
+	{service.ErrSAMLProviderNotFound, apigen.ErrorCodeNotFound},
+	{service.ErrSAMLSPKeyNotFound, apigen.ErrorCodeNotFound},
+	{service.ErrSAMLSPKeyState, apigen.ErrorCodeConflict},
+	{service.ErrSAMLSPKeyRace, apigen.ErrorCodeConflict},
+	{service.ErrSAMLProviderRace, apigen.ErrorCodeConflict},
+	{service.ErrSAMLEntityIDImmutable, apigen.ErrorCodeConflict},
+	{service.ErrSAMLReauthNoPolicy, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLReauthNoEnvironment, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLMetadataSource, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLMetadataFetch, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLMetadataInvalid, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLMetadataSignatureDowngrade, apigen.ErrorCodeBadRequest},
+	{service.ErrSAMLMetadataExpired, apigen.ErrorCodeConflict},
+
+	// Enumeration-safe server surfaces.
+	{service.ErrNoResetTarget, apigen.ErrorCodeNotFound},
+
+	// Domain and admission classes are deliberately last: specific service
+	// errors may wrap one of these while carrying a narrower public meaning.
+	{domain.ErrUnauthenticated, apigen.ErrorCodeUnauthenticated},
+	{domain.ErrNotFound, apigen.ErrorCodeNotFound},
+	{domain.ErrUnauthorized, apigen.ErrorCodeForbidden},
+	{domain.ErrLimitExceeded, apigen.ErrorCodeLimitExceeded},
+	{domain.ErrConflict, apigen.ErrorCodeConflict},
+	{domain.ErrInvalid, apigen.ErrorCodeBadRequest},
+	{admission.ErrOverloaded, apigen.ErrorCodeTooManyRequests},
+}
+
+// wireErrorFor maps an internal outcome onto one closed wire policy. It is the
+// single place that decision is made, so a handler cannot invent a status that
+// leaks what the sentinels are built to hide.
 //
 //   - ErrNotFound is BOTH "no such row" and "you may not reach it", and the
 //     two are indistinguishable by design.
@@ -154,28 +246,56 @@ func writeError(w http.ResponseWriter, code apigen.ErrorCode, detail string) {
 //     another on the wire: whether a window was absent, lapsed, spent or bound
 //     to different keys, the client's correct move is the same (re-run the
 //     ceremony the guard's own state route describes), and the enum is closed.
-func classify(err error) apigen.ErrorCode {
-	switch {
-	case errors.Is(err, service.ErrNoReauthWindow),
-		errors.Is(err, service.ErrReauthWindowExpired),
-		errors.Is(err, service.ErrReauthUnitMismatch),
-		errors.Is(err, service.ErrReauthWindowSpent):
-		return apigen.ErrorCodeForbidden
-	case errors.Is(err, domain.ErrUnauthenticated):
-		return apigen.ErrorCodeUnauthenticated
-	case errors.Is(err, domain.ErrNotFound):
-		return apigen.ErrorCodeNotFound
-	case errors.Is(err, domain.ErrUnauthorized):
-		return apigen.ErrorCodeForbidden
-	case errors.Is(err, domain.ErrLimitExceeded):
-		return apigen.ErrorCodeLimitExceeded
-	case errors.Is(err, domain.ErrConflict):
-		return apigen.ErrorCodeConflict
-	case errors.Is(err, domain.ErrInvalid):
-		return apigen.ErrorCodeBadRequest
-	case errors.Is(err, admission.ErrOverloaded):
-		return apigen.ErrorCodeTooManyRequests
-	default:
-		return apigen.ErrorCodeInternal
+func wireErrorFor(err error) WireError {
+	for _, rule := range wireErrorRules {
+		if errors.Is(err, rule.match) {
+			return wirePolicyForCode(rule.code)
+		}
 	}
+	return wirePolicyForCode(apigen.ErrorCodeInternal)
+}
+
+// workspaceHandoffLookupWireErrorFor is the sole contextual override in the
+// Hikyo JSON policy. ErrHandoffInvalid normally follows its wrapped
+// ErrUnauthorized to 403 for approve/redeem. The authenticated transaction
+// lookup deliberately answers 404 for unknown, stale, consumed, or non-owned
+// state so those cases remain indistinguishable.
+func workspaceHandoffLookupWireErrorFor(err error) WireError {
+	if errors.Is(err, service.ErrHandoffInvalid) {
+		return wirePolicyForCode(apigen.ErrorCodeNotFound)
+	}
+	return wireErrorFor(err)
+}
+
+// The helpers below identify the few endpoint-specific precondition families
+// whose timing or enumeration contract deliberately collapses only a subset of
+// otherwise-recognized classes. Keeping the membership here leaves handlers to
+// adapt a decided WireError to generated response types, not classify causes.
+func passwordPrecondition(err error) bool {
+	return errors.Is(err, service.ErrWeakPassword) || errors.Is(err, service.ErrCommonPassword)
+}
+
+func factorPrecondition(err error) bool {
+	return errors.Is(err, service.ErrTOTPAlreadyEnrolled) ||
+		errors.Is(err, service.ErrNoPendingTOTP) ||
+		errors.Is(err, service.ErrNoTOTPFactor) ||
+		errors.Is(err, service.ErrNoProofCredential)
+}
+
+func recoveryPrecondition(err error) bool {
+	return errors.Is(err, service.ErrPasskeyOnlyViolation)
+}
+
+func webauthnPrecondition(err error) bool {
+	return errors.Is(err, service.ErrWebAuthnUnavailable) ||
+		errors.Is(err, service.ErrNoWebAuthnCeremony) ||
+		errors.Is(err, service.ErrNoPasskey) ||
+		errors.Is(err, service.ErrPasskeyOnlyViolation) ||
+		errors.Is(err, service.ErrNoProofCredential)
+}
+
+func loginPrecondition(err error) bool {
+	// ONLY the instance-wide "WebAuthn not configured" refusal is a loud 400
+	// on pre-auth login. Every per-account outcome stays the uniform 401.
+	return errors.Is(err, service.ErrWebAuthnUnavailable)
 }

--- a/internal/server/errors_internal_test.go
+++ b/internal/server/errors_internal_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+func TestWirePolicyCoversEveryPublicErrorCode(t *testing.T) {
+	doc, err := api.Doc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := doc.Components.Schemas["ErrorCode"]
+	if schema == nil || schema.Value == nil {
+		t.Fatal("OpenAPI ErrorCode schema is missing")
+	}
+	if len(schema.Value.Enum) != len(wirePolicies) {
+		t.Fatalf("wire policy has %d entries for %d public codes", len(wirePolicies), len(schema.Value.Enum))
+	}
+	for _, raw := range schema.Value.Enum {
+		value, ok := raw.(string)
+		if !ok {
+			t.Fatalf("OpenAPI ErrorCode member has type %T, want string", raw)
+		}
+		code := apigen.ErrorCode(value)
+		policy, ok := wirePolicies[code]
+		if !ok {
+			t.Errorf("public error code %q has no wire policy", code)
+			continue
+		}
+		if policy.code != code || policy.status == 0 || policy.message == "" {
+			t.Errorf("public error code %q has incomplete wire policy: %+v", code, policy)
+		}
+	}
+}
+
+func TestWirePolicyCoversEveryRecognizedErrorClass(t *testing.T) {
+	for i, rule := range wireErrorRules {
+		got := wireErrorFor(fmt.Errorf("wrapped: %w", rule.match))
+		if got.code != rule.code {
+			t.Errorf("rule %d (%v) classified as %q, want %q", i, rule.match, got.code, rule.code)
+		}
+	}
+}
+
+func TestWirePolicyClassifiesWrappedErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		code   apigen.ErrorCode
+	}{
+		{"unauthenticated", domain.ErrUnauthenticated, http.StatusUnauthorized, apigen.ErrorCodeUnauthenticated},
+		{"forbidden", domain.ErrUnauthorized, http.StatusForbidden, apigen.ErrorCodeForbidden},
+		{"not found", domain.ErrNotFound, http.StatusNotFound, apigen.ErrorCodeNotFound},
+		{"conflict", domain.ErrConflict, http.StatusConflict, apigen.ErrorCodeConflict},
+		{"limit", domain.ErrLimitExceeded, http.StatusConflict, apigen.ErrorCodeLimitExceeded},
+		{"invalid", domain.ErrInvalid, http.StatusBadRequest, apigen.ErrorCodeBadRequest},
+		{"overloaded", admission.ErrOverloaded, http.StatusTooManyRequests, apigen.ErrorCodeTooManyRequests},
+		{"reauth absent", service.ErrNoReauthWindow, http.StatusForbidden, apigen.ErrorCodeForbidden},
+		{"reauth expired", service.ErrReauthWindowExpired, http.StatusForbidden, apigen.ErrorCodeForbidden},
+		{"reauth mismatch", service.ErrReauthUnitMismatch, http.StatusForbidden, apigen.ErrorCodeForbidden},
+		{"reauth spent", service.ErrReauthWindowSpent, http.StatusForbidden, apigen.ErrorCodeForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wireErrorFor(fmt.Errorf("wrapped: %w", tc.err))
+			if got.status != tc.status || got.code != tc.code {
+				t.Fatalf("policy = {%d %q}, want {%d %q}", got.status, got.code, tc.status, tc.code)
+			}
+		})
+	}
+}
+
+func TestWorkspaceHandoffInvalidHasOneExplicitLookupOverride(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", service.ErrHandoffInvalid)
+	if got := wireErrorFor(err); got.code != apigen.ErrorCodeForbidden || got.status != http.StatusForbidden {
+		t.Fatalf("generic handoff policy = {%d %q}, want 403 forbidden", got.status, got.code)
+	}
+	if got := workspaceHandoffLookupWireErrorFor(err); got.code != apigen.ErrorCodeNotFound || got.status != http.StatusNotFound {
+		t.Fatalf("lookup handoff policy = {%d %q}, want 404 not_found", got.status, got.code)
+	}
+}
+
+func TestWirePolicyFailsClosedForUnknownErrorsAndCodes(t *testing.T) {
+	unknown := errors.New("private storage failure")
+	for _, got := range []WireError{
+		wireErrorFor(unknown),
+		wireErrorFor(fmt.Errorf("wrapped: %w", unknown)),
+		wirePolicyForCode(apigen.ErrorCode("future_public_code")),
+	} {
+		if got.status != http.StatusInternalServerError || got.code != apigen.ErrorCodeInternal {
+			t.Errorf("unknown input policy = {%d %q}, want uniform internal", got.status, got.code)
+		}
+		body := got.bodyWithDetail("must not escape")
+		if body.Error.Detail != nil || body.Error.Message != "internal error" {
+			t.Errorf("unknown input body leaked detail: %+v", body)
+		}
+	}
+}
+
+func TestWirePolicyRedactsDetailUnlessExplicitlyAllowed(t *testing.T) {
+	const detail = "caller-safe member"
+	tests := []struct {
+		name       string
+		err        error
+		wantDetail bool
+	}{
+		{"bad request", domain.ErrInvalid, true},
+		{"conflict", domain.ErrConflict, true},
+		{"unauthenticated", domain.ErrUnauthenticated, false},
+		{"forbidden", domain.ErrUnauthorized, false},
+		{"not found", domain.ErrNotFound, false},
+		{"limit", domain.ErrLimitExceeded, false},
+		{"overloaded", admission.ErrOverloaded, false},
+		{"internal", errors.New("fault"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := wireErrorFor(tc.err).bodyWithDetail(detail)
+			if tc.wantDetail && (body.Error.Detail == nil || *body.Error.Detail != detail) {
+				t.Fatalf("detail = %v, want %q", body.Error.Detail, detail)
+			}
+			if !tc.wantDetail && body.Error.Detail != nil {
+				t.Fatalf("detail = %q, want redacted", *body.Error.Detail)
+			}
+		})
+	}
+}

--- a/internal/server/hierarchy.go
+++ b/internal/server/hierarchy.go
@@ -80,7 +80,7 @@ func (a *API) writeRequestError(w http.ResponseWriter, r *http.Request, _ error)
 			scimproto.ErrInvalidSyntax("The request body is not a valid SCIM resource."))
 		return
 	}
-	writeError(w, apigen.ErrorCodeBadRequest, "body")
+	writeError(w, wirePolicyForCode(apigen.ErrorCodeBadRequest), "body")
 }
 
 // writeSCIMRequestError renders a pre-handler refusal on a SCIM wire route,
@@ -105,8 +105,8 @@ func (a *API) writeSCIMRequestError(w http.ResponseWriter, r *http.Request, refu
 // login", "list orgs"), which is a second name for the operation that can drift
 // from the first; the contract already has the authoritative one.
 func (a *API) writeHandlerError(w http.ResponseWriter, r *http.Request, err error) {
-	code := classify(err)
-	if code == apigen.ErrorCodeInternal {
+	policy := wireErrorFor(err)
+	if policy.code == apigen.ErrorCodeInternal {
 		operation, ok := api.OperationIDFor(r)
 		if !ok {
 			operation = "unrouted request"
@@ -119,27 +119,22 @@ func (a *API) writeHandlerError(w http.ResponseWriter, r *http.Request, err erro
 	// errorBody honours it only for bad_request and conflict, so a detail on any
 	// other code is dropped — and detail is only ever set by an explicit
 	// SafeDetail carrier, so a plain refusal on those codes still stays uniform.
-	detail := ""
-	var sd interface{ SafeDetail() string }
-	if errors.As(err, &sd) {
-		detail = sd.SafeDetail()
-	}
 	// A Surface-2 secret-scanning refusal (#74) carries a typed findings array
 	// alongside the bad_request code: each blocked field's locator, rule id and a
 	// fresh content-bound acknowledgement token. It is machine-consumable and
 	// frozen; never the matched text.
 	var sf interface{ Findings() []service.Finding }
 	if errors.As(err, &sf) {
-		body := errorBody(code, detail)
+		body := policy.body(err)
 		if fs := wireScanFindings(sf.Findings()); len(fs) > 0 {
 			body.Error.Findings = &fs
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statuses[code])
+		w.WriteHeader(policy.status)
 		_ = json.NewEncoder(w).Encode(body)
 		return
 	}
-	writeError(w, code, detail)
+	writeError(w, policy, safeDetailOf(err))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
@@ -87,21 +86,15 @@ func oidcStartError(a *API, ctx context.Context, err error) apigen.OidcStartResp
 	// unauthenticated link/reauth, so a pre-auth prober cannot enumerate
 	// provider config by status (the timing is uniform too — login admission
 	// runs before provider resolution in the service).
-	switch {
-	case errors.Is(err, service.ErrProviderNotFound),
-		errors.Is(err, service.ErrBadPurpose),
-		errors.Is(err, service.ErrReauthNoPolicy),
-		errors.Is(err, service.ErrReauthNoEnvironment):
-		return apigen.OidcStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}
-	}
-	switch classify(err) {
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.OidcStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}
+	policy := wireErrorFor(err)
+	switch policy.code {
 	case apigen.ErrorCodeTooManyRequests:
 		return apigen.OidcStart429JSONResponse{TooManyRequestsJSONResponse: tooMany()}
-	default:
+	case apigen.ErrorCodeInternal:
 		a.fault(ctx, "oidc start", err)
 		return apigen.OidcStart500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}
+	default:
+		return apigen.OidcStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}
 	}
 }
 
@@ -121,17 +114,15 @@ func (a *API) OidcCallback(ctx context.Context, req apigen.OidcCallbackRequestOb
 		// oidc_refused cause are indistinguishable on the wire, so a stolen or
 		// observed state cannot be probed for the transaction's purpose or
 		// lifecycle. Only a true fault is 500.
-		if errors.Is(err, service.ErrReauthWindowClosed) || errors.Is(err, service.ErrBadPurpose) {
-			return apigen.OidcCallback401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		}
-		switch classify(err) {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.OidcCallback401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
+		policy := wireErrorFor(err)
+		switch policy.code {
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.OidcCallback429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
+		case apigen.ErrorCodeInternal:
 			a.fault(ctx, "oidc callback", err)
 			return apigen.OidcCallback500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
+		default:
+			return apigen.OidcCallback401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		}
 	}
 	return sessionResponse(result.Login), nil
@@ -140,7 +131,7 @@ func (a *API) OidcCallback(ctx context.Context, req apigen.OidcCallbackRequestOb
 func (a *API) ListIdentities(ctx context.Context, _ apigen.ListIdentitiesRequestObject) (apigen.ListIdentitiesResponseObject, error) {
 	rows, err := a.Auth.ListIdentities(ctx, bearer(ctx))
 	if err != nil {
-		if classify(err) == apigen.ErrorCodeUnauthenticated {
+		if wireErrorFor(err).code == apigen.ErrorCodeUnauthenticated {
 			return apigen.ListIdentities401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		}
 		a.fault(ctx, "list identities", err)
@@ -162,15 +153,14 @@ func (a *API) LinkIdentity(ctx context.Context, req apigen.LinkIdentityRequestOb
 	}
 	result, err := a.Auth.OIDCStart(ctx, req.Body.Provider, "link", "", bearer(ctx), req.Body.Proof)
 	if err != nil {
-		switch {
-		case errors.Is(err, service.ErrProviderNotFound):
-			return apigen.LinkIdentity404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-		case errors.Is(err, service.ErrNoProofCredential):
-			return apigen.LinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-		}
-		switch classify(err) {
+		policy := wireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeNotFound:
+			return apigen.LinkIdentity404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+		case apigen.ErrorCodeBadRequest:
+			return apigen.LinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeUnauthenticated:
-			return apigen.LinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
+			return apigen.LinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.LinkIdentity429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
 		default:
@@ -187,13 +177,12 @@ func (a *API) UnlinkIdentity(ctx context.Context, req apigen.UnlinkIdentityReque
 	}
 	result, err := a.Auth.UnlinkIdentity(ctx, bearer(ctx), string(req.Id), req.Body.Proof)
 	if err != nil {
-		switch {
-		case errors.Is(err, service.ErrIdentityNotFound), errors.Is(err, service.ErrLastCredential), errors.Is(err, service.ErrNoProofCredential):
-			return apigen.UnlinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-		}
-		switch classify(err) {
+		policy := wireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeBadRequest:
+			return apigen.UnlinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeUnauthenticated:
-			return apigen.UnlinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
+			return apigen.UnlinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.UnlinkIdentity429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
 		default:
@@ -229,7 +218,7 @@ func (a *API) ListOidcProviders(ctx context.Context, _ apigen.ListOidcProvidersR
 }
 
 func providerListErr(a *API, ctx context.Context, err error) apigen.ListOidcProvidersResponseObject {
-	switch classify(err) {
+	switch wireErrorFor(err).code {
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.ListOidcProviders401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}
 	case apigen.ErrorCodeForbidden:
@@ -245,10 +234,10 @@ func providerListErr(a *API, ctx context.Context, err error) apigen.ListOidcProv
 func (a *API) GetOidcProvider(ctx context.Context, req apigen.GetOidcProviderRequestObject) (apigen.GetOidcProviderResponseObject, error) {
 	v, err := a.Providers.Get(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
 	if err != nil {
-		if errors.Is(err, service.ErrProviderNotFound) {
-			return apigen.GetOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-		}
-		switch classify(err) {
+		policy := wireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeNotFound:
+			return apigen.GetOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.GetOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeForbidden:
@@ -274,11 +263,10 @@ func (a *API) PutOidcProvider(ctx context.Context, req apigen.PutOidcProviderReq
 	}
 	v, err := a.Providers.Put(ctx, service.Bearer(bearer(ctx)), string(req.Slug), in)
 	if err != nil {
-		switch {
-		case errors.Is(err, service.ErrIssuerImmutable), errors.Is(err, service.ErrProviderDiscovery), errors.Is(err, service.ErrProviderExists):
-			return apigen.PutOidcProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-		}
-		switch classify(err) {
+		policy := wireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeBadRequest:
+			return apigen.PutOidcProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.PutOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeForbidden:
@@ -295,13 +283,13 @@ func (a *API) PutOidcProvider(ctx context.Context, req apigen.PutOidcProviderReq
 
 func (a *API) DeleteOidcProvider(ctx context.Context, req apigen.DeleteOidcProviderRequestObject) (apigen.DeleteOidcProviderResponseObject, error) {
 	err := a.Providers.Delete(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
-	switch {
+	switch policy := wireErrorFor(err); {
 	case err == nil:
 		return apigen.DeleteOidcProvider204Response{}, nil
-	case errors.Is(err, service.ErrProviderNotFound):
-		return apigen.DeleteOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
+	case policy.code == apigen.ErrorCodeNotFound:
+		return apigen.DeleteOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 	}
-	switch classify(err) {
+	switch wireErrorFor(err).code {
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.DeleteOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:

--- a/internal/server/remotes.go
+++ b/internal/server/remotes.go
@@ -2,13 +2,11 @@ package server
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
-	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 )
@@ -184,20 +182,21 @@ func (a *API) StartWorkspaceHandoff(ctx context.Context, req apigen.StartWorkspa
 func (a *API) ShowWorkspaceHandoff(ctx context.Context, req apigen.ShowWorkspaceHandoffRequestObject) (apigen.ShowWorkspaceHandoffResponseObject, error) {
 	view, err := a.Workspace.ShowHandoff(ctx, service.Bearer(bearer(ctx)), req.State)
 	if err != nil {
-		if errors.Is(err, domain.ErrUnauthenticated) {
+		policy := workspaceHandoffLookupWireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ShowWorkspaceHandoff401JSONResponse{
 				UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(
-					errorBody(apigen.ErrorCodeUnauthenticated, ""),
+					policy.body(err),
 				),
 			}, nil
-		}
-		// A not-found or expired/consumed transaction is a 404, not a 403: to a
-		// caller holding a stale state the answer is "there is no such live
-		// transaction", uniformly, whichever of those it is.
-		if errors.Is(err, service.ErrHandoffInvalid) {
+		case apigen.ErrorCodeNotFound:
+			// A not-found or expired/consumed transaction is a 404, not a 403: to a
+			// caller holding a stale state the answer is "there is no such live
+			// transaction", uniformly, whichever of those it is.
 			return apigen.ShowWorkspaceHandoff404JSONResponse{
 				NotFoundJSONResponse: apigen.NotFoundJSONResponse(
-					errorBody(apigen.ErrorCodeNotFound, ""),
+					policy.body(err),
 				),
 			}, nil
 		}
@@ -271,7 +270,7 @@ func (a *API) enterWorkspaceAdmission(ctx context.Context) (func(), error) {
 func (a *API) ListMySessions(ctx context.Context, _ apigen.ListMySessionsRequestObject) (apigen.ListMySessionsResponseObject, error) {
 	sessions, err := a.Workspace.ListSessions(ctx, service.Bearer(bearer(ctx)))
 	if err != nil {
-		if classify(err) == apigen.ErrorCodeUnauthenticated {
+		if wireErrorFor(err).code == apigen.ErrorCodeUnauthenticated {
 			return apigen.ListMySessions401JSONResponse{
 				UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, "")),
 			}, nil

--- a/internal/server/reveal.go
+++ b/internal/server/reveal.go
@@ -87,28 +87,21 @@ func (a *API) ReauthTotp(ctx context.Context, req apigen.ReauthTotpRequestObject
 		}
 	}
 	if err != nil {
-		switch {
-		case errors.Is(err, service.ErrReauthWindowClosed):
+		policy := wireErrorFor(err)
+		switch policy.code {
+		case apigen.ErrorCodeConflict:
+			// Single-use and closed-window refusals are post-authentication
+			// conflicts. Only an explicit SafeDetail carrier can add detail.
 			return apigen.ReauthTotp409JSONResponse{
-				ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, "")),
+				ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err)),
 			}, nil
-		case errors.Is(err, service.ErrTOTPCodeAlreadyUsed):
-			// Single-use per (account, step): the code already opened its window,
-			// so the caller waits for the next one. Post-authentication on the
-			// caller's OWN factor, so it rides the SafeDetail channel errorBody
-			// honours for conflict rather than the uniform 401 a wrong code gets.
-			return apigen.ReauthTotp409JSONResponse{
-				ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, safeDetailOf(err))),
-			}, nil
-		case errors.Is(err, service.ErrNoTOTPFactor):
+		case apigen.ErrorCodeBadRequest:
 			return apigen.ReauthTotp400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
+				BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err)),
 			}, nil
-		}
-		switch classify(err) {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ReauthTotp401JSONResponse{
-				UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, "")),
+				UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(policy.body(err)),
 			}, nil
 		case apigen.ErrorCodeNotFound:
 			// An environment the caller cannot reach answers the uniform
@@ -120,10 +113,6 @@ func (a *API) ReauthTotp(ctx context.Context, req apigen.ReauthTotpRequestObject
 			}, nil
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.ReauthTotp429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		case apigen.ErrorCodeBadRequest:
-			return apigen.ReauthTotp400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
 		default:
 			a.fault(ctx, "totp reauth", err)
 			return apigen.ReauthTotp500JSONResponse{

--- a/internal/server/saml.go
+++ b/internal/server/saml.go
@@ -44,12 +44,7 @@ func (a *API) SamlStart(ctx context.Context, req apigen.SamlStartRequestObject) 
 	}
 	result, err := a.SAMLAuth.SAMLStart(ctx, string(req.Provider), string(req.Body.Purpose), environmentID, bearer(ctx), proof)
 	if err != nil {
-		if errors.Is(err, service.ErrSAMLProviderNotFound) || errors.Is(err, service.ErrBadPurpose) ||
-			errors.Is(err, service.ErrSAMLReauthNoPolicy) || errors.Is(err, service.ErrSAMLReauthNoEnvironment) ||
-			errors.Is(err, service.ErrSAMLMetadataExpired) {
-			return samlStartUnauthenticated(), nil
-		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeTooManyRequests:
 			return apigen.SamlStart429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
 		case apigen.ErrorCodeInternal:
@@ -121,7 +116,7 @@ func (a *API) SamlACS(ctx context.Context, req apigen.SamlACSRequestObject) (api
 	result, err := a.SAMLAuth.SAMLACS(ctx, provider, req.Body.SAMLResponse, relayState, initiator)
 	if err != nil {
 		var inner apigen.SamlACSResponseObject
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeTooManyRequests:
 			inner = apigen.SamlACS429JSONResponse{TooManyRequestsJSONResponse: tooMany()}
 		case apigen.ErrorCodeInternal:
@@ -149,11 +144,10 @@ func (a *API) SamlMetadata(ctx context.Context, req apigen.SamlMetadataRequestOb
 			Body: bytes.NewReader(payload), ContentLength: int64(len(payload)),
 		}, nil
 	}
-	switch {
-	case errors.Is(err, service.ErrSAMLProviderNotFound):
-		return apigen.SamlMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.SamlMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeTooManyRequests:
 		return apigen.SamlMetadata429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
 	default:
@@ -224,7 +218,7 @@ func (a *API) ListSamlSpKeys(ctx context.Context, _ apigen.ListSamlSpKeysRequest
 		}
 		return apigen.ListSamlSpKeys200JSONResponse(out), nil
 	}
-	switch classify(err) {
+	switch wireErrorFor(err).code {
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.ListSamlSpKeys401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -242,13 +236,12 @@ func (a *API) RotateSamlSpKey(ctx context.Context, _ apigen.RotateSamlSpKeyReque
 	if err == nil {
 		return apigen.RotateSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
 	}
-	if errors.Is(err, service.ErrSAMLSPKeyNotFound) {
-		return apigen.RotateSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	if errors.Is(err, service.ErrSAMLSPKeyRace) {
-		return apigen.RotateSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.RotateSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+	case apigen.ErrorCodeConflict:
+		return apigen.RotateSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.RotateSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -266,13 +259,12 @@ func (a *API) RetireSamlSpKey(ctx context.Context, req apigen.RetireSamlSpKeyReq
 	if err == nil {
 		return apigen.RetireSamlSpKey204Response{}, nil
 	}
-	if errors.Is(err, service.ErrSAMLSPKeyNotFound) {
-		return apigen.RetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	if errors.Is(err, service.ErrSAMLSPKeyState) || errors.Is(err, service.ErrSAMLSPKeyRace) {
-		return apigen.RetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.RetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+	case apigen.ErrorCodeConflict:
+		return apigen.RetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.RetireSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -290,13 +282,12 @@ func (a *API) CompromiseRetireSamlSpKey(ctx context.Context, req apigen.Compromi
 	if err == nil {
 		return apigen.CompromiseRetireSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
 	}
-	if errors.Is(err, service.ErrSAMLSPKeyNotFound) {
-		return apigen.CompromiseRetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	if errors.Is(err, service.ErrSAMLSPKeyState) || errors.Is(err, service.ErrSAMLSPKeyRace) {
-		return apigen.CompromiseRetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.CompromiseRetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+	case apigen.ErrorCodeConflict:
+		return apigen.CompromiseRetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.CompromiseRetireSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -312,7 +303,7 @@ func (a *API) CompromiseRetireSamlSpKey(ctx context.Context, req apigen.Compromi
 func (a *API) ListSamlProviders(ctx context.Context, _ apigen.ListSamlProvidersRequestObject) (apigen.ListSamlProvidersResponseObject, error) {
 	rows, err := a.SAMLProviders.List(ctx, service.Bearer(bearer(ctx)))
 	if err != nil {
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ListSamlProviders401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeForbidden:
@@ -336,10 +327,10 @@ func (a *API) GetSamlProvider(ctx context.Context, req apigen.GetSamlProviderReq
 	if err == nil {
 		return apigen.GetSamlProvider200JSONResponse(samlProviderWire(view)), nil
 	}
-	if errors.Is(err, service.ErrSAMLProviderNotFound) {
-		return apigen.GetSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.GetSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.GetSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -370,13 +361,10 @@ func (a *API) PutSamlProvider(ctx context.Context, req apigen.PutSamlProviderReq
 	if err == nil {
 		return apigen.PutSamlProvider200JSONResponse(samlMutationWire(result)), nil
 	}
-	if errors.Is(err, service.ErrSAMLEntityIDImmutable) || errors.Is(err, service.ErrSAMLProviderRace) {
-		return apigen.PutSamlProvider409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	if samlProviderBadInput(err) {
-		return apigen.PutSamlProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeBadRequest:
+		return apigen.PutSamlProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.PutSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -402,13 +390,10 @@ func (a *API) PatchSamlProvider(ctx context.Context, req apigen.PatchSamlProvide
 	if err == nil {
 		return apigen.PatchSamlProvider200JSONResponse(samlProviderWire(view)), nil
 	}
-	if errors.Is(err, service.ErrSAMLProviderNotFound) {
-		return apigen.PatchSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	if errors.Is(err, service.ErrSAMLProviderRace) {
-		return apigen.PatchSamlProvider409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.PatchSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.PatchSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -428,10 +413,10 @@ func (a *API) DeleteSamlProvider(ctx context.Context, req apigen.DeleteSamlProvi
 	if err == nil {
 		return apigen.DeleteSamlProvider204Response{}, nil
 	}
-	if errors.Is(err, service.ErrSAMLProviderNotFound) {
-		return apigen.DeleteSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.DeleteSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.DeleteSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -459,16 +444,12 @@ func (a *API) RefreshSamlProviderMetadata(ctx context.Context, req apigen.Refres
 	if err == nil {
 		return apigen.RefreshSamlProviderMetadata200JSONResponse(samlMutationWire(result)), nil
 	}
-	if errors.Is(err, service.ErrSAMLProviderNotFound) {
-		return apigen.RefreshSamlProviderMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(errorBody(apigen.ErrorCodeNotFound, ""))}, nil
-	}
-	if errors.Is(err, service.ErrSAMLProviderRace) {
-		return apigen.RefreshSamlProviderMetadata409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	}
-	if samlProviderBadInput(err) {
-		return apigen.RefreshSamlProviderMetadata400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-	}
-	switch classify(err) {
+	policy := wireErrorFor(err)
+	switch policy.code {
+	case apigen.ErrorCodeNotFound:
+		return apigen.RefreshSamlProviderMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+	case apigen.ErrorCodeBadRequest:
+		return apigen.RefreshSamlProviderMetadata400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
 	case apigen.ErrorCodeUnauthenticated:
 		return apigen.RefreshSamlProviderMetadata401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 	case apigen.ErrorCodeForbidden:
@@ -488,9 +469,4 @@ func sliceDeref(values *[]string) []string {
 		return nil
 	}
 	return *values
-}
-
-func samlProviderBadInput(err error) bool {
-	return errors.Is(err, service.ErrSAMLMetadataSource) || errors.Is(err, service.ErrSAMLMetadataFetch) ||
-		errors.Is(err, service.ErrSAMLMetadataInvalid) || errors.Is(err, service.ErrSAMLMetadataSignatureDowngrade)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -159,13 +159,13 @@ func New(ready ReadyChecker, a *API, ui fs.FS) http.Handler {
 		})
 	} else {
 		r.NotFound(func(w http.ResponseWriter, _ *http.Request) {
-			writeError(w, apigen.ErrorCodeNotFound, "")
+			writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		})
 	}
 	r.MethodNotAllowed(func(w http.ResponseWriter, _ *http.Request) {
 		// A method the contract does not describe on a path it does is,
 		// from outside, the same fact as a path that is not there.
-		writeError(w, apigen.ErrorCodeNotFound, "")
+		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 	})
 	return r
 }

--- a/internal/server/spa.go
+++ b/internal/server/spa.go
@@ -271,7 +271,7 @@ func serveAsset(ui fs.FS, w http.ResponseWriter, r *http.Request) {
 func serveSPA(ui fs.FS, w http.ResponseWriter, r *http.Request) {
 	if reservedFromFallback(r.URL.Path) ||
 		(r.Method != http.MethodGet && r.Method != http.MethodHead) {
-		writeError(w, apigen.ErrorCodeNotFound, "")
+		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		return
 	}
 	// A root-relative file the build emitted (favicon, manifest) is served as
@@ -297,13 +297,13 @@ func serveSPA(ui fs.FS, w http.ResponseWriter, r *http.Request) {
 	// Everything past here is the application's own routing, and only a
 	// navigation should receive a document.
 	if !wantsHTML(r) {
-		writeError(w, apigen.ErrorCodeNotFound, "")
+		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		return
 	}
 	body, err := fs.ReadFile(ui, indexPath)
 	if err != nil {
 		// An asset tree without a document is a broken build, not a route.
-		writeError(w, apigen.ErrorCodeNotFound, "")
+		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/server/webauthn.go
+++ b/internal/server/webauthn.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
@@ -22,30 +21,6 @@ import (
 // minted, reissued or rotated session is a browser session: its token is
 // delivered on the `__Host-hikyo` cookie exactly as the OIDC callback delivers
 // one, and the JSON body carries the same session for a fetch-based caller.
-
-// webauthnPrecondition reports a loud structural refusal on a caller acting on
-// their OWN authenticated account — WebAuthn unavailable on this instance, no
-// live ceremony, no usable passkey, a passkey-only-floor violation, or no
-// pre-existing credential to prove the change. A bad assertion or proof stays
-// the uniform 401.
-func webauthnPrecondition(err error) bool {
-	return errors.Is(err, service.ErrWebAuthnUnavailable) ||
-		errors.Is(err, service.ErrNoWebAuthnCeremony) ||
-		errors.Is(err, service.ErrNoPasskey) ||
-		errors.Is(err, service.ErrPasskeyOnlyViolation) ||
-		errors.Is(err, service.ErrNoProofCredential)
-}
-
-// loginPrecondition is the login-endpoint precondition: ONLY the instance-wide
-// "WebAuthn not configured" refusal is a loud 400 — it carries no per-account
-// signal. Every other login outcome (missing/disabled/unowned/invalid
-// credential, no live ceremony) normalises to the uniform 401 so login-start
-// and finish cannot be probed for whether a discoverable passkey exists or which
-// credential ids are enrolled (B3). Structural 400s stay on the OWN-account
-// surfaces (enrol/step-up/reauth/remove), never on pre-auth login.
-func loginPrecondition(err error) bool {
-	return errors.Is(err, service.ErrWebAuthnUnavailable)
-}
 
 // webauthnOptions decodes the opaque service options bytes into the free-form
 // wire object. Round-tripping through a map preserves every field verbatim.
@@ -84,7 +59,7 @@ func (a *API) EnrolPasskeyStart(ctx context.Context, req apigen.EnrolPasskeyStar
 		if webauthnPrecondition(err) {
 			return apigen.EnrolPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.EnrolPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -112,7 +87,7 @@ func (a *API) EnrolPasskeyFinish(ctx context.Context, req apigen.EnrolPasskeyFin
 		if webauthnPrecondition(err) {
 			return apigen.EnrolPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.EnrolPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -135,7 +110,7 @@ func (a *API) PasskeyLoginStart(ctx context.Context, _ apigen.PasskeyLoginStartR
 		if loginPrecondition(err) {
 			return apigen.PasskeyLoginStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.PasskeyLoginStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -163,7 +138,7 @@ func (a *API) PasskeyLoginFinish(ctx context.Context, req apigen.PasskeyLoginFin
 		if loginPrecondition(err) {
 			return apigen.PasskeyLoginFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.PasskeyLoginFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -186,7 +161,7 @@ func (a *API) StepUpPasskeyStart(ctx context.Context, _ apigen.StepUpPasskeyStar
 		if webauthnPrecondition(err) {
 			return apigen.StepUpPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.StepUpPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -214,7 +189,7 @@ func (a *API) StepUpPasskeyFinish(ctx context.Context, req apigen.StepUpPasskeyF
 		if webauthnPrecondition(err) {
 			return apigen.StepUpPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.StepUpPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -253,7 +228,7 @@ func (a *API) ReauthPasskeyStart(ctx context.Context, req apigen.ReauthPasskeySt
 		if webauthnPrecondition(err) {
 			return apigen.ReauthPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ReauthPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -292,7 +267,7 @@ func (a *API) ReauthPasskeyFinish(ctx context.Context, req apigen.ReauthPasskeyF
 		if webauthnPrecondition(err) {
 			return apigen.ReauthPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ReauthPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -329,7 +304,7 @@ func (a *API) ReauthPasskeyFinish(ctx context.Context, req apigen.ReauthPasskeyF
 func (a *API) ListPasskeys(ctx context.Context, _ apigen.ListPasskeysRequestObject) (apigen.ListPasskeysResponseObject, error) {
 	rows, err := a.Auth.ListPasskeys(ctx, bearer(ctx))
 	if err != nil {
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.ListPasskeys401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:
@@ -358,7 +333,7 @@ func (a *API) RemovePasskey(ctx context.Context, req apigen.RemovePasskeyRequest
 		if webauthnPrecondition(err) {
 			return apigen.RemovePasskey400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch classify(err) {
+		switch wireErrorFor(err).code {
 		case apigen.ErrorCodeUnauthenticated:
 			return apigen.RemovePasskey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
 		case apigen.ErrorCodeTooManyRequests:


### PR DESCRIPTION
Closes #212

## Contract and migration choices

- Adds one closed server-layer `WireError` policy for status, public code, fixed message, and safe-detail handling.
- Unknown and wrapped-unrecognized errors fail closed to the uniform `500 internal` response.
- Preserves handler control-flow timing, non-enumeration, and authentication-before-shape precedence.
- Keeps SCIM on its separate RFC 7644 wire policy.
- Preserves workspace handoff context: lookup remains `404`; approve/redeem invalid handoffs remain `403`.

## Generated outputs

None.

## Validation

- `go test -count=1 ./internal/server/...` — 183 passed
- `go test -count=1 ./internal/isolation/` — 1,084 passed
- `go test -count=1 ./...` — 2,933 passed across 56 packages
- `git diff --check` — clean
- `gofmt -d internal/server` — clean

## Review

Three spec-review rounds and two standards-review rounds completed. Final rounds: clean.