### PR TITLE
feat(tx): return committed write results

### DIFF
--- a/docs/handoff/issue-218-committed-write-results.md
+++ b/docs/handoff/issue-218-committed-write-results.md
@@ -1,0 +1,74 @@
+# Issue #218: committed-attempt write results
+
+## Stack position
+
+- Stack root: PR #274 (`d253e65614713f94377a738611e143da5a8c1702`)
+- Immediate base: PR #281 (`b6c0df2cde0522ab5793f05a7280f3a27a7e24cc`)
+- Issue: #218
+- Generated outputs: none
+
+## Contract
+
+`tx.WriteResult[T]` runs the existing `writeOnce` transaction inside the
+existing bounded retry loop. Each attempt owns its result. The result is copied
+to the return slot only after `writeOnce` reports success, which is after commit
+and denial settlement. A failed call returns the zero value of `T`.
+
+`T` must be detached data. Repositories, authorizers, proofs, interfaces,
+functions, channels, unsafe pointers, or other attempt-owned references must
+not be returned. `internal/lint.CheckTransactionResults` enforces that rule
+repository-wide from Go type information, with a negative fixture and an
+isolation invariant. `tx.Write` remains the simple no-result API and delegates
+to `WriteResult`.
+
+## Migrated high-risk callers
+
+- `internal/service/values.go`: stage, declare, revealing read, revealing diff,
+  and copy response/advisory data
+- `internal/service/retention.go`: per-chunk candidate, collection, and plan
+  counters
+- `internal/service/revisions.go`: export rows/served revision and scanning-key
+  dismissal count
+- `internal/service/adapters.go`: credential replacement and revocation results,
+  including publication only after the outer provider-fence retry succeeds
+- `internal/service/retention.go`: failed-sweep telemetry keeps the final
+  attempt's observed candidate count outside the committed-result channel and
+  resets it before each retry
+
+The remaining outer state found by the inventory is intentionally different:
+
+- `rateCharged` flags and durable-refusal errors are operation-scoped and must
+  survive retries; resetting them would double-charge or lose a committed
+  refusal.
+- Existing aggregates in rollback, publish, hierarchy, keys, delivery, and
+  import reset at the start of every attempt and publish only after `Write`
+  succeeds. They are retry-safe today; package-local conversion can happen in
+  later bounded migrations without expanding this change.
+- `ReadResult` is not added. The inspected read-only callers replace their
+  result on every attempt rather than incrementally mutating it, so no failing
+  read case justifies a second generic API in this issue.
+
+## Validation
+
+- `go test -count=1 ./internal/store/tx ./internal/lint`: 40 passed
+- `go test -count=1 ./internal/service`: 145 passed
+- `go test -count=1 ./internal/isolation -run
+  '^TestRetentionFailedSweepCountsObservedCandidates(SQLite|Postgres)$'`:
+  2 passed across SQLite and PostgreSQL 18
+- `go test -race -count=1 ./internal/store/tx ./internal/service`: 159 passed
+- `go test -count=1 ./internal/isolation -run
+  'TestInvariant09bTransactionResultsAreDetached|TestInvariant09TransactionLayerHandlesProof'`:
+  2 passed
+- `go build ./...`: passed
+- `go vet ./...`: passed
+- `GOFLAGS=-p=1 HIKYO_TEST_POSTGRES_DSN=... go test -count=1 ./...` against
+  PostgreSQL 18: 3977 passed in 57 packages
+- Immediate PostgreSQL 18 isolation reproduction:
+  `go test -count=1 ./internal/isolation`: 2083 passed
+
+The first PostgreSQL attempt used a role without `CREATEDB` and failed only the
+tests that create derived databases. A concurrent full run later pushed the
+isolation package past its ten-minute package timeout; the immediate standalone
+isolation run passed, and the final full run serialized package binaries with
+`GOFLAGS=-p=1` without changing the test timeout. All temporary databases and
+the temporary role were removed afterward.

--- a/internal/isolation/invariants_test.go
+++ b/internal/isolation/invariants_test.go
@@ -285,6 +285,16 @@ func TestInvariant09ForgeryGuard(t *testing.T) {
 	}
 }
 
+func TestInvariant09bTransactionResultsAreDetached(t *testing.T) {
+	pkgs, err := lint.LoadRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range lint.CheckTransactionResults(pkgs) {
+		t.Error(f)
+	}
+}
+
 // TestInvariant11SystemProofEnumeration: the mint-site set is exactly
 // {boot, migration, recovery-mode reconciliation, break-glass, scheduler}.
 // Boot and scheduler carry exactly their reviewed store surfaces; growth of

--- a/internal/isolation/retention_gc_e2e_test.go
+++ b/internal/isolation/retention_gc_e2e_test.go
@@ -39,6 +39,14 @@ func TestRetentionFailedSweepAuditPostgres(t *testing.T) {
 	runRetentionFailedSweepAudit(t, seededDB(t, openPostgres))
 }
 
+func TestRetentionFailedSweepCountsObservedCandidatesSQLite(t *testing.T) {
+	runRetentionFailedSweepCountsObservedCandidates(t, seededDB(t, openSQLite))
+}
+
+func TestRetentionFailedSweepCountsObservedCandidatesPostgres(t *testing.T) {
+	runRetentionFailedSweepCountsObservedCandidates(t, seededDB(t, openPostgres))
+}
+
 func runRetentionFailedSweepAudit(t *testing.T, db *store.DB) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
