### PR TITLE
ci: shard race and fuzz checks

### DIFF
--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -9,6 +9,7 @@ on:
   pull_request_target:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -19,6 +20,7 @@ jobs:
   validation:
     uses: ./.github/workflows/ci.yml
     permissions:
+      actions: read
       contents: read
 
   # Permanent required context. This job and its success criteria are loaded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,10 @@ jobs:
             --output "$archive"
           printf '%s  %s\n' "$SHELLCHECK_SHA256" "$archive" | sha256sum --check --strict
           tar -xJf "$archive" -C "$RUNNER_TEMP"
-          "$RUNNER_TEMP/shellcheck-$SHELLCHECK_VERSION/shellcheck" \
+          shellcheck_dir="$RUNNER_TEMP/shellcheck-$SHELLCHECK_VERSION"
+          "$shellcheck_dir/shellcheck" \
             scripts/lib/*.sh scripts/ci/*.sh scripts/release/*.sh scripts/compose-demo.sh install/install.sh.in
+          echo "$shellcheck_dir" >>"$GITHUB_PATH"
       - name: Actionlint
         run: ./scripts/ci/run-go-tool.sh actionlint
       - name: Save lint Go cache
@@ -947,7 +949,9 @@ jobs:
           printf '%s\n' "$FUZZ_PLAN" |
             jq -r --argjson shard "$FUZZ_SHARD" '.[$shard][]' >"$targets"
           while IFS=$'\t' read -r pkg target; do
-            [ -n "$pkg" ] && [ -n "$target" ] || continue
+            if [ -z "$pkg" ] || [ -z "$target" ]; then
+              continue
+            fi
             echo "::group::$pkg $target"
             if ! go test -run='^$' -fuzz="^${target}\$" -fuzztime=15s "$pkg"; then
               failed=1
@@ -1034,7 +1038,6 @@ jobs:
     steps:
       - name: Download shard fuzz reproducers
         if: ${{ needs.fuzz_shard.result != 'success' }}
-        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}-shard-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - name: Download the exact app build
-        uses: actions/download-artifact@3e5f637d1b665217e8c8ac7d515d5f5f90f04786 # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
       # Actions artifacts intentionally normalize file modes. Restore execute

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -739,15 +740,81 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ steps.k8s-e2e-go-cache.outputs.cache-primary-key }}
 
+  # The workflow graph is trusted base-branch code, but every validation job
+  # checks out the untrusted PR head. Build both shard plans once from a copy of
+  # the planner at BASE_SHA so a PR cannot omit its own package or fuzz target.
+  analysis_shards:
+    needs: changes
+    if: >-
+      ${{ fromJSON(needs.changes.outputs.plan).race ||
+      fromJSON(needs.changes.outputs.plan).fuzz }}
+    runs-on: ubuntu-latest
+    outputs:
+      fuzz_plan: ${{ steps.plan.outputs.fuzz_plan }}
+      race_plan: ${{ steps.plan.outputs.race_plan }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Plan complete race and fuzz shards
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -o pipefail
+          trusted_planner="$RUNNER_TEMP/analysis-shards.go"
+          if [ "$EVENT_NAME" = push ]; then
+            cp ./scripts/ci/analysis-shards-go/main.go "$trusted_planner"
+          else
+            git show "$BASE_SHA:scripts/ci/analysis-shards-go/main.go" >"$trusted_planner"
+          fi
+
+          race_plan='[]'
+          fuzz_plan='[]'
+          for shard in 0 1 2; do
+            race_shard=$(go run "$trusted_planner" race --root . \
+              --shard "$shard" --shards 3 | jq -Rsc 'split("\n") | map(select(length > 0))')
+            fuzz_shard=$(go run "$trusted_planner" fuzz --root . \
+              --shard "$shard" --shards 3 | jq -Rsc 'split("\n") | map(select(length > 0))')
+            race_plan=$(jq -cn --argjson plan "$race_plan" --argjson shard "$race_shard" \
+              '$plan + [$shard]')
+            fuzz_plan=$(jq -cn --argjson plan "$fuzz_plan" --argjson shard "$fuzz_shard" \
+              '$plan + [$shard]')
+          done
+
+          if [ "$(printf '%s' "$race_plan" | jq 'flatten | length')" -eq 0 ] ||
+            [ "$(printf '%s' "$fuzz_plan" | jq 'flatten | length')" -eq 0 ]; then
+            echo 'analysis shards: race or fuzz plan was empty' >&2
+            exit 1
+          fi
+          {
+            echo "race_plan=$race_plan"
+            echo "fuzz_plan=$fuzz_plan"
+          } >>"$GITHUB_OUTPUT"
+
   # Race detector as its own context: a concurrent server with transaction
   # retry and a single-writer SQLite pool gets its data races found here, not
   # in production. The probe-based isolation E2E suite exceeds the per-package
   # timeout under the detector, so its race-instrumented run lives in the
   # scheduled race-isolation workflow instead of on the PR wall-clock.
-  race:
-    needs: changes
+  race_shard:
+    name: race shard (${{ matrix.shard }})
+    needs:
+      - analysis_shards
+      - changes
     if: ${{ fromJSON(needs.changes.outputs.plan).race }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
     services:
       postgres:
         image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
@@ -785,13 +852,22 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build
-          key: go-race-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}
-          restore-keys: |
-            go-race-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
+          key: go-race-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: go-race-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
       - name: Race detector (all packages except the isolation suite)
         env:
           HIKYO_TEST_POSTGRES_DSN: postgres://hikyo:hikyo@127.0.0.1:5432/hikyo_test
-        run: go list ./... | grep -v '/internal/isolation$' | xargs go test -race -count=1
+          RACE_PLAN: ${{ needs.analysis_shards.outputs.race_plan }}
+          RACE_SHARD: ${{ matrix.shard }}
+        run: |
+          packages="$RUNNER_TEMP/race-packages"
+          printf '%s\n' "$RACE_PLAN" |
+            jq -r --argjson shard "$RACE_SHARD" '.[$shard][]' >"$packages"
+          if [ ! -s "$packages" ]; then
+            echo "race: shard $RACE_SHARD has no packages" >&2
+            exit 1
+          fi
+          xargs go test -race -vet=off -count=1 <"$packages"
       - name: Save race Go cache (main push only)
         if: >-
           success() && steps.race-go-cache.outputs.cache-hit != 'true' &&
@@ -801,12 +877,31 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ steps.race-go-cache.outputs.cache-primary-key }}
 
+  race:
+    needs:
+      - changes
+      - race_shard
+    if: ${{ always() && fromJSON(needs.changes.outputs.plan).race }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every race shard
+        env:
+          RACE_SHARD_RESULT: ${{ needs.race_shard.result }}
+        run: test "$RACE_SHARD_RESULT" = success
+
   # Seed corpora already run in `test`; this bounded exploration pass discovers
   # targets dynamically so a new fuzz target cannot be forgotten.
-  fuzz:
-    needs: changes
+  fuzz_shard:
+    name: fuzz shard (${{ matrix.shard }})
+    needs:
+      - analysis_shards
+      - changes
     if: ${{ fromJSON(needs.changes.outputs.plan).fuzz }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -836,43 +931,35 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build
-          key: go-fuzz-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ steps.fuzz-cache-generation.outputs.value }}
+          key: go-fuzz-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ steps.fuzz-cache-generation.outputs.value }}
           restore-keys: |
-            go-fuzz-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}-
-            go-fuzz-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
+            go-fuzz-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}-
+            go-fuzz-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
       - name: Fuzz every target for a bounded time
+        env:
+          FUZZ_PLAN: ${{ needs.analysis_shards.outputs.fuzz_plan }}
+          FUZZ_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
           failed=0
           ran=0
-          # One listing over the tree: `go test -list` prints each matching
-          # target on its own line, followed by an `ok <pkg>` line for the
-          # package it belongs to, so targets are attributed to the package
-          # that follows them. A listing failure fails the step.
-          listing=$(go test -list '^Fuzz' ./...)
-          pending=()
-          while IFS= read -r line; do
-            case "$line" in
-              Fuzz*) pending+=("$line") ;;
-              "ok "*)
-                pkg=$(printf '%s\n' "$line" | awk '{print $2}')
-                for target in "${pending[@]}"; do
-                  echo "::group::$pkg $target"
-                  if ! go test -run='^$' -fuzz="^${target}\$" -fuzztime=15s "$pkg"; then
-                    failed=1
-                  fi
-                  echo "::endgroup::"
-                  ran=$((ran + 1))
-                done
-                pending=()
-                ;;
-            esac
-          done <<<"$listing"
+          targets="$RUNNER_TEMP/fuzz-targets"
+          printf '%s\n' "$FUZZ_PLAN" |
+            jq -r --argjson shard "$FUZZ_SHARD" '.[$shard][]' >"$targets"
+          while IFS=$'\t' read -r pkg target; do
+            [ -n "$pkg" ] && [ -n "$target" ] || continue
+            echo "::group::$pkg $target"
+            if ! go test -run='^$' -fuzz="^${target}\$" -fuzztime=15s "$pkg"; then
+              failed=1
+            fi
+            echo "::endgroup::"
+            ran=$((ran + 1))
+          done <"$targets"
           if [ "$ran" -eq 0 ]; then
-            echo "fuzz: no Fuzz* target discovered — the pass cannot be vacuous" >&2
+            echo "fuzz: shard $FUZZ_SHARD has no target — the pass cannot be vacuous" >&2
             exit 1
           fi
-          echo "fuzz: $ran targets ran"
+          echo "fuzz: shard $FUZZ_SHARD ran $ran targets"
           exit "$failed"
       # Go writes a newly discovered failing input into the package's
       # testdata/fuzz tree. Preserve only regular, bounded, hash-named corpus
@@ -916,11 +1003,11 @@ jobs:
             found=true
           done < <(find . -type f -path '*/testdata/fuzz/Fuzz*/*' -print0)
           echo "found=$found" >>"$GITHUB_OUTPUT"
-      - name: Upload minimized fuzz reproducers
+      - name: Upload shard fuzz reproducers
         if: failure() && steps.fuzz-reproducers.outputs.found == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}
+          name: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}-shard-${{ matrix.shard }}
           path: ${{ runner.temp }}/fuzz-reproducers/
           if-no-files-found: error
           retention-days: 30
@@ -933,10 +1020,56 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ steps.fuzz-go-cache.outputs.cache-primary-key }}
 
+  # Preserve the reporter's single canonical artifact contract while allowing
+  # all shard failures to finish and contribute minimized reproducers.
+  fuzz:
+    needs:
+      - changes
+      - fuzz_shard
+    if: ${{ always() && fromJSON(needs.changes.outputs.plan).fuzz }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download shard fuzz reproducers
+        if: ${{ needs.fuzz_shard.result != 'success' }}
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}-shard-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/fuzz-shard-artifacts
+      - name: Find merged fuzz reproducers
+        id: merged-reproducers
+        if: ${{ needs.fuzz_shard.result != 'success' }}
+        env:
+          ARTIFACT_ROOT: ${{ runner.temp }}/fuzz-shard-artifacts
+        run: |
+          found=false
+          if [ -d "$ARTIFACT_ROOT" ] &&
+            find "$ARTIFACT_ROOT" -type f -print -quit | grep -q .; then
+            found=true
+          fi
+          echo "found=$found" >>"$GITHUB_OUTPUT"
+      - name: Upload minimized fuzz reproducers
+        if: ${{ steps.merged-reproducers.outputs.found == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-reproducers-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/fuzz-shard-artifacts/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Require every fuzz shard
+        env:
+          FUZZ_SHARD_RESULT: ${{ needs.fuzz_shard.result }}
+        run: test "$FUZZ_SHARD_RESULT" = success
+
   # Fuzz findings are reported out-of-band by fuzz-report.yml (workflow_run), so
   # no job here requests issue/PR write. That keeps this reusable workflow's
-  # permission surface at contents:read, which is all its caller (trusted-ci)
-  # grants — a write request here would startup-fail every PR's trusted-ci run.
+  # permission surface read-only (contents/actions), which is all its caller
+  # (trusted-ci) grants — a write request here would startup-fail every PR's
+  # trusted-ci run.
 
   # The headline guarantee, as its own named context (#76, mvp-boundary K3):
   # a stolen database and a stolen backup, without the root key, yield no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
         run: ./scripts/ci/check-chart_test.sh
       - name: Trusted CI scripts fixture
         run: ./scripts/ci/check-trusted-ci-scripts_test.sh
+      - name: Build artifact reuse fixture
+        run: ./scripts/ci/check-build-artifact-reuse_test.sh
       - name: Cache policy fixture
         run: ./scripts/ci/check-cache-policy_test.sh
       - name: Fuzz finding classifier fixture
@@ -203,6 +205,60 @@ jobs:
         run: ./scripts/release/release-channel_test.sh
       - name: Pinned installer fixture
         run: ./scripts/release/render-installer_test.sh
+
+  # Build the release-shaped app once for both browser shards. Release snapshot
+  # stays parallel because waiting for this native build before its six-target
+  # GoReleaser build would lengthen the critical path. This run-scoped artifact
+  # is internal build plumbing, not a release.
+  app-build:
+    needs: changes
+    if: ${{ fromJSON(needs.changes.outputs.plan).web }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: go-mod-v2-${{ runner.os }}-
+      - name: Select runner cache ABI
+        id: runner-cache-abi
+        run: ./scripts/ci/export-runner-cache-abi.sh
+      - name: Restore app-build Go cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: |
+            go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Enable pnpm
+        run: corepack enable
+      - name: Verify and build the SPA
+        run: ./scripts/ci/build-spa.sh --verify
+      - name: Build the release-shaped app
+        run: |
+          mkdir -p ci-artifacts
+          go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo
+      - name: Upload app build for downstream validation
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            internal/webui/dist/
+            ci-artifacts/hikyo-ui
+          if-no-files-found: error
+          retention-days: 1
 
   release-snapshot:
     needs: changes
@@ -239,22 +295,43 @@ jobs:
           node-version-file: .nvmrc
       - name: Enable pnpm
         run: corepack enable
-      # GoReleaser builds with the `ui` tag, so its isolated job must produce
-      # the embedded SPA before compiling all six release targets.
-      - name: Build the SPA (the `ui` build tag embeds it)
-        working-directory: web
-        run: |
-          pnpm --dir ../clients/ts install --frozen-lockfile
-          pnpm install --frozen-lockfile
-          pnpm build
+      # Keep this small build parallel with app-build. Serial reuse saves one
+      # sub-second Vite build but delays all six GoReleaser targets behind the
+      # native browser binary and frontend validation.
+      - name: Build the SPA for the release snapshot
+        run: ./scripts/ci/build-spa.sh
       - name: GoReleaser configuration and snapshot
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: v2.17.1
           args: release --snapshot --clean --skip=publish
+      # This fixture works on a temporary copy of dist. Keep it before upload:
+      # failed archive/version/manifest checks must not leave a download behind.
       - name: Classify complete snapshot manifest
         run: ./scripts/release/snapshot-manifest_test.sh
+      - name: Mark the snapshot as unsigned development output
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          printf '%s\n' \
+            'UNSIGNED DEVELOPMENT SNAPSHOT — NOT AN OFFICIAL HIKYO RELEASE' \
+            "Source commit: $GITHUB_SHA" \
+            'This artifact has checksums but no release manifest or signature.' \
+            'Do not use it for production or the offline release ceremony.' \
+            >dist/DEVELOPMENT-SNAPSHOT.txt
+      - name: Upload unsigned development snapshot
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: hikyo-development-${{ github.sha }}
+          path: |
+            dist/hikyo_*_Darwin_*.tar.gz
+            dist/hikyo_*_Linux_*.tar.gz
+            dist/hikyo_*_Windows_*.zip
+            dist/checksums.txt
+            dist/DEVELOPMENT-SNAPSHOT.txt
+          if-no-files-found: error
+          retention-days: 14
       - name: Save release-snapshot Go cache
         if: >-
           success() && steps.release-snapshot-go-cache.outputs.cache-hit != 'true' &&
@@ -433,7 +510,7 @@ jobs:
   # `check-required-jobs.sh` need no adjustment, and each leg keeps the ordering
   # above intact instead of starting a browser behind a Go suite that failed.
   web:
-    needs: changes
+    needs: [changes, app-build]
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
     runs-on: ubuntu-latest
     strategy:
@@ -447,6 +524,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - name: Download the exact app build
+        uses: actions/download-artifact@3e5f637d1b665217e8c8ac7d515d5f5f90f04786 # v8.0.1
+        with:
+          name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
+      # Actions artifacts intentionally normalize file modes. Restore execute
+      # permission before the browser harness starts the downloaded binary.
+      - name: Prepare the prebuilt app
+        run: chmod +x ci-artifacts/hikyo-ui
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
@@ -485,35 +570,12 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        working-directory: web
-        run: pnpm run typecheck
-
-      # Unit tests include the flow registry's closure check and its own
-      # negative fixtures — a check that cannot fail is not a check.
-      - name: Unit tests and flow-registry closure
-        working-directory: web
-        run: pnpm run test
-
-      - name: Build the SPA
-        working-directory: web
-        run: pnpm run build
-
-      # The embed only compiles with the `ui` tag, and only after the build
-      # above. This is the step that proves the tagged binary is buildable at
-      # all; the untagged build and the full Go suite live in the `test` job
-      # and stay green without ever running pnpm.
-      - name: Build the binary with the embedded UI
-        run: go build -tags ui ./...
-
       # The release ships the `ui`-tagged binary, so the shipped shape gets
       # its own govulncheck pass here; `test` scans the untagged build that
       # every Go-only change exercises. One leg: the binary is identical.
       - name: govulncheck (vulnerabilities reachable from the release-shaped binary)
         if: matrix.project == 'desktop'
-        run: |
-          go build -tags ui -o "$RUNNER_TEMP/hikyo-ui" ./cmd/hikyo
-          ./scripts/ci/run-go-tool.sh govulncheck -mode=binary "$RUNNER_TEMP/hikyo-ui"
+        run: ./scripts/ci/run-go-tool.sh govulncheck -mode=binary ci-artifacts/hikyo-ui
 
       - name: Go tests (transport, serving rules, browser session)
         # Restored GOCACHE may contain passing test results. Compile from cache,
@@ -538,10 +600,12 @@ jobs:
           pnpm exec playwright install chromium
 
       # `playwright test` directly, not `pnpm run e2e`: the script rebuilds the
-      # SPA so a developer cannot run the flows against a stale bundle, and the
-      # step above has already built this run's.
+      # SPA so a developer cannot run the flows against a stale bundle, and
+      # app-build already supplied this run's exact bundle and binary.
       - name: Flow suite (${{ matrix.project }})
         working-directory: web
+        env:
+          HIKYO_E2E_BINARY: ${{ github.workspace }}/ci-artifacts/hikyo-ui
         run: pnpm exec playwright test --project=${{ matrix.project }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/fuzz-report.yml
+++ b/.github/workflows/fuzz-report.yml
@@ -1,8 +1,9 @@
 # Out-of-band fuzz reporting (#189). The validation graphs (ci.yml, ci-control.yml)
 # execute untrusted PR code and therefore hold no issue/PR write authority — a
-# write request inside the reusable ci.yml is capped by trusted-ci's contents:read
-# grant and startup-fails every PR run. This workflow runs in the trusted base
-# context on workflow_run completion, where write can be granted safely.
+# write request inside the reusable ci.yml is capped by trusted-ci's read-only
+# contents/actions grant and startup-fails every PR run. This workflow runs in
+# the trusted base context on workflow_run completion, where write can be granted
+# safely.
 #
 # Trust model: the fuzz-reproducers artifact is produced by untrusted PR jobs, so
 # its contents are re-validated (corpus-path shape and count) by both the classify

--- a/docs/handoff/ci-race-fuzz-sharding.md
+++ b/docs/handoff/ci-race-fuzz-sharding.md
@@ -1,0 +1,58 @@
+# CI race and fuzz sharding handoff
+
+## Outcome
+
+Race and fuzz return as blocking pull-request checks for Go, SQL, operator, and
+Kubernetes Go changes without reducing their coverage. Both checks use three
+parallel shards and retain the existing aggregate job IDs, so `ci-required`
+continues to enforce `race` and `fuzz` without a ruleset migration.
+
+No JUnit dependency or report format was added. The planner is exercised
+through its public command-line interface by native shell fixtures, matching
+the rest of the CI policy tests.
+
+## Coverage and trust model
+
+- Race assigns all 56 Go packages except `internal/isolation` exactly once.
+  Isolation remains covered by the normal suite and the dedicated scheduled
+  race-isolation workflow because its probe-based namespace/container tests
+  exceed the detector's per-package timeout.
+- Fuzz discovers declarations from Go test files with the Go parser rather
+  than compiling every package with `go test -list`. It assigns all 17 current
+  targets exactly once and keeps targets from one package on one shard.
+- Pull requests cannot edit the planner used to plan their own validation. The
+  reusable base-branch workflow loads `analysis-shards-go/main.go` from the
+  pull request base SHA, then plans against the exact checked-out head.
+- A new package or fuzz target is deterministically assigned with FNV-1a.
+  Explicit assignments keep the currently slow packages balanced.
+- Each race shard has its own PostgreSQL service and race build cache. Each
+  fuzz shard has its own weekly rotating build/fuzz cache.
+
+## Failure reporting
+
+Every fuzz matrix lane finishes even if another lane fails. Each failing lane
+uploads only new, bounded Go reproducers. The aggregate `fuzz` job downloads
+and merges those shard artifacts into the existing canonical artifact name,
+so `fuzz-report.yml` keeps its current trusted reporting contract.
+
+## Timing evidence
+
+Before this change, the latest cold main run spent about 8m06s in race and
+10m40s in fuzz. Warm pull-request history was about 7–8 minutes for race and
+5m48s–5m57s for fuzz. Fuzz also spent about 3m30s compiling packages only to
+discover target names.
+
+Local exact-DSN race validation completed the three warm shards in 1m45s,
+1m14s, and 1m18s. This demonstrates the intended critical-path reduction but
+is not a hosted-runner benchmark. Record the first warm GitHub Actions timings
+after merge before treating the speedup as production evidence.
+
+## Validation
+
+- Full PostgreSQL-backed `go test -count=1 ./...` passed.
+- All three exact race shard commands passed with `-race -vet=off -count=1`.
+- All 17 planned fuzz targets entered their real fuzz functions and passed
+  with `-fuzztime=1x`.
+- Planner, changed-path, trusted-script, cache-policy, required-job, and fuzz
+  reporting fixtures passed.
+- Actionlint, ShellCheck, Go build, Go vet, formatting, and diff checks passed.

--- a/docs/handoff/ci-race-fuzz-sharding.md
+++ b/docs/handoff/ci-race-fuzz-sharding.md
@@ -60,6 +60,12 @@ shards. Release snapshot keeps its small SPA build so its six cross-platform
 builds can run concurrently. Hosted timing remains pending until this exact
 head runs on GitHub.
 
+The flow harness disables authenticated service budgets through an explicit
+development-only setting. The matrix deliberately reuses one principal across
+enough publish scenarios to exceed the production ten-per-minute ceiling; the
+setting is refused unless the server runs with `--dev`, while budget behavior
+remains covered by service conformance and unit tests.
+
 ## Development downloads
 
 A successful trusted `main` run retains the six GoReleaser archives,

--- a/docs/handoff/ci-race-fuzz-sharding.md
+++ b/docs/handoff/ci-race-fuzz-sharding.md
@@ -11,6 +11,11 @@ No JUnit dependency or report format was added. The planner is exercised
 through its public command-line interface by native shell fixtures, matching
 the rest of the CI policy tests.
 
+The follow-up build optimization now produces the embedded SPA and native UI
+binary once in `app-build`. Both browser shards consume that exact run-scoped
+artifact. The six-target GoReleaser snapshot stays parallel: serializing it
+behind the native browser build would lengthen the critical path.
+
 ## Coverage and trust model
 
 - Race assigns all 56 Go packages except `internal/isolation` exactly once.
@@ -47,6 +52,25 @@ Local exact-DSN race validation completed the three warm shards in 1m45s,
 is not a hosted-runner benchmark. Record the first warm GitHub Actions timings
 after merge before treating the speedup as production evidence.
 
+Before the follow-up, frontend install, typecheck, unit tests, and build ran in
+both browser matrix legs. Browser global setup also linked four more UI binaries
+across the two isolated instances in each shard. The new graph runs browser
+frontend validation and build once and supplies one prebuilt binary to both
+shards. Release snapshot keeps its small SPA build so its six cross-platform
+builds can run concurrently. Hosted timing remains pending until this exact
+head runs on GitHub.
+
+## Development downloads
+
+A successful trusted `main` run retains the six GoReleaser archives,
+`checksums.txt`, and `DEVELOPMENT-SNAPSHOT.txt` for 14 days as
+`hikyo-development-<commit>`. Pull requests do not publish this artifact.
+
+This is deliberately not a GitHub Release. It is unsigned evaluation output
+without a release manifest, installer, upgrade promise, or production support.
+The tag-only draft, offline recovery binding, primary signing, verification,
+and publish sequence in `docs/release/signing.md` remains unchanged.
+
 ## Validation
 
 - Full PostgreSQL-backed `go test -count=1 ./...` passed.
@@ -55,4 +79,6 @@ after merge before treating the speedup as production evidence.
   with `-fuzztime=1x`.
 - Planner, changed-path, trusted-script, cache-policy, required-job, and fuzz
   reporting fixtures passed.
+- Build-artifact reuse fixture, web typecheck/unit/build, and docs verification
+  passed.
 - Actionlint, ShellCheck, Go build, Go vet, formatting, and diff checks passed.

--- a/docs/release/signing.md
+++ b/docs/release/signing.md
@@ -4,6 +4,12 @@ CI builds and publishes an **unsigned draft**. It never receives either private
 key. The maintainer signs locally; only verified, already-published bytes become
 an official release.
 
+Ordinary `main` CI also retains GoReleaser archives for 14 days as an unsigned
+development artifact named for the exact source commit. Those snapshots carry
+checksums and an explicit warning, but no release manifest or signature. They
+are evaluation output only: they never create a GitHub Release and cannot enter
+this ceremony as a release candidate.
+
 ## Pinned tools
 
 - GoReleaser `v2.17.1`

--- a/docs/site/src/content/docs/docs/installation.mdx
+++ b/docs/site/src/content/docs/docs/installation.mdx
@@ -13,16 +13,31 @@ production release.
 | Goal | Path | Result |
 | --- | --- | --- |
 | Try Hikyo locally | [Getting started](/docs/getting-started/) | Loopback-only server, SQLite, embedded web UI |
+| Try the latest `main` build | [Unsigned development snapshot](#unsigned-development-snapshots) | Exact-commit archive for six desktop/server targets |
 | Build a reusable binary | [Build from source](/docs/build-from-source/) | One binary for your current platform |
 | Prepare a real deployment | [Self-hosting baseline](/docs/self-hosting/) | Explicit storage, keys, TLS boundary, and backups |
 | Upgrade an existing instance | [Upgrades](/docs/upgrades/) | Pre-migration export and verified rollout |
 
-<Callout type="info" title="Release installers are not published yet">
+<Callout type="info" title="Official release installers are not published yet">
   The repository contains the signed-release pipeline, installer template,
   OCI image, and Helm chart. Those become installation options only after a
-  release is published. No copy-paste command here points at an artifact that
-  does not exist.
+  release is published. Development snapshots below are unsigned CI output,
+  not substitutes for that ceremony.
 </Callout>
+
+## Unsigned development snapshots
+
+Every successful trusted `main` build attaches a 14-day
+`hikyo-development-<commit>` artifact to its
+[GitHub Actions run](https://github.com/Hikyo-Org/Hikyo/actions/workflows/ci.yml?query=branch%3Amain).
+It contains Linux, macOS, and Windows archives for `x86_64` and `arm64`, plus
+checksums and an unsigned-development warning. GitHub may require a signed-in
+account to download Actions artifacts.
+
+Use a snapshot only for evaluation. Its commit is immutable and its checksums
+detect download corruption, but it has no signed release manifest, official
+installer, upgrade promise, or production support. The offline signing runbook
+remains the only path from built bytes to an official Hikyo release.
 
 ## Local evaluation
 
@@ -50,9 +65,9 @@ Hikyo fails closed when these boundaries are missing. Continue with the
 
 ## Platform support
 
-Source builds follow Go's supported host platforms. The release pipeline is
-prepared for Linux and macOS on `x86_64` and `arm64`, but those downloads do not
-exist until the first release is published.
+Source builds follow Go's supported host platforms. Unsigned development
+snapshots cover Linux, macOS, and Windows on `x86_64` and `arm64`. Official
+downloads do not exist until the first signed release is published.
 
 The server is designed to run as one binary. The browser UI is embedded when
 the binary is built with the `ui` build tag.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -264,7 +264,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 	// in-memory like admission, wired into every surface that owns a named
 	// expensive category — export, publish, adapter sync, machine fetch, and
 	// schema revision.
-	budget := service.NewBudget()
+	budget := serviceBudget(cfg)
 	authSvc := &service.Auth{DB: db, Keyring: kr, KDF: kdf, Admission: limiter, Log: log, ExternalOrigin: cfg.ExternalOrigin, ReauthWindow: cfg.ReauthWindow}
 	samlProviders := &service.SAMLProviders{DB: db, Keyring: kr, ExternalOrigin: cfg.ExternalOrigin}
 	// RP ID + expected origins are immutable instance config derived from the
@@ -440,6 +440,17 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		}}},
 		adapterWorker: adapterWorker,
 	}, nil
+}
+
+// serviceBudget keeps production policy fail-closed even when a caller builds
+// Config directly instead of going through config.Load. The development-only
+// off switch exists for the browser flow harness; budget behavior itself is
+// covered by service-level conformance and unit tests.
+func serviceBudget(cfg *config.Config) *service.Budget {
+	if cfg.Dev && cfg.DevServiceBudgetsDisabled {
+		return nil
+	}
+	return service.NewBudget()
 }
 
 // AuthComponents resolves the two authentication settings and, in doing so,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -78,6 +78,21 @@ func TestHTTPServerSlowClientLimitsConfigured(t *testing.T) {
 	}
 }
 
+func TestServiceBudgetCanOnlyBeDisabledByExplicitDevConfig(t *testing.T) {
+	cfg := &config.Config{}
+	if serviceBudget(cfg) == nil {
+		t.Fatal("service budget disabled by default")
+	}
+	cfg.DevServiceBudgetsDisabled = true
+	if serviceBudget(cfg) == nil {
+		t.Fatal("production service budget disabled by a development-only setting")
+	}
+	cfg.Dev = true
+	if serviceBudget(cfg) != nil {
+		t.Fatal("explicit development service-budget override was ignored")
+	}
+}
+
 func TestPendingMigrationsWithAutoMigrateOffRefusesToServe(t *testing.T) {
 	cfg := devConfig(t)
 	cfg.AutoMigrate = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,12 @@ type Config struct {
 	// by an environment variable, and the key name says so out loud for anyone
 	// who copies it into a compose file.
 	DevAdmissionPerIPPerMinute int
+	// DevServiceBudgetsDisabled disables the authenticated, in-memory expensive
+	// operation budgets for a development server. It exists for the browser flow
+	// suite, whose scenarios intentionally reuse one principal while exercising
+	// more than the production publish allowance. Load refuses the override
+	// outside --dev; false keeps the production budget enabled.
+	DevServiceBudgetsDisabled bool
 	// ReauthWindow is the instance-default disclosure reauthentication
 	// window (human-auth ADR section Assurance; permission-model ADR's
 	// per-environment knob inherits it). Zero - the production default - means
@@ -133,6 +139,7 @@ var knownEnv = map[string]bool{
 	// Development-only. Named so the deployment it does not belong in is
 	// obvious at a glance, and refused at boot outside --dev regardless.
 	"HIKYO_DEV_ADMISSION_PER_IP_PER_MINUTE": true,
+	"HIKYO_DEV_SERVICE_BUDGETS_DISABLED":    true,
 
 	// Client-side keys. They configure no server behaviour, but they are
 	// listed here because the unknown-key warning is a typo detector: a
@@ -259,6 +266,18 @@ func Load(subcommand string, args []string, getenv func(string) string, environ 
 				return nil, nil, fmt.Errorf("HIKYO_DEV_ADMISSION_PER_IP_PER_MINUTE: %q is not a positive integer", raw)
 			}
 			cfg.DevAdmissionPerIPPerMinute = perIP
+		}
+		if raw := strings.TrimSpace(getenv("HIKYO_DEV_SERVICE_BUDGETS_DISABLED")); raw != "" {
+			if !cfg.Dev {
+				return nil, nil, fmt.Errorf(
+					"HIKYO_DEV_SERVICE_BUDGETS_DISABLED is a development-mode override and this is not a development server: " +
+						"remove it, or pass --dev if this is an evaluation instance")
+			}
+			disabled, err := strconv.ParseBool(raw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("HIKYO_DEV_SERVICE_BUDGETS_DISABLED: %q is not a boolean", raw)
+			}
+			cfg.DevServiceBudgetsDisabled = disabled
 		}
 	}
 	if subcommand == "server" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -320,6 +320,45 @@ func TestAdmissionOverrideUnsetLeavesTheDefault(t *testing.T) {
 	}
 }
 
+func TestDevServiceBudgetDisableIsRefusedOutsideDevMode(t *testing.T) {
+	_, _, err := Load("server", nil,
+		env("HIKYO_DB", "sqlite:x.db", "HIKYO_DEV_SERVICE_BUDGETS_DISABLED", "true"), nil)
+	if err == nil {
+		t.Fatal("a production server accepted a development-only service-budget override")
+	}
+	if !strings.Contains(err.Error(), "development-mode override") {
+		t.Fatalf("error should say why it is refused, got: %v", err)
+	}
+}
+
+func TestDevServiceBudgetDisableAppliesInDevMode(t *testing.T) {
+	cfg, _, err := Load("server", []string{"--dev"},
+		env("HIKYO_DEV_SERVICE_BUDGETS_DISABLED", "true"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.DevServiceBudgetsDisabled {
+		t.Fatal("development service budgets remain enabled")
+	}
+}
+
+func TestDevServiceBudgetDisableRefusesNonsense(t *testing.T) {
+	if _, _, err := Load("server", []string{"--dev"},
+		env("HIKYO_DEV_SERVICE_BUDGETS_DISABLED", "sometimes"), nil); err == nil {
+		t.Fatal("a malformed service-budget override was accepted")
+	}
+}
+
+func TestDevServiceBudgetDisableUnsetLeavesBudgetsEnabled(t *testing.T) {
+	cfg, _, err := Load("server", []string{"--dev"}, env(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DevServiceBudgetsDisabled {
+		t.Fatal("service budgets were disabled without an explicit override")
+	}
+}
+
 func TestAdmissionBudgetRefusesValuesThatCannotFitEverySupportedInt(t *testing.T) {
 	_, _, err := Load("server", []string{"--dev"},
 		env("HIKYO_ADMISSION_BUDGET_MIB", "4294967295"), nil)

--- a/scripts/ci/analysis-shards
+++ b/scripts/ci/analysis-shards
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+exec "${GO_BIN:-go}" run "$script_dir/analysis-shards-go" "$@"

--- a/scripts/ci/analysis-shards-go/main.go
+++ b/scripts/ci/analysis-shards-go/main.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"hash/fnv"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type packageInfo struct {
+	ImportPath   string
+	Dir          string
+	TestGoFiles  []string
+	XTestGoFiles []string
+	Module       *struct {
+		Dir string
+	}
+	relativePath string
+}
+
+type fuzzTarget struct {
+	packagePath string
+	name        string
+	relativeDir string
+}
+
+type options struct {
+	root       string
+	shard      int
+	shardCount int
+}
+
+var preferredShards = map[string]map[string]int{
+	"race": {
+		"internal/app":           0,
+		"internal/service":       0,
+		"internal/lint":          1,
+		"internal/store/migrate": 1,
+		"internal/conformance":   2,
+		"internal/store":         2,
+		"internal/store/tx":      2,
+	},
+	"fuzz": {
+		"internal/importer":      0,
+		"internal/crypto":        1,
+		"internal/crypto/backup": 1,
+		"internal/compose":       2,
+		"internal/samlsp":        2,
+		"internal/scimproto":     2,
+	},
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "analysis shards: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	if len(args) == 0 || (args[0] != "race" && args[0] != "fuzz") {
+		return errors.New("usage: analysis-shards race|fuzz --root DIR --shard N --shards N")
+	}
+	kind := args[0]
+	flags := flag.NewFlagSet(kind, flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	var opts options
+	flags.StringVar(&opts.root, "root", ".", "repository root")
+	flags.IntVar(&opts.shard, "shard", -1, "zero-based shard index")
+	flags.IntVar(&opts.shardCount, "shards", 0, "total shard count")
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("unexpected positional arguments")
+	}
+	if opts.shardCount < 1 {
+		return errors.New("shards must be positive")
+	}
+	if opts.shard < 0 || opts.shard >= opts.shardCount {
+		return fmt.Errorf("shard %d is outside [0,%d)", opts.shard, opts.shardCount)
+	}
+
+	packages, err := listPackages(opts.root)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case "race":
+		return writeRaceShard(output, packages, opts)
+	case "fuzz":
+		return writeFuzzShard(output, packages, opts)
+	default:
+		panic("unreachable analysis kind")
+	}
+}
+
+func listPackages(root string) ([]packageInfo, error) {
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	goBinary := os.Getenv("GO_BIN")
+	if goBinary == "" {
+		goBinary = "go"
+	}
+	command := exec.Command(goBinary, "list", "-json", "./...")
+	command.Dir = absoluteRoot
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return nil, fmt.Errorf("go list failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	decoder := json.NewDecoder(&stdout)
+	packages := make([]packageInfo, 0)
+	for {
+		var pkg packageInfo
+		if err := decoder.Decode(&pkg); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decode go list output: %w", err)
+		}
+		if pkg.Module == nil || pkg.Module.Dir == "" {
+			return nil, fmt.Errorf("package %s has no module root", pkg.ImportPath)
+		}
+		relativePath, err := filepath.Rel(pkg.Module.Dir, pkg.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve package %s path: %w", pkg.ImportPath, err)
+		}
+		if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("package %s escapes its module", pkg.ImportPath)
+		}
+		pkg.relativePath = filepath.ToSlash(relativePath)
+		packages = append(packages, pkg)
+	}
+	if len(packages) == 0 {
+		return nil, errors.New("go list returned no packages")
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].ImportPath < packages[j].ImportPath
+	})
+	return packages, nil
+}
+
+func writeRaceShard(output io.Writer, packages []packageInfo, opts options) error {
+	for _, pkg := range packages {
+		if pkg.relativePath == "internal/isolation" {
+			continue
+		}
+		if shardFor("race", pkg.relativePath, opts.shardCount) != opts.shard {
+			continue
+		}
+		if _, err := fmt.Fprintln(output, pkg.ImportPath); err != nil {
+			return fmt.Errorf("write race shard: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeFuzzShard(output io.Writer, packages []packageInfo, opts options) error {
+	targets, err := discoverFuzzTargets(packages)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return errors.New("no Fuzz* target discovered")
+	}
+	for _, target := range targets {
+		if shardFor("fuzz", target.relativeDir, opts.shardCount) != opts.shard {
+			continue
+		}
+		if _, err := fmt.Fprintf(output, "%s\t%s\n", target.packagePath, target.name); err != nil {
+			return fmt.Errorf("write fuzz shard: %w", err)
+		}
+	}
+	return nil
+}
+
+func discoverFuzzTargets(packages []packageInfo) ([]fuzzTarget, error) {
+	targets := make([]fuzzTarget, 0)
+	seen := make(map[string]string)
+	for _, pkg := range packages {
+		files := append(append([]string(nil), pkg.TestGoFiles...), pkg.XTestGoFiles...)
+		sort.Strings(files)
+		for _, name := range files {
+			path := filepath.Join(pkg.Dir, name)
+			parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+			if err != nil {
+				return nil, fmt.Errorf("parse %s: %w", path, err)
+			}
+			for _, declaration := range parsed.Decls {
+				function, ok := declaration.(*ast.FuncDecl)
+				if !ok || function.Recv != nil || !isFuzzName(function.Name.Name) {
+					continue
+				}
+				key := pkg.ImportPath + "\x00" + function.Name.Name
+				if previous, exists := seen[key]; exists {
+					return nil, fmt.Errorf("duplicate fuzz target %s in %s and %s", function.Name.Name, previous, path)
+				}
+				seen[key] = path
+				targets = append(targets, fuzzTarget{
+					packagePath: pkg.ImportPath,
+					name:        function.Name.Name,
+					relativeDir: pkg.relativePath,
+				})
+			}
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].packagePath == targets[j].packagePath {
+			return targets[i].name < targets[j].name
+		}
+		return targets[i].packagePath < targets[j].packagePath
+	})
+	return targets, nil
+}
+
+func isFuzzName(name string) bool {
+	if !strings.HasPrefix(name, "Fuzz") || len(name) == len("Fuzz") {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(name[len("Fuzz"):])
+	return !unicode.IsLower(first)
+}
+
+func shardFor(kind, relativePath string, shardCount int) int {
+	if preferred, ok := preferredShards[kind][relativePath]; ok {
+		return preferred % shardCount
+	}
+	hash := fnv.New32a()
+	_, _ = io.WriteString(hash, relativePath)
+	return int(hash.Sum32() % uint32(shardCount))
+}

--- a/scripts/ci/analysis-shards_test.sh
+++ b/scripts/ci/analysis-shards_test.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+planner=$repo_root/scripts/ci/analysis-shards
+fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/hikyo-analysis-shards.XXXXXX")
+trap 'rm -rf "$fixture_dir"' EXIT HUP INT TERM
+
+mkdir -p \
+	"$fixture_dir/extra" \
+	"$fixture_dir/internal/crypto" \
+	"$fixture_dir/internal/isolation" \
+	"$fixture_dir/internal/service" \
+	"$fixture_dir/internal/store"
+
+printf '%s\n' 'module example.com/shards' 'go 1.26.6' >"$fixture_dir/go.mod"
+
+for package in extra internal/crypto internal/isolation internal/service internal/store; do
+	package_name=${package##*/}
+	printf 'package %s\n' "$package_name" >"$fixture_dir/$package/$package_name.go"
+done
+
+cat >"$fixture_dir/extra/extra_test.go" <<'EOF'
+package extra
+
+import "testing"
+
+func FuzzAuto(f *testing.F) { f.Fuzz(func(*testing.T, []byte) {}) }
+EOF
+
+cat >"$fixture_dir/internal/crypto/crypto_test.go" <<'EOF'
+package crypto
+
+import "testing"
+
+func FuzzOpen(f *testing.F)  { f.Fuzz(func(*testing.T, []byte) {}) }
+func FuzzParse(f *testing.F) { f.Fuzz(func(*testing.T, []byte) {}) }
+EOF
+
+cat >"$fixture_dir/internal/isolation/isolation_test.go" <<'EOF'
+package isolation
+
+import "testing"
+
+func FuzzIsolation(f *testing.F) { f.Fuzz(func(*testing.T, []byte) {}) }
+EOF
+
+cat >"$fixture_dir/internal/service/service_test.go" <<'EOF'
+package service
+
+import "testing"
+
+func FuzzService(f *testing.F) { f.Fuzz(func(*testing.T, []byte) {}) }
+EOF
+
+race_actual=$fixture_dir/race-actual
+fuzz_actual=$fixture_dir/fuzz-actual
+: >"$race_actual"
+: >"$fuzz_actual"
+
+shard=0
+while [ "$shard" -lt 3 ]; do
+	"$planner" race --root "$fixture_dir" --shard "$shard" --shards 3 |
+		awk -v shard="$shard" '{ print shard "\t" $0 }' >>"$race_actual"
+	"$planner" fuzz --root "$fixture_dir" --shard "$shard" --shards 3 |
+		awk -v shard="$shard" '{ print shard "\t" $0 }' >>"$fuzz_actual"
+	shard=$((shard + 1))
+done
+
+if [ -n "$(cut -f2 "$race_actual" | sort | uniq -d)" ]; then
+	printf 'analysis shard fixture failed: race package assigned more than once\n' >&2
+	exit 1
+fi
+if [ -n "$(cut -f2- "$fuzz_actual" | sort | uniq -d)" ]; then
+	printf 'analysis shard fixture failed: fuzz target assigned more than once\n' >&2
+	exit 1
+fi
+
+cut -f2 "$race_actual" | sort >"$fixture_dir/race-packages"
+cat >"$fixture_dir/race-expected" <<'EOF'
+example.com/shards/extra
+example.com/shards/internal/crypto
+example.com/shards/internal/service
+example.com/shards/internal/store
+EOF
+cmp "$fixture_dir/race-expected" "$fixture_dir/race-packages"
+
+cut -f2- "$fuzz_actual" | sort >"$fixture_dir/fuzz-targets"
+cat >"$fixture_dir/fuzz-expected" <<'EOF'
+example.com/shards/extra	FuzzAuto
+example.com/shards/internal/crypto	FuzzOpen
+example.com/shards/internal/crypto	FuzzParse
+example.com/shards/internal/isolation	FuzzIsolation
+example.com/shards/internal/service	FuzzService
+EOF
+cmp "$fixture_dir/fuzz-expected" "$fixture_dir/fuzz-targets"
+
+crypto_shards=$(awk -F '\t' '$2 == "example.com/shards/internal/crypto" { print $1 }' \
+	"$fuzz_actual" | sort -u | wc -l | tr -d ' ')
+[ "$crypto_shards" -eq 1 ] || {
+	printf 'analysis shard fixture failed: one package was split across fuzz shards\n' >&2
+	exit 1
+}
+
+if "$planner" race --root "$fixture_dir" --shard 3 --shards 3 >/dev/null 2>&1; then
+	printf 'analysis shard fixture failed: out-of-range shard accepted\n' >&2
+	exit 1
+fi
+
+printf 'analysis shard fixture: complete, disjoint race packages and fuzz targets passed\n'

