### PR TITLE
feat(api): represent grant mutation outcomes as a closed result

### DIFF
--- a/api/apigen/apigen.gen.go
+++ b/api/apigen/apigen.gen.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	api "github.com/Hikyo-Org/hikyo/api"
 	"github.com/go-chi/chi/v5"
 	"github.com/oapi-codegen/runtime"
 )
@@ -3464,14 +3465,11 @@ type GrantResult struct {
 	// the contract additive as later tickets register their atoms.
 	Capability Capability `json:"capability"`
 
-	// Created False when an existing row was deduplicated and this call only attached an origin.
-	Created bool `json:"created"`
-
 	// GrantId A prefixed UUIDv7, e.g. `org_0198…`.
 	GrantId ID `json:"grant_id"`
 
-	// OriginAdded False when the caller's own origin already held the row - a genuinely idempotent repeat.
-	OriginAdded bool `json:"origin_added"`
+	// Outcome The only possible mutation results: a new grant row, a new origin on an existing row, or an idempotent repeat that changed nothing.
+	Outcome api.GrantOutcome `json:"outcome"`
 }
 
 // GrantResultList defines model for GrantResultList.

--- a/api/grant_outcome.go
+++ b/api/grant_outcome.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type grantOutcomeValue uint8
+
+const (
+	grantOutcomeInvalid grantOutcomeValue = iota
+	grantOutcomeCreated
+	grantOutcomeOriginAdded
+	grantOutcomeUnchanged
+)
+
+// GrantOutcome is the closed result of a grant mutation. Its zero value is
+// invalid so forgotten initialization fails loudly. Callers can obtain valid
+// values only through the constructors below, and JSON decoding rejects every
+// other wire string.
+type GrantOutcome struct {
+	value grantOutcomeValue
+}
+
+func GrantOutcomeCreated() GrantOutcome {
+	return GrantOutcome{value: grantOutcomeCreated}
+}
+
+func GrantOutcomeOriginAdded() GrantOutcome {
+	return GrantOutcome{value: grantOutcomeOriginAdded}
+}
+
+func GrantOutcomeUnchanged() GrantOutcome {
+	return GrantOutcome{value: grantOutcomeUnchanged}
+}
+
+func (o GrantOutcome) Valid() bool {
+	switch o.value {
+	case grantOutcomeCreated, grantOutcomeOriginAdded, grantOutcomeUnchanged:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o GrantOutcome) String() string {
+	switch o.value {
+	case grantOutcomeCreated:
+		return "created"
+	case grantOutcomeOriginAdded:
+		return "origin_added"
+	case grantOutcomeUnchanged:
+		return "unchanged"
+	default:
+		panic(fmt.Sprintf("invalid grant outcome value %d", o.value))
+	}
+}
+
+func ParseGrantOutcome(value string) (GrantOutcome, error) {
+	switch value {
+	case "created":
+		return GrantOutcomeCreated(), nil
+	case "origin_added":
+		return GrantOutcomeOriginAdded(), nil
+	case "unchanged":
+		return GrantOutcomeUnchanged(), nil
+	default:
+		return GrantOutcome{}, fmt.Errorf("unknown grant outcome %q", value)
+	}
+}
+
+func (o GrantOutcome) MarshalJSON() ([]byte, error) {
+	if !o.Valid() {
+		return nil, fmt.Errorf("invalid grant outcome value %d", o.value)
+	}
+	return json.Marshal(o.String())
+}
+
+func (o *GrantOutcome) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode grant outcome: %w", err)
+	}
+	parsed, err := ParseGrantOutcome(value)
+	if err != nil {
+		return err
+	}
+	*o = parsed
+	return nil
+}

--- a/api/grant_outcome_test.go
+++ b/api/grant_outcome_test.go
@@ -1,0 +1,53 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+)
+
+func TestGrantOutcomeJSONIsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		outcome api.GrantOutcome
+		wire    string
+	}{
+		{outcome: api.GrantOutcomeCreated(), wire: `"created"`},
+		{outcome: api.GrantOutcomeOriginAdded(), wire: `"origin_added"`},
+		{outcome: api.GrantOutcomeUnchanged(), wire: `"unchanged"`},
+	} {
+		t.Run(tc.outcome.String(), func(t *testing.T) {
+			encoded, err := json.Marshal(tc.outcome)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(encoded) != tc.wire {
+				t.Fatalf("wire outcome = %s, want %s", encoded, tc.wire)
+			}
+			var decoded api.GrantOutcome
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if decoded != tc.outcome {
+				t.Fatalf("decoded outcome = %q, want %q", decoded, tc.outcome)
+			}
+		})
+	}
+}
+
+func TestGrantOutcomeZeroValueIsInvalid(t *testing.T) {
+	var outcome api.GrantOutcome
+	if outcome.Valid() {
+		t.Fatal("zero outcome must be invalid")
+	}
+	if _, err := json.Marshal(outcome); err == nil {
+		t.Fatal("zero outcome must fail JSON encoding")
+	}
+}
+
+func TestGrantOutcomeJSONRejectsUnknownValue(t *testing.T) {
+	var outcome api.GrantOutcome
+	if err := json.Unmarshal([]byte(`"partly_created"`), &outcome); err == nil {
+		t.Fatal("unknown grant outcome decoded")
+	}
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1630,7 +1630,7 @@ paths:
               $ref: "#/components/schemas/CreateGrantRequest"
       responses:
         "200":
-          description: The grant, created or joined by a second origin.
+          description: The grant mutation result, including an idempotent repeat.
           content:
             application/json:
               schema:
@@ -1778,7 +1778,7 @@ paths:
               $ref: "#/components/schemas/CreateGrantRequest"
       responses:
         "200":
-          description: The grant, created or joined by a second origin.
+          description: The grant mutation result, including an idempotent repeat.
           content:
             application/json:
               schema:
@@ -1919,7 +1919,7 @@ paths:
               $ref: "#/components/schemas/CreateGrantRequest"
       responses:
         "200":
-          description: The grant, created or joined by a second origin.
+          description: The grant mutation result, including an idempotent repeat.
           content:
             application/json:
               schema:
@@ -2034,7 +2034,7 @@ paths:
               $ref: "#/components/schemas/CreateGrantRequest"
       responses:
         "200":
-          description: The grant, created or joined by a second origin.
+          description: The grant mutation result, including an idempotent repeat.
           content:
             application/json:
               schema:
@@ -12485,18 +12485,22 @@ components:
     GrantResult:
       type: object
       additionalProperties: false
-      required: [grant_id, capability, created, origin_added]
+      required: [grant_id, capability, outcome]
       properties:
         grant_id:
           $ref: "#/components/schemas/ID"
         capability:
           $ref: "#/components/schemas/Capability"
-        created:
-          type: boolean
-          description: False when an existing row was deduplicated and this call only attached an origin.
-        origin_added:
-          type: boolean
-          description: False when the caller's own origin already held the row - a genuinely idempotent repeat.
+        outcome:
+          type: string
+          enum: [created, origin_added, unchanged]
+          x-go-type: api.GrantOutcome
+          x-go-type-import:
+            path: github.com/Hikyo-Org/hikyo/api
+            name: api
+          description: >
+            The only possible mutation results: a new grant row, a new origin
+            on an existing row, or an idempotent repeat that changed nothing.
 
     GrantResultList:
       type: object

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -49,6 +49,41 @@ func TestAdapterTargetSchemaCarriesPendingConflictArtifacts(t *testing.T) {
 	}
 }
 