@@ -53,6 +61,31 @@ func runRetentionFailedSweepAudit(t *testing.T, db *store.DB) {
         WHERE type = 'retention.prune_run' AND outcome = 'failure'
           AND actor_class = 'system' AND payload LIKE '%"error_class":"canceled"%'`); n != 1 {
 		t.Fatalf("failed prune-run audit events = %d, want 1", n)
+	}
+}
+
+func runRetentionFailedSweepCountsObservedCandidates(t *testing.T, db *store.DB) {
+	t.Helper()
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	retention := &service.Retention{DB: db, Now: func() time.Time { return now }}
+	if _, err := retention.SetProject(t.Context(), service.LocalPrincipal(orgAdmin),
+		scopeProject(orgA, prjA1), &service.RetentionPolicy{MaxAge: 20 * 24 * time.Hour, LastRevisions: 2}); err != nil {
+		t.Fatalf("set project retention: %v", err)
+	}
+	seedRetentionCorpus(t, db)
+
+	// Eligible reads only snapshot lineage. Removing the payload table makes the
+	// chunk fail after it has observed both eligible candidates but before commit.
+	execRaw(t, db, "DROP TABLE snapshot_entries")
+	if _, err := retention.Sweep(t.Context()); err == nil {
+		t.Fatal("sweep succeeded after payload table removal")
+	}
+	if n := queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events
+        WHERE type = 'retention.prune_run' AND outcome = 'failure'
+          AND payload LIKE '%"candidates":2%'`); n != 1 {
+		payloads := queryStrings(t, db, `SELECT payload FROM audit_instance_events
+            WHERE type = 'retention.prune_run' AND outcome = 'failure'`)
+		t.Fatalf("failed prune-run events with two observed candidates = %d, want 1; payloads=%s", n, payloads)
 	}
 }
 

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -44,6 +44,16 @@ func TestProofForgeryRepo(t *testing.T) {
 	}
 }
 
+func TestTransactionResultsRepo(t *testing.T) {
+	pkgs, err := LoadRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range CheckTransactionResults(pkgs) {
+		t.Error(f)
+	}
+}
+
 func TestFenceCompletenessRepo(t *testing.T) {
 	pkgs, err := LoadRepo()
 	if err != nil {
@@ -245,6 +255,19 @@ func TestProofForgeryCatchesViolations(t *testing.T) {
 	if nilCount < 3 {
 		t.Errorf("nil-proof literals caught = %d, want 3 (return, var, call arg):\n%s", nilCount, strings.Join(findings, "\n"))
 	}
+}
+
+func TestTransactionResultsCatchAttemptOwnedTypes(t *testing.T) {
+	pkgs, err := Load("./testdata/badtxresult")
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := CheckTransactionResults(pkgs)
+	assertFindings(t, findings, []string{
+		"store.Repos",
+		"interface values can retain attempt-owned authority",
+		"function values can capture attempt-owned authority",
+	})
 }
 
 // The forgery guard's exemption must be an exact path match: a neighbouring

--- a/internal/lint/testdata/badtxresult/badtxresult.go
+++ b/internal/lint/testdata/badtxresult/badtxresult.go
@@ -1,0 +1,28 @@
+package badtxresult
+
+import (
+	"context"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+func repositories(ctx context.Context, db *store.DB) {
+	_, _ = tx.WriteResult(ctx, db, func(context.Context, store.Repos, *authz.TxAuthorizer) (store.Repos, error) {
+		return nil, nil
+	})
+}
+
+func hiddenInterface(ctx context.Context, db *store.DB) {
+	type result struct{ Value any }
+	_, _ = tx.WriteResult(ctx, db, func(context.Context, store.Repos, *authz.TxAuthorizer) (result, error) {
+		return result{}, nil
+	})
+}
+
+func closure(ctx context.Context, db *store.DB) {
+	_, _ = tx.WriteResult(ctx, db, func(context.Context, store.Repos, *authz.TxAuthorizer) (func(), error) {
+		return func() {}, nil
+	})
+}

--- a/internal/lint/txresult.go
+++ b/internal/lint/txresult.go
@@ -1,0 +1,116 @@
+package lint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// CheckTransactionResults keeps tx.WriteResult's generic result channel
+// detached from transaction-owned authority. Runtime reflection is forbidden
+// in packages that handle Proof values, so this repository-wide type walk is
+// the fail-closed enforcement point.
+func CheckTransactionResults(pkgs []*packages.Package) []string {
+	var findings []string
+	for _, p := range flatten(pkgs) {
+		if p.TypesInfo == nil || (!strings.HasPrefix(p.PkgPath, Module+"/") && p.PkgPath != Module) {
+			continue
+		}
+		for _, file := range p.Syntax {
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || !isWriteResultCall(p, call.Fun) {
+					return true
+				}
+				sig, _ := p.TypesInfo.TypeOf(call.Fun).(*types.Signature)
+				if sig == nil || sig.Results().Len() == 0 {
+					return true
+				}
+				resultType := sig.Results().At(0).Type()
+				if reason := detachedResultViolation(resultType, make(map[types.Type]bool)); reason != "" {
+					findings = append(findings, fmt.Sprintf(
+						"txresult: %s: tx.WriteResult result %s is not detached data: %s",
+						p.Fset.Position(call.Pos()), types.TypeString(resultType, nil), reason))
+				}
+				return true
+			})
+		}
+	}
+	return findings
+}
+
+func isWriteResultCall(p *packages.Package, expr ast.Expr) bool {
+	for {
+		switch node := expr.(type) {
+		case *ast.IndexExpr:
+			expr = node.X
+			continue
+		case *ast.IndexListExpr:
+			expr = node.X
+			continue
+		}
+		break
+	}
+	var obj types.Object
+	switch node := expr.(type) {
+	case *ast.Ident:
+		obj = p.TypesInfo.Uses[node]
+	case *ast.SelectorExpr:
+		obj = p.TypesInfo.Uses[node.Sel]
+	}
+	fn, ok := obj.(*types.Func)
+	return ok && fn.Name() == "WriteResult" && fn.Pkg() != nil && fn.Pkg().Path() == Module+"/internal/store/tx"
+}
+
+func detachedResultViolation(t types.Type, seen map[types.Type]bool) string {
+	t = types.Unalias(t)
+	if seen[t] {
+		return ""
+	}
+	seen[t] = true
+	switch current := t.(type) {
+	case *types.Named:
+		obj := current.Obj()
+		if obj.Pkg() != nil {
+			path := obj.Pkg().Path()
+			if (path == Module+"/internal/store" && (obj.Name() == "Repos" || obj.Name() == "ReadRepos")) ||
+				(path == Module+"/internal/authz" && (obj.Name() == "Proof" || obj.Name() == "TxAuthorizer" || obj.Name() == "TxToken")) {
+				return path + "." + obj.Name()
+			}
+		}
+		return detachedResultViolation(current.Underlying(), seen)
+	case *types.Pointer:
+		return detachedResultViolation(current.Elem(), seen)
+	case *types.Array:
+		return detachedResultViolation(current.Elem(), seen)
+	case *types.Slice:
+		return detachedResultViolation(current.Elem(), seen)
+	case *types.Map:
+		if reason := detachedResultViolation(current.Key(), seen); reason != "" {
+			return reason
+		}
+		return detachedResultViolation(current.Elem(), seen)
+	case *types.Struct:
+		for i := 0; i < current.NumFields(); i++ {
+			if reason := detachedResultViolation(current.Field(i).Type(), seen); reason != "" {
+				return reason
+			}
+		}
+	case *types.Interface:
+		return "interface values can retain attempt-owned authority"
+	case *types.Signature:
+		return "function values can capture attempt-owned authority"
+	case *types.Chan:
+		return "channels can transport attempt-owned authority"
+	case *types.TypeParam:
+		return "unresolved type parameter"
+	case *types.Basic:
+		if current.Kind() == types.UnsafePointer {
+			return "unsafe.Pointer"
+		}
+	}
+	return ""
+}

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -1284,58 +1284,66 @@ func (s *Adapters) ReplaceCredential(ctx context.Context, actor Actor, scope dom
 	now := store.CanonTime(s.now())
 	var result store.AdapterCredentialResult
 	err = retryAdapterProviderFence(ctx, func() error {
-		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+		committed, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (store.AdapterCredentialResult, error) {
 			caller, err := actor.resolve(ctx, az, now)
 			if err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
 			proof, err := az.Authorize(ctx, caller, authz.OpAdapterCredentialSet, scope)
 			if err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
 			environments, err := r.Adapters().Environments(ctx, proof, adapterID)
 			if err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
 			if len(environments) == 0 {
-				return ErrAdapterBootstrapCeremonyUnspecified
+				return store.AdapterCredentialResult{}, ErrAdapterBootstrapCeremonyUnspecified
 			}
 			for _, environmentID := range environments {
 				envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(environmentID)}
 				if _, err := az.Authorize(ctx, caller, authz.OpAdapterPush, envScope); err != nil {
-					return err
+					return store.AdapterCredentialResult{}, err
 				}
 				if skipsCeremony(caller) {
 					continue
 				}
 				if s.Auth == nil {
-					return ErrNoCeremonySeam
+					return store.AdapterCredentialResult{}, ErrNoCeremonySeam
 				}
 				if err := s.Auth.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, authz.OpAdapterCredentialSet, environments, now); err != nil {
-					return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
+					return store.AdapterCredentialResult{}, fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
 				}
 			}
 			// Writer fence (invariant 7): refuse if a rotate-dek retired the DEK
 			// version the new credential was sealed under.
 			if err := fenceProject(ctx, r, proof, sealer, scope); err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
-			result, err = r.Adapters().ReplaceCredential(ctx, proof, store.AdapterCredentialMutation{
+			mutation, err := r.Adapters().ReplaceCredential(ctx, proof, store.AdapterCredentialMutation{
 				AdapterID: adapterID, CredentialCiphertext: sealed,
 				AuthorityPrincipalID: string(caller.Principal), At: now,
 			})
 			if err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
 			event, err := domainEvent(ctx, audit.EventAdapterCredentialReplace, caller.Principal,
 				audit.Object{Type: "adapter", ID: adapterID}, audit.Payload{
-					"credential_present": true, "previous_authority": result.PreviousAuthorityPrincipalID, "authority": result.AuthorityPrincipalID,
+					"credential_present": true, "previous_authority": mutation.PreviousAuthorityPrincipalID, "authority": mutation.AuthorityPrincipalID,
 				})
 			if err != nil {
-				return err
+				return store.AdapterCredentialResult{}, err
 			}
-			return r.Audit().InsertTenant(ctx, proof, event)
+			if err := r.Audit().InsertTenant(ctx, proof, event); err != nil {
+				return store.AdapterCredentialResult{}, err
+			}
+			return mutation, nil
 		})
+		if err != nil {
+			return err
+		}
+		result = committed
+		return nil
 	})
 	return result, err
 }