--- a/scripts/ci/build-spa.sh
+++ b/scripts/ci/build-spa.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+verify=false
+case "$#:$*" in
+	0:) ;;
+	1:--verify) verify=true ;;
+	*) printf 'usage: %s [--verify]\n' "$0" >&2; exit 2 ;;
+esac
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+cd "$repo_root/web"
+
+pnpm --dir ../clients/ts install --frozen-lockfile
+pnpm install --frozen-lockfile
+if [ "$verify" = true ]; then
+	pnpm run typecheck
+	pnpm run test
+fi
+pnpm run build

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# GitHub expressions below are literal fixture text.
+# shellcheck disable=SC2016
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+workflow="$repo_root/.github/workflows/ci.yml"
+fixture="$repo_root/web/e2e/fixtures/instance.ts"
+spa_builder="$repo_root/scripts/ci/build-spa.sh"
+
+fail() {
+	printf 'build artifact reuse fixture failed: %s\n' "$1" >&2
+	exit 1
+}
+
+require_line() {
+	file=$1
+	expected=$2
+	grep -F -- "$expected" "$file" >/dev/null ||
+		fail "missing $expected in $(basename "$file")"
+}
+
+app_block=$(sed -n '/^  app-build:/,/^  release-snapshot:/p' "$workflow")
+release_block=$(sed -n '/^  release-snapshot:/,/^  generated:/p' "$workflow")
+web_block=$(sed -n '/^  web:/,/^  test:/p' "$workflow")
+
+[ -n "$app_block" ] || fail 'app-build job is missing'
+printf '%s\n' "$app_block" | grep -F 'run: ./scripts/ci/build-spa.sh --verify' >/dev/null ||
+	fail 'app-build does not verify and build the SPA through the shared script'
+printf '%s\n' "$app_block" | grep -F 'go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo' >/dev/null ||
+	fail 'app-build does not produce the release-shaped CI binary'
+printf '%s\n' "$app_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
+	fail 'app-build artifact is not scoped to this run attempt'
+
+printf '%s\n' "$web_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
+	fail 'web does not depend on app-build'
+printf '%s\n' "$web_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
+	fail 'web does not consume the exact app-build artifact'
+printf '%s\n' "$web_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev/null ||
+	fail 'web does not restore execute permission after artifact download'
+
+if printf '%s\n' "$web_block" |
+	grep -E 'pnpm run (typecheck|test|build)|pnpm build' >/dev/null; then
+	fail 'a browser shard repeats app-build frontend work'
+fi
+printf '%s\n' "$release_block" | grep -F 'needs: changes' >/dev/null ||
+	fail 'release snapshot is serialized behind app-build'
+printf '%s\n' "$release_block" | grep -F 'run: ./scripts/ci/build-spa.sh' >/dev/null ||
+	fail 'parallel release snapshot does not build its embedded SPA through the shared script'
+
+require_line "$spa_builder" 'cd "$repo_root/web"'
+require_line "$spa_builder" 'pnpm --dir ../clients/ts install --frozen-lockfile'
+require_line "$spa_builder" 'pnpm install --frozen-lockfile'
+require_line "$spa_builder" 'pnpm run typecheck'
+require_line "$spa_builder" 'pnpm run test'
+require_line "$spa_builder" 'pnpm run build'
+
+require_line "$workflow" 'name: Upload unsigned development snapshot'
+upload_block=$(sed -n \
+	'/name: Upload unsigned development snapshot/,/name: Save release-snapshot Go cache/p' \
+	"$workflow")
+printf '%s\n' "$upload_block" | grep -F "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" >/dev/null ||
+	fail 'development snapshot upload is not guarded on trusted main'
+for expected in \
+	'name: hikyo-development-${{ github.sha }}' \
+	'dist/hikyo_*_Darwin_*.tar.gz' \
+	'dist/hikyo_*_Linux_*.tar.gz' \
+	'dist/hikyo_*_Windows_*.zip' \
+	'dist/checksums.txt' \
+	'dist/DEVELOPMENT-SNAPSHOT.txt' \
+	'retention-days: 14'
+do
+	printf '%s\n' "$upload_block" | grep -F "$expected" >/dev/null ||
+		fail "development snapshot upload is missing $expected"
+done
+validate_line=$(grep -nF 'name: Classify complete snapshot manifest' "$workflow" | cut -d: -f1)
+upload_line=$(grep -nF 'name: Upload unsigned development snapshot' "$workflow" | cut -d: -f1)
+[ -n "$validate_line" ] && [ "$validate_line" -lt "$upload_line" ] ||
+	fail 'development snapshot is uploaded before non-mutating manifest validation'
+require_line "$fixture" "process.env.HIKYO_E2E_BINARY"
+
+if grep -Eq 'gh release|action-gh-release' "$workflow"; then
+	fail 'ordinary CI publishes a GitHub Release and bypasses the signing ceremony'
+fi
+
+printf 'build artifact reuse fixture: one app build feeds browser shards while release downloads stay parallel\n'

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -37,6 +37,8 @@ printf '%s\n' "$web_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
 	fail 'web does not depend on app-build'
 printf '%s\n' "$web_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
 	fail 'web does not consume the exact app-build artifact'
