### PR TITLE
perf(server): scope remote CSP to documents

### DIFF
--- a/docs/handoff/211-document-csp.md
+++ b/docs/handoff/211-document-csp.md
@@ -1,0 +1,47 @@
+# #211 — Document-scoped dynamic CSP
+
+## Contract
+
+Static response security remains global: every response carries the baseline
+Content Security Policy, `X-Content-Type-Options: nosniff`, and
+`Referrer-Policy: no-referrer`, including API errors, probe failures, missing
+assets, and other refusals.
+
+The datastore-backed remote-origin lookup is document-scoped. A successful SPA
+root or fallback response reads the current configured remote origins once and
+extends `connect-src` through the existing canonical origin filter. API,
+health, readiness, metrics, asset, root-file, and refusal responses do not read
+remote origins and retain the self-only baseline CSP.
+
+Remote origins are not cached and are never derived from request data. The next
+successful document navigation therefore observes remote removal immediately.
+
+## Module boundary
+
+`internal/server/spa.go` owns both layers: global static response headers and
+the single SPA document writer. `internal/server/server.go` adapts
+`RemoteService.RemoteOrigins` and passes that source only to the SPA writer.
+Root and fallback documents cannot drift because both pass through `serveSPA`.
+
+## Evidence
+
+`internal/server/spa_test.go:TestRemoteOriginsAreReadOnlyForSuccessfulSPADocuments`
+uses the real router with a counting `RemoteService`. It covers API refusal and
+404 responses, liveness, readiness, metrics, hashed and root assets,
+non-document application requests, missing index refusal, root HTML, fallback
+HTML, and document `HEAD`.
+
+## Validation
+
+```sh
+gofmt -w internal/server/server.go internal/server/spa.go internal/server/spa_test.go
+go test -count=1 ./internal/server/...
+go test -count=1 ./...
+```
+
+Verified on 2026-08-21:
+
+- focused server suite: 168 tests passed in 1 package;
+- full Go suite: 2,918 tests passed in 56 packages;
+- adversarial review Round 2: CLEAN;
+- generated outputs: none.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,11 +39,15 @@ type ReadyChecker interface {
 // rules in spa.go decide, and only for an HTML navigation to a non-reserved
 // path. A nil `ui` is an API-only binary, which is what a plain `go build`
 // produces.
-// remoteOriginSource adapts the directory service to the CSP writer. It
-// swallows the read error deliberately and answers the BASELINE: a database
+// remoteOriginSource adapts the directory service to the SPA document writer.
+// It swallows the read error deliberately and answers the BASELINE: a database
 // hiccup must tighten the policy, never loosen it, and a document served with
 // `connect-src 'self'` is a workspace that cannot connect — visible and safe —
 // where a document served with no CSP at all would be neither.
+//
+// It is handed to serveSPA rather than to the header middleware (#211): only a
+// served document consumes the extension, so only a served document pays for
+// the read.
 func remoteOriginSource(a *API) func(context.Context) []string {
 	if a == nil || a.Remotes == nil {
 		return nil
@@ -59,11 +63,12 @@ func remoteOriginSource(a *API) func(context.Context) []string {
 
 func New(ready ReadyChecker, a *API, ui fs.FS) http.Handler {
 	r := chi.NewRouter()
-	// The CSP's `connect-src` is extended with the configured remotes' origins
-	// (#71) — a closed list, read per response so an added or removed remote
-	// takes effect without a restart. Nil when no directory surface is wired,
-	// which keeps the baseline exactly as it was.
-	r.Use(securityHeaders(remoteOriginSource(a)))
+	// The static security baseline, on every response including refusals. The
+	// dynamic part — `connect-src` extended with the configured remotes'
+	// origins (#71), a closed list read per DOCUMENT so an added or removed
+	// remote takes effect without a restart — belongs to the SPA writer below,
+	// which is the only response that can use it.
+	r.Use(securityHeaders())
 	// Cross-origin readability for allowlisted workspace origins (#71), at the
 	// TOP of the chain rather than inside the API group, and that placement is
 	// load-bearing rather than tidy.
@@ -154,8 +159,9 @@ func New(ready ReadyChecker, a *API, ui fs.FS) http.Handler {
 		r.Handle(assetPrefix+"*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			serveAsset(ui, w, req)
 		}))
+		origins := remoteOriginSource(a)
 		r.NotFound(func(w http.ResponseWriter, req *http.Request) {
-			serveSPA(ui, w, req)
+			serveSPA(ui, origins, w, req)
 		})
 	} else {
 		r.NotFound(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/spa.go
+++ b/internal/server/spa.go
@@ -163,18 +163,25 @@ func reservedFromFallback(p string) bool {
 	return false
 }
 
-// securityHeaders applies the baseline to every response, API answers
-// included: `nosniff` on a JSON error body is as load-bearing as it is on the
-// document, and a single writer means no surface can be forgotten.
-func securityHeaders(remoteOrigins func(context.Context) []string) func(http.Handler) http.Handler {
+// securityHeaders applies the STATIC baseline to every response, API answers
+// and refusals included: `nosniff` on a JSON error body is as load-bearing as
+// it is on the document, and a single writer means no surface can be
+// forgotten. The ops-spec ADR calls this set carried, so it is carried —
+// including on the legs that never render anything.
+//
+// What it deliberately does NOT do is read the configured remotes (#211). The
+// dynamic `connect-src` extension is a datastore read behind the authorizer,
+// and only a served document can act on the answer: a probe, a metrics scrape,
+// a hashed asset and every refusal would spend the query to describe
+// connections they can never make. Non-document responses therefore carry the
+// BASELINE policy — the header is still there, self-only, and that is the
+// explicit behaviour rather than a silent omission — and the extension is
+// applied once, by the document writer in serveSPA.
+func securityHeaders() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h := w.Header()
-			policy := contentSecurityPolicy
-			if remoteOrigins != nil {
-				policy = policyWithRemotes(remoteOrigins(r.Context()))
-			}
-			h.Set("Content-Security-Policy", policy)
+			h.Set("Content-Security-Policy", contentSecurityPolicy)
 			h.Set("X-Content-Type-Options", "nosniff")
 			h.Set("Referrer-Policy", "no-referrer")
 			next.ServeHTTP(w, r)
@@ -268,7 +275,13 @@ func serveAsset(ui fs.FS, w http.ResponseWriter, r *http.Request) {
 // serveSPA is the not-found leg once assets exist: an HTML navigation to a
 // non-reserved path renders the application, anything else gets the
 // contract's uniform nonexistent answer.
-func serveSPA(ui fs.FS, w http.ResponseWriter, r *http.Request) {
+//
+// It is also the ONE document writer. The root and every application route
+// arrive here through the same not-found handler, so the dynamic
+// `connect-src` extension is spelled once, at the bottom, and neither path can
+// drift from the other. `remoteOrigins` is nil for a build with no directory
+// surface, which leaves the baseline exactly as it was.
+func serveSPA(ui fs.FS, remoteOrigins func(context.Context) []string, w http.ResponseWriter, r *http.Request) {
 	if reservedFromFallback(r.URL.Path) ||
 		(r.Method != http.MethodGet && r.Method != http.MethodHead) {
 		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
@@ -305,6 +318,14 @@ func serveSPA(ui fs.FS, w http.ResponseWriter, r *http.Request) {
 		// An asset tree without a document is a broken build, not a route.
 		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		return
+	}
+	// Past here the response IS a document, which is the only response whose
+	// reader can use the answer — so this is where the configured remotes are
+	// read (#71, #211). Read per document, never cached: a removed remote must
+	// stop being reachable on the next navigation, which is the whole
+	// revocation story of the workspace tier.
+	if remoteOrigins != nil {
+		w.Header().Set("Content-Security-Policy", policyWithRemotes(remoteOrigins(r.Context())))
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	// The document names the hashed assets, so it is the one file that must

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -1,14 +1,19 @@
 package server_test
 
 import (
+	"context"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
 
 	"github.com/Hikyo-Org/hikyo/internal/server"
+	"github.com/Hikyo-Org/hikyo/internal/service"
 )
 
 // Embedded-serving rules (#56, system-architecture ADR § Frontend).
@@ -46,12 +51,26 @@ func uiServer(t *testing.T) *httptest.Server {
 // response plus its body.
 func get(t *testing.T, srv *httptest.Server, method, path, accept string) (*http.Response, string) {
 	t.Helper()
-	req, err := http.NewRequest(method, srv.URL+path, nil)
+	return doRequest(t, srv, method, path, accept, "")
+}
+
+// doRequest is get with a request body, for the one caller that needs the
+// API contract's own refusal leg rather than a navigation.
+func doRequest(t *testing.T, srv *httptest.Server, method, path, accept, body string) (*http.Response, string) {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, srv.URL+path, reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if accept != "" {
 		req.Header.Set("Accept", accept)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
 	}
 	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
@@ -61,11 +80,11 @@ func get(t *testing.T, srv *httptest.Server, method, path, accept string) (*http
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { resp.Body.Close() })
-	body, err := io.ReadAll(resp.Body)
+	got, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return resp, string(body)
+	return resp, string(got)
 }
 
 const htmlAccept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
@@ -360,4 +379,174 @@ func TestNonRootEmbeddedFilesAreNotServedByName(t *testing.T) {
 			t.Fatalf("%s: served the embedded file's contents", path)
 		}
 	}
+}
+
+// The dynamic `connect-src` extension (#71) is DOCUMENT-SHAPED, and #211 moves
+// it to where it is consumed. `RemoteOrigins` is a datastore read behind the
+// authorizer, so asking for it on a liveness probe, a metrics scrape, a hashed
+// asset or a refusal spends a query on a response that can never carry the
+// answer. The static baseline — the CSP baseline itself, `nosniff` and the
+// referrer policy — stays on every response, refusals included; only the
+// remote-origin extension is confined to a successfully served document.
+//
+// countingRemotes records the reads. The five directory methods are not the
+// CSP writer's business, so they fail the test if the header path ever reaches
+// one.
+type countingRemotes struct {
+	t     *testing.T
+	calls atomic.Int64
+	mu    sync.RWMutex
+	items []string
+}
+
+// stubRemoteOrigin is the origin the stub reports. It appears in `connect-src`
+// on a document and nowhere else.
+const stubRemoteOrigin = "https://peer.example"
+
+func (c *countingRemotes) RemoteOrigins(context.Context) ([]string, error) {
+	c.calls.Add(1)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string(nil), c.items...), nil
+}
+
+func (c *countingRemotes) setOrigins(origins ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = append(c.items[:0], origins...)
+}
+
+func (c *countingRemotes) unexpected(method string) {
+	c.t.Errorf("%s: the CSP writer reached the directory surface", method)
+}
+
+func (c *countingRemotes) AddRemote(context.Context, service.Actor, string, string, string, string) (service.RemoteView, error) {
+	c.unexpected("AddRemote")
+	return service.RemoteView{}, nil
+}
+
+func (c *countingRemotes) ListRemotes(context.Context, service.Actor) ([]service.RemoteView, error) {
+	c.unexpected("ListRemotes")
+	return nil, nil
+}
+
+func (c *countingRemotes) ShowRemote(context.Context, service.Actor, string) (service.RemoteView, error) {
+	c.unexpected("ShowRemote")
+	return service.RemoteView{}, nil
+}
+
+func (c *countingRemotes) RenameRemote(context.Context, service.Actor, string, string) (service.RemoteView, error) {
+	c.unexpected("RenameRemote")
+	return service.RemoteView{}, nil
+}
+
+func (c *countingRemotes) RemoveRemote(context.Context, service.Actor, string) error {
+	c.unexpected("RemoveRemote")
+	return nil
+}
+
+// countingServer is the real router with a directory surface whose only live
+// method is the origin read.
+func countingServer(t *testing.T, ui fs.FS) (*httptest.Server, *countingRemotes) {
+	t.Helper()
+	remotes := &countingRemotes{t: t, items: []string{stubRemoteOrigin}}
+	srv := httptest.NewServer(server.New(stubReady{}, &server.API{Remotes: remotes}, ui))
+	t.Cleanup(srv.Close)
+	return srv, remotes
+}
+
+// staticBaseline asserts the headers that belong to EVERY response, whatever
+// it is: the CSP baseline, `nosniff` and the referrer policy. A response that
+// drops them because it is not a document is the failure #211 must not cause.
+func staticBaseline(t *testing.T, resp *http.Response) {
+	t.Helper()
+	csp := resp.Header.Get("Content-Security-Policy")
+	if !strings.Contains(csp, "default-src 'self'") || !strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Errorf("Content-Security-Policy = %q, want the baseline", csp)
+	}
+	if !strings.Contains(csp, "connect-src 'self';") {
+		t.Errorf("Content-Security-Policy connect-src = %q, want exactly self", csp)
+	}
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := resp.Header.Get("Referrer-Policy"); got != "no-referrer" {
+		t.Errorf("Referrer-Policy = %q, want no-referrer", got)
+	}
+}
+
+func TestRemoteOriginsAreReadOnlyForSuccessfulSPADocuments(t *testing.T) {
+	// Everything that is not a served document. Each carries the static
+	// baseline and none of them may spend a datastore read on it.
+	for _, c := range []struct {
+		name, method, path, accept, body string
+	}{
+		{"contract refusal", http.MethodPost, "/api/v1/orgs", "application/json", `{}`},
+		{"unrouted contract path", http.MethodGet, "/api/v1/nope", htmlAccept, ""},
+		{"liveness probe", http.MethodGet, "/healthz", htmlAccept, ""},
+		{"readiness probe", http.MethodGet, "/readyz", htmlAccept, ""},
+		{"metrics", http.MethodGet, "/metrics", htmlAccept, ""},
+		{"hashed asset", http.MethodGet, "/assets/app-deadbeef.js", "", ""},
+		{"missing hashed asset", http.MethodGet, "/assets/app-00000000.js", htmlAccept, ""},
+		{"root file", http.MethodGet, "/favicon.svg", "", ""},
+		{"json client on an application route", http.MethodGet, "/some/route", "application/json", ""},
+		{"non-navigation method", http.MethodPost, "/some/route", htmlAccept, ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			srv, remotes := countingServer(t, testUI())
+			resp, _ := doRequest(t, srv, c.method, c.path, c.accept, c.body)
+			if n := remotes.calls.Load(); n != 0 {
+				t.Errorf("RemoteOrigins called %d times for a non-document response", n)
+			}
+			staticBaseline(t, resp)
+			if csp := resp.Header.Get("Content-Security-Policy"); strings.Contains(csp, stubRemoteOrigin) {
+				t.Errorf("a remote origin reached a non-document response: %q", csp)
+			}
+		})
+	}
+
+	// The document legs share one live server. Root and HTML fallback use the
+	// same writer; each asks exactly once, and changing the configured origin
+	// between requests proves the writer does not cache across navigations.
+	srv, remotes := countingServer(t, testUI())
+	for i, c := range []struct{ name, method, path, origin string }{
+		{"root document", http.MethodGet, "/", stubRemoteOrigin},
+		{"html fallback", http.MethodGet, "/org/acme/projects", "https://replacement.example"},
+		{"head on the root document", http.MethodHead, "/", "https://head.example"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			remotes.setOrigins(c.origin)
+			resp, _ := get(t, srv, c.method, c.path, htmlAccept)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if n := remotes.calls.Load(); n != int64(i+1) {
+				t.Errorf("RemoteOrigins called %d times, want %d", n, i+1)
+			}
+			csp := resp.Header.Get("Content-Security-Policy")
+			if !strings.Contains(csp, "connect-src 'self' "+c.origin+";") {
+				t.Errorf("the document's connect-src was not extended: %q", csp)
+			}
+			if i > 0 && strings.Contains(csp, stubRemoteOrigin) {
+				t.Errorf("the document retained removed origin %q: %q", stubRemoteOrigin, csp)
+			}
+		})
+	}
+
+	// A build with no document is not a successful document response. The
+	// refusal takes the baseline and spends nothing.
+	t.Run("missing index is not a document", func(t *testing.T) {
+		srv, remotes := countingServer(t, fstest.MapFS{})
+		resp, body := get(t, srv, http.MethodGet, "/", htmlAccept)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", resp.StatusCode)
+		}
+		if strings.Contains(body, "<html") {
+			t.Fatalf("a build without a document served one:\n%s", body)
+		}
+		if n := remotes.calls.Load(); n != 0 {
+			t.Errorf("RemoteOrigins called %d times for a refusal", n)
+		}
+		staticBaseline(t, resp)
+	})
 }


### PR DESCRIPTION
## Summary

- keep baseline CSP, `nosniff`, and referrer policy on every response
- read `RemoteOrigins` only for successful SPA root and fallback documents
- prove live revocation semantics with one server and changing remote origins

## Contract and migration

Non-document responses retain the self-only baseline CSP. Successful SPA documents extend `connect-src` with the existing canonical remote-origin filter. No cache, datastore migration, request-derived origin, or compatibility change was added.

Generated outputs: none.

## Validation

- `go test -count=1 ./internal/server/...` — 168 tests passed in 1 package
- `go test -count=1 ./...` — 2,918 tests passed in 56 packages
- standards/spec review — CLEAN
- native Codex adversarial review, 3 rounds — CLEAN

Closes #211