@@ -1345,28 +1353,29 @@ func (s *Adapters) RevokeCredential(ctx context.Context, actor Actor, scope doma
 		return store.AdapterCredentialResult{}, fmt.Errorf("%w: credential revocation requires project scope and adapter id", domain.ErrInvalid)
 	}
 	now := store.CanonTime(s.now())
-	var result store.AdapterCredentialResult
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	return tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (store.AdapterCredentialResult, error) {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
-			return err
+			return store.AdapterCredentialResult{}, err
 		}
 		proof, err := az.Authorize(ctx, caller, authz.OpAdapterCredentialRevoke, scope)
 		if err != nil {
-			return err
+			return store.AdapterCredentialResult{}, err
 		}
-		result, err = r.Adapters().RevokeCredential(ctx, proof, adapterID, now)
+		result, err := r.Adapters().RevokeCredential(ctx, proof, adapterID, now)
 		if err != nil {
-			return err
+			return store.AdapterCredentialResult{}, err
 		}
 		event, err := domainEvent(ctx, audit.EventAdapterCredentialRevoke, caller.Principal,
 			audit.Object{Type: "adapter", ID: adapterID}, audit.Payload{"credential_present": false})
 		if err != nil {
-			return err
+			return store.AdapterCredentialResult{}, err
 		}
-		return r.Audit().InsertTenant(ctx, proof, event)
+		if err := r.Audit().InsertTenant(ctx, proof, event); err != nil {
+			return store.AdapterCredentialResult{}, err
+		}
+		return result, nil
 	})
