### PR TITLE
refactor(authz): validate operation registry construction

### DIFF
--- a/docs/handoff/216-registry-constructor.md
+++ b/docs/handoff/216-registry-constructor.md
@@ -1,0 +1,120 @@
+# Handoff: #216 validating registry constructor
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/216. Related invariants live in
+`docs/adr/tenant-isolation.md` (registry completeness, invariant 6) and
+`docs/adr/audit-model.md` (audit disposition, CI invariant 2).
+
+## Outcome
+
+An invalid authorization registry can no longer be installed. The operation
+policy table is validated by a constructor that runs at package init; a
+malformed row aborts initialization (panic in `mustNewRegistry`) rather than
+surfacing later as a runtime authorization anomaly. Production lookups read the
+immutable `*Registry`, never the raw table.
+
+## What exists
+
+`internal/authz/registry.go`:
+
+- `operationTable` — the reviewable policy table, unchanged in content. It was
+  renamed from `operations` and is **never read directly** by production; only
+  `newRegistry` and the constructor tests touch it.
+- `type Registry struct{ ops map[Operation]opSpec }` — immutable. The
+  constructor **deep-clones** every mutable field of each row (`cloneSpec`:
+  `formula`/`events` slices and the `storeOps` map), so an installed row shares
+  no backing with `operationTable` or a caller fixture — a later mutation of the
+  source cannot reach in. Read-side access also exposes no mutable backing:
+  `authorizationSpec(op)` returns only authorization fields and defensively
+  copies the formula, while `permitsStoreOp` and `permitsEvent` answer membership
+  inside `Registry`. Unknown operations, store ops, and events return false.
+- `newRegistry(table) (*Registry, error)` / `mustNewRegistry` — validate then
+  freeze. `var registry = mustNewRegistry(operationTable)` installs the one
+  registry at init.
+- `validateSpec` / `validateAuditDisposition` — the single place every
+  in-package invariant lives (acceptance #4). Adding an operation must satisfy
+  it. `opSpec` gained an internal `reviewExempt` marker (set on
+  `definitions.plan.get` and `scim-discovery.read`) so the reviewed
+  no-event/no-audited-none disposition is explicit in the row, not implicit in
+  the absence of the other two. It is not exposed by `RegistryFacts`/
+  `AuditMappings`, so those exports stay byte-equivalent.
+- `storeOpCatalogue` — the closed in-package set of the 250 `StoreOp` constants,
+  generated from the const block and diff-verified equal to it at authoring
+  (const identifiers vs catalogue keys, sorted `diff` → identical). A row naming
+  a StoreOp absent here is rejected at construction. Adding a StoreOp const means
+  adding it to the catalogue. Deleting a const compile-breaks the catalogue entry
+  that references it, so the two cannot silently diverge.
+
+Lookups rewired from `operations[op]` to `registry.authorizationSpec(op)`,
+`permitsStoreOp`, `permitsEvent`, or internal `registry.ops`: `authorize.go`
+(×2), `denial.go`, `session.go`, `verify.go` (×2), and the six `RegistryFacts`
+iterators. Fail-closed semantics at both `verify.go` sites are preserved.
+
+## Invariants enforced in the constructor (in-package)
+
+| Invariant | Rule |
+|---|---|
+| valid class | `class ∈ {tenant, instance}` only; unauthenticated / system / stub rejected (those are wire/verb classes, never operation rows) |
+| class/level | tenant op ⇒ `level ∈ {org, project, env}`; instance op ⇒ `level = none` |
+| deny-by-default | non-empty formula |
+| capability | every atom's `Cap` passes `domain.IsCapability`; atom level is one of the four depths; atom no deeper than `domain.DeepestLevel(cap)`; tenant atom no deeper than the op's level |
+| known store op | every `storeOps` key is in `storeOpCatalogue`; no `false` value (presence must mean licensed) |
+| one audit disposition | **exactly one** of `events`, `auditedNone`, `reviewExempt`; exemptions accepted only for the two reviewed operation names; `auditedNone` only under the permit rule (tenant class, all-`read` formula, all store ops read-only); each event non-empty, registered via `audit.Spec`, no duplicates |
+
+## What deliberately stayed in `internal/isolation` (cross-contract)
+
+- **Store-op existence.** The catalogue is the in-package "known store op" half.
+  That a StoreOp corresponds to a real store *method* needs `internal/store`
+  reflection; `boundary_test.go:22` restricts `internal/authz` to `store/authn`
+  only, so that half stays in `TestInvariant06...Completeness`.
+- **Audit completeness "audited or pinned".** The two `reviewExempt` rows carry
+  no event and no audited-none by design; the completeness invariant still pins
+  them by name in `testdata/audited_exemptions.json` (isolation). The
+  constructor enforces exactly-one-disposition; isolation keeps the name pin.
+
+## Key uniqueness
+
+Enforced one step earlier than any constructor could: `operationTable` is a map
+literal, so the compiler rejects a duplicate operation key. The constructor
+instead rejects the empty-key case. No runtime duplicate-key test exists because
+the shape makes duplicates uncompilable — converting the 178 KB table to a slice
+to make it runtime-checkable would destroy reviewability for zero safety gain.
+
+## Tests
+
+`internal/authz/registry_test.go` (`package authz`, needs unexported `opSpec`):
+focused constructor negatives across every invariant above (class, class/level,
+capability, atom depth, store-op catalogue, false store-op entry, the three
+audit dispositions incl. none/conflicting, event well-formedness/registration/
+duplicates, empty key), plus `TestConstructorAcceptsBaseSpec` (keeps the
+negatives from passing vacuously), `TestConstructorDeepClonesSpec` (immutability:
+mutating every nested source field after construction leaves the row unchanged),
+and `TestConstructorAcceptsRealTable` (green anchor).
+
+## Verification run
+
+- `go test ./internal/authz/` — 52 passed after parent review added negative
+  fixtures for unreviewed exemptions, instance operations with tenant formula
+  atoms, and lookup mutation; it also added StoreOp catalogue totality coverage.
+- `HIKYO_TEST_POSTGRES_DSN=... go test -count=1 ./internal/authz/... ./api/...
+  ./internal/isolation/...` — 2,197 passed across four packages. This retained
+  `TestInvariant06a` (formula pins byte-identical), audit completeness (the two
+  reviewed exemptions remain name-pinned), and both database engines.
+- `HIKYO_TEST_POSTGRES_DSN=... go test -count=1 ./...` — 4,002 passed across 56
+  packages against SQLite and isolated PostgreSQL 18.
+- `go vet ./...`, `gofmt -l internal/authz`, and `git diff --check` — clean.
+- Blocking native Codex review: Standards CLEAN in round 3; Spec CLEAN in round
+  2. Findings fixed before the final suite: instance formula scope, StoreOp
+  catalogue totality, and read-side registry immutability.
+
+## Notes for the reviewer
+
+- TDD deviation: negatives were batch-written rather than one red-green slice at
+  a time — both the first round and the second-round negatives added for these
+  acceptance fixes were written against an already-working validator, never seen
+  red individually. The positive `baseSpec` anchor plus the real-table anchor
+  close the vacuous-pass risk that discipline guards against: if `baseSpec` were
+  itself invalid the anchor fails, so each negative's rejection is attributable
+  to its single mutation.
+- Init-panic means a mid-edit developer sees every authz-importing package fail
+  at once. That is the ticket's stated intent ("impossible to install"); the
+  constructor negatives give the focused failure first.

--- a/internal/authz/authorize.go
+++ b/internal/authz/authorize.go
@@ -58,7 +58,7 @@ func NewTxAuthorizer(r *authn.Resolver, tok *TxToken) *TxAuthorizer {
 // authority — bootstrap, break-glass, `hikyo admin` — and is exempt, presenting
 // no session and therefore no factor.
 func (a *TxAuthorizer) Authorize(ctx context.Context, caller Identity, op Operation, scope domain.Scope) (Proof, error) {
-	spec, ok := operations[op]
+	spec, ok := registry.authorizationSpec(op)
 	if !ok {
 		return nil, fmt.Errorf("authz: operation %q is not in the operation registry", op)
 	}
@@ -124,7 +124,7 @@ func (a *TxAuthorizer) assuranceInadequate(caller Identity, op Operation) bool {
 	return AssuranceEnforced && caller.SessionID != "" && FormulaDemandsMFA(op) && !AdequateAssurance(caller.Assurance)
 }
 
-func (a *TxAuthorizer) authorizeTenant(ctx context.Context, caller Identity, op Operation, spec opSpec, scope domain.Scope) (Proof, error) {
+func (a *TxAuthorizer) authorizeTenant(ctx context.Context, caller Identity, op Operation, spec authorizationSpec, scope domain.Scope) (Proof, error) {
 	principal := caller.Principal
 	level, err := scope.Level()
 	if err != nil {
@@ -240,7 +240,7 @@ func (a *TxAuthorizer) MachineRevealOptIn(ctx context.Context, caller Identity, 
 	return st.Enabled, st.Generation, nil
 }
 
-func (a *TxAuthorizer) authorizeInstance(ctx context.Context, caller Identity, op Operation, spec opSpec) (Proof, error) {
+func (a *TxAuthorizer) authorizeInstance(ctx context.Context, caller Identity, op Operation, spec authorizationSpec) (Proof, error) {
 	principal := caller.Principal
 	grants, err := a.r.Grants(ctx, principal)
 	if err != nil {
@@ -455,10 +455,10 @@ func (a *TxAuthorizer) principalHoldsFormula(ctx context.Context, principal doma
 }
 
 func (a *TxAuthorizer) principalFormulaEvaluation(ctx context.Context, principal domain.PrincipalID,
-	op Operation, scope domain.Scope) (opSpec, domain.Scope, bool, error) {
-	spec, ok := operations[op]
+	op Operation, scope domain.Scope) (authorizationSpec, domain.Scope, bool, error) {
+	spec, ok := registry.authorizationSpec(op)
 	if !ok {
-		return opSpec{}, domain.Scope{}, false, fmt.Errorf("authz: operation %q is not in the operation registry", op)
+		return authorizationSpec{}, domain.Scope{}, false, fmt.Errorf("authz: operation %q is not in the operation registry", op)
 	}
 	chain, err := a.r.ResolveChain(ctx, scope)
 	if err != nil {
@@ -468,11 +468,11 @@ func (a *TxAuthorizer) principalFormulaEvaluation(ctx context.Context, principal
 		if errors.Is(err, domain.ErrNotFound) {
 			return spec, domain.Scope{}, false, nil
 		}
-		return opSpec{}, domain.Scope{}, false, err
+		return authorizationSpec{}, domain.Scope{}, false, err
 	}
 	grants, err := a.r.Grants(ctx, principal)
 	if err != nil {
-		return opSpec{}, domain.Scope{}, false, err
+		return authorizationSpec{}, domain.Scope{}, false, err
 	}
 	return spec, chain, evaluate(spec.formula, chain, grants), nil
 }

--- a/internal/authz/denial.go
+++ b/internal/authz/denial.go
@@ -89,7 +89,7 @@ const (
 // trail with the addressed identifiers as bounded, sanitized caller-asserted
 // claims. Instance-operation refusals are resolvable grant refusals with no
 // tenant object, so they take the instance trail too.
-func (a *TxAuthorizer) captureDenial(ctx context.Context, principal domain.PrincipalID, op Operation, spec opSpec, resolution string, resolvedChain domain.Scope, claimed domain.Scope) {
+func (a *TxAuthorizer) captureDenial(ctx context.Context, principal domain.PrincipalID, op Operation, spec authorizationSpec, resolution string, resolvedChain domain.Scope, claimed domain.Scope) {
 	id, err := audit.NewEventID()
 	if err != nil {
 		// Cannot mint an id (entropy exhaustion): nothing writable exists,

--- a/internal/authz/registry.go
+++ b/internal/authz/registry.go
@@ -1,6 +1,7 @@
 package authz
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -908,6 +909,78 @@ const (
 // CI invariant 2): an operation may skip audit mapping only when every store
 // op it can invoke is in this set. A wrongly listed op is caught by review
 // of this pinned table, exactly like the formula pins.
+// storeOpCatalogue is the closed set of store operations the registry may name.
+// It is the in-package half of "known store operations": the constructor
+// rejects any operation naming a StoreOp absent here, before initialization
+// succeeds. Adding a StoreOp const means adding it here too. That the method
+// actually exists on the store is invariant 6's reflection cross-check
+// (internal/isolation), which needs internal/store this package must not import.
+var storeOpCatalogue = map[StoreOp]bool{
+	StoreAdaptersAddTarget: true, StoreAdaptersAdopt: true, StoreAdaptersBeginConfigureEffect: true, StoreAdaptersCancelMove: true,
+	StoreAdaptersConfiguration: true, StoreAdaptersConflicts: true, StoreAdaptersCreate: true, StoreAdaptersEnqueueManual: true,
+	StoreAdaptersEnqueuePublished: true, StoreAdaptersEnvironments: true, StoreAdaptersFinishConfigureEffect: true, StoreAdaptersGet: true,
+	StoreAdaptersList: true, StoreAdaptersListForReencrypt: true, StoreAdaptersListMovesForReencrypt: true, StoreAdaptersListTargets: true,
+	StoreAdaptersMapping: true, StoreAdaptersMove: true, StoreAdaptersMoveOrigin: true, StoreAdaptersMoveTarget: true,
+	StoreAdaptersPlanMaterial: true, StoreAdaptersRecordCredentialExpiry: true, StoreAdaptersRecordPlan: true, StoreAdaptersReencrypt: true,
+	StoreAdaptersReencryptMove: true, StoreAdaptersReplaceCredential: true, StoreAdaptersReplaceMoveOrigin: true, StoreAdaptersReplaceMoveTarget: true,
+	StoreAdaptersRevokeCredential: true, StoreAdaptersTarget: true, StoreAdaptersTargetEnvironments: true, StoreAdaptersTargetKeyIDs: true,
+	StoreAdaptersTeardownAdapter: true, StoreAdaptersTeardownTarget: true, StoreAdaptersUpdateTarget: true, StoreAuditClaimOfflineRecord: true,
+	StoreAuditInstanceInsert: true, StoreAuditInstancePage: true, StoreAuditTenantInsert: true, StoreAuditTenantPage: true,
+	StoreCatalogueAdapterPins: true, StoreCatalogueCount: true, StoreCatalogueCreate: true, StoreCatalogueDelete: true,
+	StoreCatalogueGet: true, StoreCatalogueGroupClearMembers: true, StoreCatalogueGroupCount: true, StoreCatalogueGroupCreate: true,
+	StoreCatalogueGroupDelete: true, StoreCatalogueGroupGet: true, StoreCatalogueGroupList: true, StoreCatalogueGroupRename: true,
+	StoreCatalogueList: true, StoreCataloguePresenceCascade: true, StoreCataloguePresenceList: true, StoreCataloguePresenceReplace: true,
+	StoreCatalogueRename: true, StoreCatalogueRevisionBump: true, StoreCatalogueRevisionGet: true, StoreCatalogueSetClassification: true,
+	StoreCatalogueSetGroup: true, StoreCatalogueUpdateDeclaration: true, StoreCatalogueUpdateMetadata: true, StoreDefinitionsLatestAppliedPlan: true,
+	StoreDefinitionsPlanApply: true, StoreDefinitionsPlanCountOpen: true, StoreDefinitionsPlanCreate: true, StoreDefinitionsPlanGet: true,
+	StoreDefinitionsPlanPrune: true, StoreEnvironmentsCount: true, StoreEnvironmentsCreate: true, StoreEnvironmentsDelete: true,
+	StoreEnvironmentsGet: true, StoreEnvironmentsGetSettings: true, StoreEnvironmentsList: true, StoreEnvironmentsListProtection: true,
+	StoreEnvironmentsNextOrder: true, StoreEnvironmentsRename: true, StoreEnvironmentsSetOrder: true, StoreEnvironmentsSetSettings: true,
+	StoreEnvironmentsUpdateNote: true, StoreFoldersCreate: true, StoreFoldersDelete: true, StoreFoldersGet: true,
+	StoreFoldersList: true, StoreFoldersRename: true, StoreKeysAcquireHierarchyGeneration: true, StoreKeysActiveMasterWrappers: true,
+	StoreKeysActiveTier3: true, StoreKeysAllOpenableTier3: true, StoreKeysAssertActiveDEKVersion: true, StoreKeysInsertMaster: true,
+	StoreKeysInsertScopeGeneration: true, StoreKeysInsertTier3: true, StoreKeysRetireRetiringTier3: true, StoreKeysRootRotateFinalize: true,
+	StoreKeysRootRotatePrepare: true, StoreKeysRotateDEK: true, StoreKeysRotateMasterKey: true, StoreKeysRotateScanningKey: true,
+	StoreKeysRotateTokenKey: true, StoreKeysTier3Versions: true, StoreOrgsCount: true, StoreOrgsCreate: true,
+	StoreOrgsDelete: true, StoreOrgsGet: true, StoreOrgsList: true, StoreOrgsLock: true,
+	StoreOrgsRename: true, StoreOrgsSetRetention: true, StorePendingCountForProjectExcludingCell: true, StorePendingDiscard: true,
+	StorePendingDiscardEnvironment: true, StorePendingDiscardKey: true, StorePendingListForOwner: true, StorePendingListForOwnerInEnvironment: true,
+	StorePendingListForReencrypt: true, StorePendingListMarkers: true, StorePendingReencrypt: true, StorePendingStage: true,
+	StorePinsCountProject: true, StorePinsDelete: true, StorePinsDeleteEnvironment: true, StorePinsGetForWorkload: true,
+	StorePinsInsert: true, StorePinsList: true, StoreProjectsCreate: true, StoreProjectsDelete: true,
+	StoreProjectsGet: true, StoreProjectsList: true, StoreProjectsListAll: true, StoreProjectsLock: true,
+	StoreProjectsRename: true, StoreProjectsSetDefinitionsSource: true, StoreProjectsSetMachineReveal: true, StoreProjectsSetRetention: true,
+	StoreReencryptListOidcProviders: true, StoreReencryptListPasswordCreds: true, StoreReencryptListRecoveryCodes: true, StoreReencryptListRemotes: true,
+	StoreReencryptListSamlKeys: true, StoreReencryptListTotpCreds: true, StoreReencryptOidcProvider: true, StoreReencryptPasswordCred: true,
+	StoreReencryptRecoveryCodes: true, StoreReencryptRemote: true, StoreReencryptSamlKey: true, StoreReencryptTotpCred: true,
+	StoreRemoteSnapshotsFail: true, StoreRemoteSnapshotsGet: true, StoreRemoteSnapshotsList: true, StoreRemoteSnapshotsWrite: true,
+	StoreRemotesCount: true, StoreRemotesCreate: true, StoreRemotesDelete: true, StoreRemotesGet: true,
+	StoreRemotesGetByName: true, StoreRemotesList: true, StoreRemotesRename: true, StoreRemotesSealed: true,
+	StoreRetentionDeleteEntries: true, StoreRetentionEligible: true, StoreRetentionLastSuccess: true, StoreRetentionMarkCollected: true,
+	StoreRetentionSetLastSuccess: true, StoreSCIMAddGroupMember: true, StoreSCIMAttention: true, StoreSCIMBinding: true,
+	StoreSCIMBindings: true, StoreSCIMClearAttention: true, StoreSCIMClearGroupMembers: true, StoreSCIMCreateBinding: true,
+	StoreSCIMCreateCredential: true, StoreSCIMCreateGroup: true, StoreSCIMCreateMapping: true, StoreSCIMCreateUser: true,
+	StoreSCIMCredential: true, StoreSCIMCredentials: true, StoreSCIMDeleteAttentionForBinding: true, StoreSCIMDeleteBinding: true,
+	StoreSCIMDeleteCredentialsForBinding: true, StoreSCIMDeleteGroup: true, StoreSCIMDeleteGroupMembersForBinding: true, StoreSCIMDeleteGroupsForBinding: true,
+	StoreSCIMDeleteMapping: true, StoreSCIMDeleteMappingsForBinding: true, StoreSCIMDeleteUser: true, StoreSCIMDeleteUsersForBinding: true,
+	StoreSCIMEnterAttention: true, StoreSCIMGroup: true, StoreSCIMGroupMembers: true, StoreSCIMGroups: true,
+	StoreSCIMGroupsByDisplayName: true, StoreSCIMGroupsByExternalID: true, StoreSCIMLockBinding: true, StoreSCIMMapping: true,
+	StoreSCIMMappings: true, StoreSCIMMappingsForGroup: true, StoreSCIMMembershipsForUser: true, StoreSCIMPageGroups: true,
+	StoreSCIMPageUsers: true, StoreSCIMRemoveGroupMember: true, StoreSCIMRemoveMembershipsForUser: true, StoreSCIMRetireConnection: true,
+	StoreSCIMRevokeCredential: true, StoreSCIMRevokeCredentialsForBinding: true, StoreSCIMSetMappingInert: true, StoreSCIMTouchBinding: true,
+	StoreSCIMUpdateGroup: true, StoreSCIMUpdateMappingTemplate: true, StoreSCIMUpdateUser: true, StoreSCIMUser: true,
+	StoreSCIMUserByAccount: true, StoreSCIMUserBySubject: true, StoreSCIMUserByUserName: true, StoreSCIMUsers: true,
+	StoreSCIMUsersByExternalID: true, StoreScanningDismissalsDeleteAll: true, StoreScanningDismissalsDeleteByKey: true, StoreScanningDismissalsDeleteByProject: true,
+	StoreScanningDismissalsExists: true, StoreScanningDismissalsInsert: true, StoreSnapshotsAtRevision: true, StoreSnapshotsChanges: true,
+	StoreSnapshotsDeleteEnvironment: true, StoreSnapshotsEntries: true, StoreSnapshotsInsert: true, StoreSnapshotsInsertChange: true,
+	StoreSnapshotsInsertEntry: true, StoreSnapshotsInstancePayloadByProject: true, StoreSnapshotsLatest: true, StoreSnapshotsList: true,
+	StoreSnapshotsListForReencrypt: true, StoreSnapshotsPayloadBytesForProject: true, StoreSnapshotsProjectRevisions: true, StoreSnapshotsRecordSecretValueOccurrence: true,
+	StoreSnapshotsReencrypt: true, StoreSnapshotsSecretValueOccurrenceIDs: true, StoreValuesClear: true, StoreValuesClearEnvironment: true,
+	StoreValuesClearKey: true, StoreValuesCountEnvironment: true, StoreValuesEnvironmentsWithValue: true, StoreValuesGet: true,
+	StoreValuesInstancePayloadByProject: true, StoreValuesList: true, StoreValuesListForReencrypt: true, StoreValuesPayloadBytesForProject: true,
+	StoreValuesPut: true, StoreValuesReencrypt: true,
+}
+
 var readOnlyStoreOps = map[StoreOp]bool{
 	StoreOrgsGet:         true,
 	StoreOrgsList:        true,
@@ -1049,20 +1122,250 @@ type opSpec struct {
 	// reauthentication windows; failure is a reachable, non-enumerating 403.
 	postGrantForbidden bool
 
-	// events maps the operation to the audit event type(s) it emits, or —
-	// exactly one of the two — auditedNone declares a proof-scoped pure read
-	// whose result the trail would only duplicate. auditedNone is
-	// default-deny (audit-model ADR CI invariant 2): the completeness
-	// invariant permits it only for tenant-class, non-empty read-only formulas,
-	// non-mutating operations, and refuses it everywhere else.
-	events      []audit.EventType
-	auditedNone bool
+	// events maps the operation to the audit event type(s) it emits. Exactly one
+	// audit disposition holds per row: events, auditedNone, or reviewExempt.
+	// auditedNone declares a proof-scoped pure read whose result the trail would
+	// only duplicate; it is default-deny (audit-model ADR CI invariant 2), the
+	// completeness invariant permitting it only for tenant-class, non-empty
+	// read-only formulas mutating nothing. reviewExempt marks the handful of rows
+	// the ADR exempts by name (definitions.plan.get, scim-discovery.read): they
+	// emit no event yet fail the audited-none permit rule, so the completeness
+	// invariant pins them in testdata/audited_exemptions.json. The marker makes
+	// that reviewed disposition explicit in the row rather than implicit in the
+	// absence of the other two.
+	events       []audit.EventType
+	auditedNone  bool
+	reviewExempt bool
 }
 
-// operations is the operation registry. Every formula is built from capability
-// atoms the permission-model ADR already fixes — this ticket adds no atom and
-// invents no capability. Registry completeness is invariant 6.
-var operations = map[Operation]opSpec{
+// Registry is the validated, immutable operation registry. newRegistry is the
+// only way to build one, and mustNewRegistry installs it at package init, so a
+// malformed policy table aborts initialization instead of surfacing later as a
+// runtime authorization anomaly. Production lookups read this, never the raw
+// table.
+type Registry struct {
+	ops map[Operation]opSpec
+}
+
+// authorizationSpec is the read-only portion needed to mint a proof. Its only
+// mutable field is defensively copied by authorizationSpec(), so a caller
+// cannot alter the installed registry after validation.
+type authorizationSpec struct {
+	class   Class
+	level   domain.Level
+	formula Formula
+}
+
+func (r *Registry) authorizationSpec(op Operation) (authorizationSpec, bool) {
+	spec, ok := r.ops[op]
+	if !ok {
+		return authorizationSpec{}, false
+	}
+	return authorizationSpec{
+		class:   spec.class,
+		level:   spec.level,
+		formula: append(Formula(nil), spec.formula...),
+	}, true
+}
+
+// permitsStoreOp keeps the mutable store-op set inside Registry. Unknown
+// operations and store ops both return false, preserving fail-closed lookups.
+func (r *Registry) permitsStoreOp(operation Operation, storeOp StoreOp) bool {
+	spec, ok := r.ops[operation]
+	return ok && spec.storeOps[storeOp]
+}
+
+// permitsEvent keeps the mutable event slice inside Registry. Unknown
+// operations and events both return false.
+func (r *Registry) permitsEvent(operation Operation, event audit.EventType) bool {
+	spec, ok := r.ops[operation]
+	return ok && slices.Contains(spec.events, event)
+}
+
+// registrableClasses is the set of classes an operation registry row may carry.
+// Production mints only tenant- and instance-class operations; the
+// unauthenticated, system and stub classes are wire/verb classifications
+// (classify.go), never operation rows, so a row bearing one is a registry
+// programming error.
+var registrableClasses = map[Class]bool{
+	ClassTenant:   true,
+	ClassInstance: true,
+}
+
+// tenantLevel reports whether l is a chain depth a tenant operation may address.
+func tenantLevel(l domain.Level) bool {
+	return l == domain.LevelOrg || l == domain.LevelProject || l == domain.LevelEnv
+}
+
+// validLevel reports whether l is one of the four scope depths.
+func validLevel(l domain.Level) bool {
+	return l == domain.LevelNone || tenantLevel(l)
+}
+
+// validateSpec enforces every in-package registry invariant for one row.
+func validateSpec(op Operation, spec opSpec) error {
+	if !registrableClasses[spec.class] {
+		return fmt.Errorf("authz registry: operation %q has unregisterable class %d", op, spec.class)
+	}
+	// Class/level pairing: a tenant operation addresses one of the three tenant
+	// depths; an instance operation addresses no tenant object, so its level is
+	// none.
+	switch spec.class {
+	case ClassTenant:
+		if !tenantLevel(spec.level) {
+			return fmt.Errorf("authz registry: tenant operation %q has non-tenant level %d", op, spec.level)
+		}
+	case ClassInstance:
+		if spec.level != domain.LevelNone {
+			return fmt.Errorf("authz registry: instance operation %q must address level none, has %d", op, spec.level)
+		}
+	}
+	// Deny-by-default: no formula, no operation.
+	if len(spec.formula) == 0 {
+		return fmt.Errorf("authz registry: operation %q has an empty formula", op)
+	}
+	for _, atom := range spec.formula {
+		if !domain.IsCapability(atom.Cap) {
+			return fmt.Errorf("authz registry: operation %q names unknown capability %q", op, atom.Cap)
+		}
+		if !validLevel(atom.At) {
+			return fmt.Errorf("authz registry: operation %q has an atom at invalid level %d", op, atom.At)
+		}
+		// An atom cannot sit deeper than the capability's own deepest grantable
+		// level or the chain the operation addresses. Instance operations address
+		// LevelNone, so this also keeps every InstanceProof formula instance-scoped.
+		if deepest, _ := domain.DeepestLevel(atom.Cap); atom.At > deepest {
+			return fmt.Errorf("authz registry: operation %q has capability %q at level %d deeper than its deepest %d", op, atom.Cap, atom.At, deepest)
+		}
+		if atom.At > spec.level {
+			return fmt.Errorf("authz registry: operation %q (depth %d) has an atom at deeper level %d", op, spec.level, atom.At)
+		}
+	}
+	// Store ops: presence in the map must mean licensed (no `false` entries), and
+	// every key must be a known store operation. That the method exists on the
+	// store is invariant 6's reflection cross-check, which needs internal/store
+	// and so stays in internal/isolation; the closed catalogue here is the
+	// in-package half.
+	for so, licensed := range spec.storeOps {
+		if !licensed {
+			return fmt.Errorf("authz registry: operation %q has a false store-op entry %q — presence must mean licensed", op, so)
+		}
+		if !storeOpCatalogue[so] {
+			return fmt.Errorf("authz registry: operation %q names unknown store op %q", op, so)
+		}
+	}
+	if err := validateAuditDisposition(op, spec); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateAuditDisposition requires exactly one audit disposition — events,
+// auditedNone, or reviewExempt — and enforces the shape rules that go with each.
+func validateAuditDisposition(op Operation, spec opSpec) error {
+	n := 0
+	if len(spec.events) > 0 {
+		n++
+	}
+	if spec.auditedNone {
+		n++
+	}
+	if spec.reviewExempt {
+		n++
+	}
+	if n != 1 {
+		return fmt.Errorf("authz registry: operation %q must carry exactly one audit disposition (events, audited-none, or reviewed exemption), has %d", op, n)
+	}
+	if spec.reviewExempt && op != OpDefinitionsPlanGet && op != OpSCIMDiscovery {
+		return fmt.Errorf("authz registry: operation %q claims an unreviewed audit exemption", op)
+	}
+	// Each declared event must be a non-empty, registered type, and no type may
+	// be declared twice. Registration is the closed audit registry (audit.Spec).
+	seen := map[audit.EventType]bool{}
+	for _, et := range spec.events {
+		if et == "" {
+			return fmt.Errorf("authz registry: operation %q declares an empty audit event type", op)
+		}
+		if _, ok := audit.Spec(et); !ok {
+			return fmt.Errorf("authz registry: operation %q declares unregistered audit event %q", op, et)
+		}
+		if seen[et] {
+			return fmt.Errorf("authz registry: operation %q declares duplicate audit event %q", op, et)
+		}
+		seen[et] = true
+	}
+	// audited-none only under the default-deny permit rule: tenant class, a
+	// non-empty read-only conjunction, mutating nothing.
+	if spec.auditedNone {
+		if spec.class != ClassTenant {
+			return fmt.Errorf("authz registry: operation %q is audited-none on a non-tenant class", op)
+		}
+		for _, atom := range spec.formula {
+			if atom.Cap != domain.CapRead {
+				return fmt.Errorf("authz registry: operation %q is audited-none with a non-read atom %q", op, atom.Cap)
+			}
+		}
+		for so := range spec.storeOps {
+			if !readOnlyStoreOps[so] {
+				return fmt.Errorf("authz registry: operation %q is audited-none but mutates through %q", op, so)
+			}
+		}
+	}
+	return nil
+}
+
+// cloneSpec deep-copies the mutable fields of a spec so the immutable registry
+// shares no slice or map with operationTable or a caller's fixture: a later
+// mutation of the source cannot reach through into an installed row.
+func cloneSpec(spec opSpec) opSpec {
+	out := spec
+	out.formula = append(Formula(nil), spec.formula...)
+	out.events = append([]audit.EventType(nil), spec.events...)
+	if spec.storeOps != nil {
+		out.storeOps = make(map[StoreOp]bool, len(spec.storeOps))
+		for so, v := range spec.storeOps {
+			out.storeOps[so] = v
+		}
+	}
+	return out
+}
+
+// newRegistry validates the policy table and returns the immutable registry.
+// Adding an operation therefore meets every invariant here, in one place. Key
+// uniqueness is enforced one step earlier: operationTable is a map literal, so
+// the compiler rejects a duplicate operation key.
+func newRegistry(table map[Operation]opSpec) (*Registry, error) {
+	ops := make(map[Operation]opSpec, len(table))
+	for op, spec := range table {
+		if op == "" {
+			return nil, fmt.Errorf("authz registry: empty operation key")
+		}
+		if err := validateSpec(op, spec); err != nil {
+			return nil, err
+		}
+		ops[op] = cloneSpec(spec)
+	}
+	return &Registry{ops: ops}, nil
+}
+
+func mustNewRegistry(table map[Operation]opSpec) *Registry {
+	r, err := newRegistry(table)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// registry is the one installed operation registry. A validation failure here
+// aborts package initialization, so no importer can wire up an invalid registry.
+var registry = mustNewRegistry(operationTable)
+
+// operationTable is the reviewable operation policy table. Every formula is
+// built from capability atoms the permission-model ADR already fixes — this
+// ticket adds no atom and invents no capability. Registry completeness is
+// invariant 6. The table is never read directly: newRegistry validates it into
+// the immutable registry below, so no lookup can observe an unvalidated row.
+var operationTable = map[Operation]opSpec{
 	// The Org aggregate (#48). Creation and enumeration are instance-scoped
 	// under the operator set's instance-config atom: a create has no parent
 	// tenant to authorize against, and an enumeration of every org is
@@ -1667,10 +1970,11 @@ var operations = map[Operation]opSpec{
 	// apply carry the events — so it is name-pinned in the audit exemption fixture
 	// rather than emitting a read event once per poll.
 	OpDefinitionsPlanGet: {
-		class:    ClassTenant,
-		level:    domain.LevelProject,
-		formula:  Formula{{Cap: domain.CapDefinitionsEdit, At: domain.LevelProject}},
-		storeOps: map[StoreOp]bool{StoreDefinitionsPlanGet: true},
+		class:        ClassTenant,
+		level:        domain.LevelProject,
+		formula:      Formula{{Cap: domain.CapDefinitionsEdit, At: domain.LevelProject}},
+		storeOps:     map[StoreOp]bool{StoreDefinitionsPlanGet: true},
+		reviewExempt: true, // audited_exemptions.json — immutable plan read, no event
 	},
 	// Apply is the one write path a git-mode project allows. It executes the
 	// whole final definition set through the STORE layer inside one transaction,
@@ -3203,10 +3507,11 @@ var operations = map[Operation]opSpec{
 	// exemption entry: one for this operation and one per discovery route, each
 	// carrying its reason, each failing the build if removed without a mapping.
 	OpSCIMDiscovery: {
-		class:    ClassTenant,
-		level:    domain.LevelOrg,
-		formula:  scimWireFormula,
-		storeOps: scimDiscoveryOps(),
+		class:        ClassTenant,
+		level:        domain.LevelOrg,
+		formula:      scimWireFormula,
+		storeOps:     scimDiscoveryOps(),
+		reviewExempt: true, // audited_exemptions.json — discovery docs carry no tenant data
 	},
 	// The serving side of the directory tier (#71). The formula is bare
 	// `instance-directory` at instance scope, evaluated on the CONNECTION
@@ -3552,8 +3857,8 @@ type RegistryFacts struct{}
 
 // Operations lists every registered operation and its class.
 func (RegistryFacts) Operations() map[Operation]Class {
-	out := make(map[Operation]Class, len(operations))
-	for op, spec := range operations {
+	out := make(map[Operation]Class, len(registry.ops))
+	for op, spec := range registry.ops {
 		out[op] = spec.class
 	}
 	return out
@@ -3563,7 +3868,7 @@ func (RegistryFacts) Operations() map[Operation]Class {
 // addresses, for registry well-formedness checks.
 func (RegistryFacts) TenantOperations() map[Operation]domain.Level {
 	out := map[Operation]domain.Level{}
-	for op, spec := range operations {
+	for op, spec := range registry.ops {
 		if spec.class == ClassTenant {
 			out[op] = spec.level
 		}
@@ -3575,7 +3880,7 @@ func (RegistryFacts) TenantOperations() map[Operation]domain.Level {
 // operation registry, keyed by which operations may invoke them.
 func (RegistryFacts) StoreOps() map[StoreOp][]Operation {
 	out := make(map[StoreOp][]Operation)
-	for op, spec := range operations {
+	for op, spec := range registry.ops {
 		for so := range spec.storeOps {
 			out[so] = append(out[so], op)
 		}
@@ -3586,8 +3891,8 @@ func (RegistryFacts) StoreOps() map[StoreOp][]Operation {
 // Formulas returns each operation's formula; a registered operation with an
 // empty formula fails invariant 6.
 func (RegistryFacts) Formulas() map[Operation]Formula {
-	out := make(map[Operation]Formula, len(operations))
-	for op, spec := range operations {
+	out := make(map[Operation]Formula, len(registry.ops))
+	for op, spec := range registry.ops {
 		out[op] = append(Formula(nil), spec.formula...)
 	}
 	return out
@@ -3633,8 +3938,8 @@ type AuditMapping struct {
 
 // AuditMappings returns every registered operation's audit linkage.
 func (RegistryFacts) AuditMappings() map[Operation]AuditMapping {
-	out := make(map[Operation]AuditMapping, len(operations))
-	for op, spec := range operations {
+	out := make(map[Operation]AuditMapping, len(registry.ops))
+	for op, spec := range registry.ops {
 		ro := true
 		for so := range spec.storeOps {
 			if !readOnlyStoreOps[so] {
@@ -3678,8 +3983,8 @@ var levelNames = map[domain.Level]string{
 // FormulaPins returns the whole operation registry in a stable, diffable
 // shape, sorted by operation name.
 func (RegistryFacts) FormulaPins() []FormulaPin {
-	out := make([]FormulaPin, 0, len(operations))
-	for op, spec := range operations {
+	out := make([]FormulaPin, 0, len(registry.ops))
+	for op, spec := range registry.ops {
 		pin := FormulaPin{
 			Operation:          string(op),
 			Class:              classNames[spec.class],

--- a/internal/authz/registry_test.go
+++ b/internal/authz/registry_test.go
@@ -1,0 +1,282 @@
+package authz
+
+// Constructor-negative fixtures for the validating registry constructor. Every
+// registry invariant that is checkable inside this package aborts newRegistry
+// (and therefore package initialization, via mustNewRegistry) rather than
+// surfacing later as a runtime authorization anomaly. The cross-contract half —
+// that a named store op corresponds to a real store method, and that every
+// operation is audited or reviewed-exempt — stays in internal/isolation, where
+// the store method set and the exemption fixture live.
+
+import (
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/audit"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+)
+
+// baseSpec is a well-formed tenant read row. Each negative test mutates it into
+// exactly one violation; TestConstructorAcceptsBaseSpec proves the unmutated
+// fixture is accepted, so a rejection can only come from the mutation.
+func baseSpec() opSpec {
+	return opSpec{
+		class:    ClassTenant,
+		level:    domain.LevelEnv,
+		formula:  Formula{{Cap: domain.CapRead, At: domain.LevelEnv}},
+		storeOps: map[StoreOp]bool{StoreEnvironmentsGet: true},
+		events:   []audit.EventType{audit.EventOrgRead},
+	}
+}
+
+func rejects(t *testing.T, name string, spec opSpec) {
+	t.Helper()
+	if _, err := newRegistry(map[Operation]opSpec{Operation("x.op"): spec}); err == nil {
+		t.Fatalf("%s: newRegistry accepted a malformed spec", name)
+	}
+}
+
+// TestConstructorAcceptsBaseSpec keeps the negative fixtures honest: if the
+// unmutated baseSpec were itself rejected, every rejects() case would pass
+// vacuously.
+func TestConstructorAcceptsBaseSpec(t *testing.T) {
+	if _, err := newRegistry(map[Operation]opSpec{Operation("x.op"): baseSpec()}); err != nil {
+		t.Fatalf("baseSpec rejected: %v", err)
+	}
+}
+
+func TestConstructorRejectsBothAuditDispositions(t *testing.T) {
+	s := baseSpec() // already carries events
+	s.auditedNone = true
+	rejects(t, "events+audited-none", s)
+}
+
+func TestConstructorRejectsAuditedNoneOnNonTenant(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassInstance
+	s.level = domain.LevelNone
+	s.events = nil
+	s.auditedNone = true
+	rejects(t, "audited-none non-tenant", s)
+}
+
+func TestConstructorRejectsAuditedNoneWithNonReadFormula(t *testing.T) {
+	s := baseSpec()
+	s.formula = Formula{{Cap: domain.CapEdit, At: domain.LevelEnv}}
+	s.storeOps = map[StoreOp]bool{StoreEnvironmentsGet: true}
+	s.events = nil
+	s.auditedNone = true
+	rejects(t, "audited-none non-read formula", s)
+}
+
+func TestConstructorRejectsAuditedNoneThatMutates(t *testing.T) {
+	s := baseSpec()
+	s.storeOps = map[StoreOp]bool{StoreEnvironmentsGet: true, StoreEnvironmentsUpdateNote: true}
+	s.events = nil
+	s.auditedNone = true
+	rejects(t, "audited-none mutating", s)
+}
+
+func TestConstructorRejectsEmptyFormula(t *testing.T) {
+	s := baseSpec()
+	s.formula = nil
+	rejects(t, "empty formula", s)
+}
+
+func TestConstructorRejectsAtomWithoutCapability(t *testing.T) {
+	s := baseSpec()
+	s.formula = Formula{{Cap: "", At: domain.LevelEnv}}
+	rejects(t, "empty atom capability", s)
+}
+
+func TestConstructorRejectsTenantAtomDeeperThanLevel(t *testing.T) {
+	s := baseSpec()
+	s.level = domain.LevelOrg
+	s.formula = Formula{{Cap: domain.CapRead, At: domain.LevelEnv}}
+	rejects(t, "atom deeper than tenant level", s)
+}
+
+func TestConstructorRejectsTenantWithNonTenantLevel(t *testing.T) {
+	s := baseSpec()
+	s.level = domain.LevelNone
+	s.formula = Formula{{Cap: domain.CapRead, At: domain.LevelNone}}
+	rejects(t, "tenant op at instance level", s)
+}
+
+func TestConstructorRejectsStubClass(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassStub
+	rejects(t, "stub class", s)
+}
+
+func TestConstructorRejectsMalformedStoreOp(t *testing.T) {
+	s := baseSpec()
+	s.storeOps = map[StoreOp]bool{StoreOp("environmentsGet"): true}
+	rejects(t, "store op without package", s)
+}
+
+func TestConstructorRejectsUnknownStoreOp(t *testing.T) {
+	s := baseSpec()
+	// Well-formed `package.Method` shape but absent from the catalogue.
+	s.storeOps = map[StoreOp]bool{StoreOp("orgs.Nonexistent"): true}
+	rejects(t, "unknown store op", s)
+}
+
+func TestConstructorRejectsFalseStoreOpEntry(t *testing.T) {
+	s := baseSpec()
+	s.storeOps = map[StoreOp]bool{StoreEnvironmentsGet: false}
+	rejects(t, "false store-op entry", s)
+}
+
+func TestConstructorRejectsNoAuditDisposition(t *testing.T) {
+	s := baseSpec()
+	s.events = nil // no events, no audited-none, no reviewed exemption
+	rejects(t, "no audit disposition", s)
+}
+
+func TestConstructorRejectsReviewExemptWithEvents(t *testing.T) {
+	s := baseSpec() // carries events
+	s.reviewExempt = true
+	rejects(t, "reviewed exemption + events", s)
+}
+
+func TestConstructorRejectsReviewExemptWithAuditedNone(t *testing.T) {
+	s := baseSpec()
+	s.events = nil
+	s.auditedNone = true
+	s.reviewExempt = true
+	rejects(t, "reviewed exemption + audited-none", s)
+}
+
+func TestConstructorRejectsUnreviewedAuditExemption(t *testing.T) {
+	s := baseSpec()
+	s.events = nil
+	s.reviewExempt = true
+	rejects(t, "unreviewed audit exemption", s)
+}
+
+func TestConstructorRejectsUnknownCapability(t *testing.T) {
+	s := baseSpec()
+	s.formula = Formula{{Cap: domain.Capability("not-a-capability"), At: domain.LevelEnv}}
+	rejects(t, "unknown capability", s)
+}
+
+func TestConstructorRejectsAtomDeeperThanCapability(t *testing.T) {
+	s := baseSpec()
+	// manage-projects is grantable no deeper than org; an env atom is illegal
+	// even though the tenant op addresses env.
+	s.formula = Formula{{Cap: domain.CapManageProjects, At: domain.LevelEnv}}
+	rejects(t, "atom deeper than capability", s)
+}
+
+func TestConstructorRejectsInstanceWithTenantLevel(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassInstance
+	s.level = domain.LevelOrg
+	rejects(t, "instance op at tenant level", s)
+}
+
+func TestConstructorRejectsInstanceWithTenantFormulaAtom(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassInstance
+	s.level = domain.LevelNone
+	rejects(t, "instance op with tenant formula atom", s)
+}
+
+func TestConstructorRejectsUnauthenticatedClass(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassUnauthenticated
+	rejects(t, "unauthenticated class", s)
+}
+
+func TestConstructorRejectsSystemClass(t *testing.T) {
+	s := baseSpec()
+	s.class = ClassSystem
+	rejects(t, "system class", s)
+}
+
+func TestConstructorRejectsEmptyEvent(t *testing.T) {
+	s := baseSpec()
+	s.events = []audit.EventType{""}
+	rejects(t, "empty event type", s)
+}
+
+func TestConstructorRejectsUnregisteredEvent(t *testing.T) {
+	s := baseSpec()
+	s.events = []audit.EventType{audit.EventType("not.a.registered.event")}
+	rejects(t, "unregistered event type", s)
+}
+
+func TestConstructorRejectsDuplicateEvent(t *testing.T) {
+	s := baseSpec()
+	s.events = []audit.EventType{audit.EventOrgRead, audit.EventOrgRead}
+	rejects(t, "duplicate event type", s)
+}
+
+// TestConstructorDeepClonesSpec proves immutability: mutating every nested
+// mutable field of the source spec after construction cannot reach into the
+// installed registry row.
+func TestConstructorDeepClonesSpec(t *testing.T) {
+	spec := baseSpec()
+	r, err := newRegistry(map[Operation]opSpec{Operation("x.op"): spec})
+	if err != nil {
+		t.Fatalf("baseSpec rejected: %v", err)
+	}
+	got := r.ops[Operation("x.op")]
+
+	spec.storeOps[StoreEnvironmentsGet] = false
+	spec.storeOps[StoreEnvironmentsUpdateNote] = true
+	spec.formula[0].Cap = domain.CapEdit
+	spec.events[0] = audit.EventOrgDeleted
+
+	if !got.storeOps[StoreEnvironmentsGet] || got.storeOps[StoreEnvironmentsUpdateNote] {
+		t.Error("registry storeOps map shares backing with the source spec")
+	}
+	if got.formula[0].Cap != domain.CapRead {
+		t.Error("registry formula slice shares backing with the source spec")
+	}
+	if got.events[0] != audit.EventOrgRead {
+		t.Error("registry events slice shares backing with the source spec")
+	}
+}
+
+func TestRegistryLookupDoesNotExposeMutableState(t *testing.T) {
+	r, err := newRegistry(map[Operation]opSpec{Operation("x.op"): baseSpec()})
+	if err != nil {
+		t.Fatalf("baseSpec rejected: %v", err)
+	}
+	first, ok := r.authorizationSpec(Operation("x.op"))
+	if !ok {
+		t.Fatal("registered operation missing")
+	}
+	first.formula[0].Cap = domain.CapEdit
+
+	second, ok := r.authorizationSpec(Operation("x.op"))
+	if !ok {
+		t.Fatal("registered operation missing after lookup mutation")
+	}
+	if second.formula[0].Cap != domain.CapRead {
+		t.Fatal("registry lookup exposed mutable formula backing")
+	}
+}
+
+func TestConstructorRejectsEmptyOperationKey(t *testing.T) {
+	if _, err := newRegistry(map[Operation]opSpec{Operation(""): baseSpec()}); err == nil {
+		t.Fatal("newRegistry accepted an empty operation key")
+	}
+}
+
+// TestConstructorAcceptsRealTable is the green anchor: the production policy
+// table must satisfy every constructor invariant. mustNewRegistry already
+// asserts this at package init, but a focused test names the seam under review.
+func TestConstructorAcceptsRealTable(t *testing.T) {
+	r, err := newRegistry(operationTable)
+	if err != nil {
+		t.Fatalf("real operation table rejected: %v", err)
+	}
+	if len(r.ops) != len(operationTable) {
+		t.Fatalf("registry holds %d ops, table has %d", len(r.ops), len(operationTable))
+	}
+	if len(registry.ops) != len(operationTable) {
+		t.Fatalf("package registry holds %d ops, table has %d", len(registry.ops), len(operationTable))
+	}
+}

--- a/internal/authz/session.go
+++ b/internal/authz/session.go
@@ -443,7 +443,7 @@ func (a *TxAuthorizer) authenticateResolvedSession(ctx context.Context, row auth
 // enumerate exactly which operations will need an adequate session once
 // factors exist.
 func FormulaDemandsMFA(op Operation) bool {
-	spec, ok := operations[op]
+	spec, ok := registry.authorizationSpec(op)
 	if !ok {
 		return false
 	}

--- a/internal/authz/store_op_catalogue_test.go
+++ b/internal/authz/store_op_catalogue_test.go
@@ -1,0 +1,84 @@
+package authz
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestStoreOpCatalogueMatchesConstants keeps the constructor's closed runtime
+// catalogue total over the exported StoreOp constants. The compiler catches a
+// stale catalogue reference after deletion; this test catches a newly declared
+// constant that was not added to the catalogue and duplicate constant values
+// that would collapse to one map key.
+func TestStoreOpCatalogueMatchesConstants(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "registry.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	declared := map[string]bool{}
+	catalogued := map[string]bool{}
+	for _, declaration := range f.Decls {
+		gen, ok := declaration.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, rawSpec := range gen.Specs {
+			spec, ok := rawSpec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if gen.Tok == token.CONST {
+				typeName, ok := spec.Type.(*ast.Ident)
+				if !ok || typeName.Name != "StoreOp" {
+					continue
+				}
+				for _, name := range spec.Names {
+					if strings.HasPrefix(name.Name, "Store") {
+						declared[name.Name] = true
+					}
+				}
+				continue
+			}
+			if gen.Tok != token.VAR || len(spec.Names) != 1 || spec.Names[0].Name != "storeOpCatalogue" || len(spec.Values) != 1 {
+				continue
+			}
+			literal, ok := spec.Values[0].(*ast.CompositeLit)
+			if !ok {
+				t.Fatal("storeOpCatalogue is not a composite literal")
+			}
+			for _, element := range literal.Elts {
+				entry, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					t.Fatal("storeOpCatalogue contains a non-keyed entry")
+				}
+				name, ok := entry.Key.(*ast.Ident)
+				if !ok {
+					t.Fatal("storeOpCatalogue contains a non-identifier key")
+				}
+				catalogued[name.Name] = true
+			}
+		}
+	}
+
+	missing := difference(declared, catalogued)
+	extra := difference(catalogued, declared)
+	if len(missing) > 0 || len(extra) > 0 || len(storeOpCatalogue) != len(declared) {
+		t.Fatalf("StoreOp catalogue drift: declared=%d runtime=%d missing=%v extra=%v", len(declared), len(storeOpCatalogue), missing, extra)
+	}
+}
+
+func difference(left, right map[string]bool) []string {
+	out := []string{}
+	for value := range left {
+		if !right[value] {
+			out = append(out, value)
+		}
+	}
+	slices.Sort(out)
+	return out
+}

--- a/internal/authz/verify.go
+++ b/internal/authz/verify.go
@@ -47,7 +47,7 @@ func Verify(p Proof, op StoreOp, tok *TxToken) (domain.Scope, error) {
 			return domain.Scope{}, fmt.Errorf("authz: system proof from site %q may not invoke %q", c.site, op)
 		}
 	default:
-		if !operations[c.op].storeOps[op] {
+		if !registry.permitsStoreOp(c.op, op) {
 			return domain.Scope{}, fmt.Errorf("authz: proof minted for %q may not invoke %q", c.op, op)
 		}
 	}
@@ -81,12 +81,12 @@ func VerifyEvent(p Proof, op StoreOp, tok *TxToken, et audit.EventType) (domain.
 	if !ok || c == nil {
 		return domain.Scope{}, errors.New("authz: non-canonical proof")
 	}
-	licensed := operations[c.op].events
 	if c.kind == kindSystem {
-		licensed = systemSiteEvents[c.site]
+		if slices.Contains(systemSiteEvents[c.site], et) {
+			return chain, nil
+		}
+	} else if registry.permitsEvent(c.op, et) {
+		return chain, nil
 	}
-	if !slices.Contains(licensed, et) {
-		return domain.Scope{}, fmt.Errorf("authz: proof minted for %q may not emit audit event %q", c.op, et)
-	}
-	return chain, nil
+	return domain.Scope{}, fmt.Errorf("authz: proof minted for %q may not emit audit event %q", c.op, et)
 }


### PR DESCRIPTION
Closes #216

## Summary

- construct the authorization operation registry through a fail-fast validating `Registry`
- enforce closed class/level/formula, StoreOp, audit-event, and audit-disposition invariants before package initialization succeeds
- keep registry-owned mutable data behind defensive authorization views and membership queries
- retain stable formula pins and cross-contract registry exports

## Contract and migration

No public API, wire, database, or policy-formula migration. Duplicate operation keys remain compile-time errors through the reviewable map literal. The two existing reviewed audit exemptions are now explicit internal dispositions and remain name-pinned by the isolation fixture.

## Generated outputs

None. Formula-pin and registry fixtures are unchanged.

## Validation

- `go test -count=1 ./internal/authz/... ./api/... ./internal/isolation/...` with SQLite and PostgreSQL 18: 2,197 passed across 4 packages
- `go test -count=1 ./...` with SQLite and PostgreSQL 18: 4,002 passed across 56 packages
- `go vet ./...`: clean
- `gofmt -l internal/authz`: clean
- `git diff --check`: clean

## Review

- Standards: CLEAN, round 3
- Spec: CLEAN, round 2

Implementation handoff: `docs/handoff/216-registry-constructor.md`.