### PR TITLE
Represent account backoff as one state value

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -114,8 +114,27 @@ type Limiter struct {
 	// amplification an unknown `kid` buys is aimed at the ISSUER, so one
 	// fabricated-`kid` stream from a thousand addresses is one outbound flood.
 	issuerRefreshes map[string][]time.Time
-	failures        map[[32]byte]int
-	blocked         map[[32]byte]time.Time
+	// accounts is the per-account backoff state. One map, not a count map
+	// beside a deadline map: two maps keyed by the same value can disagree
+	// about which accounts exist, and every read, write and eviction here
+	// depends on them agreeing. A single entry makes the invariant structural.
+	accounts map[subjectKey]accountBackoff
+}
+
+// subjectKey is the irreversible bucket key for a presented account identifier.
+// Keeping the hash as a domain type prevents account state from accepting raw
+// identifiers by accident.
+type subjectKey [sha256.Size]byte
+
+// accountBackoff is one account's place on the failure curve. The key is the
+// hash of the presented identifier, never the identifier itself.
+type accountBackoff struct {
+	// failures counts consecutive failures; a success deletes the entry.
+	failures int
+	// until is the instant the delay expires. The zero value means no delay
+	// has been set yet, which is the state of every account still under the
+	// threshold.
+	until time.Time
 }
 
 // New derives the concurrency and refuses a configuration in which a single