-	return result, err
 }
 
 func (s *Adapters) planModule(provider, origin, credential string) (adapter.Module, func(), error) {

--- a/internal/service/retention.go
+++ b/internal/service/retention.go
@@ -325,6 +325,12 @@ func (s *Retention) SetProject(ctx context.Context, actor Actor, scope domain.Sc
 // Sweep collects eligible payloads in bounded chunks. The caller supplies the
 // 10-minute run deadline. Each chunk owns one transaction, bounding its lock
 // window before the next chunk begins.
+type retentionSweepChunk struct {
+	candidates  int
+	collected   int64
+	prunedPlans bool
+}
+
 func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 	startedAt := store.CanonTime(s.now())
 	var total, totalCandidates int64
@@ -334,14 +340,16 @@ func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 			return total, s.recordFailedPruneRun(ctx, startedAt, store.CanonTime(s.now()), totalCandidates, total, err)
 		}
 		now := store.CanonTime(s.now())
-		var candidates int
-		var collected int64
-		var prunedThisChunk bool
-		err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			candidates, collected, prunedThisChunk = 0, 0, false
+		// Failure telemetry is deliberately attempt-scoped, not a returned
+		// result: WriteResult publishes only committed data. Reset it before
+		// every retry so a terminal failure reports only rows that attempt saw.
+		attemptCandidates := 0
+		chunk, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (retentionSweepChunk, error) {
+			attemptCandidates = 0
+			var chunk retentionSweepChunk
 			p, err := authz.SystemAuthority(authz.SiteScheduler, az.Token())
 			if err != nil {
-				return err
+				return retentionSweepChunk{}, err
 			}
 			// Expired definitions plans share the hourly GC lifecycle. Run once per
 			// sweep, including startup catch-up, before payload batching begins.
@@ -351,32 +359,33 @@ func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 			// chunk rolled back and retried.
 			if !plansPruned {
 				if _, err := r.Definitions().PruneExpiredPlans(ctx, p, now); err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
-				prunedThisChunk = true
+				chunk.prunedPlans = true
 			}
 			rows, err := r.Retention().Eligible(ctx, p, now, RetentionBatchSize)
 			if err != nil {
-				return err
+				return retentionSweepChunk{}, err
 			}
-			candidates = len(rows)
+			chunk.candidates = len(rows)
+			attemptCandidates = chunk.candidates
 			for _, row := range rows {
 				policy := formatRetentionPolicy(servicePolicy(row.Policy))
 				marked, err := r.Retention().MarkCollected(ctx, p, row.ID, policy, now)
 				if err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
 				if !marked {
 					continue
 				}
 				if _, err := r.Retention().DeleteCollectedEntries(ctx, p, row.ID); err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
 				auditProof, err := az.ScopedSystemAuthority(ctx, authz.SiteScheduler, domain.Scope{
 					Org: domain.OrgID(row.OrgID), Project: domain.ProjectID(row.ProjectID), Env: domain.EnvID(row.EnvironmentID),
 				})
 				if err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
 				ev, err := newAuditEvent(ctx, audit.EventRetentionPayloadGC, "",
 					audit.Object{Type: "snapshot", ID: row.ID}, audit.OutcomeSuccess, "", audit.Payload{
@@ -385,39 +394,41 @@ func (s *Retention) Sweep(ctx context.Context) (int64, error) {
 						"collected_at": now.Format(time.RFC3339Nano),
 					})
 				if err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
 				ev.Actor.Class = audit.ActorSystem
 				ev.OccurredAt = now
 				if err := r.Audit().InsertTenant(ctx, auditProof, ev); err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
-				collected++
+				chunk.collected++
 			}
-			if candidates < RetentionBatchSize {
+			if chunk.candidates < RetentionBatchSize {
 				finishedAt := store.CanonTime(s.now())
 				if err := r.Retention().SetLastPruneSuccess(ctx, p, finishedAt); err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
 				ev, err := pruneRunEvent(ctx, audit.OutcomeSuccess, startedAt, finishedAt,
-					totalCandidates+int64(candidates), total+collected, "")
+					totalCandidates+int64(chunk.candidates), total+chunk.collected, "")
 				if err != nil {
-					return err
+					return retentionSweepChunk{}, err
 				}
-				return r.Audit().InsertInstance(ctx, p, ev)
+				if err := r.Audit().InsertInstance(ctx, p, ev); err != nil {
+					return retentionSweepChunk{}, err
+				}
 			}
-			return nil
+			return chunk, nil
 		})
 		if err != nil {
 			return total, s.recordFailedPruneRun(ctx, startedAt, store.CanonTime(s.now()),
-				totalCandidates+int64(candidates), total, err)
+				totalCandidates+int64(attemptCandidates), total, err)
 		}
-		if prunedThisChunk {
+		if chunk.prunedPlans {
 			plansPruned = true
 		}
-		total += collected
-		totalCandidates += int64(candidates)
-		if candidates < RetentionBatchSize {
+		total += chunk.collected
+		totalCandidates += int64(chunk.candidates)
+		if chunk.candidates < RetentionBatchSize {
 			return total, nil
 		}
 	}

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -414,6 +414,11 @@ type ExportedValue struct {
 	Revealed bool
 }
 
+type revisionExportResult struct {
+	values   []ExportedValue
+	revision int64
+}
+
 // Export is the one bulk-disclosure verb: the resolved snapshot of one
 // environment, from committed state, never from live values.
 //
@@ -447,37 +452,35 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 	if err != nil {
 		return nil, 0, err
 	}
-	var out []ExportedValue
-	var served int64
 	var rateCharged bool
 	// A disclosing export runs in a WRITE transaction: its disclosure records
 	// must be durable BEFORE the plaintext leaves the server.
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		out, served = nil, 0
+	result, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (revisionExportResult, error) {
+		var result revisionExportResult
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
-			return err
+			return revisionExportResult{}, err
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpValueExport, scope)
 		if err != nil {
-			return err
+			return revisionExportResult{}, err
 		}
 		// § 179 export rate: 5/min per principal (shares the "export" bucket with
 		// audit export), charged once here now the principal is known. The
 		// per-org/instance concurrency was taken at entry.
 		if err := s.Budget.chargeOnce(&rateCharged, budgetExportRate, budgetKeys{Principal: caller.Principal}); err != nil {
-			return err
+			return revisionExportResult{}, err
 		}
 		snapshot, err := readSnapshot(ctx, r.Snapshots(), p, revision)
 		if err != nil {
-			return err
+			return revisionExportResult{}, err
 		}
-		served = snapshot.Revision
+		result.revision = snapshot.Revision
 		historical := false
 		if revision > 0 {
 			latest, err := r.Snapshots().Latest(ctx, p)
 			if err != nil {
-				return err
+				return revisionExportResult{}, err
 			}
 			historical = snapshot.Revision != latest.Revision
 		}
@@ -493,12 +496,12 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 				revealOp = authz.OpValueExportRevealHistory
 			}
 			if p, err = az.Authorize(ctx, caller, revealOp, scope); err != nil {
-				return err
+				return revisionExportResult{}, err
 			}
 		}
 		entries, err := r.Snapshots().Entries(ctx, p, snapshot)
 		if err != nil {
-			return err
+			return revisionExportResult{}, err
 		}
 		if reveal {
 			unit := make([]string, 0, len(entries))
@@ -509,7 +512,7 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 			}
 			gate := ceremonyGate(ctx, s.Auth, az, caller, PurposeReveal, string(scope.Env))
 			if err := gate(unit); err != nil {
-				return err
+				return revisionExportResult{}, err
 			}
 		}
 		for _, entry := range entries {
@@ -518,11 +521,11 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 				plain, err := sealer.OpenField(snapshotAAD(
 					entry.OrgID, entry.ProjectID, entry.EnvironmentID, entry.KeyID, entry.SnapshotID, entry.ID), entry.Ciphertext)
 				if err != nil {
-					return fmt.Errorf("service: snapshot entry %s: %w", entry.ID, err)
+					return revisionExportResult{}, fmt.Errorf("service: snapshot entry %s: %w", entry.ID, err)
 				}
 				value.Value, value.Revealed = string(plain), true
 			}
