### PR TITLE
Resolve OpenAPI routes once during admission

### DIFF
--- a/api/match_test.go
+++ b/api/match_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers"
+)
+
+// countingRouter counts contract route lookups. The admission path's cost is
+// not a detail: every lookup is a second chance for two matches to disagree
+// about which operation a request is, and the artifact allowlist is decided
+// from that row.
+type countingRouter struct {
+	inner routers.Router
+	calls int
+}
+
+func (c *countingRouter) FindRoute(r *http.Request) (*routers.Route, map[string]string, error) {
+	c.calls++
+	return c.inner.FindRoute(r)
+}
+
+type fixedRouter struct {
+	route *routers.Route
+}
+
+func (f fixedRouter) FindRoute(*http.Request) (*routers.Route, map[string]string, error) {
+	return f.route, nil, nil
+}
+
+// withCountingRouter swaps the package router for a counting wrapper. The
+// document is loaded FIRST: loadOnce would otherwise overwrite the wrapper.
+func withCountingRouter(t *testing.T) *countingRouter {
+	t.Helper()
+	if _, err := Doc(); err != nil {
+		t.Fatalf("load the embedded contract: %v", err)
+	}
+	counting := &countingRouter{inner: router}
+	previous := router
+	router = counting
+	t.Cleanup(func() { router = previous })
+	return counting
+}
+
+// TestMatchRequestResolvesTheContractRouteExactlyOnce pins the public match
+// seam to one underlying router lookup. The server test separately proves its
+// admission middleware calls this seam once.
+func TestMatchRequestResolvesTheContractRouteExactlyOnce(t *testing.T) {
+	counting := withCountingRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, PathPrefix+"/orgs",
+		strings.NewReader(`{"name":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	match, err := MatchRequest(req)
+	if err != nil {
+		t.Fatalf("createOrg did not resolve through the embedded contract: %v", err)
+	}
+	op := match.Operation()
+	if op.ID != "createOrg" {
+		t.Fatalf("operation id = %q, want createOrg", op.ID)
+	}
+	if IsSCIMWireOperation(op.ID) {
+		t.Fatal("createOrg classified as a SCIM wire operation")
+	}
+	validated, err := match.Validate()
+	if err != nil {
+		t.Fatalf("a contract-conforming request was refused: %v", err)
+	}
+	admitted := validated.Request()
+	if admitted.URL.Path != req.URL.Path {
+		t.Fatalf("validated request path = %q, want original %q", admitted.URL.Path, req.URL.Path)
+	}
+	attached, ok := OperationFromContext(admitted.Context())
+	if !ok {
+		t.Fatal("the matched operation was not attached to the request context")
+	}
+	if attached.ID != op.ID {
+		t.Fatalf("attached operation = %q, want %q", attached.ID, op.ID)
+	}
+
+	if counting.calls != 1 {
+		t.Fatalf("route lookups = %d, want 1", counting.calls)
+	}
+}
+
+// TestMatchedOperationIsACopyOfTheImmutableRow pins that a caller holding a
+// match cannot edit the artifact allowlist the next request is admitted by.
+func TestMatchedOperationIsACopyOfTheImmutableRow(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, PathPrefix+"/orgs",
+		strings.NewReader(`{"name":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	match, err := MatchRequest(req)
+	if err != nil {
+		t.Fatalf("createOrg did not resolve through the embedded contract: %v", err)
+	}
+	mutated := match.Operation()
+	mutated.Artifacts[0] = "forged"
+
+	fresh := match.Operation()
+	if fresh.Artifacts[0] == "forged" {
+		t.Fatal("editing a matched operation changed the row a later consumer reads")
+	}
+	validated, err := match.Validate()
+	if err != nil {
+		t.Fatalf("a contract-conforming request was refused: %v", err)
+	}
+	validatedCopy := validated.Operation()
+	validatedCopy.Artifacts[0] = "forged"
+	ctx := validated.Request().Context()
+	originalRegistryRow := operations[fresh.ID]
+	changedRegistryRow := cloneOperation(originalRegistryRow)
+	changedRegistryRow.Artifacts[0] = "registry-forged"
+	operations[fresh.ID] = changedRegistryRow
+	t.Cleanup(func() { operations[fresh.ID] = originalRegistryRow })
+	if attached, ok := OperationFromContext(ctx); !ok ||
+		attached.Artifacts[0] == "forged" {
+		t.Fatal("editing a returned operation changed the validated row attached to context")
+	} else if attached.Artifacts[0] == "registry-forged" {
+		t.Fatal("context re-read the registry instead of carrying the validated row")
+	}
+}
+
+// TestMatchRequestRefusesAnUndescribedPath keeps the no-route refusal
+// distinguishable from a malformed request: the server answers the first with
+// 404 and the second with 400.
+func TestMatchRequestRefusesAnUndescribedPath(t *testing.T) {
+	counting := withCountingRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, PathPrefix+"/nothing-here", nil)
+	if _, err := MatchRequest(req); err != ErrNoRoute {
+		t.Fatalf("error = %v, want ErrNoRoute", err)
+	}
+	if counting.calls != 1 {
+		t.Fatalf("route lookups = %d, want 1", counting.calls)
+	}
+}
+
+func TestMatchRequestFailsLoudOnContractInvariantBreak(t *testing.T) {
+	if _, err := Doc(); err != nil {
+		t.Fatalf("load the embedded contract: %v", err)
+	}
+	for name, route := range map[string]*routers.Route{
+		"route without operation": {},
+		"operation absent from registry": {
+			Operation: &openapi3.Operation{OperationID: "notInRegistry"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			previous := router
+			router = fixedRouter{route: route}
+			t.Cleanup(func() { router = previous })
+
+			_, err := MatchRequest(httptest.NewRequest(http.MethodGet, PathPrefix+"/meta", nil))
+			if err == nil {
+				t.Fatal("broken contract invariant was accepted")
+			}
+			if errors.Is(err, ErrNoRoute) {
+				t.Fatalf("contract invariant error was downgraded to ErrNoRoute: %v", err)
+			}
+		})
+	}
+}
+
+// TestZeroValidatedRequestReturnsNoRequest pins the in-process semantics: a
+// value an out-of-package caller can construct cannot attach any operation.
+func TestZeroValidatedRequestReturnsNoRequest(t *testing.T) {
+	var zero ValidatedRequest
+	if zero.Request() != nil {
+		t.Fatal("a zero-value validation result returned an admitted request")
+	}
+}

--- a/api/spec.go
+++ b/api/spec.go
@@ -224,33 +224,21 @@ func AuthorizationOperationAdmitsArtifact(id, class string) (admitted, described
 
 type operationContextKey struct{}
 
-// WithRequestOperation resolves a request through the embedded contract and
-// attaches only its operationId. Consumers re-read the immutable cached row;
-// no caller can inject a parallel artifact list through context.
-func WithRequestOperation(ctx context.Context, r *http.Request) (context.Context, bool) {
-	op, ok := OperationFor(r)
-	if !ok {
-		return ctx, false
-	}
-	return context.WithValue(ctx, operationContextKey{}, op.ID), true
-}
-
 // OperationFromContext returns the contract row attached at HTTP admission.
 // Absence means an in-process caller rather than an unclassified HTTP route.
 func OperationFromContext(ctx context.Context) (Operation, bool) {
-	id, ok := ctx.Value(operationContextKey{}).(string)
-	if !ok {
-		return Operation{}, false
-	}
-	loadOnce.Do(load)
-	if loadErr != nil {
-		return Operation{}, false
-	}
-	op, ok := operations[id]
-	if !ok {
+	op, ok := ctx.Value(operationContextKey{}).(Operation)
+	if !ok || op.ID == "" {
 		return Operation{}, false
 	}
 	return cloneOperation(op), true
+}
+
+func withOperation(ctx context.Context, op Operation) context.Context {
+	if op.ID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, operationContextKey{}, cloneOperation(op))
 }
 
 // Operations returns every operation in the contract, keyed by operationId.
@@ -328,27 +316,88 @@ type ValidationError struct {
 func (e *ValidationError) Error() string { return e.Err.Error() }
 func (e *ValidationError) Unwrap() error { return e.Err }
 
-// ValidateRequest checks a request against the contract and reports the
-// offending member on failure.
+type resolvedRequest struct {
+	request *http.Request
+	route   *routers.Route
+	params  map[string]string
+	op      Operation
+}
+
+func resolveRequest(r *http.Request) (*resolvedRequest, error) {
+	loadOnce.Do(load)
+	if loadErr != nil {
+		return nil, loadErr
+	}
+	route, params, err := router.FindRoute(r)
+	if err != nil {
+		return nil, ErrNoRoute
+	}
+	if route == nil || route.Operation == nil {
+		return nil, fmt.Errorf("api: matched route %q has no OpenAPI operation", r.URL.Path)
+	}
+	op, ok := operations[route.Operation.OperationID]
+	if !ok {
+		return nil, fmt.Errorf("api: matched operation %q is absent from the contract registry", route.Operation.OperationID)
+	}
+	return &resolvedRequest{request: r, route: route, params: params, op: cloneOperation(op)}, nil
+}
+
+// MatchedRequest is one request's single resolution through the contract:
+// the route the OpenAPI router matched, its path parameters, and a cloned
+// immutable operation row. The mutable kin-openapi values stay attempt-local
+// and never enter a request context.
+type MatchedRequest struct {
+	request *http.Request
+	route   *routers.Route
+	params  map[string]string
+	op      Operation
+}
+
+// ValidatedRequest carries the original request and the cloned operation row
+// proven by its validation. Its fields are private, so another package cannot
+// construct an alternate row or attach one to a different request.
+type ValidatedRequest struct {
+	request *http.Request
+	op      Operation
+}
+
+// MatchRequest resolves a request through the embedded contract exactly once.
+// A request the contract does not describe is ErrNoRoute — the caller's 404,
+// distinct from a described route carrying a bad request.
+func MatchRequest(r *http.Request) (*MatchedRequest, error) {
+	resolved, err := resolveRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	return &MatchedRequest{
+		request: resolved.request,
+		route:   resolved.route,
+		params:  resolved.params,
+		op:      resolved.op,
+	}, nil
+}
+
+// Operation returns a copy of the immutable contract row this request matched.
+// Consumers may hold and read it; editing the copy changes nothing.
+func (m *MatchedRequest) Operation() Operation { return cloneOperation(m.op) }
+
+// Validate checks the matched request against the contract and reports the
+// offending member on failure. The request is validated AS MATCHED: a caller
+// that replaces r.Body on the same *http.Request between MatchRequest and
+// Validate (the SCIM wire body bound does) is honoured; one that swaps in a
+// different request must match again.
 //
 // Authentication is deliberately NOT evaluated here: the security scheme is
 // satisfied by resolving a session row inside the request's own transaction
 // at the authorization chokepoint, never by a middleware that decides
 // "authenticated" before one exists. The filter is told to accept every
-// security requirement so it validates shape only.
-func ValidateRequest(r *http.Request) error {
-	loadOnce.Do(load)
-	if loadErr != nil {
-		return loadErr
-	}
-	route, params, err := router.FindRoute(r)
-	if err != nil {
-		return ErrNoRoute
-	}
+// security requirement so it validates shape only. Only successful validation
+// returns a value capable of attaching the matched operation to context.
+func (m *MatchedRequest) Validate() (*ValidatedRequest, error) {
 	input := &openapi3filter.RequestValidationInput{
-		Request:    r,
-		PathParams: params,
-		Route:      route,
+		Request:    m.request,
+		PathParams: m.params,
+		Route:      m.route,
 		Options: &openapi3filter.Options{
 			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
 			// The SCIM WIRE routes' bodies are validated by the protocol layer,
@@ -365,13 +414,42 @@ func ValidateRequest(r *http.Request) error {
 			// check only ever rejected "not a JSON object" — which
 			// `scimproto.DecodeUser`/`DecodeGroup`/`ParsePatch` reject
 			// themselves, post-auth, as an RFC 7644 `invalidSyntax`.
-			ExcludeRequestBody: IsSCIMWireOperation(route.Operation.OperationID),
+			ExcludeRequestBody: IsSCIMWireOperation(m.op.ID),
 		},
 	}
-	if err := openapi3filter.ValidateRequest(r.Context(), input); err != nil {
-		return &ValidationError{Member: offendingMember(err), Err: err}
+	if err := openapi3filter.ValidateRequest(m.request.Context(), input); err != nil {
+		return nil, &ValidationError{Member: offendingMember(err), Err: err}
 	}
-	return nil
+	return &ValidatedRequest{request: m.request, op: cloneOperation(m.op)}, nil
+}
+
+// Operation returns a copy of the operation row proven by validation.
+func (v *ValidatedRequest) Operation() Operation {
+	if v == nil {
+		return Operation{}
+	}
+	return cloneOperation(v.op)
+}
+
+// Request returns the request that passed validation with its immutable
+// operation row attached. It deliberately accepts no request or context: a
+// caller cannot validate route A and attach that result to request B.
+func (v *ValidatedRequest) Request() *http.Request {
+	if v == nil || v.request == nil {
+		return nil
+	}
+	return v.request.WithContext(withOperation(v.request.Context(), v.op))
+}
+
+// ValidateRequest matches and validates once, returning the immutable row that
+// passed validation. Admission uses the two-step form because SCIM body policy
+// must run between matching and shape validation.
+func ValidateRequest(r *http.Request) (*ValidatedRequest, error) {
+	match, err := MatchRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	return match.Validate()
 }
 
 // IsSCIMWireOperation reports whether a contract operation is one of the
@@ -392,19 +470,15 @@ func IsSCIMWireOperation(operationID string) bool {
 // the CI wire-response duty: contract tests assert what actually went over
 // the socket, not what a handler intended.
 func ValidateResponse(r *http.Request, status int, header http.Header, body []byte) error {
-	loadOnce.Do(load)
-	if loadErr != nil {
-		return loadErr
-	}
-	route, params, err := router.FindRoute(r)
+	resolved, err := resolveRequest(r)
 	if err != nil {
-		return ErrNoRoute
+		return err
 	}
 	return openapi3filter.ValidateResponse(r.Context(), &openapi3filter.ResponseValidationInput{
 		RequestValidationInput: &openapi3filter.RequestValidationInput{
 			Request:    r,
-			PathParams: params,
-			Route:      route,
+			PathParams: resolved.params,
+			Route:      resolved.route,
 			Options: &openapi3filter.Options{
 				AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
 			},
@@ -419,38 +493,15 @@ func ValidateResponse(r *http.Request, status int, header http.Header, body []by
 	})
 }
 
-// OperationIDFor reports which contract operation a request resolves to, so
-// the transport layer can look up its artifact eligibility and minimum
-// revision without a second routing table.
-func OperationIDFor(r *http.Request) (string, bool) {
-	loadOnce.Do(load)
-	if loadErr != nil {
-		return "", false
-	}
-	route, _, err := router.FindRoute(r)
-	if err != nil || route.Operation == nil {
-		return "", false
-	}
-	return route.Operation.OperationID, true
-}
-
 // OperationFor reports the full contract row for the request. Artifact
 // admission consumes this row at runtime, so the same embedded OpenAPI bytes
 // drive both request validation and bearer-class eligibility.
 func OperationFor(r *http.Request) (Operation, bool) {
-	loadOnce.Do(load)
-	if loadErr != nil {
+	resolved, err := resolveRequest(r)
+	if err != nil {
 		return Operation{}, false
 	}
-	route, _, err := router.FindRoute(r)
-	if err != nil || route.Operation == nil {
-		return Operation{}, false
-	}
-	op, ok := operations[route.Operation.OperationID]
-	if !ok {
-		return Operation{}, false
-	}
-	return cloneOperation(op), true
+	return cloneOperation(resolved.op), true
 }
 
 // jsonPointerInReason recovers the offending member from a schema error.

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -269,7 +269,7 @@ func TestRequestValidationRefusesUnknownMembers(t *testing.T) {
 		bytes.NewReader([]byte(`{"name":"acme","typo":true}`)))
 	req.Header.Set("Content-Type", "application/json")
 	var verr *api.ValidationError
-	err := api.ValidateRequest(req)
+	_, err := api.ValidateRequest(req)
 	if !errors.As(err, &verr) {
 		t.Fatalf("unknown member accepted: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestRequestValidationAcceptsAbsentNullAndValue(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, api.PathPrefix+"/orgs",
 				bytes.NewReader([]byte(body)))
 			req.Header.Set("Content-Type", "application/json")
-			if err := api.ValidateRequest(req); err != nil {
+			if _, err := api.ValidateRequest(req); err != nil {
 				t.Fatalf("rejected: %v", err)
 			}
 		})
@@ -300,7 +300,7 @@ func TestRequestValidationReportsTheOffendingMember(t *testing.T) {
 		bytes.NewReader([]byte(`{"username":"","password":"x"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	var verr *api.ValidationError
-	if !errors.As(api.ValidateRequest(req), &verr) {
+	if _, err := api.ValidateRequest(req); !errors.As(err, &verr) {
 		t.Fatal("empty username accepted")
 	}
 	if verr.Member != "username" {
@@ -310,7 +310,7 @@ func TestRequestValidationReportsTheOffendingMember(t *testing.T) {
 
 func TestUnroutedRequestIsDistinguishableFromMalformed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, api.PathPrefix+"/nothing-here", nil)
-	if !errors.Is(api.ValidateRequest(req), api.ErrNoRoute) {
+	if _, err := api.ValidateRequest(req); !errors.Is(err, api.ErrNoRoute) {
 		t.Fatal("an undescribed path must be reported as unrouted, not as a bad body")
 	}
 }

--- a/docs/handoff/214-match-route-once.md
+++ b/docs/handoff/214-match-route-once.md
@@ -1,0 +1,111 @@
+# #214 — Match and carry each Go API route once per request
+
+Baseline: `d31919a8`. Scope: `api/spec.go`, `internal/server/api.go`,
+`internal/server/hierarchy.go`, one isolation consumer, and focused API/server
+tests.
+
+## Contract choice
+
+Admission uses a two-step type-state seam because SCIM body policy must run
+between route matching and shape validation:
+
+```go
+match, err := api.MatchRequest(r)       // one router.FindRoute
+op := match.Operation()                 // cloned row for SCIM classification
+validated, err := match.Validate()      // same route, params, request, and row
+request := validated.Request()          // original request + cloned row
+```
+
+`ValidateRequest(r)` is the one-shot form: it matches and validates once and
+returns `*ValidatedRequest`. The server uses the split form because
+`http.MaxBytesReader` cannot wrap SCIM wire bodies before the wire-specific
+single-value/body-size policy runs; doing so could disclose a pre-authentication
+400 that the SCIM contract requires to be ranked behind authentication.
+
+Immutability and injection boundaries:
+
+- `MatchedRequest` alone holds the kin-openapi route and path parameters. They
+  are private, attempt-local, and never enter context.
+- The operation row is cloned at match, validation, context attachment, and
+  context read boundaries. Registry changes after validation cannot alter the
+  row carried through that request.
+- Only `ValidatedRequest.Request()` can attach a row, and only to the original
+  request that passed validation. It accepts no caller-supplied request or
+  context, while its row field and context key remain private.
+- A zero `ValidatedRequest` returns no request and cannot attach an operation.
+
+## Behaviour
+
+- No route: unchanged `ErrNoRoute` → uniform 404.
+- Malformed request: unchanged `ValidationError.Member` → 400 naming member.
+- Matched route without an operation/registry row: fail-loud internal error →
+  uniform 500. It is an impossible contract invariant, never a public 404.
+- `OperationFor` remains for registry inspection. The unvalidated
+  `WithRequestOperation` compatibility helper was removed; its isolation
+  consumer now validates before attaching the row.
+
+## Changed files
+
+| File | Change |
+| --- | --- |
+| `api/spec.go` | Central request resolver; `MatchedRequest`/`ValidatedRequest`; cloned-row context accessors; result-returning `ValidateRequest`; removed dead `OperationIDFor`. |
+| `internal/server/api.go` | Match once, classify/bound, validate, attach validated row; injectable matcher seam for admission count test. |
+| `internal/server/hierarchy.go` | Strict-server error legs consume context row instead of re-routing. |
+| `internal/isolation/identities_e2e_test.go` | Artifact-refusal fixture validates its contract-shaped request and consumes that request's carried row. |
+| `api/match_test.go` | Underlying router count, cloned-row carry, no-route, fail-loud invariant, zero-value pins. |
+| `internal/server/admission_internal_test.go` | Real middleware matcher count plus admitted, 404, malformed, over-bound, and invariant-500 pins. |
+
+## Lookup count
+
+Admitted request before → after: **3 → 1**; strict-server error legs previously
+made it 4. Before: SCIM classification + validation + context attachment each
+routed. After: `MatchRequest` routes once; every later consumer uses its result.
+
+The count proof has two layers: `api` wraps the real kin-openapi router and
+asserts `MatchRequest` calls it once; `internal/server` wraps `MatchRequest` and
+asserts the real admission middleware calls that seam once. Either layer
+regressing fails a focused test without adding a production counter.
+
+## TDD and review evidence
+
+Initial red:
+
+```text
+api/match_test.go:50:16: undefined: MatchRequest
+api/match_test.go:121:11: undefined: MatchedRequest
+--- FAIL: TestPreChangeAdmissionSequenceLookupCount
+    route lookups = 3, want 1
+```
+
+Review R1 found three valid gaps and all were fixed:
+
+1. Impossible registry mismatches were downgraded to 404 → now fail as 500.
+2. Context carried only operation ID and re-read registry → now carries cloned
+   validated row through a private key.
+3. Count test replayed calls rather than real middleware → added server matcher
+   seam and real admission assertion.
+
+Native R2 found one remaining injection path: exported `WithRequestOperation`
+could attach a route row without validating its request. The helper was removed
+and its sole isolation consumer now uses `ValidateRequest`.
+
+Native R3 found that `ValidatedRequest.WithContext(ctx)` still allowed a valid
+route A result to be attached to an arbitrary context B. That method was
+removed: `ValidatedRequest.Request()` can only return the original validated
+request with its row attached. The first broader `AuthzOp` binding attempt was
+discarded after TDD correctly exposed valid SCIM dynamic-operation semantics;
+the request-bound API fixes the injection seam without changing authorization.
+
+Scoped green after fixes:
+
+```text
+gofmt -l api internal/server                                      # no output
+go test -count=1 ./api ./internal/server/... ./internal/authz      # 249 passed
+go test -count=1 ./internal/isolation                              # 1,084 passed
+go vet ./api/... ./internal/server/... ./internal/authz/... ./internal/isolation/...  # clean
+go test -count=1 ./...                                             # 2,916 passed; 56 packages
+```
+
+Standards R2 and spec R2 were clean. Native R3's final blocker was fixed and
+closed by the request-bound attachment API above; the three-round review cap
+precludes another cross-model pass. The final full-suite gate is green.

--- a/internal/isolation/identities_e2e_test.go
+++ b/internal/isolation/identities_e2e_test.go
@@ -960,13 +960,18 @@ func runIdentityLifecycle(t *testing.T, db *store.DB) {
 	// #113's named authentication refusal: drive a live machine credential
 	// through a human-session-only contract row before revoking it. This is the
 	// real admission emitter the audit registry's runtime-closure check needs.
+	// These IDs exercise the public wire contract. The service call below keeps
+	// using the isolation fixture's database scope; admission only consumes the
+	// validated operation row carried by this request.
 	request := httptest.NewRequest(http.MethodGet,
-		api.PathPrefix+"/orgs/"+string(orgA)+"/projects/"+string(prjA1)+
-			"/environments/"+string(envA1), nil)
-	admissionCtx, ok := api.WithRequestOperation(ctx, request)
-	if !ok {
-		t.Fatal("getEnvironment did not resolve through the embedded contract")
+		api.PathPrefix+"/orgs/org_0193f0b4-1f2a-7c31-9c1e-2a4b6d8e0fee/"+
+			"projects/prj_0193f0b4-1f2a-7c31-9c1e-2a4b6d8e0fdd/"+
+			"environments/env_0193f0b4-1f2a-7c31-9c1e-2a4b6d8e0fcc", nil).WithContext(ctx)
+	validated, err := api.ValidateRequest(request)
+	if err != nil {
+		t.Fatalf("getEnvironment did not validate through the embedded contract: %v", err)
 	}
+	admissionCtx := validated.Request().Context()
 	if _, err := (&service.Environments{DB: db}).Get(admissionCtx,
 		service.Bearer(minted.Value), envScope(envA1)); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("auth.artifact_class_refused: %v", err)

--- a/internal/server/admission_internal_test.go
+++ b/internal/server/admission_internal_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+)
+
+// admitted runs a request through the contract-admission middleware and
+// reports the response plus the operation the handler saw, so the admission
+// boundary is pinned from outside: what reaches a handler, and under which
+// contract row.
+func admitted(t *testing.T, r *http.Request) (*httptest.ResponseRecorder, api.Operation, bool) {
+	t.Helper()
+	var (
+		reached   bool
+		operation api.Operation
+		attached  bool
+	)
+	next := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		reached = true
+		operation, attached = api.OperationFromContext(req.Context())
+	})
+	rec := httptest.NewRecorder()
+	(&API{}).validateAgainstContract(next).ServeHTTP(rec, r)
+	if !reached {
+		return rec, api.Operation{}, false
+	}
+	if !attached {
+		t.Fatal("an admitted request reached the handler with no contract operation")
+	}
+	return rec, operation, true
+}
+
+func TestAdmissionAttachesTheMatchedOperation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, api.PathPrefix+"/orgs",
+		strings.NewReader(`{"name":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec, operation, reached := admitted(t, req)
+	if !reached {
+		t.Fatalf("a contract-conforming request was refused: %d %s", rec.Code, rec.Body)
+	}
+	if operation.ID != "createOrg" {
+		t.Fatalf("operation id = %q, want createOrg", operation.ID)
+	}
+	if len(operation.Artifacts) == 0 {
+		t.Fatal("the attached operation carries no artifact allowlist")
+	}
+}
+
+func TestAdmissionCallsTheRouteMatcherExactlyOnce(t *testing.T) {
+	calls := 0
+	matcher := func(r *http.Request) (*api.MatchedRequest, error) {
+		calls++
+		return api.MatchRequest(r)
+	}
+	reached := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reached = true })
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, api.PathPrefix+"/orgs",
+		strings.NewReader(`{"name":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	(&API{}).validateAgainstContractWith(matcher, next).ServeHTTP(rec, req)
+
+	if !reached {
+		t.Fatalf("a contract-conforming request was refused: %d %s", rec.Code, rec.Body)
+	}
+	if calls != 1 {
+		t.Fatalf("route matcher calls = %d, want 1", calls)
+	}
+}
+
+func TestAdmissionRendersMatcherInvariantFailureAsInternal(t *testing.T) {
+	matcher := func(*http.Request) (*api.MatchedRequest, error) {
+		return nil, errors.New("broken contract registry")
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, api.PathPrefix+"/meta", nil)
+
+	(&API{}).validateAgainstContractWith(matcher, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("matcher invariant failure reached the handler")
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "internal") {
+		t.Fatalf("body = %s, want the uniform internal refusal", rec.Body)
+	}
+}
+
+func TestAdmissionRefusesAnUndescribedPathAsNotFound(t *testing.T) {
+	rec, _, reached := admitted(t, httptest.NewRequest(http.MethodGet, api.PathPrefix+"/nothing-here", nil))
+	if reached {
+		t.Fatal("an undescribed path reached a handler")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "not_found") {
+		t.Fatalf("body = %s, want the uniform not_found refusal", rec.Body)
+	}
+}
+
+func TestAdmissionRefusesAMalformedRequestNamingTheMember(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, api.PathPrefix+"/auth/local/login",
+		strings.NewReader(`{"username":"","password":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec, _, reached := admitted(t, req)
+	if reached {
+		t.Fatal("a malformed request reached a handler")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "username") {
+		t.Fatalf("body = %s, want the offending member named", rec.Body)
+	}
+}
+
+func TestAdmissionRefusesAnOverBoundBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, api.PathPrefix+"/orgs",
+		strings.NewReader(`{"name":"`+strings.Repeat("a", MaxRequestBytes+1)+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec, _, reached := admitted(t, req)
+	if reached {
+		t.Fatal("an over-bound body reached a handler")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -696,53 +696,60 @@ func (a *API) extractBearer(next http.Handler) http.Handler {
 const MaxRequestBytes = 1 << 20
 
 func (a *API) validateAgainstContract(next http.Handler) http.Handler {
+	return a.validateAgainstContractWith(api.MatchRequest, next)
+}
+
+func (a *API) validateAgainstContractWith(
+	matchRequest func(*http.Request) (*api.MatchedRequest, error),
+	next http.Handler,
+) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// ONE route match per request, here. Everything downstream — the SCIM
+		// wire decision, shape validation, the artifact allowlist enforced at
+		// the authorization chokepoint — consumes this one matched row, so no
+		// two lookups can disagree about which operation a request is.
+		match, err := matchRequest(r)
+		if err != nil {
+			if errors.Is(err, api.ErrNoRoute) {
+				// A path the contract does not describe. 404, like any other
+				// thing that is not there.
+				writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
+				return
+			}
+			writeError(w, wirePolicyForCode(apigen.ErrorCodeInternal), "")
+			return
+		}
 		// The SCIM wire bounds and shape-checks its own body, BEFORE contract
 		// validation and with its refusal ranked behind authentication.
 		// http.MaxBytesReader cannot be used there: it fails the read, and the
 		// contract validator's own body handling turns that into a
 		// pre-authentication Hikyo 400 describing the request — which is the
 		// thing the wire must never do.
-		wire := isSCIMWireRequest(r)
-		if wire {
+		operation := match.Operation()
+		if api.IsSCIMWireOperation(operation.ID) {
 			if !a.scimBodyIsOneValue(w, r) {
 				return
 			}
 		} else if r.Body != nil {
 			r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBytes)
 		}
-		err := api.ValidateRequest(r)
-		switch {
-		case err == nil:
-			ctx, ok := api.WithRequestOperation(r.Context(), r)
-			if !ok {
-				writeError(w, wirePolicyForCode(apigen.ErrorCodeInternal), "")
-				return
-			}
-			next.ServeHTTP(w, r.WithContext(ctx))
-		case errors.Is(err, api.ErrNoRoute):
-			// A path the contract does not describe. 404, like any other
-			// thing that is not there.
-			writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
-		default:
+		validated, err := match.Validate()
+		if err != nil {
 			var verr *api.ValidationError
 			detail := ""
 			if errors.As(err, &verr) {
 				detail = verr.Member
 			}
 			writeError(w, wirePolicyForCode(apigen.ErrorCodeBadRequest), detail)
+			return
 		}
+		next.ServeHTTP(w, validated.Request())
 	})
 }
 
 // scimBodyIsOneValue enforces the single-JSON-value rule on a SCIM wire body
 // and answers the request itself when it is broken. It reports whether the
 // chain may continue.
-func isSCIMWireRequest(r *http.Request) bool {
-	operation, ok := api.OperationIDFor(r)
-	return ok && api.IsSCIMWireOperation(operation)
-}
-
 func (a *API) scimBodyIsOneValue(w http.ResponseWriter, r *http.Request) bool {
 	if r.Body == nil {
 		return true

--- a/internal/server/hierarchy.go
+++ b/internal/server/hierarchy.go
@@ -75,7 +75,11 @@ func (a *API) writeRequestError(w http.ResponseWriter, r *http.Request, _ error)
 	// credential, or the wrong one, gets the uniform 401 and learns nothing
 	// about the shape of what it sent. Only an authenticated caller is told the
 	// body was malformed, and then in the RFC 7644 shape rather than Hikyo's.
-	if operation, ok := api.OperationIDFor(r); ok && api.IsSCIMWireOperation(operation) {
+	//
+	// The operation is read from the CONTEXT the admission middleware attached,
+	// not matched again: this leg only ever runs on a request that already
+	// passed contract validation, and one match per request is the rule.
+	if operation, ok := api.OperationFromContext(r.Context()); ok && api.IsSCIMWireOperation(operation.ID) {
 		a.writeSCIMRequestError(w, r,
 			scimproto.ErrInvalidSyntax("The request body is not a valid SCIM resource."))
 		return
@@ -107,11 +111,12 @@ func (a *API) writeSCIMRequestError(w http.ResponseWriter, r *http.Request, refu
 func (a *API) writeHandlerError(w http.ResponseWriter, r *http.Request, err error) {
 	policy := wireErrorFor(err)
 	if policy.code == apigen.ErrorCodeInternal {
-		operation, ok := api.OperationIDFor(r)
+		op, ok := api.OperationFromContext(r.Context())
+		name := op.ID
 		if !ok {
-			operation = "unrouted request"
+			name = "unrouted request"
 		}
-		a.fault(r.Context(), operation, err)
+		a.fault(r.Context(), name, err)
 	}
 	// A service refusal may carry a caller-safe detail (the clone abort names
 	// the stranded keys; a duplicate-item refusal names the duplicate; the


### PR DESCRIPTION
## Summary

- Resolve each admitted OpenAPI request route exactly once.
- Carry the cloned validated operation row on the original request for downstream artifact classification.
- Keep mutable router/path-parameter state attempt-local and remove alternate-row attachment seams.
- Preserve no-route 404, malformed-request 400, and contract-invariant 500 behavior.

## Verification

- `go test -count=1 ./api ./internal/server/... ./internal/authz` — 249 passed
- `go test -count=1 ./internal/isolation` — 1,084 passed
- `go test -count=1 ./...` — 2,916 passed across 56 packages
- `go vet ./api ./internal/server/... ./internal/authz ./internal/isolation` — clean
- `gofmt` and `git diff --check` — clean

## Review

- Standards review R2: clean
- Specification review R2: clean
- Native Codex adversarial review: three rounds completed; R3 alternate-context blocker fixed by binding attachment to the original validated request

Closes #214