### PR TITLE
fix(app): guard boot resources until ownership transfer

### DIFF
--- a/docs/handoff/209-boot-resource-guard.md
+++ b/docs/handoff/209-boot-resource-guard.md
@@ -1,0 +1,65 @@
+# Handoff: #209 boot resource ownership guard
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/209. Implementation is based
+on `origin/main` commit `d31919a877732abfa1293fe2784462aeb9798b22`.
+
+## Implemented locally
+
+- `internal/app/app.go` now arms a private `bootGuard` before startup resource
+  acquisition, registers database and listener cleanup immediately, releases
+  them in reverse acquisition order on every error, and disarms only after the
+  complete `Server` exists.
+- Cleanup is idempotent. Cleanup errors are logged without replacing the
+  primary boot error. Successful boot leaves `Server.Close` as the sole
+  steady-state owner.
+- A narrow private `bootResources` seam covers only database, listener, and
+  outbound-directory-client construction/cleanup. Service wiring remains local
+  to boot; no general dependency-injection container was added.
+- `internal/app/boot_cleanup_test.go` injects failures before database
+  acquisition, after database acquisition, and after listener acquisition. It
+  asserts exact close counts, listener-before-database order, primary-error
+  preservation, idempotence, continued cleanup after a close error, and
+  successful ownership transfer.
+
+## Verification
+
+```text
+rtk go test -count=1 ./internal/app/
+Go test: 32 passed in 1 package
+
+rtk go test -race -count=1 ./internal/app/
+Go test: 32 passed in 1 package
+
+rtk go test -count=1 ./...
+Go test: 2913 passed in 56 packages
+
+go list ./... | grep -v '/internal/isolation$' | xargs go test -race -count=1
+All selected packages passed, including internal/app, internal/lint,
+internal/service, and internal/store.
+
+rtk go vet ./internal/app/
+rtk go build ./...
+rtk git diff --check
+All succeeded.
+```
+
+## Review
+
+- Matt Pocock Standards axis: `CLEAN`.
+- Matt Pocock Spec axis: initial review found early disarm and missing
+  Boot-level close assertions; both were fixed; round 2: `CLEAN`.
+- Native Codex (`gpt-5.6-sol`, high) found no blocking issue: resource
+  ownership transfer and cleanup were reported consistent and correctly
+  ordered. Its sandbox could not bind local sockets, so parent-run socket and
+  race evidence above is authoritative.
+
+## Delivery state
+
+Local implementation only. No push, pull request, merge, CI, or deployment is
+claimed. PR description must reference `Closes #209`, state that no migration
+or generated output changed, and include the verification results above.
+
+## Suggested skills
+
+- `code-review` for any follow-up diff.
+- `cross-model-review` if Claude-authored code changes.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -188,6 +188,71 @@ func (s rootKeySource) Next(context.Context) ([]byte, error) {
 	return crypto.ReadRootKey(s.cfg.NewRootKeyFile, "")
 }
 