+printf '%s\n' "$web_block" | grep -F 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1' >/dev/null ||
+	fail 'web does not use the repository-pinned download-artifact action'
 printf '%s\n' "$web_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev/null ||
 	fail 'web does not restore execute permission after artifact download'
 

--- a/scripts/ci/check-trusted-ci-scripts_test.sh
+++ b/scripts/ci/check-trusted-ci-scripts_test.sh
@@ -30,11 +30,22 @@ require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/analysis-shards-go/ma
 require_line "$workflow" 'name: Upload shard fuzz reproducers'
 require_line "$workflow" 'name: Download shard fuzz reproducers'
 require_line "$workflow" 'name: Upload minimized fuzz reproducers'
+# Workflow shell variables below are literal fixture text.
+# shellcheck disable=SC2016
+require_line "$workflow" 'echo "$shellcheck_dir" >>"$GITHUB_PATH"'
 # GitHub expressions below are literal fixture text.
 # shellcheck disable=SC2016
 require_line "$workflow" 'FUZZ_SHARD_RESULT: ${{ needs.fuzz_shard.result }}'
 # shellcheck disable=SC2016
 require_line "$workflow" 'RACE_SHARD_RESULT: ${{ needs.race_shard.result }}'
+
+download_block=$(sed -n \
+	'/name: Download shard fuzz reproducers/,/name: Find merged fuzz reproducers/p' \
+	"$workflow")
+if printf '%s\n' "$download_block" | grep -F 'continue-on-error: true' >/dev/null; then
+	printf 'trusted CI scripts fixture failed: shard artifact download errors are suppressed\n' >&2
+	exit 1
+fi
 
 if grep -Eq '^[[:space:]]+pull_request:' "$workflow"; then
 	printf 'trusted CI scripts fixture failed: direct pull-request trigger is enabled\n' >&2