-			out = append(out, value)
+			result.values = append(result.values, value)
 			if entry.Classification != string(schema.Secret) || !value.Revealed {
 				continue
 			}
@@ -534,13 +537,13 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 					"revision": snapshot.Revision,
 				})
 			if err != nil {
-				return err
+				return revisionExportResult{}, err
 			}
 			if err := r.Audit().InsertTenant(ctx, p, ev); err != nil {
-				return err
+				return revisionExportResult{}, err
 			}
 		}
-		slices.SortFunc(out, func(a, b ExportedValue) int {
+		slices.SortFunc(result.values, func(a, b ExportedValue) int {
 			switch {
 			case a.Name < b.Name:
 				return -1
@@ -549,12 +552,12 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 			}
 			return 0
 		})
-		return nil
+		return result, nil
 	})
 	if err != nil {
 		return nil, 0, err
 	}
-	return out, served, nil
+	return result.values, result.revision, nil
 }
 
 // TokenKeyRotation is one `rotate-token-key`.
@@ -663,31 +666,34 @@ func (s *Revisions) RotateScanningKey(ctx context.Context, actor Actor) (Scannin
 		return ScanningKeyRotation{}, err
 	}
 	next.CreatedAt = store.CanonTime(s.now())
-	var dropped int64
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	dropped, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (int64, error) {
 		caller, err := actor.resolve(ctx, az, s.now())
 		if err != nil {
-			return err
+			return 0, err
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpRotateScanningKey, domain.Scope{})
 		if err != nil {
-			return err
+			return 0, err
 		}
 		if err := r.Keys().RotateScanningKey(ctx, p, next); err != nil {
-			return err
+			return 0, err
 		}
 		// Every fingerprint is now unrecomputable under the new key: drop them
 		// all in the same transaction as the key swap.
-		if dropped, err = r.ScanningDismissals().DeleteAll(ctx, p); err != nil {
-			return err
+		dropped, err := r.ScanningDismissals().DeleteAll(ctx, p)
+		if err != nil {
+			return 0, err
 		}
 		ev, err := newAuditEvent(ctx, audit.EventScanningKeyRotated, caller.Principal,
 			audit.Object{Type: "instance", ID: "instance"}, audit.OutcomeSuccess, "",
 			audit.Payload{"key_version": int64(next.Version)})
 		if err != nil {
-			return err
+			return 0, err
 		}
-		return r.Audit().InsertInstance(ctx, p, ev)
+		if err := r.Audit().InsertInstance(ctx, p, ev); err != nil {
+			return 0, err
+		}
+		return dropped, nil
 	})
 	if errors.Is(err, store.ErrRotationSuperseded) {
 		return ScanningKeyRotation{}, fmt.Errorf("%w: %s", domain.ErrConflict, err)

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -156,6 +156,11 @@ type CopyResult struct {
 	Findings []Finding
 }
 
+type copyWriteResult struct {
+	copy      CopyResult
+	published []PublishedEnvironment
+}
+
 // CopiedValue is one cell that landed.
 type CopiedValue struct {
 	KeyName                string
@@ -467,6 +472,13 @@ func (s *Values) Unset(ctx context.Context, actor Actor, scope domain.Scope, key
 	return s.stage(ctx, actor, scope, keyName, store.PendingUnset, "", nil)
 }
 
+type stageWriteResult struct {
+	change  StagedChange
+	keyID   string
+	keyName string
+	owner   domain.PrincipalID
+}
+
 func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, keyName string,
 	operation store.PendingOperation, value string, acks []string) (StagedChange, error) {
 	if scope.Env == "" {
@@ -476,28 +488,24 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 	if err != nil {
 		return StagedChange{}, err
 	}
-	var out StagedChange
-	var keyID, keyNameOut string
-	var owner domain.PrincipalID
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		out = StagedChange{}
+	result, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (stageWriteResult, error) {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		p, err := az.Authorize(ctx, caller, authz.OpValueStage, scope)
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		// One serialization domain per project: the draft records the published
 		// entry it was staged against, and a concurrent publish must not slip
 		// between reading that entry and writing the row that pins it.
 		if err := r.Projects().Lock(ctx, p); err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		key, err := findKey(ctx, r.Catalogue(), p, keyName)
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		// The per-project pending cap (ops-spec § 8: ≤ 100 pending versions per
 		// project, loud). Counted under the project lock, excluding this cell —
@@ -505,15 +513,15 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 		// grows the count, and only a genuinely new cell can breach the cap.
 		pending, err := r.Pending().CountForProjectExcludingCell(ctx, p, key.ID, string(caller.Principal))
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		if pending >= MaxPendingPerProject {
-			return fmt.Errorf("%w: a project holds at most %d pending changes",
+			return stageWriteResult{}, fmt.Errorf("%w: a project holds at most %d pending changes",
 				domain.ErrLimitExceeded, MaxPendingPerProject)
 		}
 		revision, err := currentRevision(ctx, r, p)
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		baseline := ""
 		switch entry, err := r.Values().Get(ctx, p, key.ID); {
@@ -522,25 +530,25 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 			// is a real value here rather than a missing one: a cell that gains
 			// a published value after this point makes the draft stale.
 		case err != nil:
-			return err
+			return stageWriteResult{}, err
 		default:
 			baseline = entry.ID
 		}
 		versionID, err := newID("pcv")
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		var sealed []byte
 		if operation == store.PendingSet {
 			if sealed, err = sealer.SealField(
 				pendingAAD(string(scope.Org), string(scope.Project), string(scope.Env), key.ID, versionID),
 				[]byte(schema.Normalize(value))); err != nil {
-				return err
+				return stageWriteResult{}, err
 			}
 			// Writer fence: refuse if the sealer's DEK version was retired by a
 			// rotate-dek since it was built (invariant 7).
 			if err := fenceProject(ctx, r, p, sealer, scope); err != nil {
-				return err
+				return stageWriteResult{}, err
 			}
 		}
 		now := store.CanonTime(time.Now())
@@ -552,7 +560,7 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 			Secret:         key.Classification == string(schema.Secret),
 			MaterialSecret: key.Classification == string(schema.Secret),
 		}); err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		ev, err := domainEvent(ctx, audit.EventValueStaged, caller.Principal,
 			audit.Object{Type: "key", ID: key.ID}, audit.Payload{
@@ -563,10 +571,10 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 				"version_id":     versionID,
 			})
 		if err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		if err := r.Audit().InsertTenant(ctx, p, ev); err != nil {
-			return err
+			return stageWriteResult{}, err
 		}
 		// Surface-1 warn (#74). Only a Set of a config-classified key scans; the
 		// dismissal store ops this path authorizes make stage the sole dismissal-
@@ -579,17 +587,18 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 				key.Classification, []byte(schema.Normalize(value)), surfaceValueWrite,
 				caller.Principal, newAckSet(acks), true, &total)
 			if err != nil {
-				return err
+				return stageWriteResult{}, err
 			}
 		}
-		keyID, keyNameOut, owner = key.ID, key.Name, caller.Principal
-		out = StagedChange{
-			VersionID: versionID, KeyID: key.ID, Name: key.Name,
-			Classification: key.Classification, Operation: string(operation),
-			StagedFromRevision: revision, CreatedAt: now,
-			Findings: findings,
-		}
-		return nil
+		return stageWriteResult{
+			change: StagedChange{
+				VersionID: versionID, KeyID: key.ID, Name: key.Name,
+				Classification: key.Classification, Operation: string(operation),
+				StagedFromRevision: revision, CreatedAt: now,
+				Findings: findings,
+			},
+			keyID: key.ID, keyName: key.Name, owner: caller.Principal,
+		}, nil
 	})
 	if err != nil {
 		return StagedChange{}, err
@@ -597,8 +606,8 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 	// Post-commit: the matrix's quieter "another user has a pending change here"
 	// marker is exactly this fact, and it must not be announced for a draft
 	// whose transaction rolled back.
-	s.Advisory.staged(scope, keyID, keyNameOut, owner)
-	return out, nil
+	s.Advisory.staged(scope, result.keyID, result.keyName, result.owner)
+	return result.change, nil
 }
 
 // Declare is declare-into-environments: ONE supplied plaintext into several
