### PR TITLE
Compile declarations together with their classification

### DIFF
--- a/docs/handoff/215-classified-declarations.md
+++ b/docs/handoff/215-classified-declarations.md
@@ -1,0 +1,42 @@
+# #215 — Classified declaration compilation
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/215.
+
+**State: implemented.** Declaration validity, normalization, classification
+compatibility, validator compilation, canonical storage bytes, and validation
+disclosure now originate from one classified artifact.
+
+## Contract
+
+- `schema.CompileClassified` is the only production constructor. It rejects an
+  unknown classification, normalizes once, enforces secret/config compatibility,
+  and compiles validators from that normalized declaration.
+- `schema.Compiled` retains the classification. `Validate` accepts only a value,
+  so a caller cannot compile as config and validate as secret or the reverse.
+- `Compiled.Canonical` serializes the artifact's normalized declaration.
+  `Compiled.Declaration` returns a deep clone, preserving artifact immutability.
+- Classification-compatibility-skipping fixtures use
+  `CompileWithoutCompatibilityCheckForTest`, available only in `export_test.go`.
+
+## Boundary migration
+
+- Definition parsing returns a `CompiledBundle`: raw normalized wire DTOs remain
+  in `Bundle`, while a private sidecar carries compiled declarations through
+  apply. Normal and scanner-skew apply paths reuse those artifacts and never
+  compile a declaration twice in one apply.
+- Direct key create/update, definition create/update, stored value validation,
+  and both reclassification directions use classified artifacts.
+- Import type suggestions compile their fixed primitive declarations as secret,
+  which is compatible with both suggested primitives.
+
+Canonical bundle/declaration JSON bytes and wire shapes are unchanged. Generated
+outputs: none.
+
+## Validation
+
+- `go vet ./...`: green.
+- `go test -count=1 ./internal/schema/... ./internal/definitions/... ./internal/service/...`: green.
+- `go test -count=1 ./...`: green across all Go packages.
+- Two-axis review rounds 1 and 2 found four issues; all were fixed. Round 3
+  returned spec `SOUND`; its sole standards finding was this handoff's helper
+  wording, corrected before commit.