--- a/scripts/ci/check-trusted-ci-scripts_test.sh
+++ b/scripts/ci/check-trusted-ci-scripts_test.sh
@@ -26,7 +26,15 @@ require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/classify-changed-path
 require_line "$workflow" "\"\$trusted_classifier\" --files"
 require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/check-required-jobs.sh\" >\"\$trusted_checker\""
 require_line "$workflow" "\"\$trusted_checker\" \"\$GITHUB_EVENT_NAME\" \"\$NEEDS_JSON\" \"\$PLAN_JSON\""
+require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/analysis-shards-go/main.go\" >\"\$trusted_planner\""
+require_line "$workflow" 'name: Upload shard fuzz reproducers'
+require_line "$workflow" 'name: Download shard fuzz reproducers'
 require_line "$workflow" 'name: Upload minimized fuzz reproducers'
+# GitHub expressions below are literal fixture text.
+# shellcheck disable=SC2016
+require_line "$workflow" 'FUZZ_SHARD_RESULT: ${{ needs.fuzz_shard.result }}'
+# shellcheck disable=SC2016
+require_line "$workflow" 'RACE_SHARD_RESULT: ${{ needs.race_shard.result }}'
 
 if grep -Eq '^[[:space:]]+pull_request:' "$workflow"; then
 	printf 'trusted CI scripts fixture failed: direct pull-request trigger is enabled\n' >&2