+func TestGrantResultUsesClosedOutcome(t *testing.T) {
+	doc, err := api.Doc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := doc.Components.Schemas["GrantResult"].Value
+	if schema == nil {
+		t.Fatal("GrantResult schema is missing")
+	}
+	if !slices.Contains(schema.Required, "outcome") {
+		t.Fatalf("GrantResult required fields = %v, want outcome", schema.Required)
+	}
+	for _, legacy := range []string{"created", "origin_added"} {
+		if _, exists := schema.Properties[legacy]; exists {
+			t.Errorf("GrantResult still exposes legacy boolean %q", legacy)
+		}
+	}
+	outcome := schema.Properties["outcome"]
+	if outcome == nil || outcome.Value == nil {
+		t.Fatal("GrantResult outcome schema is missing")
+	}
+	got := make([]string, 0, len(outcome.Value.Enum))
+	for _, value := range outcome.Value.Enum {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("GrantResult outcome enum contains non-string %T", value)
+		}
+		got = append(got, text)
+	}
+	want := []string{"created", "origin_added", "unchanged"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("GrantResult outcomes = %v, want %v", got, want)
+	}
+}
+
 func TestCollectedRevisionOperationsDeclareConflict(t *testing.T) {
 	doc, err := api.Doc()
 	if err != nil {

--- a/clients/ts/src/contract.test.ts
+++ b/clients/ts/src/contract.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { zCreateOrgRequest, zErrorCode, zMeta, zProtocolCapability } from './generated/zod.gen.ts';
+import {
+  zCreateOrgRequest,
+  zErrorCode,
+  zGrantResult,
+  zMeta,
+  zProtocolCapability,
+} from './generated/zod.gen.ts';
 
 // The TypeScript half of the bound 3.1 profile (system-architecture ADR,
 // 2026-08-07 amendment): the round-trip fixtures must run through the Zod
@@ -38,6 +44,27 @@ test('a closed enum refuses an unknown value', () => {
   // a contract this client does not have.
   assert.equal(zErrorCode.parse('not_found'), 'not_found');
   assert.throws(() => zErrorCode.parse('teapot'));
+});
+
+test('grant mutations expose exactly one closed outcome', () => {
+  const grantId = 'grt_0198b727-19e3-7c31-a2df-904b89224e4c';
+  for (const outcome of ['created', 'origin_added', 'unchanged']) {
+    assert.equal(
+      zGrantResult.parse({ grant_id: grantId, capability: 'read', outcome }).outcome,
+      outcome,
+    );
+  }
+  assert.throws(() =>
+    zGrantResult.parse({ grant_id: grantId, capability: 'read', outcome: 'partly_created' }),
+  );
+  assert.throws(() =>
+    zGrantResult.parse({
+      grant_id: grantId,
+      capability: 'read',
+      created: false,
+      origin_added: true,
+    }),
+  );
 });
 
 test('a request missing a required member is refused before it is sent', () => {

--- a/clients/ts/src/generated/types.gen.ts
+++ b/clients/ts/src/generated/types.gen.ts
@@ -2215,13 +2215,10 @@ export type GrantResult = {
     grant_id: Id;
     capability: Capability;
     /**
-     * False when an existing row was deduplicated and this call only attached an origin.
+     * The only possible mutation results: a new grant row, a new origin on an existing row, or an idempotent repeat that changed nothing.
+     *
      */
-    created: boolean;
-    /**
-     * False when the caller's own origin already held the row - a genuinely idempotent repeat.
-     */
-    origin_added: boolean;
+    outcome: 'created' | 'origin_added' | 'unchanged';
 };
 
 export type GrantResultList = {
@@ -6483,7 +6480,7 @@ export type CreateInstanceGrantError = CreateInstanceGrantErrors[keyof CreateIns
 
 export type CreateInstanceGrantResponses = {
     /**
-     * The grant, created or joined by a second origin.
+     * The grant mutation result, including an idempotent repeat.
      */
     200: GrantResult;
 };
@@ -6781,7 +6778,7 @@ export type CreateOrgGrantError = CreateOrgGrantErrors[keyof CreateOrgGrantError
 
 export type CreateOrgGrantResponses = {
     /**
-     * The grant, created or joined by a second origin.
+     * The grant mutation result, including an idempotent repeat.
      */
     200: GrantResult;
 };
@@ -7096,7 +7093,7 @@ export type CreateProjectGrantError = CreateProjectGrantErrors[keyof CreateProje
 
 export type CreateProjectGrantResponses = {
     /**
-     * The grant, created or joined by a second origin.
+     * The grant mutation result, including an idempotent repeat.
      */
     200: GrantResult;
 };
@@ -7353,7 +7350,7 @@ export type CreateEnvGrantError = CreateEnvGrantErrors[keyof CreateEnvGrantError
 
 export type CreateEnvGrantResponses = {
     /**
-     * The grant, created or joined by a second origin.
+     * The grant mutation result, including an idempotent repeat.
      */
     200: GrantResult;
 };

--- a/clients/ts/src/generated/zod.gen.ts
+++ b/clients/ts/src/generated/zod.gen.ts
@@ -1260,8 +1260,11 @@ export const zGrantList = z.object({
 export const zGrantResult = z.object({
     grant_id: zId,
     capability: zCapability,
-    created: z.boolean(),
-    origin_added: z.boolean()
+    outcome: z.enum([
+        'created',
+        'origin_added',
+        'unchanged'
+    ])
 });
 
 export const zGrantResultList = z.object({
@@ -3236,7 +3239,7 @@ export const zListInstanceGrantsResponse = zGrantList;
 export const zCreateInstanceGrantBody = zCreateGrantRequest;
 
 /**
- * The grant, created or joined by a second origin.
+ * The grant mutation result, including an idempotent repeat.
  */
 export const zCreateInstanceGrantResponse = zGrantResult;
 
@@ -3277,7 +3280,7 @@ export const zCreateOrgGrantPath = z.object({
 });
 
 /**
- * The grant, created or joined by a second origin.
+ * The grant mutation result, including an idempotent repeat.
  */
 export const zCreateOrgGrantResponse = zGrantResult;
 
@@ -3325,7 +3328,7 @@ export const zCreateProjectGrantPath = z.object({
 });
 
 /**
- * The grant, created or joined by a second origin.
+ * The grant mutation result, including an idempotent repeat.
  */
 export const zCreateProjectGrantResponse = zGrantResult;
 
@@ -3366,7 +3369,7 @@ export const zCreateEnvGrantPath = z.object({
 });
 
 /**
- * The grant, created or joined by a second origin.
+ * The grant mutation result, including an idempotent repeat.
  */
 export const zCreateEnvGrantResponse = zGrantResult;
 

--- a/docs/handoff/217-grant-mutation-outcomes.md
+++ b/docs/handoff/217-grant-mutation-outcomes.md
@@ -1,0 +1,49 @@
+# #217 — Closed grant mutation outcomes
+
+Status: implemented on the PR #274 stack before the #79 API freeze.
+
+## Contract
+
+Every grant mutation now returns one required `outcome` value alongside
+`grant_id` and `capability`:
+
+- `created`: a new grant row and origin were written;
+- `origin_added`: an origin joined an existing grant row;
+- `unchanged`: the same origin already held the existing row.
+
+The former `created` and `origin_added` booleans are removed. This makes the
+invalid `created: true, origin_added: false` combination unrepresentable in
+the OpenAPI contract and generated TypeScript client. Go uses a sealed value
+whose representation is private; only the three constructors produce valid
+values, while the zero value and unknown JSON strings fail loudly. Every
+service, server, operator, and CLI branch handles the three outcomes
+exhaustively.
+
+## Compatibility and migration
+
+This is an intentional pre-1.0 response-shape break. Issue #79 remains open,
+so the API is not frozen and no compatibility decoding window is required.
+Servers, the Go model, the generated TypeScript/Zod client, CLI, and SPA land
+together. External `0.x` consumers must regenerate from `api/openapi.yaml` and
+replace Boolean-combination checks with an exhaustive `outcome` branch.
+
+No database migration or persisted-data rewrite is needed. Grant rows, grant
+origins, audit event types, template counters, session invalidation, and the
+break-glass `grant_created` audit fact keep their existing semantics.
+
+## Rendering
+
+The network CLI prints `created`, `origin added`, or `unchanged`; its decoder
+refuses an unknown server value. The local break-glass command does the same.
+SPA member, instance-admin, and machine-access success notices name each
+returned outcome. Partial-failure notices retain those outcomes too, so an
+idempotent repeat is never described as a newly created grant.
+
+## Validation
+
+- service outcome and audit regressions on SQLite and PostgreSQL;
+- OpenAPI schema and server conversion tests;
+- generated TypeScript closed-enum contract test;
+- CLI and SPA rendering tests;
+- generated-artifact check, Go suite, TypeScript typechecks/tests, lint, and
+  production web build.

--- a/internal/app/admin.go
+++ b/internal/app/admin.go
@@ -312,9 +312,16 @@ func runAdminGrant(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 	}
 	// The grant id, not the capability value: there is nothing secret here, and
 	// the operator needs the id to revoke it again through the ordinary surface.
-	verb := "joined"
-	if res.Created {
+	var verb string
+	switch res.Outcome {
+	case service.GrantCreated():
 		verb = "created"
+	case service.GrantOriginAdded():
+		verb = "origin added"
+	case service.GrantUnchanged():
+		verb = "unchanged"
+	default:
+		return fmt.Errorf("invalid grant outcome %q", res.Outcome)
 	}
 	fmt.Fprintf(stderr, "break-glass grant %s: %s (%s at %s) for %s\n",
 		verb, res.GrantID, *capability, scopeLabel(scope), *principal)

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -176,8 +176,12 @@ func runAccessGrant(ctx context.Context, ios IO, args []string) error {
 		if err != nil {
 			return err
 		}
+		row, err := grantResultRow(res)
+		if err != nil {
+			return err
+		}
 		return Render(ios.Stdout, f, Table{
-			Columns: grantResultColumns, Rows: [][]string{grantResultRow(res)}, JSON: res,
+			Columns: grantResultColumns, Rows: [][]string{row}, JSON: res,
 		})
 
 	case "remove":
@@ -197,7 +201,11 @@ func runAccessGrant(ctx context.Context, ios IO, args []string) error {
 		}
 		rows := make([][]string, 0, len(res.Items))
 		for _, r := range res.Items {
-			rows = append(rows, grantResultRow(r))
+			row, err := grantResultRow(r)
+			if err != nil {
+				return err
+			}
+			rows = append(rows, row)
 		}
 		return Render(ios.Stdout, f, Table{Columns: grantResultColumns, Rows: rows, JSON: res})
 	}
@@ -531,15 +539,19 @@ func grantTable(list apigen.GrantList) Table {
 	return Table{Columns: grantColumns, Rows: rows, JSON: list}
 }
 
-func grantResultRow(r apigen.GrantResult) []string {
-	outcome := "joined"
-	switch {
-	case r.Created:
+func grantResultRow(r apigen.GrantResult) ([]string, error) {
+	var outcome string
+	switch r.Outcome {
+	case api.GrantOutcomeCreated():
 		outcome = "created"
-	case !r.OriginAdded:
+	case api.GrantOutcomeOriginAdded():
+		outcome = "origin added"
+	case api.GrantOutcomeUnchanged():
 		outcome = "unchanged"
+	default:
+		return nil, fmt.Errorf("server returned invalid grant outcome")
 	}
-	return []string{r.Capability, r.GrantId, outcome}
+	return []string{r.Capability, r.GrantId, outcome}, nil
 }
 
 // memberTable collapses the capability lines into one row per principal — the

--- a/internal/cli/access_internal_test.go
+++ b/internal/cli/access_internal_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+)
+
+func TestGrantResultRowRendersEveryOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		outcome api.GrantOutcome
+		want    string
+	}{
+		{outcome: api.GrantOutcomeCreated(), want: "created"},
+		{outcome: api.GrantOutcomeOriginAdded(), want: "origin added"},
+		{outcome: api.GrantOutcomeUnchanged(), want: "unchanged"},
+	} {
+		t.Run(tc.outcome.String(), func(t *testing.T) {
+			row, err := grantResultRow(apigen.GrantResult{
+				GrantId: "grt_1", Capability: "read", Outcome: tc.outcome,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(row, "|"); got != "read|grt_1|"+tc.want {
+				t.Fatalf("row = %q", got)
+			}
+		})
+	}
+}

--- a/internal/isolation/grants_e2e_test.go
+++ b/internal/isolation/grants_e2e_test.go
@@ -164,35 +164,32 @@ func runGrantDedup(t *testing.T, db *store.DB) {
 	ctx := t.Context()
 	spec := service.GrantSpec{Target: grantee, Capability: domain.CapRead, Scope: prjScope()}
 
-	first, err := g.Create(ctx, service.LocalPrincipal(orgAdmin), spec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !first.Created {
-		t.Fatal("the first grant of a triple must create a row")
-	}
-	// The same grantor, again: idempotent, no second origin, no second row.
-	repeat, err := g.Create(ctx, service.LocalPrincipal(orgAdmin), spec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if repeat.Created || repeat.OriginAdded || repeat.GrantID != first.GrantID {
-		t.Fatalf("re-granting the same triple from the same grantor must be a no-op, got %+v", repeat)
-	}
-	if n := originCount(t, db, grantee, domain.CapRead, prjScope()); n != 1 {
-		t.Fatalf("origins after an idempotent repeat = %d, want 1", n)
-	}
-
-	// A SECOND grantor: same row, second origin.
-	second, err := g.Create(ctx, service.LocalPrincipal(prjAdmin), spec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if second.Created || !second.OriginAdded || second.GrantID != first.GrantID {
-		t.Fatalf("a second grantor must join the existing row, got %+v", second)
-	}
-	if n := originCount(t, db, grantee, domain.CapRead, prjScope()); n != 2 {
-		t.Fatalf("origins after a second grantor = %d, want 2", n)
+	var grantID string
+	for _, tc := range []struct {
+		name        string
+		actor       domain.PrincipalID
+		want        service.GrantOutcome
+		wantOrigins int
+	}{
+		{name: "new grant", actor: orgAdmin, want: service.GrantCreated(), wantOrigins: 1},
+		{name: "idempotent repeat", actor: orgAdmin, want: service.GrantUnchanged(), wantOrigins: 1},
+		{name: "second origin", actor: prjAdmin, want: service.GrantOriginAdded(), wantOrigins: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := g.Create(ctx, service.LocalPrincipal(tc.actor), spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if grantID == "" {
+				grantID = result.GrantID
+			}
+			if result.Outcome != tc.want || result.GrantID != grantID {
+				t.Fatalf("grant result = %+v, want outcome %q and id %q", result, tc.want, grantID)
+			}
+			if got := originCount(t, db, grantee, domain.CapRead, prjScope()); got != tc.wantOrigins {
+				t.Fatalf("origin count = %d, want %d", got, tc.wantOrigins)
+			}
+		})
 	}
 
 	// A grant at a DIFFERENT scope is a different row, not a dedup: the two
@@ -459,8 +456,8 @@ func runBreakGlassGrant(t *testing.T, db *store.DB) {
 	if err != nil {
 		t.Fatalf("break-glass grant: %v", err)
 	}
-	if !res.Created {
-		t.Fatal("break-glass must have created the recovery grant")
+	if res.Outcome != service.GrantCreated() {
+		t.Fatalf("break-glass outcome = %q, want %q", res.Outcome, service.GrantCreated())
 	}
 	lines, err := g.List(ctx, service.LocalPrincipal(root), orgAScope)
 	if err != nil {
@@ -951,7 +948,7 @@ func runGrantLifecycleEvents(t *testing.T, db *store.DB) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Created || res.OriginAdded {
+	if res.Outcome != service.GrantUnchanged() {
 		t.Fatalf("the idempotent repeat changed state: %+v", res)
 	}
 	if n := count("grant.modified"); n != beforeModified {
@@ -1053,7 +1050,7 @@ func runOriginAddKeepsSessionAlive(t *testing.T, db *store.DB) {
 	if err != nil {
 		t.Fatalf("second origin: %v", err)
 	}
-	if res.Created || !res.OriginAdded {
+	if res.Outcome != service.GrantOriginAdded() {
 		t.Fatalf("expected an origin join on an existing row, got %+v", res)
 	}
 	if _, err := auth.Identity(ctx, login.SessionToken); err != nil {

--- a/internal/server/access.go
+++ b/internal/server/access.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
@@ -58,19 +59,26 @@ func grantSpec(scope domain.Scope, principal, capability string) service.GrantSp
 	}
 }
 
-func wireGrantResult(r service.GrantResult, capability domain.Capability) apigen.GrantResult {
+func wireGrantResult(r service.GrantResult, capability domain.Capability) (apigen.GrantResult, error) {
+	if !r.Outcome.Valid() {
+		return apigen.GrantResult{}, errors.New("invalid grant outcome")
+	}
 	return apigen.GrantResult{
 		GrantId: r.GrantID, Capability: string(capability),
-		Created: r.Created, OriginAdded: r.OriginAdded,
-	}
+		Outcome: r.Outcome,
+	}, nil
 }
 
-func wireGrantResults(results []service.GrantResult, caps []domain.Capability) apigen.GrantResultList {
+func wireGrantResults(results []service.GrantResult, caps []domain.Capability) (apigen.GrantResultList, error) {
 	items := make([]apigen.GrantResult, 0, len(results))
 	for i, r := range results {
-		items = append(items, wireGrantResult(r, caps[i]))
+		item, err := wireGrantResult(r, caps[i])
+		if err != nil {
+			return apigen.GrantResultList{}, err
+		}
+		items = append(items, item)
 	}
-	return apigen.GrantResultList{Items: items, Count: len(items)}
+	return apigen.GrantResultList{Items: items, Count: len(items)}, nil
 }
 
 func wireGrantScope(s domain.Scope) apigen.GrantScope {
@@ -132,7 +140,7 @@ func (a *API) applyTemplate(ctx context.Context, scope domain.Scope, principal, 
 	if len(results) != len(caps) {
 		return apigen.GrantResultList{}, domain.ErrInvalid
 	}
-	return wireGrantResults(results, caps), nil
+	return wireGrantResults(results, caps)
 }
 
 // ---------------------------------------------------------------------------
@@ -153,7 +161,11 @@ func (a *API) CreateInstanceGrant(ctx context.Context, req apigen.CreateInstance
 	if err != nil {
 		return nil, err
 	}
-	return apigen.CreateInstanceGrant200JSONResponse(wireGrantResult(res, spec.Capability)), nil
+	out, err := wireGrantResult(res, spec.Capability)
+	if err != nil {
+		return nil, err
+	}
+	return apigen.CreateInstanceGrant200JSONResponse(out), nil
 }
 
 func (a *API) RevokeInstanceGrant(ctx context.Context, req apigen.RevokeInstanceGrantRequestObject) (apigen.RevokeInstanceGrantResponseObject, error) {
@@ -190,7 +202,11 @@ func (a *API) CreateOrgGrant(ctx context.Context, req apigen.CreateOrgGrantReque
 	if err != nil {
 		return nil, err
 	}
-	return apigen.CreateOrgGrant200JSONResponse(wireGrantResult(res, spec.Capability)), nil
+	out, err := wireGrantResult(res, spec.Capability)
+	if err != nil {
+		return nil, err
+	}
+	return apigen.CreateOrgGrant200JSONResponse(out), nil
 }
 
 func (a *API) RevokeOrgGrant(ctx context.Context, req apigen.RevokeOrgGrantRequestObject) (apigen.RevokeOrgGrantResponseObject, error) {
@@ -227,7 +243,11 @@ func (a *API) CreateProjectGrant(ctx context.Context, req apigen.CreateProjectGr
 	if err != nil {
 		return nil, err
 	}
-	return apigen.CreateProjectGrant200JSONResponse(wireGrantResult(res, spec.Capability)), nil
+	out, err := wireGrantResult(res, spec.Capability)
+	if err != nil {
+		return nil, err
+	}
+	return apigen.CreateProjectGrant200JSONResponse(out), nil
 }
 
 func (a *API) RevokeProjectGrant(ctx context.Context, req apigen.RevokeProjectGrantRequestObject) (apigen.RevokeProjectGrantResponseObject, error) {
@@ -256,7 +276,11 @@ func (a *API) CreateEnvGrant(ctx context.Context, req apigen.CreateEnvGrantReque
 	if err != nil {
 		return nil, err
 	}
-	return apigen.CreateEnvGrant200JSONResponse(wireGrantResult(res, spec.Capability)), nil
+	out, err := wireGrantResult(res, spec.Capability)
+	if err != nil {
+		return nil, err
+	}
+	return apigen.CreateEnvGrant200JSONResponse(out), nil
 }
 
 func (a *API) RevokeEnvGrant(ctx context.Context, req apigen.RevokeEnvGrantRequestObject) (apigen.RevokeEnvGrantResponseObject, error) {

--- a/internal/server/access_wire_test.go
+++ b/internal/server/access_wire_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+func TestWireGrantResultMapsEveryOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		service service.GrantOutcome
+		wire    api.GrantOutcome
+	}{
+		{service: service.GrantCreated(), wire: api.GrantOutcomeCreated()},
+		{service: service.GrantOriginAdded(), wire: api.GrantOutcomeOriginAdded()},
+		{service: service.GrantUnchanged(), wire: api.GrantOutcomeUnchanged()},
+	} {
+		t.Run(tc.service.String(), func(t *testing.T) {
+			got, err := wireGrantResult(
+				service.GrantResult{GrantID: "grt_1", Outcome: tc.service},
+				domain.CapRead,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.GrantId != "grt_1" || string(got.Capability) != string(domain.CapRead) || got.Outcome != tc.wire {
+				t.Fatalf("wire result = %#v", got)
+			}
+		})
+	}
+}

--- a/internal/service/grants.go
+++ b/internal/service/grants.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
@@ -134,16 +135,17 @@ type GrantSpec struct {
 	Scope domain.Scope
 }
 
-// GrantResult reports what a create actually did, so the caller can render
-// "granted" versus "already held, now also held by you" without a second read.
+type GrantOutcome = api.GrantOutcome
+
+func GrantCreated() GrantOutcome     { return api.GrantOutcomeCreated() }
+func GrantOriginAdded() GrantOutcome { return api.GrantOutcomeOriginAdded() }
+func GrantUnchanged() GrantOutcome   { return api.GrantOutcomeUnchanged() }
+
+// GrantResult reports what a create actually did, so callers can render the
+// result without interpreting combinations of independently-set booleans.
 type GrantResult struct {
 	GrantID string
-	// Created is false when an existing row was deduplicated and this call
-	// only attached an origin to it.
-	Created bool
-	// OriginAdded is false when the caller's own origin already held the row —
-	// a genuinely idempotent repeat.
-	OriginAdded bool
+	Outcome GrantOutcome
 }
 
 // grantOps maps an addressed scope depth to the (create, revoke, list,
@@ -305,15 +307,19 @@ func (s *Grants) grantOne(
 	}
 
 	// F5: the lifecycle event must match the state transition. A repeat that
-	// created no row and attached no origin changed nothing — emitting
-	// `grant.modified` for it would put a modification in the trail that never
-	// happened, and an investigator counting modifications would count polls.
-	if !out.Created && !out.OriginAdded {
+	// changed nothing emits no event, or an investigator would count polls as
+	// modifications.
+	if out.Outcome == GrantUnchanged() {
 		return out, nil, nil
 	}
-	typ := audit.EventGrantModified
-	if out.Created {
+	var typ audit.EventType
+	switch out.Outcome {
+	case GrantCreated():
 		typ = audit.EventGrantCreated
+	case GrantOriginAdded():
+		typ = audit.EventGrantModified
+	default:
+		return zero, nil, fmt.Errorf("invalid grant outcome %q", out.Outcome)
 	}
 	payload := audit.Payload{
 		"target_principal": string(spec.Target),
@@ -709,7 +715,7 @@ func writeGrantRow(ctx context.Context, az *authz.TxAuthorizer, spec GrantSpec, 
 		return GrantResult{}, err
 	}
 	existing := findGrant(rows, spec.Capability, spec.Scope)
-	out.Created = existing == nil
+	out.Outcome = GrantUnchanged()
 	if existing != nil {
 		out.GrantID = existing.ID
 	} else {
@@ -736,6 +742,7 @@ func writeGrantRow(ctx context.Context, az *authz.TxAuthorizer, spec GrantSpec, 
 			return GrantResult{}, err
 		}
 		out.GrantID = grantID
+		out.Outcome = GrantCreated()
 	}
 
 	// Attaching an origin that already holds the row is a genuine no-op, not
@@ -757,7 +764,9 @@ func writeGrantRow(ctx context.Context, az *authz.TxAuthorizer, spec GrantSpec, 
 		if err := az.AddGrantOrigin(ctx, originID, out.GrantID, spec.Target, origin, now); err != nil {
 			return GrantResult{}, err
 		}
-		out.OriginAdded = true
+		if existing != nil {
+			out.Outcome = GrantOriginAdded()
+		}
 	}
 
 	// Every EFFECTIVE authority change kills the grantee's sessions in the
@@ -771,7 +780,7 @@ func writeGrantRow(ctx context.Context, az *authz.TxAuthorizer, spec GrantSpec, 
 	// bookkeeping. The trail still records it as `grant.modified`, which is
 	// what it is. (Symmetric with revoke, where the advance is gated on the
 	// row actually dying.)
-	if out.Created {
+	if out.Outcome == GrantCreated() {
 		if err := az.AdvanceGeneration(ctx, spec.Target); err != nil {
 			return GrantResult{}, err
 		}
@@ -1060,13 +1069,15 @@ func (s *Grants) ApplyTemplate(ctx context.Context, actor Actor, template domain
 			results = append(results, res)
 			events = append(events, evs...)
 			names = append(names, string(capability))
-			switch {
-			case res.Created:
+			switch res.Outcome {
+			case GrantCreated():
 				created++
-			case res.OriginAdded:
+			case GrantOriginAdded():
 				joined++
-			default:
+			case GrantUnchanged():
 				unchanged++
+			default:
+				return fmt.Errorf("invalid grant outcome %q", res.Outcome)
 			}
 		}
 		out = results
@@ -1395,6 +1406,15 @@ func (s *Grants) BreakGlassGrant(ctx context.Context, spec GrantSpec) (GrantResu
 		// break-glass credential reset does: there is no proof to bind it to,
 		// and it commits in the same transaction as the grant, so durability
 		// holds.
+		var grantCreated bool
+		switch out.Outcome {
+		case GrantCreated():
+			grantCreated = true
+		case GrantOriginAdded(), GrantUnchanged():
+			grantCreated = false
+		default:
+			return fmt.Errorf("invalid grant outcome %q", out.Outcome)
+		}
 		e, err := newAuditEvent(ctx, audit.EventBreakGlassGrant, "",
 			audit.Object{Type: "grant", ID: out.GrantID}, audit.OutcomeSuccess, "",
 			audit.Payload{
@@ -1402,7 +1422,7 @@ func (s *Grants) BreakGlassGrant(ctx context.Context, spec GrantSpec) (GrantResu
 				"capability":       string(spec.Capability),
 				"scope":            renderScope(spec.Scope),
 				"authority":        "local-host",
-				"grant_created":    out.Created,
+				"grant_created":    grantCreated,
 			})
 		if err != nil {
 			return err
@@ -1477,10 +1497,17 @@ func cureIfMemberManagement(
 	ctx context.Context, az *authz.TxAuthorizer, clear clearRetentionAttention,
 	capability domain.Capability, scope domain.Scope, res GrantResult,
 ) ([]CureResult, []grantEventInput, error) {
-	if capability != domain.CapManageMembers || !res.Created {
+	if capability != domain.CapManageMembers {
 		return nil, nil, nil
 	}
-	return cureLockoutRetentions(ctx, az, clear, res.GrantID, scope)
+	switch res.Outcome {
+	case GrantCreated():
+		return cureLockoutRetentions(ctx, az, clear, res.GrantID, scope)
+	case GrantOriginAdded(), GrantUnchanged():
+		return nil, nil, nil
+	default:
+		return nil, nil, fmt.Errorf("invalid grant outcome %q", res.Outcome)
+	}
 }
 
 // retentionAttentionClearer builds the cure's audited exit path for a caller

--- a/internal/service/scim.go
+++ b/internal/service/scim.go
@@ -489,15 +489,17 @@ func (s *SCIM) applyMappings(
 			if err != nil {
 				return nil, 0, err
 			}
-			if !out.Created && !out.OriginAdded {
+			var typ audit.EventType
+			switch out.Outcome {
+			case GrantUnchanged():
 				continue // already held by this exact origin: nothing happened
-			}
-			if out.Created {
+			case GrantCreated():
 				created++
-			}
-			typ := audit.EventGrantModified
-			if out.Created {
 				typ = audit.EventGrantCreated
+			case GrantOriginAdded():
+				typ = audit.EventGrantModified
+			default:
+				return nil, 0, fmt.Errorf("invalid grant outcome %q", out.Outcome)
 			}
 			events = append(events, grantEventInput{
 				typ:    typ,

--- a/web/e2e/flows/members.spec.ts
+++ b/web/e2e/flows/members.spec.ts
@@ -324,7 +324,7 @@ test.describe('members and grants', () => {
       await dialog.getByLabel('Scope').selectOption(`env:${seed.project}:${seed.dev}`);
       await dialog.getByRole('button', { name: 'Grant', exact: true }).click();
 
-      const partial = page.getByRole('alert').filter({ hasText: 'Granted: read, edit' });
+      const partial = page.getByRole('alert').filter({ hasText: 'Completed 2 of 3' });
       await expect(partial).toContainText('2 of 3');
       await expect(partial).toContainText('pin was refused');
       await expect(partial).toContainText('live and listed below');

--- a/web/e2e/flows/members.spec.ts
+++ b/web/e2e/flows/members.spec.ts
@@ -348,9 +348,12 @@ test.describe('members and grants', () => {
       await dialog.getByLabel('Scope').selectOption(`env:${seed.project}:${seed.dev}`);
       await dialog.getByRole('button', { name: 'Grant', exact: true }).click();
 
-      const feedback = page.locator('.notice').filter({ hasText: 'Granted' });
+      const feedback = page.locator('.notice').filter({ hasText: 'Grant results' });
       await expectStatusIsTextAndAria(page, feedback);
-      await expect(feedback).toContainText('separate lines');
+      await expect(feedback).toContainText('Created: read, edit');
+      await expect(feedback).toContainText('Origin added: none');
+      await expect(feedback).toContainText('Unchanged: none');
+      await expect(feedback).toContainText('independently revocable');
 
       // Two independent rows, not a bundle.
       const row = page.getByRole('row').filter({ hasText: principal });

--- a/web/src/api/access.test.ts
+++ b/web/src/api/access.test.ts
@@ -12,6 +12,7 @@ import {
   expandTemplate,
   GrantPartialFailure,
   grantFailureText,
+  grantOutcomeSummary,
   grantScopeLabel,
   membershipFailureText,
   membershipRows,
@@ -181,14 +182,17 @@ describe('scope ordering and the safe default', () => {
 describe('grant refusals', () => {
   it('maps a partial failure with explicit progress and the mapped refusal cause', () => {
     const failure = new GrantPartialFailure(
-      ['read', 'edit'],
+      [
+        { capability: 'read', outcome: 'origin_added' },
+        { capability: 'edit', outcome: 'unchanged' },
+      ],
       'publish',
       3,
       new ApiError(403, 'forbidden'),
     );
 
     expect(grantFailureText(failure)).toBe(
-      'Granted: read, edit (2 of 3, live and listed below). publish was refused: Managing members needs a second factor. Sign in again and present your passkey or a code, then retry.',
+      'Completed 2 of 3 (live and listed below). Created: none. Origin added: read. Unchanged: edit. publish was refused: Managing members needs a second factor. Sign in again and present your passkey or a code, then retry.',
     );
   });
 });
@@ -307,15 +311,56 @@ describe('sequential grant creation', () => {
       if (capability === 'publish') {
         throw refusal;
       }
+      if (capability === 'read') {
+        return { capability, outcome: 'origin_added' };
+      }
+      return { capability, outcome: 'unchanged' };
     });
 
     await expect(run).rejects.toMatchObject({
-      granted: ['read', 'edit'],
+      completed: [
+        { capability: 'read', outcome: 'origin_added' },
+        { capability: 'edit', outcome: 'unchanged' },
+      ],
       failedCapability: 'publish',
       cause: refusal,
     });
     await expect(run).rejects.toBeInstanceOf(GrantPartialFailure);
     expect(attempted).toEqual(['read', 'edit', 'publish']);
+  });
+
+  it('returns each server outcome instead of treating every success as a new grant', async () => {
+    const result = await createGrantsSequentially(
+      ['read', 'edit', 'publish'],
+      async (capability) => {
+        switch (capability) {
+          case 'read':
+            return { capability, outcome: 'created' };
+          case 'edit':
+            return { capability, outcome: 'origin_added' };
+          default:
+            return { capability, outcome: 'unchanged' };
+        }
+      },
+    );
+
+    expect(result).toEqual([
+      { capability: 'read', outcome: 'created' },
+      { capability: 'edit', outcome: 'origin_added' },
+      { capability: 'publish', outcome: 'unchanged' },
+    ]);
+  });
+});
+
+describe('grant outcome rendering', () => {
+  it('renders all three closed outcomes', () => {
+    expect(
+      grantOutcomeSummary([
+        { capability: 'read', outcome: 'created' },
+        { capability: 'edit', outcome: 'origin_added' },
+        { capability: 'publish', outcome: 'unchanged' },
+      ]),
+    ).toBe('Created: read. Origin added: edit. Unchanged: publish.');
   });
 });
 

--- a/web/src/api/access.ts
+++ b/web/src/api/access.ts
@@ -14,6 +14,7 @@ import {
   revokeOrgGrantOp,
   revokeProjectGrantOp,
 } from '@hikyo/operations';
+import type { GrantResult } from '@hikyo/client';
 import { zGrantList } from '@hikyo/zod';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import type { z } from 'zod';
@@ -581,6 +582,7 @@ export function useInstanceGrants(): UseQueryResult<GrantList> {
 }
 
 type GrantInput = { readonly principal: string; readonly capability: string };
+type GrantOutcomeView = Pick<GrantResult, 'capability' | 'outcome'>;
 
 function createOne(scope: ScopeRef, input: GrantInput) {
   const body = { principal: input.principal, capability: input.capability };
@@ -603,31 +605,55 @@ export class GrantPartialFailure extends Error {
   override readonly cause: unknown;
 
   constructor(
-    readonly granted: readonly string[],
+    readonly completed: readonly GrantOutcomeView[],
     readonly failedCapability: string,
     readonly total: number,
     cause: unknown,
   ) {
-    super(`granting ${failedCapability} failed after ${granted.length} earlier capabilities`, { cause });
+    super(`granting ${failedCapability} failed after ${completed.length} earlier capabilities`, { cause });
     this.name = 'GrantPartialFailure';
     this.cause = cause;
   }
 }
 
-export async function createGrantsSequentially(
+export async function createGrantsSequentially<Result extends GrantOutcomeView>(
   capabilities: readonly string[],
-  create: (capability: string) => Promise<unknown>,
-): Promise<readonly string[]> {
-  const granted: string[] = [];
+  create: (capability: string) => Promise<Result>,
+): Promise<readonly Result[]> {
+  const results: Result[] = [];
   for (const capability of capabilities) {
     try {
-      await create(capability);
+      results.push(await create(capability));
     } catch (error) {
-      throw new GrantPartialFailure(granted, capability, capabilities.length, error);
+      throw new GrantPartialFailure(results, capability, capabilities.length, error);
     }
-    granted.push(capability);
   }
-  return granted;
+  return results;
+}
+
+export function grantOutcomeSummary(results: readonly GrantOutcomeView[]): string {
+  const created: string[] = [];
+  const originAdded: string[] = [];
+  const unchanged: string[] = [];
+  for (const result of results) {
+    switch (result.outcome) {
+      case 'created':
+        created.push(result.capability);
+        break;
+      case 'origin_added':
+        originAdded.push(result.capability);
+        break;
+      case 'unchanged':
+        unchanged.push(result.capability);
+        break;
+      default: {
+        const impossible: never = result.outcome;
+        return impossible;
+      }
+    }
+  }
+  const render = (items: readonly string[]) => (items.length === 0 ? 'none' : items.join(', '));
+  return `Created: ${render(created)}. Origin added: ${render(originAdded)}. Unchanged: ${render(unchanged)}.`;
 }
 
 /**
@@ -743,12 +769,12 @@ export function useRevokeGrant() {
  */
 export function grantFailureText(error: unknown): string {
   if (error instanceof GrantPartialFailure) {
-    if (error.granted.length === 0) {
+    if (error.completed.length === 0) {
       return grantFailureText(error.cause);
     }
-    const granted = error.granted.join(', ');
     return (
-      `Granted: ${granted} (${String(error.granted.length)} of ${String(error.total)}, live and listed below). ` +
+      `Completed ${String(error.completed.length)} of ${String(error.total)} (live and listed below). ` +
+      `${grantOutcomeSummary(error.completed)} ` +
       `${error.failedCapability} was refused: ${grantFailureText(error.cause)}`
     );
   }

--- a/web/src/routes/InstanceAdmin.tsx
+++ b/web/src/routes/InstanceAdmin.tsx
@@ -10,6 +10,7 @@ import { generatePath, Link } from 'react-router';
 import {
   capabilitiesAt,
   grantFailureText,
+  grantOutcomeSummary,
   grantScopeLabel,
   templatesAt,
   useApplyTemplate,
@@ -169,13 +170,13 @@ export function InstanceAdmin() {
         const principal = grantPrincipal.trim();
         if (grantTemplate !== '') {
           applyTemplate.mutate({ scope: { kind: 'instance' }, principal, template: grantTemplate }, {
-            onSuccess: (created) => { setGrantTemplate(''); ok(`Created ${String(created.count)} instance grant line${created.count === 1 ? '' : 's'} for ${principal}.`); },
+            onSuccess: (result) => { setGrantTemplate(''); ok(`Result for ${String(result.count)} instance grant line${result.count === 1 ? '' : 's'} for ${principal}: ${grantOutcomeSummary(result.items)}`); },
             onError: (error) => report(new SurfaceMessage(grantFailureText(error))),
           });
           return;
         }
         createGrants.mutate({ scope: { kind: 'instance' }, principal, capabilities: selectedCapabilities }, {
-          onSuccess: (created) => { setSelectedCapabilities([]); ok(`Created ${String(created.length)} instance grant line${created.length === 1 ? '' : 's'} for ${principal}.`); },
+          onSuccess: (result) => { setSelectedCapabilities([]); ok(`Result for ${String(result.length)} instance grant line${result.length === 1 ? '' : 's'} for ${principal}: ${grantOutcomeSummary(result)}`); },
           onError: (error) => {
             report(new SurfaceMessage(grantFailureText(error)));
           },

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 
-import type { FederatedClaimPin } from '@hikyo/client';
+import type { FederatedClaimPin, GrantResult } from '@hikyo/client';
 
+import { grantOutcomeSummary } from '../api/access.ts';
 import {
   BINDING_LIFETIMES,
   bindingFailureText,
@@ -447,10 +448,10 @@ export function MachineAccess() {
           // that stopped authenticating weeks ago.
           liveCredentials={dialog.account.live_credentials}
           onClose={() => setDialog(null)}
-          onGranted={(environment) => {
+          onGranted={(environment, result) => {
             setDialog(null);
             setNotice(
-              `Granted. Every credential this service account already holds now reads ${environment}.`,
+              `Grant result for ${environment}: ${grantOutcomeSummary([result])}`,
             );
           }}
         />
@@ -1584,7 +1585,7 @@ function GrantDialog({
   scope: readonly MachineEnvScope[];
   liveCredentials: number;
   onClose: () => void;
-  onGranted: (environment: string) => void;
+  onGranted: (environment: string, result: GrantResult) => void;
 }) {
   const dialog = useModalDialog();
   const grantable = scope.filter((s) => !s.read);
@@ -1651,7 +1652,7 @@ function GrantBody({
   /** GrantDialog's Escape gate — held while the mutation is in flight. */
   inFlight: MutableRefObject<boolean>;
   onClose: () => void;
-  onGranted: (environment: string) => void;
+  onGranted: (environment: string, result: GrantResult) => void;
 }) {
   const grant = useGrantEnvironment(project);
   const refreshGrants = useRefreshGrants(project);
@@ -1701,12 +1702,12 @@ function GrantBody({
         });
       }
       issued = true;
-      await grant.mutateAsync({
+      const result = await grant.mutateAsync({
         environment,
         principal: account.principal_id,
         capability: 'read',
       });
-      onGranted(chosen?.name ?? environment);
+      onGranted(chosen?.name ?? environment, result);
     } catch (error) {
       if (issued) {
         refreshGrants();

--- a/web/src/routes/Members.tsx
+++ b/web/src/routes/Members.tsx
@@ -7,6 +7,7 @@ import {
   defaultScopeValue,
   expandTemplate,
   grantFailureText,
+  grantOutcomeSummary,
   grantScopeLabel,
   membershipFailureText,
   membershipRows,
@@ -493,7 +494,7 @@ function GrantModal({
         {
           onSuccess: (result) =>
             onDone(
-              `Applied ${draft.template} to ${principal} on ${chosen.label}: ${result.count} independent grant ${result.count === 1 ? 'line' : 'lines'}, each revocable on its own.`,
+              `Applied ${draft.template} to ${principal} on ${chosen.label}: ${grantOutcomeSummary(result.items)} Each grant line remains independently revocable.`,
             ),
           onError: (error) => {
             onStage('grant');
@@ -508,7 +509,7 @@ function GrantModal({
       {
         onSuccess: (done) =>
           onDone(
-            `Granted ${done.join(', ')} to ${principal} on ${chosen.label}. ${done.length === 1 ? 'It is' : 'They are'} separate lines and revocable one at a time.`,
+            `Grant results for ${principal} on ${chosen.label}: ${grantOutcomeSummary(done)} Each grant line remains independently revocable.`,
           ),
         onError: (error) => {
           onStage('grant');


### PR DESCRIPTION
## Stack

- stacked directly on #279
- stack root: #274
- merge only after lower stack entries land

## Summary

- replace created/origin_added Boolean combinations with closed created, origin_added, or unchanged outcomes
- seal Go construction and reject zero or unknown JSON values
- regenerate OpenAPI Go, TypeScript, Zod, and operation descriptors
- update service, server, CLI, SPA success and partial-failure consumers exhaustively
- preserve grant audit, origin, session, template, and break-glass behavior

## Contract and migration

Intentional pre-1.0 response-shape break before #79 API freeze. Server and generated clients land atomically. External 0.x consumers must regenerate and branch on outcome. No database migration or persisted-data rewrite.

## Validation

- go test -count=1 -timeout 20m ./... — 4,125 passed across 57 packages using SQLite and PostgreSQL
- go build ./... — passed
- go vet ./... — passed
- client verify — generation exact, typecheck passed, 12 tests passed
- web typecheck — passed
- web tests — 250 passed
- web production build — passed
- DCO — passed
- Standards review round 3 — CLEAN
- Spec review round 3 — CLEAN

Closes #217