--- a/internal/conformance/catalogue_test.go
+++ b/internal/conformance/catalogue_test.go
@@ -252,17 +252,17 @@ func scenarioDeclarationFixtures(t *testing.T, db *store.DB) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		compiled, err := schema.Compile(stored.Declaration)
+		compiled, err := schema.CompileClassified(schema.Classification(stored.Classification), stored.Declaration)
 		if err != nil {
 			t.Fatalf("%s: the STORED declaration no longer compiles: %v", tc.name, err)
 		}
 		for _, value := range tc.valid {
-			if v := compiled.Validate(value, schema.Config); !v.Valid {
+			if v := compiled.Validate(value); !v.Valid {
 				t.Errorf("%s: %q refused: %+v", tc.name, value, v.Errors)
 			}
 		}
 		for _, value := range tc.invalid {
-			if v := compiled.Validate(value, schema.Config); v.Valid {
+			if v := compiled.Validate(value); v.Valid {
 				t.Errorf("%s: %q accepted", tc.name, value)
 			}
 		}

--- a/internal/definitions/bundle_test.go
+++ b/internal/definitions/bundle_test.go
@@ -89,6 +89,31 @@ func TestEncodeParseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseCompiledCarriesClassifiedDeclarations(t *testing.T) {
+	norm := mustNormalize(t, sampleBundle())
+	raw, err := Encode(norm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseCompiled(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(parsed.Bundle, norm) {
+		t.Fatalf("ParseCompiled bundle differs\n got: %+v\nwant: %+v", parsed.Bundle, norm)
+	}
+	compiled, ok := parsed.CompiledDeclaration("DB_URL")
+	if !ok {
+		t.Fatal("ParseCompiled omitted DB_URL's compiled declaration")
+	}
+	if verdict := compiled.Validate("postgres://db.example.test/app"); !verdict.Valid {
+		t.Fatalf("compiled DB_URL declaration refused a string: %+v", verdict.Errors)
+	}
+	if _, ok := parsed.CompiledDeclaration("MISSING"); ok {
+		t.Fatal("ParseCompiled returned an artifact for an absent key")
+	}
+}
+
 func TestDigestStableOverCanonical(t *testing.T) {
 	norm, _ := Normalize(sampleBundle())
 	d1, err := Digest(norm)

--- a/internal/definitions/parse.go
+++ b/internal/definitions/parse.go
@@ -15,30 +15,54 @@ import (
 // name, declarations in schema-canonical form, presence lists sorted), so it is
 // the sole producer of the canonical form Encode assumes.
 func Parse(raw []byte) (Bundle, error) {
+	parsed, err := ParseCompiled(raw)
+	if err != nil {
+		return Bundle{}, err
+	}
+	return parsed.Bundle, nil
+}
+
+// CompiledBundle keeps parsed wire data separate from the classified
+// declaration artifacts built from it. Apply paths consume both so a
+// declaration is not compiled again after parsing.
+type CompiledBundle struct {
+	Bundle       Bundle
+	declarations map[string]*schema.Compiled
+}
+
+// CompiledDeclaration returns the artifact for a normalized key name.
+func (b CompiledBundle) CompiledDeclaration(keyName string) (*schema.Compiled, bool) {
+	compiled, ok := b.declarations[keyName]
+	return compiled, ok
+}
+
+// ParseCompiled parses and normalizes a wire bundle while retaining each
+// declaration's classified artifact for an immediate apply.
+func ParseCompiled(raw []byte) (CompiledBundle, error) {
 	if len(raw) > MaxBundleBytes {
-		return Bundle{}, limitDetail("bundle is %d bytes, over the %d byte limit", len(raw), MaxBundleBytes)
+		return CompiledBundle{}, limitDetail("bundle is %d bytes, over the %d byte limit", len(raw), MaxBundleBytes)
 	}
 
 	var b Bundle
 	if err := DecodeStrict(raw, &b); err != nil {
-		return Bundle{}, mapDecodeError(err)
+		return CompiledBundle{}, mapDecodeError(err)
 	}
 
 	if b.FormatVersion != FormatVersion {
-		return Bundle{}, invalidDetail(
+		return CompiledBundle{}, invalidDetail(
 			"bundle format_version %d is not this build's %d: version mismatch", b.FormatVersion, FormatVersion)
 	}
 
 	entries := len(b.Keys) + len(b.Environments) + len(b.KeyGroups)
 	if entries > MaxBundleEntries {
-		return Bundle{}, limitDetail("bundle holds %d entries, over the %d entry limit", entries, MaxBundleEntries)
+		return CompiledBundle{}, limitDetail("bundle holds %d entries, over the %d entry limit", entries, MaxBundleEntries)
 	}
 
 	if b.Additive() && hasIDs(b) {
-		return Bundle{}, invalidDetail("malformed template: ids without base revision")
+		return CompiledBundle{}, invalidDetail("malformed template: ids without base revision")
 	}
 
-	return normalize(b)
+	return normalizeCompiled(b)
 }
 
 // mapDecodeError translates the neutral strict-decode errors into caller-safe
@@ -86,9 +110,15 @@ func hasIDs(b Bundle) bool {
 
 // Normalize sorts and canonicalizes a bundle. Import and tests that build a
 // bundle by hand call it before Encode; Parse calls it on decode.
-func Normalize(b Bundle) (Bundle, error) { return normalize(b) }
+func Normalize(b Bundle) (Bundle, error) {
+	compiled, err := normalizeCompiled(b)
+	if err != nil {
+		return Bundle{}, err
+	}
+	return compiled.Bundle, nil
+}
 
-func normalize(b Bundle) (Bundle, error) {
+func normalizeCompiled(b Bundle) (CompiledBundle, error) {
 	out := Bundle{
 		FormatVersion: FormatVersion,
 		BaseRevision:  b.BaseRevision,
@@ -96,6 +126,7 @@ func normalize(b Bundle) (Bundle, error) {
 		KeyGroups:     append([]KeyGroup(nil), b.KeyGroups...),
 		Keys:          append([]Key(nil), b.Keys...),
 	}
+	declarations := make(map[string]*schema.Compiled, len(out.Keys))
 	if out.Environments == nil {
 		out.Environments = []Environment{}
 	}
@@ -112,33 +143,27 @@ func normalize(b Bundle) (Bundle, error) {
 	for i := range out.Keys {
 		k := out.Keys[i]
 		if k.Classification != string(schema.Secret) && k.Classification != string(schema.Config) {
-			return Bundle{}, invalidDetail(
+			return CompiledBundle{}, invalidDetail(
 				"key %q declares classification %q, which is neither `secret` nor `config`", k.Name, k.Classification)
 		}
-		if err := schema.CheckDeclarationClassification(schema.Classification(k.Classification), k.Declaration); err != nil {
-			return Bundle{}, invalidDetail("key %q has an invalid declaration: %v", k.Name, err)
-		}
-		canonicalDecl, err := schema.Canonical(k.Declaration)
+		compiled, err := schema.CompileClassified(schema.Classification(k.Classification), k.Declaration)
 		if err != nil {
-			return Bundle{}, invalidDetail("key %q has an invalid declaration: %v", k.Name, err)
+			return CompiledBundle{}, invalidDetail("key %q has an invalid declaration: %v", k.Name, err)
 		}
-		decl, err := schema.ParseDeclaration(canonicalDecl)
-		if err != nil {
-			return Bundle{}, invalidDetail("key %q has an invalid declaration: %v", k.Name, err)
-		}
-		k.Declaration = decl
+		k.Declaration = compiled.Declaration()
 		req, err := normalizePresence("required_in", k.Name, k.RequiredIn)
 		if err != nil {
-			return Bundle{}, err
+			return CompiledBundle{}, err
 		}
 		forb, err := normalizePresence("forbidden_in", k.Name, k.ForbiddenIn)
 		if err != nil {
-			return Bundle{}, err
+			return CompiledBundle{}, err
 		}
 		k.RequiredIn, k.ForbiddenIn = req, forb
 		out.Keys[i] = k
+		declarations[k.Name] = compiled
 	}
-	return out, nil
+	return CompiledBundle{Bundle: out, declarations: declarations}, nil
 }
 
 // normalizePresence validates a bundle presence rule's mode/shape and returns

--- a/internal/importer/suggest.go
+++ b/internal/importer/suggest.go
@@ -25,7 +25,7 @@ var (
 
 func mustCompile(t schema.Type) *schema.Compiled {
 	rule := schema.Rule{Type: t}
-	c, err := schema.Compile(schema.Declaration{Rule: &rule})
+	c, err := schema.CompileClassified(schema.Secret, schema.Declaration{Rule: &rule})
 	if err != nil {
 		// The rules are compile-time constants; a failure is a build-time bug.
 		panic("importer: compiling the " + string(t) + " suggestion rule: " + err.Error())
@@ -41,9 +41,9 @@ func SuggestType(values []string) schema.Type {
 		return schema.TypeString
 	}
 	switch {
-	case allSatisfy(values, func(v string) bool { return suggestBoolean.Validate(v, schema.Secret).Valid }):
+	case allSatisfy(values, func(v string) bool { return suggestBoolean.Validate(v).Valid }):
 		return schema.TypeBoolean
-	case allSatisfy(values, func(v string) bool { return suggestInteger.Validate(v, schema.Secret).Valid }):
+	case allSatisfy(values, func(v string) bool { return suggestInteger.Validate(v).Valid }):
 		return schema.TypeInteger
 	case allSatisfy(values, isJSONObjectOrArray):
 		return schema.TypeJSON

--- a/internal/importer/suggest_test.go
+++ b/internal/importer/suggest_test.go
@@ -47,12 +47,12 @@ func TestSuggestionIsAlwaysAcceptedByTheDeclaration(t *testing.T) {
 	for _, values := range sets {
 		typ := SuggestType(values)
 		rule := schema.Rule{Type: typ}
-		compiled, err := schema.Compile(schema.Declaration{Rule: &rule})
+		compiled, err := schema.CompileClassified(schema.Secret, schema.Declaration{Rule: &rule})
 		if err != nil {
 			t.Fatalf("suggested type %s does not compile: %v", typ, err)
 		}
 		for _, v := range values {
-			if verdict := compiled.Validate(v, schema.Secret); !verdict.Valid {
+			if verdict := compiled.Validate(v); !verdict.Valid {
 				t.Errorf("suggested %s for %q but the declaration rejects it: %+v", typ, v, verdict.Errors)
 			}
 		}

--- a/internal/schema/classification.go
+++ b/internal/schema/classification.go
@@ -5,11 +5,11 @@ import (
 	"sort"
 )
 
-// CheckDeclarationClassification enforces the source-of-truth ADR's
+// checkDeclarationClassification enforces the source-of-truth ADR's
 // classification boundary. A secret declaration may constrain a shape with a
 // pattern, but it may not carry value literals through enum members or through
 // const/enum/examples anywhere in an embedded JSON Schema document.
-func CheckDeclarationClassification(classification Classification, d Declaration) error {
+func checkDeclarationClassification(classification Classification, d Declaration) error {
 	if classification != Secret {
 		return nil
 	}

--- a/internal/schema/deadline_internal_test.go
+++ b/internal/schema/deadline_internal_test.go
@@ -124,7 +124,7 @@ func TestJSONSchemaEvaluationFailsLoudWhenNotAdmitted(t *testing.T) {
 	release := saturateEvaluationSlots(t)
 	defer release()
 
-	c, err := Compile(Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(`{"type":"object"}`)}})
+	c, err := compileWithoutCompatibilityCheckForTest(Config, Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(`{"type":"object"}`)}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestJSONSchemaEvaluationFailsLoudWhenNotAdmitted(t *testing.T) {
 	evaluationDeadline = time.Millisecond
 	defer func() { evaluationDeadline = restore }()
 
-	v := c.Validate(`{}`, Config)
+	v := c.Validate(`{}`)
 	if v.Valid {
 		t.Fatal("an evaluation that was never admitted was reported valid")
 	}
@@ -150,14 +150,14 @@ func TestJSONSchemaEvaluationFailsLoudOnTheDeadline(t *testing.T) {
 	evaluationDeadline = 0 // every evaluation overruns
 	defer func() { evaluationDeadline = restore }()
 
-	c, err := Compile(Declaration{Rule: &Rule{
+	c, err := compileWithoutCompatibilityCheckForTest(Config, Declaration{Rule: &Rule{
 		Type:       TypeJSON,
 		JSONSchema: []byte(`{"type":"object"}`),
 	}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	v := c.Validate(`{}`, Config)
+	v := c.Validate(`{}`)
 	if v.Valid {
 		t.Fatal("an evaluation past its deadline was reported valid")
 	}
@@ -219,7 +219,7 @@ func TestRefExpansionIsRefusedAgainstTheWorkBudget(t *testing.T) {
 	if declared := strings.Count(doc, `"type"`) + strings.Count(doc, `"allOf"`); declared > MaxJSONSchemaSubschemas {
 		t.Fatalf("the fixture is not structurally small (%d declared constructs)", declared)
 	}
-	_, err := Compile(Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(doc)}})
+	_, err := compileWithoutCompatibilityCheckForTest(Config, Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(doc)}})
 	if err == nil {
 		t.Fatal("a $ref chain expanding to thousands of evaluation paths was accepted")
 	}
@@ -244,15 +244,15 @@ func TestLinearRefReuseStillCompiles(t *testing.T) {
 		b.WriteString(`"p` + strconv.Itoa(i) + `":{"$ref":"#/$defs/t"}`)
 	}
 	b.WriteString(`}}`)
-	c, err := Compile(Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(b.String())}})
+	c, err := compileWithoutCompatibilityCheckForTest(Config, Declaration{Rule: &Rule{Type: TypeJSON, JSONSchema: []byte(b.String())}})
 	if err != nil {
 		t.Fatalf("linear $ref reuse was refused: %v", err)
 	}
 	// And it still validates: the bound rejected nothing it should have kept.
-	if v := c.Validate(`{"p0":"x"}`, Config); !v.Valid {
+	if v := c.Validate(`{"p0":"x"}`); !v.Valid {
 		t.Fatalf("the compiled schema refuses a valid instance: %+v", v.Errors)
 	}
-	if v := c.Validate(`{"p0":""}`, Config); v.Valid {
+	if v := c.Validate(`{"p0":""}`); v.Valid {
 		t.Fatal("the referenced constraint was not applied")
 	}
 }

--- a/internal/schema/declare.go
+++ b/internal/schema/declare.go
@@ -13,29 +13,47 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-// Compile is the declaration authority. It performs every declaration-time
-// check the ADR fixes and returns the artifact the value engine runs against —
-// so "was this declaration well-formed?" and "what do I validate with?" cannot
-// drift apart, because they are the same call.
+// CompileClassified is the persisted-declaration authority. It normalizes the
+// wire declaration once, enforces the key classification against that exact
+// form, and builds the validators from it. Boundary callers must use this
+// constructor so a declaration cannot reach storage or application with its
+// classification check omitted or reordered.
 //
 // Compilation is per schema revision, not per validation: patterns and JSON
 // Schemas are compiled once here and reused by every Validate (ADR § Bounds:
 // "compiled once per schema revision and cached, never recompiled per
 // validation, so a fetch storm cannot be amplified into CPU").
-func Compile(d Declaration) (*Compiled, error) {
-	switch {
-	case (d.Rule == nil) == (len(d.AnyOf) == 0):
-		return nil, declErr("a declaration carries exactly one of `rule` or `any_of`")
-	case d.Rule == nil && len(d.AnyOf) < 2:
-		return nil, declErr("an `any_of` union carries at least two alternatives")
-	case len(d.AnyOf) > MaxAnyOfAlternatives:
-		return nil, declErr("an `any_of` union carries at most %d alternatives", MaxAnyOfAlternatives)
-	}
-	norm, err := normalize(d)
+func CompileClassified(classification Classification, d Declaration) (*Compiled, error) {
+	norm, err := normalizeForCompilation(classification, d)
 	if err != nil {
 		return nil, err
 	}
-	c := &Compiled{decl: norm}
+	if err := checkDeclarationClassification(classification, norm); err != nil {
+		return nil, err
+	}
+	return compileNormalized(classification, norm)
+}
+func normalizeForCompilation(classification Classification, d Declaration) (Declaration, error) {
+	if !classification.Valid() {
+		return Declaration{}, declErr("classification %q is neither `secret` nor `config`", classification)
+	}
+	return normalizeForCompile(d)
+}
+
+func normalizeForCompile(d Declaration) (Declaration, error) {
+	switch {
+	case (d.Rule == nil) == (len(d.AnyOf) == 0):
+		return Declaration{}, declErr("a declaration carries exactly one of `rule` or `any_of`")
+	case d.Rule == nil && len(d.AnyOf) < 2:
+		return Declaration{}, declErr("an `any_of` union carries at least two alternatives")
+	case len(d.AnyOf) > MaxAnyOfAlternatives:
+		return Declaration{}, declErr("an `any_of` union carries at most %d alternatives", MaxAnyOfAlternatives)
+	}
+	return normalize(d)
+}
+
+func compileNormalized(classification Classification, norm Declaration) (*Compiled, error) {
+	c := &Compiled{classification: classification, decl: norm}
 	for i, r := range norm.alternatives() {
 		cr, err := compileRule(r)
 		if err != nil {
@@ -53,13 +71,18 @@ func Compile(d Declaration) (*Compiled, error) {
 // concurrent use: compiled regexps and compiled JSON Schemas are, and the
 // engine writes nothing back.
 type Compiled struct {
-	decl Declaration
-	alts []compiledRule
+	classification Classification
+	decl           Declaration
+	alts           []compiledRule
 }
 
 // Declaration returns the normalized declaration this artifact was built from
 // — the canonical form, so a caller storing it stores what validation used.
-func (c *Compiled) Declaration() Declaration { return c.decl }
+func (c *Compiled) Declaration() Declaration { return cloneDeclaration(c.decl) }
+
+// Canonical renders the byte-stable storage form of the same normalized
+// declaration that the compiled validators use.
+func (c *Compiled) Canonical() ([]byte, error) { return json.Marshal(c.decl) }
 
 type compiledRule struct {
 	rule    Rule

--- a/internal/schema/declare_test.go
+++ b/internal/schema/declare_test.go
@@ -76,7 +76,7 @@ func TestDeclarationRefusals(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := schema.Compile(tc.decl)
+			_, err := schema.CompileClassified(schema.Config, tc.decl)
 			if err == nil {
 				t.Fatalf("Compile accepted %+v", tc.decl)
 			}
@@ -87,41 +87,145 @@ func TestDeclarationRefusals(t *testing.T) {
 	}
 }
 
-func TestSecretDeclarationRefusesValueLiteralsRecursively(t *testing.T) {
+func TestCompileClassified(t *testing.T) {
 	cases := []struct {
-		name string
-		decl schema.Declaration
-		want string
+		name           string
+		classification schema.Classification
+		decl           schema.Declaration
+		wantCanonical  string
+		wantErr        string
 	}{
-		{"enum rule", rule(schema.Rule{Type: schema.TypeEnum, Members: []string{"live-value"}}), "members"},
-		{"any_of enum alternative", schema.Declaration{AnyOf: []schema.Rule{
-			{Type: schema.TypeString},
-			{Type: schema.TypeEnum, Members: []string{"live-value"}},
-		}}, "members"},
-		{"nested json schema const", rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
-			`{"properties":{"nested":{"allOf":[{"const":"live-value"}]}}}`)}), "const"},
-		{"nested json schema enum", rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
-			`{"$defs":{"nested":{"enum":["live-value"]}}}`)}), "enum"},
-		{"nested json schema examples", rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
-			`{"items":{"examples":["live-value"]}}`)}), "examples"},
+		{
+			name:           "config declaration is normalized once for storage and validation",
+			classification: schema.Config,
+			decl: rule(schema.Rule{
+				Type: schema.TypeEnum, Members: []string{" live ", "test"},
+			}),
+			wantCanonical: `{"rule":{"type":"enum","members":["live","test"]}}`,
+		},
+		{
+			name:           "secret pattern is allowed",
+			classification: schema.Secret,
+			decl:           rule(schema.Rule{Type: schema.TypeString, Pattern: `[A-Z]+`}),
+			wantCanonical:  `{"rule":{"type":"string","pattern":"[A-Z]+"}}`,
+		},
+		{
+			name:           "secret enum rule is refused",
+			classification: schema.Secret,
+			decl:           rule(schema.Rule{Type: schema.TypeEnum, Members: []string{"live-value"}}),
+			wantErr:        "members",
+		},
+		{
+			name:           "secret any_of enum alternative is refused",
+			classification: schema.Secret,
+			decl: schema.Declaration{AnyOf: []schema.Rule{
+				{Type: schema.TypeString},
+				{Type: schema.TypeEnum, Members: []string{"live-value"}},
+			}},
+			wantErr: "members",
+		},
+		{
+			name:           "secret nested json schema const is refused",
+			classification: schema.Secret,
+			decl: rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
+				`{"properties":{"nested":{"allOf":[{"const":"live-value"}]}}}`)}),
+			wantErr: "const",
+		},
+		{
+			name:           "secret nested json schema enum is refused",
+			classification: schema.Secret,
+			decl: rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
+				`{"$defs":{"nested":{"enum":["live-value"]}}}`)}),
+			wantErr: "enum",
+		},
+		{
+			name:           "secret nested json schema examples is refused",
+			classification: schema.Secret,
+			decl: rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
+				`{"items":{"examples":["live-value"]}}`)}),
+			wantErr: "examples",
+		},
+		{
+			name:           "unknown classification is refused",
+			classification: schema.Classification("public"),
+			decl:           rule(schema.Rule{Type: schema.TypeString}),
+			wantErr:        "classification",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := schema.CheckDeclarationClassification(schema.Secret, tc.decl)
-			if err == nil || !strings.Contains(err.Error(), tc.want) ||
-				!strings.Contains(err.Error(), "use `pattern`, or declassify the key") {
-				t.Fatalf("secret declaration refusal = %v", err)
+			compiled, err := schema.CompileClassified(tc.classification, tc.decl)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("CompileClassified error = %v, want error naming %q", err, tc.wantErr)
+				}
+				if tc.classification == schema.Secret &&
+					!strings.Contains(err.Error(), "use `pattern`, or declassify the key") {
+					t.Fatalf("secret declaration refusal = %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CompileClassified refused declaration: %v", err)
+			}
+			canonical, err := compiled.Canonical()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(canonical) != tc.wantCanonical {
+				t.Fatalf("canonical declaration = %s, want %s", canonical, tc.wantCanonical)
 			}
 		})
 	}
+}
 
-	allowed := rule(schema.Rule{Type: schema.TypeJSON, JSONSchema: json.RawMessage(
-		`{"properties":{"nested":{"type":"string","pattern":"^[A-Z]+$"}}}`)})
-	if err := schema.CheckDeclarationClassification(schema.Secret, allowed); err != nil {
-		t.Fatalf("pattern-only secret declaration refused: %v", err)
+func TestCompiledValidationUsesConstructorClassification(t *testing.T) {
+	compiled, err := schema.CompileClassified(schema.Secret, rule(schema.Rule{
+		Type: schema.TypeJSON,
+		JSONSchema: json.RawMessage(
+			`{"type":"object","additionalProperties":false,"properties":{"declared":{"type":"string"}}}`),
+	}))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := schema.CheckDeclarationClassification(schema.Config, cases[0].decl); err != nil {
-		t.Fatalf("config enum declaration refused: %v", err)
+	const marker = "AKIA_CLASSIFICATION_MISMATCH"
+	verdict := compiled.Validate(`{"` + marker + `":"x"}`)
+	if verdict.Valid {
+		t.Fatal("secret value unexpectedly passed validation")
+	}
+	for _, failure := range verdict.Errors {
+		if failure.InstancePath != "" || strings.Contains(failure.Message, marker) {
+			t.Fatalf("secret failure disclosed instance data: %+v", failure)
+		}
+	}
+}
+
+func TestCompiledDeclarationIsImmutable(t *testing.T) {
+	input := rule(schema.Rule{Type: schema.TypeEnum, Members: []string{"live", "test"}})
+	compiled, err := schema.CompileClassified(schema.Config, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input.Rule.Members[0] = "input-mutated"
+	returned := compiled.Declaration()
+	returned.Rule.Members[1] = "output-mutated"
+
+	canonical, err := compiled.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = `{"rule":{"type":"enum","members":["live","test"]}}`
+	if string(canonical) != want {
+		t.Fatalf("compiled declaration mutated: got %s, want %s", canonical, want)
+	}
+	if verdict := compiled.Validate("live"); !verdict.Valid {
+		t.Fatalf("original member stopped validating: %+v", verdict.Errors)
+	}
+	for _, mutant := range []string{"input-mutated", "output-mutated"} {
+		if verdict := compiled.Validate(mutant); verdict.Valid {
+			t.Fatalf("mutated member %q reached compiled validation", mutant)
+		}
 	}
 }
 
@@ -183,7 +287,7 @@ func TestJSONSchemaProfileRefusals(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := schema.Compile(rule(schema.Rule{
+			_, err := schema.CompileClassified(schema.Config, rule(schema.Rule{
 				Type: schema.TypeJSON, JSONSchema: json.RawMessage(tc.schema),
 			}))
 			if err == nil {
@@ -199,7 +303,7 @@ func TestJSONSchemaProfileRefusals(t *testing.T) {
 func TestJSONSchemaBoundRefusals(t *testing.T) {
 	deep := strings.Repeat(`{"properties":{"a":`, schema.MaxJSONSchemaDepth+2) + `{}` +
 		strings.Repeat(`}}`, schema.MaxJSONSchemaDepth+2)
-	if _, err := schema.Compile(rule(schema.Rule{
+	if _, err := schema.CompileClassified(schema.Config, rule(schema.Rule{
 		Type: schema.TypeJSON, JSONSchema: json.RawMessage(deep),
 	})); err == nil || !strings.Contains(err.Error(), "depth") {
 		t.Fatalf("deep schema refusal = %v, want a depth bound", err)
@@ -214,7 +318,7 @@ func TestJSONSchemaBoundRefusals(t *testing.T) {
 		defs.WriteString(`"d` + itoa(i) + `":{"type":"string"}`)
 	}
 	defs.WriteString(`}}`)
-	_, err := schema.Compile(rule(schema.Rule{
+	_, err := schema.CompileClassified(schema.Config, rule(schema.Rule{
 		Type: schema.TypeJSON, JSONSchema: json.RawMessage(defs.String()),
 	}))
 	if err == nil || !strings.Contains(err.Error(), "subschema") {
@@ -227,7 +331,7 @@ func TestJSONSchemaBoundRefusals(t *testing.T) {
 	}
 
 	big := `{"description":"` + strings.Repeat("x", schema.MaxJSONSchemaBytes) + `"}`
-	if _, err := schema.Compile(rule(schema.Rule{
+	if _, err := schema.CompileClassified(schema.Config, rule(schema.Rule{
 		Type: schema.TypeJSON, JSONSchema: json.RawMessage(big),
 	})); err == nil || !strings.Contains(err.Error(), "bytes") {
 		t.Fatalf("large schema refusal = %v, want a byte bound", err)
@@ -242,7 +346,7 @@ func TestJSONSchemaProfileAccepts(t *testing.T) {
 		`{"$defs":{"port":{"type":"integer","minimum":1,"maximum":65535}},"type":"object","properties":{"p":{"$ref":"#/$defs/port"}}}`,
 		`{"anyOf":[{"type":"string"},{"type":"integer"}]}`,
 	} {
-		if _, err := schema.Compile(rule(schema.Rule{
+		if _, err := schema.CompileClassified(schema.Config, rule(schema.Rule{
 			Type: schema.TypeJSON, JSONSchema: json.RawMessage(s),
 		})); err != nil {
 			t.Fatalf("Compile(%s) refused an in-profile schema: %v", s, err)
@@ -321,7 +425,7 @@ func TestCanonicalDoesNotMutateItsInput(t *testing.T) {
 	if _, err := schema.Canonical(d); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := schema.Compile(d); err != nil {
+	if _, err := schema.CompileClassified(schema.Config, d); err != nil {
 		t.Fatal(err)
 	}
 	if d.AnyOf[0].Members[0] != " a " {

--- a/internal/schema/export_test.go
+++ b/internal/schema/export_test.go
@@ -1,0 +1,16 @@
+package schema
+
+// CompileWithoutCompatibilityCheckForTest exposes the compatibility-skipping
+// primitive only in test builds. Engine fixtures can exercise unreachable
+// declaration/classification pairs without reopening a production bypass.
+func CompileWithoutCompatibilityCheckForTest(classification Classification, d Declaration) (*Compiled, error) {
+	return compileWithoutCompatibilityCheckForTest(classification, d)
+}
+
+func compileWithoutCompatibilityCheckForTest(classification Classification, d Declaration) (*Compiled, error) {
+	norm, err := normalizeForCompilation(classification, d)
+	if err != nil {
+		return nil, err
+	}
+	return compileNormalized(classification, norm)
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -6,11 +6,11 @@
 //
 // Two authorities live here and nowhere else:
 //
-//   - Compile() is the DECLARATION authority. Saving a declaration blocks on
-//     well-formedness: a value may be wrong, a rule may not be meaningless
-//     (ADR § Validation timing). Every refusal names what it refused, because
-//     a rule that appears to enforce something and does not is worse than no
-//     rule at all.
+//   - CompileClassified() is the DECLARATION authority. Saving a declaration
+//     blocks on well-formedness and classification compatibility: a value may
+//     be wrong, a rule may not be meaningless (ADR § Validation timing). Every
+//     refusal names what it refused, because a rule that appears to enforce
+//     something and does not is worse than no rule at all.
 //   - Compiled.Validate() is the VALUE authority: one declaration against one
 //     string, with the ADR's fixed lexical semantics and its error-disclosure
 //     rules. Everything Hikyo delivers is a string on the wire, so a type is a
@@ -275,6 +275,40 @@ type Declaration struct {
 	AnyOf []Rule `json:"any_of,omitempty"`
 }
 
+func cloneRule(r Rule) Rule {
+	r.MinLength = clonePointer(r.MinLength)
+	r.MaxLength = clonePointer(r.MaxLength)
+	r.Min = clonePointer(r.Min)
+	r.Max = clonePointer(r.Max)
+	r.Members = slices.Clone(r.Members)
+	r.Schemes = slices.Clone(r.Schemes)
+	r.JSONSchema = slices.Clone(r.JSONSchema)
+	return r
+}
+
+func clonePointer[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func cloneDeclaration(d Declaration) Declaration {
+	out := Declaration{}
+	if d.Rule != nil {
+		r := cloneRule(*d.Rule)
+		out.Rule = &r
+	}
+	if d.AnyOf != nil {
+		out.AnyOf = make([]Rule, len(d.AnyOf))
+		for i, r := range d.AnyOf {
+			out.AnyOf[i] = cloneRule(r)
+		}
+	}
+	return out
+}
+
 // alternatives returns the rules to try, in declared order. A single rule is
 // the one-alternative case, so the engine has one loop rather than two paths.
 func (d Declaration) alternatives() []Rule {
@@ -330,8 +364,7 @@ func normalize(d Declaration) (Declaration, error) {
 		// as a side effect of asking for its canonical form — and Canonical is
 		// called on declarations the caller still holds (the reveal gate's diff
 		// runs on both sides before anything is written).
-		r.Members = slices.Clone(r.Members)
-		r.Schemes = slices.Clone(r.Schemes)
+		r = cloneRule(r)
 		for i, m := range r.Members {
 			r.Members[i] = strings.TrimSpace(m)
 		}

--- a/internal/schema/suite_test.go
+++ b/internal/schema/suite_test.go
@@ -77,7 +77,7 @@ func TestJSONSchemaConformanceBaseline(t *testing.T) {
 		}
 		file := strings.TrimSuffix(entry.Name(), ".json")
 		for _, group := range groups {
-			compiled, err := schema.Compile(schema.Declaration{Rule: &schema.Rule{
+			compiled, err := schema.CompileClassified(schema.Config, schema.Declaration{Rule: &schema.Rule{
 				Type: schema.TypeJSON, JSONSchema: group.Schema,
 			}})
 			if err != nil {
@@ -96,7 +96,7 @@ func TestJSONSchemaConformanceBaseline(t *testing.T) {
 					continue
 				}
 				ran++
-				got := compiled.Validate(string(tc.Data), schema.Config)
+				got := compiled.Validate(string(tc.Data))
 				if got.Valid != tc.Valid {
 					t.Errorf("%s: valid=%v, suite says %v (errors %+v)", name, got.Valid, tc.Valid, got.Errors)
 				}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -76,12 +76,10 @@ func Normalize(value string) string { return strings.TrimSpace(value) }
 // delivery — the value is a string, so `01` is not normalized to `1`.
 var integerRe = regexp.MustCompile(`\A-?[0-9]+\z`)
 
-// Validate runs the declaration against one value.
-//
-// The classification is an input because it decides what a failure may say,
-// not whether the value is valid: the same value gets the same verdict either
-// way, and only the reporting narrows.
-func (c *Compiled) Validate(value string, cls Classification) Verdict {
+// Validate runs the declaration against one value. Failure disclosure uses
+// the classification fixed by CompileClassified, so callers cannot compile
+// under one classification and validate under another.
+func (c *Compiled) Validate(value string) Verdict {
 	trimmed := Normalize(value)
 	var v Verdict
 
@@ -109,7 +107,7 @@ func (c *Compiled) Validate(value string, cls Classification) Verdict {
 		if single {
 			index = -1
 		}
-		failures := alt.validate(trimmed, cls, index)
+		failures := alt.validate(trimmed, c.classification, index)
 		if len(failures) == 0 {
 			// At least one alternative accepts, so the value is valid.
 			// Overlapping alternatives are explicitly fine and never an error;

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -23,9 +23,9 @@ func rule(r schema.Rule) schema.Declaration {
 	return schema.Declaration{Rule: &r}
 }
 
-func compile(t *testing.T, d schema.Declaration) *schema.Compiled {
+func compile(t *testing.T, classification schema.Classification, d schema.Declaration) *schema.Compiled {
 	t.Helper()
-	c, err := schema.Compile(d)
+	c, err := schema.CompileWithoutCompatibilityCheckForTest(classification, d)
 	if err != nil {
 		t.Fatalf("Compile(%+v): %v", d, err)
 	}
@@ -107,8 +107,8 @@ func TestValueFixtures(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := compile(t, tc.decl)
-			v := c.Validate(tc.value, schema.Secret)
+			c := compile(t, schema.Secret, tc.decl)
+			v := c.Validate(tc.value)
 			if v.Valid != tc.valid {
 				t.Fatalf("Validate(%q) valid=%v, want %v (errors: %+v)", tc.value, v.Valid, tc.valid, v.Errors)
 			}
@@ -141,11 +141,11 @@ func TestValueFixtures(t *testing.T) {
 // The probe value is a distinctive token, so a leak is detectable by search.
 func TestSecretFailuresCarryNoInstanceData(t *testing.T) {
 	const marker = "AKIALEAKCANARY"
-	c := compile(t, rule(schema.Rule{
+	c := compile(t, schema.Secret, rule(schema.Rule{
 		Type:       schema.TypeJSON,
 		JSONSchema: []byte(`{"type":"object","additionalProperties":false,"properties":{"declared":{"type":"string"}}}`),
 	}))
-	v := c.Validate(`{"`+marker+`":"x"}`, schema.Secret)
+	v := c.Validate(`{"` + marker + `":"x"}`)
 	if v.Valid {
 		t.Fatal("additionalProperties:false accepted an undeclared property")
 	}
@@ -162,11 +162,11 @@ func TestSecretFailuresCarryNoInstanceData(t *testing.T) {
 // A config key is readable under ordinary environment read, so its failures
 // may carry the instance path the operator needs.
 func TestConfigFailuresMayCarryInstancePaths(t *testing.T) {
-	c := compile(t, rule(schema.Rule{
+	c := compile(t, schema.Config, rule(schema.Rule{
 		Type:       schema.TypeJSON,
 		JSONSchema: []byte(`{"type":"object","properties":{"a":{"type":"integer"}}}`),
 	}))
-	v := c.Validate(`{"a":"nope"}`, schema.Config)
+	v := c.Validate(`{"a":"nope"}`)
 	if v.Valid {
 		t.Fatal("expected a type failure")
 	}
@@ -189,13 +189,13 @@ func TestAnyOf(t *testing.T) {
 		{Type: schema.TypeInteger, Min: i64p(1)},
 		{Type: schema.TypeEnum, Members: []string{"auto"}},
 	}}
-	c := compile(t, d)
+	c := compile(t, schema.Secret, d)
 	for _, ok := range []string{"4", "auto"} {
-		if v := c.Validate(ok, schema.Secret); !v.Valid {
+		if v := c.Validate(ok); !v.Valid {
 			t.Fatalf("Validate(%q) refused: %+v", ok, v.Errors)
 		}
 	}
-	v := c.Validate("banana", schema.Secret)
+	v := c.Validate("banana")
 	if v.Valid {
 		t.Fatal("banana satisfied neither alternative but was accepted")
 	}
@@ -210,19 +210,19 @@ func TestAnyOf(t *testing.T) {
 
 // allow_empty lives on the string alternative, never on the union.
 func TestAnyOfEmptyRidesTheStringAlternative(t *testing.T) {
-	c := compile(t, schema.Declaration{AnyOf: []schema.Rule{
+	c := compile(t, schema.Secret, schema.Declaration{AnyOf: []schema.Rule{
 		{Type: schema.TypeInteger},
 		{Type: schema.TypeString, AllowEmpty: true},
 	}})
-	if v := c.Validate("", schema.Secret); !v.Valid {
+	if v := c.Validate(""); !v.Valid {
 		t.Fatalf("empty refused despite an allow_empty string alternative: %+v", v.Errors)
 	}
 }
 
 // The instance-byte budget fails loud; it never degrades to "assume valid".
 func TestInstanceByteBudget(t *testing.T) {
-	c := compile(t, rule(schema.Rule{Type: schema.TypeString}))
-	v := c.Validate(strings.Repeat("a", schema.MaxValueBytes+1), schema.Secret)
+	c := compile(t, schema.Secret, rule(schema.Rule{Type: schema.TypeString}))
+	v := c.Validate(strings.Repeat("a", schema.MaxValueBytes+1))
 	if v.Valid {
 		t.Fatal("an over-budget value was accepted")
 	}
@@ -242,8 +242,8 @@ func TestErrorCapsHold(t *testing.T) {
 	for range schema.MaxAnyOfAlternatives {
 		alts = append(alts, schema.Rule{Type: schema.TypeEnum, Members: members})
 	}
-	c := compile(t, schema.Declaration{AnyOf: alts})
-	v := c.Validate("nothing-matches", schema.Secret)
+	c := compile(t, schema.Secret, schema.Declaration{AnyOf: alts})
+	v := c.Validate("nothing-matches")
 	if v.Valid {
 		t.Fatal("expected a total failure")
 	}
@@ -266,8 +266,8 @@ func TestNormalizeIsTheWriteTimeTrim(t *testing.T) {
 	if got := schema.Normalize("  padded\t\n"); got != "padded" {
 		t.Fatalf("Normalize = %q, want %q", got, "padded")
 	}
-	c := compile(t, rule(schema.Rule{Type: schema.TypeString}))
-	if v := c.Validate("  padded\t\n", schema.Config); !v.Valid {
+	c := compile(t, schema.Config, rule(schema.Rule{Type: schema.TypeString}))
+	if v := c.Validate("  padded\t\n"); !v.Valid {
 		t.Fatalf("a value valid after the trim was refused: %+v", v.Errors)
 	}
 }
@@ -289,9 +289,9 @@ func TestWholeSecretVerdictCarriesNoPlaintext(t *testing.T) {
 		{"enum", rule(schema.Rule{Type: schema.TypeEnum, Members: []string{"a"}})},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := compile(t, tc.decl)
+			c := compile(t, schema.Secret, tc.decl)
 			for _, value := range []string{marker, `{"` + marker + `":"x"}`} {
-				v := c.Validate(value, schema.Secret)
+				v := c.Validate(value)
 				if v.Valid {
 					continue
 				}
@@ -317,11 +317,11 @@ func TestErrorCapIsOnEncodedBytes(t *testing.T) {
 	// what the message reports — the escaping pressure comes from the schema
 	// location instead, which is where instance-independent text can grow.
 	heavy := strings.Repeat(`\u0001\u2028`, 900)
-	c := compile(t, rule(schema.Rule{
+	c := compile(t, schema.Config, rule(schema.Rule{
 		Type:       schema.TypeJSON,
 		JSONSchema: []byte(`{"type":"object","required":["` + heavy + `"]}`),
 	}))
-	v := c.Validate(`{}`, schema.Config)
+	v := c.Validate(`{}`)
 	if v.Valid {
 		t.Fatal("a missing required property was accepted")
 	}

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -42,7 +42,7 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 	// This pre-flight reaches the verdict in a read transaction before the mint, so
 	// a skew-blocked apply persists NOTHING but the finding_blocked events. A
 	// same-version apply runs no scan here and returns no overrides.
-	overrides, err := s.scanApplySkew(ctx, actor, scope, planID, opts.Acknowledgements)
+	precompiled, overrides, err := s.scanApplySkew(ctx, actor, scope, planID, opts.Acknowledgements)
 	if err != nil {
 		return ApplyResult{}, err
 	}
@@ -78,10 +78,16 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 			return &detailErr{detail: "plan expired; re-plan", err: fmt.Errorf("%w: plan %s expired", domain.ErrConflict, planID)}
 		}
 
-		bundle, err := definitions.Parse([]byte(plan.Bundle))
-		if err != nil {
-			return fmt.Errorf("service: plan %s: stored bundle unreadable: %w", planID, err)
+		var compiledBundle definitions.CompiledBundle
+		if precompiled == nil {
+			compiledBundle, err = definitions.ParseCompiled([]byte(plan.Bundle))
+			if err != nil {
+				return fmt.Errorf("service: plan %s: stored bundle unreadable: %w", planID, err)
+			}
+		} else {
+			compiledBundle = *precompiled
 		}
+		bundle := compiledBundle.Bundle
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)
 		if err != nil {
 			return err
@@ -113,7 +119,7 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 			return err
 		}
 
-		if err := s.executeResolution(ctx, r, az, caller, p, scope, res, cur, cur.SchemaRevision+1); err != nil {
+		if err := s.executeResolution(ctx, r, az, caller, p, scope, res, cur, compiledBundle, cur.SchemaRevision+1); err != nil {
 			return err
 		}
 		// § 151 schema-revision rate: charged only for a non-empty plan (the
@@ -194,10 +200,11 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 // An already-applied or expired plan re-scans nothing: the write transaction
 // yields the proper conflict, and blocking a plan that cannot apply would emit
 // spurious events.
-func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope domain.Scope, planID string, acks []string) ([]overrideAck, error) {
+func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope domain.Scope, planID string, acks []string) (*definitions.CompiledBundle, []overrideAck, error) {
 	if s.Scan == nil {
-		return nil, nil // scanning off (pre-#74 test); a booted server always wires it
+		return nil, nil, nil // scanning off (pre-#74 test); a booted server always wires it
 	}
+	var compiled *definitions.CompiledBundle
 	var overrides []overrideAck
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, s.now())
@@ -215,14 +222,15 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 		if plan.Applied || !s.now().Before(plan.ExpiresAt) {
 			return nil // the write transaction produces the applied/expired conflict
 		}
-		if plan.ScanSnapshot == s.Scan.SnapshotVersion() {
-			return nil // no skew: a same-version apply adds no second scan
-		}
-		bundle, err := definitions.Parse([]byte(plan.Bundle))
+		parsed, err := definitions.ParseCompiled([]byte(plan.Bundle))
 		if err != nil {
 			return fmt.Errorf("service: plan %s: stored bundle unreadable: %w", planID, err)
 		}
-		res, err := scanDeclaration(ctx, s.Keyring, s.Scan, bundleLeaves(bundle), newAckSet(acks), s.now(), ingressApply)
+		compiled = &parsed
+		if plan.ScanSnapshot == s.Scan.SnapshotVersion() {
+			return nil // no skew: a same-version apply adds no second scan
+		}
+		res, err := scanDeclaration(ctx, s.Keyring, s.Scan, bundleLeaves(parsed.Bundle), newAckSet(acks), s.now(), ingressApply)
 		if err != nil {
 			return err
 		}
@@ -240,9 +248,9 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return overrides, nil
+	return compiled, overrides, nil
 }
 
 // recheckPins refuses the apply if the file digest or any pinned revision moved
@@ -439,7 +447,8 @@ func protectedSetGrew(pinned, current []string) bool {
 // and the two-phase rename resolve swaps, and key creates/updates resolve their
 // group and presence references against the final topology.
 func (s *Definitions) executeResolution(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity,
-	p authz.Proof, scope domain.Scope, res definitions.Resolution, cur definitions.CurrentState, finalRevision int64) error {
+	p authz.Proof, scope domain.Scope, res definitions.Resolution, cur definitions.CurrentState,
+	compiledBundle definitions.CompiledBundle, finalRevision int64) error {
 	now := s.now()
 
 	// 1. Key deletes: clear the key's live values (so the foreign key admits the
@@ -587,12 +596,20 @@ func (s *Definitions) executeResolution(ctx context.Context, r store.Repos, az *
 	// 8. Key creates and updates, resolving group and presence names to the
 	// final topology's ids.
 	for _, k := range res.KeyCreates {
-		if err := s.createKey(ctx, r, caller, p, k, envIDByName, groupIDByName); err != nil {
+		compiled, ok := compiledBundle.CompiledDeclaration(k.Name)
+		if !ok {
+			return fmt.Errorf("service: compiled declaration missing for key %q", k.Name)
+		}
+		if err := s.createKey(ctx, r, caller, p, k, compiled, envIDByName, groupIDByName); err != nil {
 			return err
 		}
 	}
 	for _, upd := range res.KeyUpdates {
-		if err := s.updateKey(ctx, r, caller, p, upd, envIDByName, groupIDByName, finalRevision); err != nil {
+		compiled, ok := compiledBundle.CompiledDeclaration(upd.Desired.Name)
+		if !ok {
+			return fmt.Errorf("service: compiled declaration missing for key %q", upd.Desired.Name)
+		}
+		if err := s.updateKey(ctx, r, caller, p, upd, compiled, envIDByName, groupIDByName, finalRevision); err != nil {
 			return err
 		}
 	}
@@ -761,15 +778,15 @@ func (s *Definitions) renameEnv(ctx context.Context, r store.Repos, az *authz.Tx
 }
 
 func (s *Definitions) createKey(ctx context.Context, r store.Repos, caller authz.Identity, p authz.Proof, k definitions.Key,
-	envIDByName, groupIDByName map[string]string) error {
+	compiled *schema.Compiled, envIDByName, groupIDByName map[string]string) error {
 	presence, err := resolvePresence(k, envIDByName)
 	if err != nil {
 		return err
 	}
-	if err := checkClassifiedDeclaration(k.Classification, k.Declaration, presence); err != nil {
+	if err := checkPresenceRules(presence); err != nil {
 		return err
 	}
-	canonical, err := schema.Canonical(k.Declaration)
+	canonical, err := compiled.Canonical()
 	if err != nil {
 		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
@@ -800,7 +817,7 @@ func (s *Definitions) createKey(ctx context.Context, r store.Repos, caller authz
 }
 
 func (s *Definitions) updateKey(ctx context.Context, r store.Repos, caller authz.Identity, p authz.Proof, upd definitions.KeyUpdate,
-	envIDByName, groupIDByName map[string]string, finalRevision int64) error {
+	compiled *schema.Compiled, envIDByName, groupIDByName map[string]string, finalRevision int64) error {
 	k := upd.Desired
 	before, err := r.Catalogue().Get(ctx, p, upd.ID)
 	if err != nil {
@@ -810,7 +827,7 @@ func (s *Definitions) updateKey(ctx context.Context, r store.Repos, caller authz
 	if err != nil {
 		return err
 	}
-	if err := checkClassifiedDeclaration(k.Classification, k.Declaration, presence); err != nil {
+	if err := checkPresenceRules(presence); err != nil {
 		return err
 	}
 	// Rename was already applied in the two-phase pass; metadata, declaration,
@@ -828,7 +845,7 @@ func (s *Definitions) updateKey(ctx context.Context, r store.Repos, caller authz
 		}
 	}
 	if upd.DeclChanged || upd.PresenceChanged {
-		canonical, err := schema.Canonical(k.Declaration)
+		canonical, err := compiled.Canonical()
 		if err != nil {
 			return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 		}

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -216,24 +216,24 @@ func checkKeySpec(spec KeySpec) error {
 	return nil
 }
 
-// checkDeclaration runs the two declaration authorities together: the rules
-// must compile, and the presence rules must be well-formed and free of the
-// statically decidable required∧forbidden conflict.
-func checkDeclaration(d schema.Declaration, p schema.PresenceRules) error {
-	if _, err := schema.Compile(d); err != nil {
-		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
+// checkClassifiedDeclaration runs the declaration and presence authorities
+// together and returns the normalized artifact boundary callers persist.
+func checkClassifiedDeclaration(classification string, d schema.Declaration, p schema.PresenceRules) (*schema.Compiled, error) {
+	compiled, err := schema.CompileClassified(schema.Classification(classification), d)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
+	if err := checkPresenceRules(p); err != nil {
+		return nil, err
+	}
+	return compiled, nil
+}
+
+func checkPresenceRules(p schema.PresenceRules) error {
 	if err := schema.CheckPresence(p.Required, p.Forbidden); err != nil {
 		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
 	return nil
-}
-
-func checkClassifiedDeclaration(classification string, d schema.Declaration, p schema.PresenceRules) error {
-	if err := schema.CheckDeclarationClassification(schema.Classification(classification), d); err != nil {
-		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
-	}
-	return checkDeclaration(d, p)
 }
 
 // keyOf converts a store row plus its presence rows into the service key.
@@ -547,10 +547,11 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	if err := checkKeySpec(spec); err != nil {
 		return Key{}, err
 	}
-	if err := checkClassifiedDeclaration(spec.Classification, spec.Declaration, spec.Presence); err != nil {
+	compiled, err := checkClassifiedDeclaration(spec.Classification, spec.Declaration, spec.Presence)
+	if err != nil {
 		return Key{}, err
 	}
-	canonical, err := schema.Canonical(spec.Declaration)
+	canonical, err := compiled.Canonical()
 	if err != nil {
 		return Key{}, fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
@@ -559,10 +560,7 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	// the JSON Schema re-encoded — so echoing the request would hand back a
 	// declaration that differs from the one a later read returns, byte for
 	// byte, on exactly the values the canonicalization exists to normalize.
-	stored, err := schema.ParseDeclaration(canonical)
-	if err != nil {
-		return Key{}, fmt.Errorf("service: canonical declaration unreadable: %w", err)
-	}
+	stored := compiled.Declaration()
 	id, err := newID("key")
 	if err != nil {
 		return Key{}, err
@@ -1061,10 +1059,11 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 		}
 
 		// Only now is the new declaration examined at all.
-		if err := checkClassifiedDeclaration(before.Classification, u.Declaration, u.Presence); err != nil {
+		compiled, err := checkClassifiedDeclaration(before.Classification, u.Declaration, u.Presence)
+		if err != nil {
 			return err
 		}
-		canonical, err := schema.Canonical(u.Declaration)
+		canonical, err := compiled.Canonical()
 		if err != nil {
 			return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 		}
@@ -1094,10 +1093,8 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 		// scanning declaration TEXT touches no stored value, so it opens no
 		// abort/success channel, and an unchanged declaration is never re-scanned
 		// (no retro-scan, ADR §6.1).
-		if stored, perr := schema.ParseDeclaration(canonical); perr == nil {
-			if err := applyDeclarationScan(ctx, r, p, az, s.Keyring, s.Scan, caller.Principal, scope, declarationLeaves(stored), newAckSet(acks), ingressEdit); err != nil {
-				return err
-			}
+		if err := applyDeclarationScan(ctx, r, p, az, s.Keyring, s.Scan, caller.Principal, scope, declarationLeaves(compiled.Declaration()), newAckSet(acks), ingressEdit); err != nil {
+			return err
 		}
 		if err := r.Catalogue().UpdateDeclaration(ctx, p, id, store.KeyDeclaration{
 			Declaration:   string(canonical),
@@ -1214,14 +1211,12 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 			// happened.
 			return fmt.Errorf("%w: the key is already classified %q", domain.ErrInvalid, classification)
 		}
-		if classification == string(schema.Secret) {
-			decl, err := schema.ParseDeclaration([]byte(before.Declaration))
-			if err != nil {
-				return fmt.Errorf("service: key %s: stored declaration unreadable: %w", id, err)
-			}
-			if err := schema.CheckDeclarationClassification(schema.Secret, decl); err != nil {
-				return fmt.Errorf("%w: key %q cannot be classified secret: %s", domain.ErrInvalid, before.Name, err)
-			}
+		decl, err := schema.ParseDeclaration([]byte(before.Declaration))
+		if err != nil {
+			return fmt.Errorf("service: key %s: stored declaration unreadable: %w", id, err)
+		}
+		if _, err := schema.CompileClassified(schema.Classification(classification), decl); err != nil {
+			return fmt.Errorf("%w: key %q cannot be classified %s: %s", domain.ErrInvalid, before.Name, classification, err)
 		}
 		if classification == string(schema.Config) {
 			// The ATTEMPT record rides the rollback-surviving settlement path;

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -341,11 +341,11 @@ func validateValue(key store.CatalogueKey, value string) error {
 	if err != nil {
 		return fmt.Errorf("service: key %s: stored declaration unreadable: %w", key.ID, err)
 	}
-	compiled, err := schema.Compile(decl)
+	compiled, err := schema.CompileClassified(schema.Classification(key.Classification), decl)
 	if err != nil {
 		return fmt.Errorf("service: key %s: stored declaration does not compile: %w", key.ID, err)
 	}
-	verdict := compiled.Validate(value, schema.Classification(key.Classification))
+	verdict := compiled.Validate(value)
 	if verdict.Valid {
 		return nil
 	}


### PR DESCRIPTION
Closes #215

## Contract and migration

- `schema.CompileClassified` is the only production declaration constructor. It owns normalization, classification compatibility, compiled validators, canonical bytes, and validation disclosure.
- `schema.Compiled` retains classification and returns deep-cloned declarations, preventing caller mutation or classification mismatch during validation.
- Definition parsing keeps raw `Bundle` wire DTOs separate from a private `CompiledBundle` sidecar. Normal and scanner-skew apply paths reuse these artifacts without compiling twice.
- Direct key writes, definition apply, stored-value validation, import suggestion primitives, and both reclassification directions now use classified artifacts.
- Bundle/declaration wire formats and canonical JSON bytes are unchanged.

## Generated outputs

- None.

## Validation

```text
go vet ./...                                                                       PASS
go test -count=1 ./internal/schema/... ./internal/definitions/... ./internal/service/... PASS
go test -count=1 ./...                                                             PASS
```

## Review

- Implemented test-first at the classified-constructor and parsed-bundle seams.
- Three review rounds completed. Spec verdict: `SOUND`; all standards and spec findings resolved before commit.
- DCO sign-off present on commit `4a1bda54656dd7b6dc42b8f466958b76d7504a5b`.