+// bootGuard tracks the resources Boot acquires so that any error after
+// acquisition releases exactly what was acquired, in reverse order. It is
+// armed by default — Boot defers cleanup so it runs on every return — and
+// disarmed once ownership transfers to the Server, which then becomes the sole
+// steady-state owner. Arming by default is the point: a future post-listen
+// constructor that forgets its cleanup on an error return is still released by
+// the deferred cleanup, so no error path can bypass it.
+type bootGuard struct {
+	closers []func() error
+	log     *slog.Logger
+}
+
+// bootResources is the narrow seam for resources whose acquisition can leave
+// Boot with something to release. Service construction and wiring stay local
+// to boot; tests replace only these constructors and cleanup functions so they
+// can inject failures at the ownership boundaries and count releases.
+type bootResources struct {
+	openDatabase       func(context.Context, store.Config) (*store.DB, error)
+	closeDatabase      func(*store.DB) error
+	listen             func(string, string) (net.Listener, error)
+	closeListener      func(net.Listener) error
+	newDirectoryClient func(remotefetch.Config) (*remotefetch.Client, error)
+}
+
+func defaultBootResources() bootResources {
+	return bootResources{
+		openDatabase: store.Open,
+		closeDatabase: func(db *store.DB) error {
+			return db.Close()
+		},
+		listen: net.Listen,
+		closeListener: func(ln net.Listener) error {
+			return ln.Close()
+		},
+		newDirectoryClient: remotefetch.New,
+	}
+}
+
+// add registers a resource's release in acquisition order. cleanup runs these
+// in reverse, so registering the database before the listener yields the
+// listener-before-database shutdown order Server.Close also uses.
+func (g *bootGuard) add(closer func() error) {
+	g.closers = append(g.closers, closer)
+}
+
+// cleanup releases every still-registered resource in reverse acquisition
+// order. It is idempotent (clears the list) and never returns an error: a
+// cleanup failure is logged, never allowed to mask the primary boot error that
+// triggered it.
+func (g *bootGuard) cleanup() {
+	for i := len(g.closers) - 1; i >= 0; i-- {
+		if err := g.closers[i](); err != nil {
+			g.log.Warn("boot cleanup: releasing an acquired resource failed", "err", err)
+		}
+	}
+	g.closers = nil
+}
+
+// disarm transfers ownership to the Server: the deferred cleanup becomes a
+// no-op. Called once, immediately before Boot's success return, with nothing
+// between it and the return that can fail.
+func (g *bootGuard) disarm() {
+	g.closers = nil
+}
+
 // Boot runs the fail-closed startup sequence: process hardening before any
 // key material exists, migrations (auto-apply by default; with auto-apply
 // disabled a pending migration state refuses to serve), datastore open with
@@ -196,10 +261,20 @@ func (s rootKeySource) Next(context.Context) ([]byte, error) {
 // does this), then the listener. Any error means the process must exit
 // without serving.
 func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, error) {
+	return boot(ctx, cfg, log, defaultBootResources())
+}
+
+func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources bootResources) (*Server, error) {
 	if err := crypto.HardenProcess(); err != nil {
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
 	sc := storeConfig(cfg)
+
+	// Every resource acquired below has one temporary owner — this guard —
+	// until the Server takes over. Armed by default; disarmed only at the
+	// ownership transfer immediately before the success return.
+	guard := &bootGuard{log: log}
+	defer guard.cleanup()
 
 	var migrationRecord preMigrationRecord
 	if cfg.AutoMigrate {
@@ -224,16 +299,17 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
 
-	db, err := store.Open(ctx, sc)
+	db, err := resources.openDatabase(ctx, sc)
 	if err != nil {
 		crypto.Zero(root)
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
+	// Registered immediately after Open so every later error path releases it.
+	guard.add(func() error { return resources.closeDatabase(db) })
 
 	// LoadKeyring consumes root: it is zeroed before this returns.
 	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
 	if kr.RootRotationPending() {
@@ -248,13 +324,11 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 	// is a scanner that silently is not one).
 	ruleset, err := scanning.Load()
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: refusing to serve: secret-scanning ruleset: %w", err)
 	}
 
 	kdf, limiter, err := AuthComponents(cfg)
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
 	// The advisory channel is in-process fan-out: one per server, wired into
@@ -272,21 +346,21 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 	// origin that cannot yield a valid relying party is a boot refusal, not a
 	// first-ceremony surprise.
 	if err := authSvc.ConfigureWebAuthnRP(); err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: refusing to serve: webauthn relying party: %w", err)
 	}
 
 	proxies, err := parseCIDRs(cfg.TrustedProxyCIDRs)
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
 	}
 
-	ln, err := net.Listen("tcp", cfg.Listen)
+	ln, err := resources.listen("tcp", cfg.Listen)
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("boot: listen %s: %w", cfg.Listen, err)
 	}
+	// Registered immediately after Listen so every later error path releases
+	// it, and — being registered after the database — before the database.
+	guard.add(func() error { return resources.closeListener(ln) })
 
 	federation := &service.Federation{
 		DB: db, Auth: authSvc, Admission: limiter,
@@ -308,7 +382,7 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 		}
 		fetchCfg.Proxy = proxy
 	}
-	fetcher, err := remotefetch.New(fetchCfg)
+	fetcher, err := resources.newDirectoryClient(fetchCfg)
 	if err != nil {
 		return nil, fmt.Errorf("boot: outbound directory client: %w", err)
 	}