@@ -614,6 +623,12 @@ func (s *Values) Declare(ctx context.Context, actor Actor, scope domain.Scope, e
 	// The empty/blank/duplicate checks live in declare (below), which Set shares:
 	// stating them twice invites the two spellings to drift.
 	return s.declare(ctx, actor, scope, envIDs, keyName, value)
+}
+
+type declareWriteResult struct {
+	cells     []ValueCell
+	findings  []Finding
+	published []PublishedEnvironment
 }
 
 func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, envIDs []string, keyName, value string) ([]ValueCell, []Finding, error) {
@@ -633,45 +648,42 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 	if err != nil {
 		return nil, nil, err
 	}
-	var out []ValueCell
-	var findings []Finding
-	var advanced []PublishedEnvironment
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		out, advanced, findings = nil, nil, nil
+	result, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (declareWriteResult, error) {
+		var result declareWriteResult
 		total := 0
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
-			return err
+			return declareWriteResult{}, err
 		}
 		for _, envID := range envIDs {
 			envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(envID)}
 			p, err := az.Authorize(ctx, caller, authz.OpValueSet, envScope)
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			// One serialization domain per project: the value is validated
 			// against the key's declaration, and a concurrent declaration
 			// change must not slip between the read and the write.
 			if err := r.Projects().Lock(ctx, p); err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			key, err := findKey(ctx, r.Catalogue(), p, keyName)
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			rows, err := r.Catalogue().ListPresence(ctx, p)
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			if err := checkNotForbidden(key, presenceOfKey(key, rows), envID); err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			if err := validateValue(key, value); err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			updatedAt, err := writeCell(ctx, r, p, sealer, envScope, key, caller.Principal, value)
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			ev, err := domainEvent(ctx, audit.EventValueSet, caller.Principal,
 				audit.Object{Type: "key", ID: key.ID}, audit.Payload{
@@ -680,10 +692,10 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 					"classification": key.Classification,
 				})
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			if err := r.Audit().InsertTenant(ctx, p, ev); err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
 			// Surface-1 warn (#74), warn-only: declare's operation does not
 			// authorize the dismissal store ops, so a finding rides the response
@@ -692,9 +704,9 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 				key.Classification, []byte(schema.Normalize(value)), surfaceValueWrite,
 				caller.Principal, nil, false, &total)
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
-			findings = append(findings, envFindings...)
+			result.findings = append(result.findings, envFindings...)
 			// Declare is a supplied-plaintext write that DELIVERS -- its locked
 			// formula carries `publish` on every destination, and #50 shipped it
 			// as an immediate write. It therefore materializes each destination
@@ -702,21 +714,21 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 			// then does not deliver would be a third state nobody asked for.
 			env, err := republish(ctx, r, az, caller, sealer, s.Keyring, envScope, time.Now().UTC(), "declare")
 			if err != nil {
-				return err
+				return declareWriteResult{}, err
 			}