--- a/scripts/ci/classify-changed-paths.sh
+++ b/scripts/ci/classify-changed-paths.sh
@@ -23,15 +23,8 @@ test=false
 web=false
 saw_path=false
 
-# `race` and `fuzz` are deliberately absent from every per-path rule below, so
-# they are selected only by all_jobs — that is, by a main push, by a dependency
-# or workflow change, and by the fail-closed default. Both are long (~440s and
-# ~360s) and neither is a per-change regression gate: the race detector wants
-# repeated executions over time rather than one pass per commit, and the fuzz
-# job is a bounded exploration whose value comes from cumulative runs. Merges
-# still cover them, and fuzz-report.yml's report-main job already routes push
-# findings to a repository issue, so nothing is lost by keeping them off the
-# per-PR critical path.
+# Race and fuzz remain blocking for Go and SQL changes. Their jobs shard the
+# complete package and target sets, so path selection does not narrow coverage.
 all_jobs() {
 	client=true
 	compose_demo=true
@@ -115,9 +108,11 @@ else
 		# The operator (Go under test by the kind e2e) and the kind e2e test
 		# itself carry the *.go integration set PLUS the k8s_e2e job.
 		internal/operator/* | internal/isolation/k8s_*)
+			fuzz=true
 			generated=true
 			headline_guarantee=true
 			k8s_e2e=true
+			race=true
 			release_snapshot=true
 			test=true
 			web=true
@@ -142,8 +137,10 @@ else
 			supply_chain_checks=true
 			;;
 		*.go | *.sql)
+			fuzz=true
 			generated=true
 			headline_guarantee=true
+			race=true
 			release_snapshot=true
 			test=true
 			web=true

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -48,12 +48,14 @@ fi
 
 core_actual=$(printf '%s\n' 'internal/service/values.go' | "$classifier" --files)
 if ! printf '%s\n' "$core_actual" | jq -e '
+	.fuzz == true and
 	.generated == true and
 	.headline_guarantee == true and
+	.race == true and
 	.release_snapshot == true and
 	.test == true and
 	.web == true and
-	([.client, .compose_demo, .docs, .fuzz, .k8s_e2e, .lint, .race, .supply_chain_checks] | all(. == false))
+	([.client, .compose_demo, .docs, .k8s_e2e, .lint, .supply_chain_checks] | all(. == false))
 ' >/dev/null; then
 	printf 'changed-path classifier fixture failed: core plan was wrong\n' >&2
 	printf 'actual: %s\n' "$core_actual" >&2
@@ -151,20 +153,30 @@ if ! printf '%s\n' "$all_actual" | jq -e 'all(.[]; . == true)' >/dev/null; then
 	exit 1
 fi
 
-# The race detector and the fuzz pass are reachable ONLY through all_jobs: a main
-# push, a dependency or workflow change, or the fail-closed default. No per-path
-# rule may select them, or they land back on the per-PR critical path.
-for scoped_path in \
+# Race and fuzz are blocking for code and schema changes. Their sharded jobs keep
+# complete package/target coverage without putting their old serial runtimes back
+# on the pull-request critical path.
+for code_path in \
 	'internal/service/values.go' \
 	'internal/store/query.sql' \
-	'api/openapi.yaml' \
 	'internal/operator/reconciler.go' \
-	'internal/isolation/k8s_operator_e2e_test.go' \
+	'internal/isolation/k8s_operator_e2e_test.go'; do
+	code_actual=$(printf '%s\n' "$code_path" | "$classifier" --files)
+	if ! printf '%s\n' "$code_actual" | jq -e '.fuzz == true and .race == true' >/dev/null; then
+		printf 'changed-path classifier fixture failed: %s did not select race/fuzz\n' \
+			"$code_path" >&2
+		printf 'actual: %s\n' "$code_actual" >&2
+		exit 1
+	fi
+done
+
+for scoped_path in \
+	'api/openapi.yaml' \
 	'web/src/routes/Values.tsx' \
 	'docs/site/src/content/docs/docs/index.mdx'; do
 	scoped_actual=$(printf '%s\n' "$scoped_path" | "$classifier" --files)
 	if ! printf '%s\n' "$scoped_actual" | jq -e '.fuzz == false and .race == false' >/dev/null; then
-		printf 'changed-path classifier fixture failed: %s selected race/fuzz on a scoped plan\n' \
+		printf 'changed-path classifier fixture failed: %s unexpectedly selected race/fuzz\n' \
 			"$scoped_path" >&2
 		printf 'actual: %s\n' "$scoped_actual" >&2
 		exit 1
@@ -221,13 +233,15 @@ for operator_path in \
 	'internal/isolation/k8s_operator_e2e_test.go'; do
 	operator_actual=$(printf '%s\n' "$operator_path" | "$classifier" --files)
 	if ! printf '%s\n' "$operator_actual" | jq -e '
+		.fuzz == true and
 		.k8s_e2e == true and
 		.generated == true and
 		.headline_guarantee == true and
+		.race == true and
 		.release_snapshot == true and
 		.test == true and
 		.web == true and
-		([.client, .docs, .fuzz, .lint, .race, .supply_chain_checks] | all(. == false))
+		([.client, .docs, .lint, .supply_chain_checks] | all(. == false))
 	' >/dev/null; then
 		printf 'changed-path classifier fixture failed: %s did not select k8s_e2e\n' \
 			"$operator_path" >&2

--- a/scripts/release/snapshot-manifest_test.sh
+++ b/scripts/release/snapshot-manifest_test.sh
@@ -41,30 +41,32 @@ case "$native_version" in
 	"hikyo $version ("*) ;;
 	*) printf 'snapshot manifest fixture: binary version does not match archive version\n' >&2; exit 1 ;;
 esac
-rm -f "$dist/artifacts.json" "$dist/config.yaml" "$dist/metadata.json"
+fixture_dist="$fixture_dir/dist"
+cp -R "$dist" "$fixture_dist"
+rm -f "$fixture_dist/artifacts.json" "$fixture_dist/config.yaml" "$fixture_dist/metadata.json"
 
-printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-source.spdx.json"
-printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-image.spdx.json"
-printf '#!/bin/sh\nexit 0\n' >"$dist/install.sh"
+printf '{"spdxVersion":"SPDX-2.3"}\n' >"$fixture_dist/hikyo-source.spdx.json"
+printf '{"spdxVersion":"SPDX-2.3"}\n' >"$fixture_dist/hikyo-image.spdx.json"
+printf '#!/bin/sh\nexit 0\n' >"$fixture_dist/install.sh"
 image_digest=sha256:1111111111111111111111111111111111111111111111111111111111111111
 chart_digest=sha256:2222222222222222222222222222222222222222222222222222222222222222
 jq -n --arg digest "$image_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/hikyo"},image:{"docker-manifest-digest":$digest}}}' \
-	>"$dist/image-index.oci-payload.json"
+	>"$fixture_dist/image-index.oci-payload.json"
 jq -n --arg digest "$chart_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},image:{"docker-manifest-digest":$digest}}}' \
-	>"$dist/chart-index.oci-payload.json"
+	>"$fixture_dist/chart-index.oci-payload.json"
 mkdir -p "$fixture_dir/hikyo"
 printf 'name: hikyo\nversion: %s\nappVersion: %s\n' "$version" "$version" >"$fixture_dir/hikyo/Chart.yaml"
 printf 'image:\n  digest: %s\n' "$image_digest" >"$fixture_dir/hikyo/values.yaml"
-tar -czf "$dist/hikyo-$version.tgz" -C "$fixture_dir" hikyo
+tar -czf "$fixture_dist/hikyo-$version.tgz" -C "$fixture_dir" hikyo
 printf '{"releases":[{"version":"%s","sequence":1}]}\n' "$version" >"$fixture_dir/trust-metadata.json"
 
 "$script_dir/create-manifest.sh" "$version" "$commit" primary-1 \
 	ghcr.io/hikyo-org/hikyo "$image_digest" ghcr.io/hikyo-org/charts/hikyo "$chart_digest" \
-	"$dist" "$fixture_dir/trust-metadata.json" >/dev/null
+	"$fixture_dist" "$fixture_dir/trust-metadata.json" >/dev/null
 
 jq -e '
 	([.artifacts[] | select(.kind == "binary")] | length) == 6 and
 	([.artifacts[] | select(.kind == "chart")] | length) == 1 and
 	([.artifacts[] | select(.kind == "oci-payload")] | length) == 2
-' "$dist/release-manifest.json" >/dev/null
+' "$fixture_dist/release-manifest.json" >/dev/null
 printf 'snapshot manifest fixture: complete GoReleaser output classified\n'

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -465,6 +465,11 @@ async function startInstanceAt(host: string, port: number, base: string): Promis
       // production. The alternative was deleting tests to fit under the
       // ceiling, which is measuring the throttle instead of the UI.
       HIKYO_DEV_ADMISSION_PER_IP_PER_MINUTE: '500',
+      // Flow scenarios also reuse one authenticated principal and collectively
+      // publish more than the production allowance of ten per minute. Budget
+      // behavior has its own conformance/unit coverage; this harness validates
+      // UI behavior. The server refuses this switch unless --dev is active.
+      HIKYO_DEV_SERVICE_BUDGETS_DISABLED: 'true',
     },
   });
   const instance: Instance = { proc, dir, binary, base, host, cookies: [] };

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -439,12 +439,18 @@ async function startInstanceAt(host: string, port: number, base: string): Promis
   }
 
   const dir = mkdtempSync(join(tmpdir(), 'hikyo-e2e-'));
-  const binary = join(dir, 'hikyo');
+  const prebuiltBinary = process.env.HIKYO_E2E_BINARY;
+  const binary = prebuiltBinary ?? join(dir, 'hikyo');
   // `-tags ui` is what embeds the bundle. A binary built without it serves the
   // API and answers 404 for the document, which is the correct default and the
-  // wrong thing to test a UI against. Built once per instance directory because
-  // `admin` reads its datastore from the working directory it is run in.
-  run('go', ['build', '-tags', 'ui', '-o', binary, './cmd/hikyo'], { cwd: repoRoot });
+  // wrong thing to test a UI against. CI supplies the exact app-build artifact
+  // once for both isolated instances; local runs retain the self-contained
+  // source-build path. `admin` selects its datastore from cwd, not binary path.
+  if (prebuiltBinary === undefined) {
+    run('go', ['build', '-tags', 'ui', '-o', binary, './cmd/hikyo'], { cwd: repoRoot });
+  } else if (!existsSync(prebuiltBinary)) {
+    throw new Error(`HIKYO_E2E_BINARY does not exist: ${prebuiltBinary}`);
+  }
 
   const proc = spawn(binary, ['server', '--dev', '--listen', `${host}:${port}`], {
     cwd: dir,


### PR DESCRIPTION
## Summary

- restore race and fuzz as blocking checks for Go, SQL, operator, and Kubernetes pull requests
- split all 56 race packages and all 17 fuzz targets into three deterministic, package-coherent shards
- discover fuzz targets with the Go AST instead of compiling every package with `go test -list`
- build and verify the SPA once, then reuse the exact release-shaped app binary in both Playwright lanes
- retain validated six-target GoReleaser archives from trusted `main` CI for 14 days as unsigned exact-SHA development downloads
- preserve the existing signed/tagged release ceremony; ordinary CI never creates an official GitHub Release
- use native Go and shell fixtures; no JUnit dependency or report format is needed

## Why

Race and fuzz were moved off scoped pull requests because their serial jobs took roughly 7–8 minutes and 5m48s–5m57s on warm runners. Sharding restores their regression coverage without restoring that serial critical path.

The skipped `lint` job seen on unrelated pull requests remains intentional path selection: it runs ShellCheck and Actionlint, while Go build and vet remain separate checks.

The application was already built repeatedly in CI. The optimized graph now uploads one run-scoped binary for downstream browser validation and retains separately validated multi-platform GoReleaser archives after trusted `main` runs. Development snapshots are explicitly unsigned and are not production releases.

## Validation

- full optimized workflow smoke: https://github.com/Hikyo-Org/Hikyo/actions/runs/32517454498
- `go test -count=1 ./...` with PostgreSQL 18
- all three exact `go test -race -vet=off -count=1` shards
- all 17 fuzz entrypoints with `-fuzztime=1x`
- desktop and mobile Playwright flows using the downloaded prebuilt binary
- six-target GoReleaser snapshot and manifest classification
- `go build ./...`, `go vet ./...`, repository-wide gofmt, ShellCheck, and Actionlint
- planner, changed-path, trust-boundary, cache-policy, required-job, artifact-reuse, and fuzz-reporting fixtures
- independent standards and spec reviews: no findings

## Hosted timing evidence

Compared with main run `32484251946`, full workflow smoke `32517454498` measured:

| Check | Before | After | Change |
| --- | ---: | ---: | ---: |
| Fuzz critical shard | 5m42s | 3m35s | 37% faster |
| Race critical shard | 7m21s | 6m08s | 17% faster |
| Release snapshot | 4m36s | 1m42s | 63% faster |
| App build/verify/upload | repeated per browser lane | 54s once | reused by desktop and mobile |

The browser flows still dominate their lanes; this change removes duplicate builds and proves both lanes consume the exact uploaded app artifact.