@@ -405,7 +479,9 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 
 	log.Info("boot complete", "engine", sc.Engine, "addr", ln.Addr().String(), "dev", cfg.Dev,
 		"argon2_memory_kib", cfg.Argon2MemoryKiB, "auth_concurrency", limiter.Concurrency())
-	return &Server{
+	// Construct the complete owner before disarming: future fallible work added
+	// to construction stays inside the guard's protection.
+	srv := &Server{
 		Addr:    ln.Addr().String(),
 		db:      db,
 		keyring: kr,
@@ -439,7 +515,11 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 			},
 		}}},
 		adapterWorker: adapterWorker,
-	}, nil
+	}
+	// Ownership transfers only after the Server is complete. Nothing remains
+	// between disarm and return, so Server.Close is now the sole owner.
+	guard.disarm()
+	return srv, nil
 }
 
 // serviceBudget keeps production policy fail-closed even when a caller builds

--- a/internal/app/boot_cleanup_test.go
+++ b/internal/app/boot_cleanup_test.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net"
+	"slices"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+type bootResourceRecord struct {
+	database       *store.DB
+	listener       net.Listener
+	databaseCloses int
+	listenerCloses int
+	closeOrder     []string
+}
+
+func recordingBootResources(record *bootResourceRecord) bootResources {
+	resources := defaultBootResources()
+	resources.openDatabase = func(ctx context.Context, cfg store.Config) (*store.DB, error) {
+		db, err := store.Open(ctx, cfg)
+		record.database = db
+		return db, err
+	}
+	resources.closeDatabase = func(db *store.DB) error {
+		record.databaseCloses++
+		record.closeOrder = append(record.closeOrder, "database")
+		return db.Close()
+	}
+	resources.listen = func(network, address string) (net.Listener, error) {
+		ln, err := net.Listen(network, address)
+		record.listener = ln
+		return ln, err
+	}
+	resources.closeListener = func(ln net.Listener) error {
+		record.listenerCloses++
+		record.closeOrder = append(record.closeOrder, "listener")
+		return ln.Close()
+	}
+	return resources
+}
+
+func TestBootResourceOwnershipOnFailure(t *testing.T) {
+	injected := errors.New("injected constructor failure")
+
+	t.Run("before database acquisition closes nothing", func(t *testing.T) {
+		record := &bootResourceRecord{}
+		resources := recordingBootResources(record)
+		resources.openDatabase = func(context.Context, store.Config) (*store.DB, error) {
+			return nil, injected
+		}
+
+		_, err := boot(t.Context(), devConfig(t), testLogger(), resources)
+		if !errors.Is(err, injected) {
+			t.Fatalf("boot error = %v, want injected database-open error", err)
+		}
+		if record.databaseCloses != 0 || record.listenerCloses != 0 {
+			t.Fatalf("close counts = database %d, listener %d; want 0, 0", record.databaseCloses, record.listenerCloses)
+		}
+	})
+
+	t.Run("after database acquisition closes only database", func(t *testing.T) {
+		record := &bootResourceRecord{}
+		resources := recordingBootResources(record)
+		resources.listen = func(string, string) (net.Listener, error) {
+			return nil, injected
+		}
+
+		_, err := boot(t.Context(), devConfig(t), testLogger(), resources)
+		if !errors.Is(err, injected) {
+			t.Fatalf("boot error = %v, want injected listener error", err)
+		}
+		if record.databaseCloses != 1 || record.listenerCloses != 0 {
+			t.Fatalf("close counts = database %d, listener %d; want 1, 0", record.databaseCloses, record.listenerCloses)
+		}
+		if want := []string{"database"}; !slices.Equal(record.closeOrder, want) {
+			t.Fatalf("close order = %v, want %v", record.closeOrder, want)
+		}
+	})
+
+	t.Run("after listener acquisition closes listener then database", func(t *testing.T) {
+		record := &bootResourceRecord{}
+		resources := recordingBootResources(record)
+		resources.newDirectoryClient = func(remotefetch.Config) (*remotefetch.Client, error) {
+			return nil, injected
+		}
+
+		_, err := boot(t.Context(), devConfig(t), testLogger(), resources)
+		if !errors.Is(err, injected) {
+			t.Fatalf("boot error = %v, want injected directory-client error", err)
+		}
+		if record.databaseCloses != 1 || record.listenerCloses != 1 {
+			t.Fatalf("close counts = database %d, listener %d; want 1, 1", record.databaseCloses, record.listenerCloses)
+		}
+		if want := []string{"listener", "database"}; !slices.Equal(record.closeOrder, want) {
+			t.Fatalf("close order = %v, want %v", record.closeOrder, want)
+		}
+	})
+}
+
+func TestBootSuccessTransfersResourceOwnershipToServer(t *testing.T) {
+	record := &bootResourceRecord{}
+	srv, err := boot(t.Context(), devConfig(t), testLogger(), recordingBootResources(record))
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = srv.Close()
+		}
+	})
+
+	if record.databaseCloses != 0 || record.listenerCloses != 0 {
+		t.Fatalf("guard close counts after success = database %d, listener %d; want 0, 0", record.databaseCloses, record.listenerCloses)
+	}
+	if err := record.database.Ping(t.Context()); err != nil {
+		t.Fatalf("database was closed before Server ownership: %v", err)
+	}
+	if competing, err := net.Listen("tcp", srv.Addr); err == nil {
+		competing.Close()
+		t.Fatal("listener was closed before Server ownership")
+	}
+
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Server.Close: %v", err)
+	}
+	closed = true
+	if err := record.database.Ping(t.Context()); err == nil {
+		t.Fatal("database remained open after Server.Close")
+	}
+	rebound, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		t.Fatalf("listener remained open after Server.Close: %v", err)
+	}
+	rebound.Close()
+}
+
+func TestBootGuard(t *testing.T) {
+	t.Run("cleans in reverse registration order", func(t *testing.T) {
+		var order []string
+		g := &bootGuard{log: testLogger()}
+		g.add(func() error { order = append(order, "db"); return nil })
+		g.add(func() error { order = append(order, "ln"); return nil })
+		g.cleanup()
+		if want := []string{"ln", "db"}; !slices.Equal(order, want) {
+			t.Fatalf("cleanup order = %v, want %v (listener before database)", order, want)
+		}
+	})
+
+	t.Run("cleanup is idempotent", func(t *testing.T) {
+		var n int
+		g := &bootGuard{log: testLogger()}
+		g.add(func() error { n++; return nil })
+		g.cleanup()
+		g.cleanup()
+		if n != 1 {
+			t.Fatalf("closer ran %d times across two cleanups, want 1", n)
+		}
+	})
+
+	t.Run("disarm prevents cleanup", func(t *testing.T) {
+		var n int
+		g := &bootGuard{log: testLogger()}
+		g.add(func() error { n++; return nil })
+		g.disarm()
+		g.cleanup()
+		if n != 0 {
+			t.Fatalf("disarmed guard ran %d closers, want 0", n)
+		}
+	})
+
+	t.Run("a failing closer does not stop the rest", func(t *testing.T) {
+		var closed int
+		g := &bootGuard{log: testLogger()}
+		g.add(func() error { closed++; return nil })
+		g.add(func() error { closed++; return errors.New("boom") })
+		g.cleanup()
+		if closed != 2 {
+			t.Fatalf("closed %d resources, want 2 (a cleanup failure must not abort the rest)", closed)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add a private reverse-order boot acquisition guard for database and listener ownership
- keep cleanup armed across every boot error and disarm only after the complete Server exists
- cover pre-database, post-database, post-listener, cleanup-order, idempotence, and successful-transfer behavior
- add an issue-keyed implementation handoff

## Contract and migration

No API, datastore migration, or generated output changed. `Server.Close` remains the sole steady-state resource owner after successful boot.

## Validation

- `go test -count=1 ./internal/app/` — 32 passed
- `go test -race -count=1 ./internal/app/` — 32 passed
- `go test -count=1 ./...` — 2,913 passed across 56 packages
- full CI race package set excluding scheduled `internal/isolation` — passed
- `go vet ./internal/app/` — passed
- `go build ./...` — passed
- Standards review — CLEAN
- Spec review — CLEAN
- native Codex high review — zero findings

Closes #209