-			advanced = append(advanced, env)
-			out = append(out, ValueCell{
+			result.published = append(result.published, env)
+			result.cells = append(result.cells, ValueCell{
 				KeyID: key.ID, Name: key.Name, Classification: key.Classification,
 				Set: true, UpdatedAt: updatedAt, UpdatedBy: string(caller.Principal),
 			})
 		}
-		return nil
+		return result, nil
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	s.Advisory.published(scope, advanced)
-	return out, findings, nil
+	s.Advisory.published(scope, result.published)
+	return result.cells, result.findings, nil
 }
 
 // Get reads one cell. reveal asks for `secret` plaintext and carries the
@@ -761,21 +773,24 @@ func (s *Values) read(ctx context.Context, actor Actor, scope domain.Scope, keyN
 	}
 	var out []ValueCell
 	if reveal {
-		err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+		out, err = tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) ([]ValueCell, error) {
 			caller, err := actor.resolve(ctx, az, time.Now().UTC())
 			if err != nil {
-				return err
+				return nil, err
 			}
 			p, err := az.Authorize(ctx, caller, op, scope)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			out, err = readCells(ctx, r.Catalogue(), r.Values(), p, sealer, keyName, true,
+			cells, err := readCells(ctx, r.Catalogue(), r.Values(), p, sealer, keyName, true,
 				ceremonyGate(ctx, s.Auth, az, caller, PurposeReveal, string(scope.Env)))
 			if err != nil {
-				return err
+				return nil, err
 			}
-			return auditDisclosures(ctx, r.Audit(), p, caller.Principal, out, "cell")
+			if err := auditDisclosures(ctx, r.Audit(), p, caller.Principal, cells, "cell"); err != nil {
+				return nil, err
+			}
+			return cells, nil
 		})
 	} else {
 		err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
@@ -945,7 +960,7 @@ func (s *Values) Diff(ctx context.Context, actor Actor, scope domain.Scope, left
 	// key per side, so it takes a write transaction; the presence-only diff
 	// stays on the read pool.
 	sides := func(ctx context.Context, cat store.CatalogueReader, vals store.ValueReader, trail store.AuditRepo,
-		az *authz.TxAuthorizer, caller authz.Identity) error {
+		az *authz.TxAuthorizer, caller authz.Identity) ([]DiffRow, error) {
 		read := func(envID string) ([]ValueCell, error) {
 			envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(envID)}
 			op := authz.OpValueList
@@ -977,20 +992,19 @@ func (s *Values) Diff(ctx context.Context, actor Actor, scope domain.Scope, left
 		}
 		left, err := read(leftEnv)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		right, err := read(rightEnv)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		out = diffRows(left, right)
-		return nil
+		return diffRows(left, right), nil
 	}
 	if reveal {
-		err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+		out, err = tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) ([]DiffRow, error) {
 			caller, err := actor.resolve(ctx, az, time.Now().UTC())
 			if err != nil {
-				return err
+				return nil, err
 			}
 			return sides(ctx, r.Catalogue(), r.Values(), r.Audit(), az, caller)
 		})
@@ -1000,7 +1014,8 @@ func (s *Values) Diff(ctx context.Context, actor Actor, scope domain.Scope, left
 			if err != nil {
 				return err
 			}
-			return sides(ctx, r.Catalogue(), r.Values(), nil, az, caller)
+			out, err = sides(ctx, r.Catalogue(), r.Values(), nil, az, caller)
+			return err
 		})
 	}
 	if err != nil {
@@ -1095,22 +1110,19 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 		return CopyResult{}, err
 	}
 	defer release()
-	var out CopyResult
-	var advanced []PublishedEnvironment
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		out = CopyResult{}
-		advanced = nil
+	result, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (copyWriteResult, error) {
+		var result copyWriteResult
 		total := 0
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
-			return err
+			return copyWriteResult{}, err
 		}
 		// Classify the named keys under the source read — nothing is opened here.
 		// This decides which destination legs the copy will need, and supplies
 		// the units the two ceremonies enumerate.
 		hasConfig, secretKeyIDs, allKeyIDs, err := classifyCopyKeys(ctx, r, az, caller, sourceScope, req.KeyNames)
 		if err != nil {
-			return err
+			return copyWriteResult{}, err
 		}
 		// PREFLIGHT every destination — the copy formula and the protected-
 		// destination ceremony — BEFORE any source secret is opened. A
@@ -1125,7 +1137,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 			if err := authorizeDestination(ctx, r, az, caller, destScope,
 				req.ConfirmProtected, hasConfig, len(secretKeyIDs) > 0, allKeyIDs,
 				ceremonyGate(ctx, s.Auth, az, caller, PurposePublish, destID)); err != nil {
-				return err
+				return copyWriteResult{}, err
 			}
 		}
 		// The SOURCE ceremony. A copy carries `reveal(source E)` in the locked
@@ -1136,31 +1148,31 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 			req.SourceEnvironmentID, req.KeyNames, false, copyOpCopy,
 			ceremonyGate(ctx, s.Auth, az, caller, PurposeCopy, req.SourceEnvironmentID))
 		if err != nil {
-			return err
+			return copyWriteResult{}, err
 		}
 		for _, destID := range req.DestinationEnvironmentIDs {
 			destScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(destID)}
 			copied, f, err := applyMaterial(ctx, r, az, caller, sealer, s.Keyring, s.Scan, destScope,
 				req.SourceEnvironmentID, material, operation, &total)
-			out.Copied = append(out.Copied, copied...)
-			out.Findings = append(out.Findings, f...)
+			result.copy.Copied = append(result.copy.Copied, copied...)
+			result.copy.Findings = append(result.copy.Findings, f...)
 			if err != nil {
-				return err
+				return copyWriteResult{}, err
 			}
 			published, err := republish(ctx, r, az, caller, sealer, s.Keyring, destScope,
 				store.CanonTime(time.Now()), operation)
 			if err != nil {
-				return err
+				return copyWriteResult{}, err
 			}
-			advanced = append(advanced, published)
+			result.published = append(result.published, published)
 		}
-		return nil
+		return result, nil
 	})
 	if err != nil {
 		return CopyResult{}, err
 	}