@@ -157,8 +176,7 @@ func New(cfg Config) (*Limiter, error) {
 		ipHits:          map[string][]time.Time{},
 		metaHits:        map[string][]time.Time{},
 		issuerRefreshes: map[string][]time.Time{},
-		failures:        map[[32]byte]int{},
-		blocked:         map[[32]byte]time.Time{},
+		accounts:        map[subjectKey]accountBackoff{},
 	}
 	for range concurrency {
 		l.slots <- struct{}{}
@@ -315,11 +333,16 @@ func (l *Limiter) AccountDelay(presented string) time.Duration {
 	key := bucketKey(presented)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	until, ok := l.blocked[key]
-	if !ok {
+	return l.accountDelay(key)
+}
+
+// accountDelay reports the current delay for key. l.mu must be held.
+func (l *Limiter) accountDelay(key subjectKey) time.Duration {
+	state, ok := l.accounts[key]
+	if !ok || state.until.IsZero() {
 		return 0
 	}
-	if d := until.Sub(l.now()); d > 0 {
+	if d := state.until.Sub(l.now()); d > 0 {
 		return d
 	}
 	return 0
@@ -336,17 +359,25 @@ func (l *Limiter) RecordFailure(presented string) (crossedThreshold bool) {
 	key := bucketKey(presented)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if _, tracked := l.failures[key]; !tracked && len(l.failures) >= MaxTrackedSubjects {
+	return l.recordFailure(key)
+}
+
+// recordFailure advances key's backoff state. l.mu must be held.
+func (l *Limiter) recordFailure(key subjectKey) (crossedThreshold bool) {
+	state, tracked := l.accounts[key]
+	if !tracked && len(l.accounts) >= MaxTrackedSubjects {
 		l.evictAccounts()
 	}
-	l.failures[key]++
-	n := l.failures[key]
+	state.failures++
+	n := state.failures
 	if n <= FailuresBeforeBackoff {
+		l.accounts[key] = state
 		return false
 	}
 	delay := time.Duration(1<<min(n-FailuresBeforeBackoff-1, 16)) * time.Second
 	delay = min(delay, MaxAccountBackoff)
-	l.blocked[key] = l.now().Add(delay)
+	state.until = l.now().Add(delay)
+	l.accounts[key] = state
 	return n == FailuresBeforeBackoff+1
 }
 
@@ -355,8 +386,12 @@ func (l *Limiter) RecordSuccess(presented string) {
 	key := bucketKey(presented)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	delete(l.failures, key)
-	delete(l.blocked, key)
+	l.recordSuccess(key)
+}
+
+// recordSuccess resets key's backoff state. l.mu must be held.
+func (l *Limiter) recordSuccess(key subjectKey) {
+	delete(l.accounts, key)
 }
 
 // evictAccounts drops account buckets whose backoff has elapsed. An account
@@ -369,35 +404,38 @@ func (l *Limiter) RecordSuccess(presented string) {
 // eviction, fall back to forgetting the account whose delay expires soonest:
 // it is the one closest to being forgiven anyway, and the instance-wide
 // semaphore still bounds the actual work an admitted attempt can do.
+//
+// Both passes read the same map in the same order — an entry's count and its
+// deadline are one value, so there is no way for the sweep to drop one and
+// keep the other, and no length comparison between two maps to get backwards.
 func (l *Limiter) evictAccounts() {
 	now := l.now()
-	for k := range l.failures {
-		if until, blocked := l.blocked[k]; !blocked || !until.After(now) {
-			delete(l.failures, k)
-			delete(l.blocked, k)
+	for key, state := range l.accounts {
+		// A zero `until` is an account still under the threshold: no live
+		// delay, nothing to lose by forgetting it.
+		if !state.until.After(now) {
+			delete(l.accounts, key)
 		}
 	}
-	if len(l.failures) < MaxTrackedSubjects {
+	if len(l.accounts) < MaxTrackedSubjects {
 		return
 	}
-	var soonestKey [32]byte
+	var soonestKey subjectKey
 	var soonest time.Time
 	found := false
-	for k := range l.failures {
-		until := l.blocked[k]
-		if !found || until.Before(soonest) {
-			soonestKey, soonest, found = k, until, true
+	for key, state := range l.accounts {
+		if !found || state.until.Before(soonest) {
+			soonestKey, soonest, found = key, state.until, true
 		}
 	}
 	if found {
-		delete(l.failures, soonestKey)
-		delete(l.blocked, soonestKey)
+		delete(l.accounts, soonestKey)
 	}
 }
 
 // bucketKey hashes the presented identifier. Storing it raw would put every
 // attempted username in memory in plaintext for the process lifetime, which
 // is a log of who is being attacked that nothing needs.
-func bucketKey(presented string) [32]byte {
-	return sha256.Sum256([]byte(presented))
+func bucketKey(presented string) subjectKey {
+	return subjectKey(sha256.Sum256([]byte(presented)))
 }

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -152,57 +152,56 @@ func TestPerIPSlidingWindow(t *testing.T) {
 	rel()
 }
 
-func TestPerAccountBackoffCurve(t *testing.T) {
+func TestPerAccountBackoffTransitions(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
 	l, err := New(Config{BudgetMiB: DefaultBudgetMiB, ArgonMemoryKiB: 64 * 1024, Now: fixedClock(&now)})
 	if err != nil {
 		t.Fatal(err)
 	}
 	const who = "someone"
-	for i := range FailuresBeforeBackoff {
-		if crossed := l.RecordFailure(who); crossed {
-			t.Fatalf("threshold reported crossed at failure %d", i+1)
-		}
-		if d := l.AccountDelay(who); d != 0 {
-			t.Fatalf("delay %v before the threshold", d)
-		}
-	}
-	// Failure 6 crosses: delay = 2^(6-5) ... the ops spec's min(2^(n-5), 60).
-	if !l.RecordFailure(who) {
-		t.Fatal("crossing the threshold was not reported — no audit event would be emitted")
-	}
-	if got, want := l.AccountDelay(who), 1*time.Second; got != want {
-		t.Fatalf("first backoff %v, want %v", got, want)
-	}
-	for want := 2 * time.Second; want <= 32*time.Second; want *= 2 {
-		if l.RecordFailure(who) {
-			t.Fatal("threshold reported crossed more than once")
-		}
-		if got := l.AccountDelay(who); got != want {
-			t.Fatalf("backoff %v, want %v", got, want)
-		}
-	}
-	// The cap holds, and no hard lockout ever appears.
-	for range 20 {
-		l.RecordFailure(who)
-	}
-	if got := l.AccountDelay(who); got != MaxAccountBackoff {
-		t.Fatalf("backoff %v, want the %v cap", got, MaxAccountBackoff)
+	transitions := []struct {
+		name          string
+		advance       time.Duration
+		checkBefore   bool
+		wantBefore    time.Duration
+		failures      int
+		success       bool
+		wantCrossings int
+		wantDelay     time.Duration
+	}{
+		{name: "below threshold", failures: FailuresBeforeBackoff},
+		{name: "threshold crossing", failures: 1, wantCrossings: 1, wantDelay: time.Second},
+		{name: "exponential delay", failures: 1, wantDelay: 2 * time.Second},
+		{name: "maximum delay", failures: cappedFailures - (FailuresBeforeBackoff + 2), wantDelay: MaxAccountBackoff},
+		{name: "expiry preserves failure count", advance: MaxAccountBackoff + time.Second, checkBefore: true, failures: 1, wantDelay: MaxAccountBackoff},
+		{name: "success resets delay and count", success: true},
+		{name: "first failure after success", failures: 1},
 	}
 
-	// The delay is an absolute instant, so concurrent attempts on the account
-	// queue behind the same one rather than each serving its own.
-	now = now.Add(MaxAccountBackoff)
-	if got := l.AccountDelay(who); got != 0 {
-		t.Fatalf("delay %v after it should have elapsed", got)
-	}
-
-	l.RecordSuccess(who)
-	if got := l.AccountDelay(who); got != 0 {
-		t.Fatalf("success did not reset the curve: %v", got)
-	}
-	if crossed := l.RecordFailure(who); crossed {
-		t.Fatal("the failure count did not reset")
+	for _, transition := range transitions {
+		t.Run(transition.name, func(t *testing.T) {
+			now = now.Add(transition.advance)
+			if transition.checkBefore {
+				if got := l.AccountDelay(who); got != transition.wantBefore {
+					t.Fatalf("delay before transition %v, want %v", got, transition.wantBefore)
+				}
+			}
+			if transition.success {
+				l.RecordSuccess(who)
+			}
+			crossings := 0
+			for range transition.failures {
+				if l.RecordFailure(who) {
+					crossings++
+				}
+			}
+			if crossings != transition.wantCrossings {
+				t.Fatalf("threshold crossed %d times, want %d", crossings, transition.wantCrossings)
+			}
+			if got := l.AccountDelay(who); got != transition.wantDelay {
+				t.Fatalf("delay %v, want %v", got, transition.wantDelay)
+			}
+		})
 	}
 }
 
@@ -218,6 +217,143 @@ func TestUnknownAccountGetsABucketExactlyLikeARealOne(t *testing.T) {
 	}
 	if l.AccountDelay("definitely-not-an-account") == 0 {
 		t.Fatal("an unknown identifier got no backoff bucket, which is observable")
+	}
+}
+
+// cappedFailures drives an account far enough up the curve that its delay
+// clamps at MaxAccountBackoff: 2^(12-5-1) = 64s, over the 60s cap.
+const cappedFailures = 12
+
+func TestEvictionForgivesTheAccountClosestToForgiveness(t *testing.T) {
+	// At the bound with nothing stale, the sweep frees nothing and the
+	// fallback must forget the account whose delay expires soonest — the one
+	// closest to being forgiven anyway. Forgiving is the safe direction; the
+	// instance-wide semaphore still bounds the work an admitted attempt does.
+	now := time.Unix(1_800_000_000, 0)
+	l, err := New(Config{BudgetMiB: DefaultBudgetMiB, ArgonMemoryKiB: 64 * 1024, Now: fixedClock(&now)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range MaxTrackedSubjects - 1 {
+		who := fmt.Sprintf("long-%d", i)
+		for range cappedFailures {
+			l.RecordFailure(who)
+		}
+	}
+	const soonest = "soonest"
+	for range FailuresBeforeBackoff + 1 {
+		l.RecordFailure(soonest)
+	}
+	if got, want := l.AccountDelay(soonest), 1*time.Second; got != want {
+		t.Fatalf("setup: soonest delay %v, want %v", got, want)
+	}
+
+	// The clock has not moved, so every tracked account is live and this one
+	// new subject puts the map past its bound.
+	l.RecordFailure("newcomer")
+
+	if got := l.AccountDelay(soonest); got != 0 {
+		t.Fatalf("eviction kept the soonest-expiring account: delay %v", got)
+	}
+	// Forgiveness is total: count and delay leave together, so the account
+	// has to climb the whole curve again.
+	for i := range FailuresBeforeBackoff {
+		if l.RecordFailure(soonest) {
+			t.Fatalf("forgiven account crossed the threshold at failure %d", i+1)
+		}
+	}
+	if !l.RecordFailure(soonest) {
+		t.Fatal("forgiven account did not cross the threshold on its 6th fresh failure")
+	}
+	// Exactly one account went, and it was the right one.
+	if got, want := l.AccountDelay("long-0"), MaxAccountBackoff; got != want {
+		t.Fatalf("a longer-backoff account was evicted instead: delay %v, want %v", got, want)
+	}
+}
+
+func TestEvictionDropsStaleAccountsBeforeLiveOnes(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	l, err := New(Config{BudgetMiB: DefaultBudgetMiB, ArgonMemoryKiB: 64 * 1024, Now: fixedClock(&now)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const half = MaxTrackedSubjects / 2
+	for i := range half {
+		who := fmt.Sprintf("short-%d", i)
+		for range FailuresBeforeBackoff + 1 { // 1s of backoff
+			l.RecordFailure(who)
+		}
+	}
+	for i := range half {
+		who := fmt.Sprintf("long-%d", i)
+		for range cappedFailures { // 60s of backoff
+			l.RecordFailure(who)
+		}
+	}
+	now = now.Add(2 * time.Second) // the short half is now stale
+
+	// A new subject hits the bound. Reclaiming the stale half is enough, so
+	// no live backoff may be forgiven.
+	l.RecordFailure("newcomer")
+
+	want := MaxAccountBackoff - 2*time.Second
+	for i := range half {
+		who := fmt.Sprintf("long-%d", i)
+		if got := l.AccountDelay(who); got != want {
+			t.Fatalf("live account %s: delay %v, want %v — a live entry was evicted while stale ones remained", who, got, want)
+		}
+	}
+}
+
+func TestConcurrentAccountCallsHoldTheCurve(t *testing.T) {
+	// One mutex guards the whole account map, so interleaved calls must not
+	// tear it or lose failures. Run with -race.
+	//
+	// The clock is frozen and never advanced once the goroutines are running,
+	// so the expected delay is exact rather than a wall-clock tolerance.
+	now := time.Unix(1_800_000_000, 0)
+	l, err := New(Config{BudgetMiB: DefaultBudgetMiB, ArgonMemoryKiB: 64 * 1024, Now: fixedClock(&now)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const workers = 16
+	var wg sync.WaitGroup
+	// Each worker owns a key and drives it just past the threshold, so the
+	// end state is deterministic however the calls interleave.
+	for w := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			who := fmt.Sprintf("worker-%d", w)
+			for range FailuresBeforeBackoff + 1 {
+				l.RecordFailure(who)
+				_ = l.AccountDelay(who)
+			}
+		}()
+	}
+	// Meanwhile one contended key is failed, read and reset concurrently. Its
+	// end state is racy by construction; what must hold is that nothing panics
+	// and no reader observes a half-written entry.
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				l.RecordFailure("contended")
+				_ = l.AccountDelay("contended")
+				l.RecordSuccess("contended")
+			}
+		}()
+	}
+	wg.Wait()
+
+	for w := range workers {
+		who := fmt.Sprintf("worker-%d", w)
+		// Exactly 6 failures landed on this key: one more or one fewer moves
+		// the delay off the first rung of the curve.
+		if got, want := l.AccountDelay(who), 1*time.Second; got != want {
+			t.Fatalf("%s: delay %v, want %v — failures were lost or double-counted", who, got, want)
+		}
 	}
 }
 
@@ -241,7 +377,7 @@ func TestLimiterStateIsBounded(t *testing.T) {
 		now = now.Add(time.Second)
 	}
 	l.mu.Lock()
-	ips, accounts := len(l.ipHits), len(l.failures)
+	ips, accounts := len(l.ipHits), len(l.accounts)
 	l.mu.Unlock()
 	if ips > MaxTrackedSubjects {
 		t.Errorf("tracking %d source IPs, bound is %d", ips, MaxTrackedSubjects)


### PR DESCRIPTION
Closes #210

## Contract and migration

- Replaces the parallel per-subject failure-count and blocked-until maps with one `map[subjectKey]accountBackoff`.
- Keeps `AccountDelay`, `RecordFailure`, and `RecordSuccess` signatures and behavior unchanged.
- Preserves the exact threshold-crossing audit signal, exponential delay, 60-second cap, expiry behavior, success reset, existing mutex, and safe-forgiveness eviction direction.
- Keeps presented identifiers out of memory by retaining SHA-256 bucket keys.
- No data migration: this is process-local in-memory admission state and restarts already rebuild it.

## Changes

- Adds one structural backoff state value and lock-held transition helpers.
- Makes eviction use one map, ordering, and length source.
- Adds table-driven threshold, expiry, cap, and success transitions plus stale/live eviction and concurrency coverage.

## Generated outputs

- None.

## Validation

- `go test -count=1 ./internal/admission/` — PASS, 18 tests.
- `go test -race -count=1 ./internal/admission/` — PASS, 18 tests.
- `go vet ./internal/admission/` — PASS.
- `go vet ./...` — PASS.
- `go test -count=1 ./...` — 2,905 passed and 214 skipped; unrelated `internal/isolation` hit the local 10-minute package timeout under concurrent machine load. Isolation-only rerun completed 1,068 tests with 200 skips before the same timeout. No admission test failed.

## Review

Three-round blocking review completed after fixes:

- Standards: CLEAN.
- Spec: CLEAN.