-	s.Advisory.published(scope, advanced)
-	return out, nil
+	s.Advisory.published(scope, result.published)
+	return result.copy, nil
 }
 
 // classifyCopyKeys resolves the named keys under the source read and reports

--- a/internal/store/tx/tx.go
+++ b/internal/store/tx/tx.go
@@ -43,6 +43,11 @@ const deadline = 15 * time.Second
 // authorizer minting proofs valid exactly for this attempt.
 type WriteFn func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error
 
+// WriteResultFn is one result-bearing write-transaction attempt. Returned
+// values must be detached data: repositories, authorizers, proofs, and other
+// attempt-owned references must not escape the closure.
+type WriteResultFn[T any] func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (T, error)
+
 // ReadFn is one read-transaction attempt: read-only repositories plus the
 // attempt's authorizer. There is no proof-free read path — authorization is
 // evaluated in-transaction (permission-model ADR), so reads transact too.
@@ -52,9 +57,46 @@ type ReadFn func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer)
 // exhaustion surfaces as a loud failure wrapping the last error — never an
 // infinite loop or a silent drop.
 func Write(ctx context.Context, db *store.DB, fn WriteFn) error {
-	return retryLoop(ctx, db.Engine(), func(ctx context.Context) error {
-		return writeOnce(ctx, db, fn)
+	_, err := WriteResult(ctx, db, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (struct{}, error) {
+		return struct{}{}, fn(ctx, r, az)
 	})
+	return err
+}
+
+// WriteResult runs fn inside a write transaction with bounded retries and
+// returns only the value produced by the attempt whose transaction committed.
+// Values from rolled-back attempts are discarded, including when Commit itself
+// reports the retryable failure.
+func WriteResult[T any](ctx context.Context, db *store.DB, fn WriteResultFn[T]) (T, error) {
+	return retryResult(ctx, db.Engine(), func(ctx context.Context) (T, error) {
+		var result T
+		err := writeOnce(ctx, db, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+			var err error
+			result, err = fn(ctx, r, az)
+			return err
+		})
+		return result, err
+	})
+}
+
+// retryResult publishes an attempt's result only when the complete attempt —
+// including commit — succeeds. Keeping this boundary separate makes commit
+// failure injection deterministic without driver-specific fault hooks.
+func retryResult[T any](ctx context.Context, engine store.Engine, attemptFn func(context.Context) (T, error)) (T, error) {
+	var committed T
+	err := retryLoop(ctx, engine, func(ctx context.Context) error {
+		attemptResult, err := attemptFn(ctx)
+		if err != nil {
+			return err
+		}
+		committed = attemptResult
+		return nil
+	})
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return committed, nil
 }
 
 // Read runs fn inside a read-only transaction with the same bounded-retry

--- a/internal/store/tx/tx_readwrite_test.go
+++ b/internal/store/tx/tx_readwrite_test.go
@@ -58,3 +58,33 @@ func TestReadTransactionDoesNotBlockWriter(t *testing.T) {
 		t.Fatalf("writer took %v with a read transaction open — the read pool is taking write intent", elapsed)
 	}
 }
+
+func TestWriteResultPublishesOnlyCommittedAttemptValue(t *testing.T) {
+	cfg := store.Config{Engine: store.EngineSQLite, Path: filepath.Join(t.TempDir(), "write-result.db")}
+	if err := migrate.Run(t.Context(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	attempts := 0
+	got, err := WriteResult(t.Context(), db, func(context.Context, store.Repos, *authz.TxAuthorizer) (string, error) {
+		attempts++
+		if attempts == 1 {
+			return "rolled-back-attempt", store.ErrRetrySerialization
+		}
+		return "committed-attempt", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if got != "committed-attempt" {
+		t.Fatalf("result = %q, want committed attempt value", got)
+	}
+}

--- a/internal/store/tx/tx_test.go
+++ b/internal/store/tx/tx_test.go
@@ -101,3 +101,34 @@ func TestRetryLoopRespectsCancelledContext(t *testing.T) {
 		t.Fatalf("calls = %d, want 1 (no retry after cancellation)", calls)
 	}
 }
+
+func TestRetryResultDiscardsValueWhenCommitRetries(t *testing.T) {
+	calls := 0
+	got, err := retryResult(t.Context(), store.EnginePostgres, func(context.Context) (string, error) {
+		calls++
+		if calls == 1 {
+			// The transaction body produced this value, then commit reported a
+			// serialization failure for the complete attempt.
+			return "rolled-back-after-body", &pgconn.PgError{Code: "40001"}
+		}
+		return "committed", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "committed" {
+		t.Fatalf("result = %q, want committed attempt value", got)
+	}
+}
+
+func TestRetryResultReturnsZeroWhenNoAttemptCommits(t *testing.T) {
+	got, err := retryResult(t.Context(), store.EnginePostgres, func(context.Context) (string, error) {
+		return "rolled-back-after-body", errors.New("commit failed")
+	})
+	if err == nil {
+		t.Fatal("commit failure must surface")
+	}
+	if got != "" {
+		t.Fatalf("result = %q, want zero value", got)
+	}
+}


### PR DESCRIPTION
## Stack

- Depends on #281
- Stack root: #274
- Closes #218

## Summary

- add typed tx.WriteResult result publication after a transaction attempt commits
- keep tx.Write as the compatibility no-result wrapper
- migrate high-risk service callers that previously mutated outer result state
- preserve failed retention-sweep candidate telemetry without publishing failed transaction results
- enforce detached result types repository-wide with Go type analysis

## Validation

- go test -count=1 ./internal/store/tx ./internal/lint ./internal/service (185 passed on the current stack tip)
- go test -count=1 ./internal/isolation -run ^TestRetentionFailedSweepCountsObservedCandidates(SQLite|Postgres)$ (2 passed across SQLite and PostgreSQL 18)
- go test -race -count=1 ./internal/store/tx ./internal/service (159 passed)
- GOFLAGS=-p=1 HIKYO_TEST_POSTGRES_DSN=... go test -count=1 ./... against PostgreSQL 18 (3977 passed in 57 packages)
- go build ./...
- go vet ./...
- git diff --check

## Delivery notes

- No generated outputs changed.
- Full implementation and validation evidence is committed in docs/handoff/issue-218-committed-write-results.md.