### PR TITLE
refactor(crypto): centralize scoped token derivation

### DIFF
--- a/docs/handoff/220-scoped-token-derivation.md
+++ b/docs/handoff/220-scoped-token-derivation.md
@@ -1,0 +1,39 @@
+# Handoff: #220 private scoped-token derivation
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/220 (parent #204; programme
+#203; audit ID `BE05-A`).
+
+## Contract
+
+- `Keyring.deriveScopedTokenKey` is the only scoped token-key derivation. It
+  applies HKDF-SHA256 to the live root token key with the canonical
+  length-prefixed `(label, org, project, environment)` info encoding.
+- Change tokens, delivery cursors, import occurrences, and publish previews
+  retain their immutable purpose labels and public token bytes.
+- `ScopedTokenKey` is retired. No exported API returns a raw scoped token key;
+  each purpose API derives per call, defers `Zero`, tags its caller-owned
+  encoding, and retains no cache.
+- Root-token-key locking and rotation behavior are unchanged.
+
+## Regression evidence
+
+`TestScopedTokenFamiliesPreserveGoldenVectorsAndScopeSeparation` uses a fixed
+root, scope, and payload to pin one byte-exact token for every purpose. Each
+purpose also proves cross-purpose domain separation, cross-organization scope
+separation, and injectivity across the `("a", "bc")` / `("ab", "c")` field
+boundary. The former raw-key injectivity test is removed with the exported raw
+key seam.
+
+Generated outputs: none.
+
+## Validation
+
+```text
+go test -count=1 ./internal/crypto/...         123 passed
+go test -race -count=1 ./internal/crypto/...   123 passed
+go test -count=1 ./...                         3066 passed in 57 packages
+git diff --cached --check origin/main          passed
+```
+
+Two-axis Codex review against issue #220 and the crypto ADRs reported zero
+standards findings and zero specification findings.

--- a/internal/crypto/delivery.go
+++ b/internal/crypto/delivery.go
@@ -1,11 +1,9 @@
 package crypto
 
 import (
-	"crypto/hkdf"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
 )
 
 // The two keyed values the machine delivery path publishes (#62; revision-model ADR
@@ -52,7 +50,7 @@ const TokenVersion = "v1"
 // own project constructs a candidate payload, reads its token, and compares it
 // against a target environment's pod annotation.
 func (k *Keyring) ChangeToken(orgID, projectID, envID string, manifest []byte) (string, error) {
-	key, err := k.ScopedTokenKey(orgID, projectID, envID)
+	key, err := k.deriveScopedTokenKey(tokenInfoLabel, orgID, projectID, envID)
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +58,7 @@ func (k *Keyring) ChangeToken(orgID, projectID, envID string, manifest []byte) (
 	return tag(key, manifest), nil
 }
 
-// DeliveryCursor is HMAC-SHA256(scopedCursorKey, tuple), base64url, prefixed.
+// DeliveryCursor is HMAC-SHA256(scoped cursor key, tuple), base64url, prefixed.
 //
 // The caller passes the whole four-tuple encoding — change token, authorized
 // delivery projection, authorization revision, pin generation — and the server
@@ -75,27 +73,12 @@ func (k *Keyring) ChangeToken(orgID, projectID, envID string, manifest []byte) (
 // behind this seam, every outstanding cursor mismatches once and every caller
 // re-syncs.
 func (k *Keyring) DeliveryCursor(orgID, projectID, envID string, tuple []byte) (string, error) {
-	key, err := k.scopedCursorKey(orgID, projectID, envID)
+	key, err := k.deriveScopedTokenKey(cursorInfoLabel, orgID, projectID, envID)
 	if err != nil {
 		return "", err
 	}
 	defer Zero(key)
 	return tag(key, tuple), nil
-}
-
-// scopedCursorKey mirrors ScopedTokenKey under its own label, with the same
-// length-prefixed info encoding — load-bearing for the same reason: raw
-// concatenation would let ("a","bc") and ("ab","c") derive the identical key.
-func (k *Keyring) scopedCursorKey(orgID, projectID, envID string) ([]byte, error) {
-	info := appendLP(nil, []byte(cursorInfoLabel))
-	info = appendLP(info, []byte(orgID))
-	info = appendLP(info, []byte(projectID))
-	info = appendLP(info, []byte(envID))
-	key, err := hkdf.Key(sha256.New, k.rootTokenKey(), nil, string(info), KeySize)
-	if err != nil {
-		return nil, fmt.Errorf("crypto: derive scoped cursor key: %w", err)
-	}
-	return key, nil
 }
 
 // tag renders one keyed value. base64url without padding, because both values

--- a/internal/crypto/keyring_test.go
+++ b/internal/crypto/keyring_test.go
@@ -603,35 +603,6 @@ func TestProjectDEKMintRaceConverges(t *testing.T) {
 	}
 }
 
-// Invariant 10: identifier tuples that differ only in where the boundary
-// falls derive distinct scoped token keys.
-func TestScopedTokenKeyInjective(t *testing.T) {
-	ctx := context.Background()
-	kr, err := LoadKeyring(ctx, newMemStore(), newRoot(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	k1, err := kr.ScopedTokenKey("a", "bc", "e")
-	if err != nil {
-		t.Fatal(err)
-	}
-	k2, err := kr.ScopedTokenKey("ab", "c", "e")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Equal(k1, k2) {
-		t.Error("boundary-shifted scopes derive the same token key")
-	}
-	// Determinism: same scope, same key.
-	k1b, err := kr.ScopedTokenKey("a", "bc", "e")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(k1, k1b) {
-		t.Error("scoped token key is not deterministic")
-	}
-}
-
 func TestDEKCacheBounded(t *testing.T) {
 	ctx := context.Background()
 	kr, err := LoadKeyring(ctx, newMemStore(), newRoot(t))

--- a/internal/crypto/stamp.go
+++ b/internal/crypto/stamp.go
@@ -62,7 +62,7 @@ type StampPair struct {
 // Change propagation).
 //
 // The info string is PIPE-JOINED exactly as § 0.2 fixes it — not the
-// length-prefixed encoding scopedCursorKey uses — and it is injective anyway:
+// length-prefixed encoding scoped token derivation uses — and it is injective anyway:
 // a Kubernetes UID is a hyphenated hex UUID and a Secret name obeys RFC 1123,
 // so neither component can contain the `|` separator.
 func StampKey(root []byte, instanceUID, crUID, secretName string) ([]byte, error) {

--- a/internal/crypto/token.go
+++ b/internal/crypto/token.go
@@ -11,7 +11,7 @@ import (
 // protocol data; changing it would derive different keys for existing values.
 const tokenInfoLabel = "wenv/change-token/v1"
 
-// ScopedTokenKey derives the per-scope change-token key from the root token
+// deriveScopedTokenKey derives one purpose's per-scope key from the root token
 // key (encryption-model ADR § Key hierarchy):
 //
 //	scopedTokenKey = HKDF-SHA256(rootTokenKey, info = LP(label, org_id, project_id, env_id))
@@ -19,10 +19,11 @@ const tokenInfoLabel = "wenv/change-token/v1"
 // The info encoding is the same length-prefixed canonical encoding as the
 // AADs — load-bearing: raw concatenation would let ("a","bc") and ("ab","c")
 // derive the identical key, resurrecting the cross-scope equality oracle the
-// revision-model ADR keyed the token to eliminate. Derived per use, never cached
-// or stored.
-func (k *Keyring) ScopedTokenKey(orgID, projectID, envID string) ([]byte, error) {
-	info := appendLP(nil, []byte(tokenInfoLabel))
+// revision-model ADR keyed the token to eliminate. label is immutable protocol
+// data and domain-separates each token purpose. Derived per use, never cached or
+// stored; callers zero the returned key after tagging.
+func (k *Keyring) deriveScopedTokenKey(label, orgID, projectID, envID string) ([]byte, error) {
+	info := appendLP(nil, []byte(label))
 	info = appendLP(info, []byte(orgID))
 	info = appendLP(info, []byte(projectID))
 	info = appendLP(info, []byte(envID))
@@ -41,7 +42,7 @@ const occurrenceInfoLabel = "hikyo/import-occurrence/v1"
 
 const publishPreviewInfoLabel = "hikyo/publish-preview/v1"
 
-// OccurrenceToken is HMAC-SHA256(scopedOccurrenceKey, encoding), base64url,
+// OccurrenceToken is HMAC-SHA256(scoped occurrence key, encoding), base64url,
 // prefixed — the server-minted opaque token an import's phase 1 records per
 // (key, environment) and phase 2 verifies inside its own authorized
 // transaction.
@@ -58,7 +59,7 @@ const publishPreviewInfoLabel = "hikyo/publish-preview/v1"
 // The caller owns the encoding (internal/delivery.EncodeOccurrence); this
 // package receives bytes and returns a token.
 func (k *Keyring) OccurrenceToken(orgID, projectID, envID string, encoding []byte) (string, error) {
-	key, err := k.scopedOccurrenceKey(orgID, projectID, envID)
+	key, err := k.deriveScopedTokenKey(occurrenceInfoLabel, orgID, projectID, envID)
 	if err != nil {
 		return "", err
 	}
@@ -70,31 +71,12 @@ func (k *Keyring) OccurrenceToken(orgID, projectID, envID string, encoding []byt
 // inputs. It has its own derivation label so a preview token is never usable as
 // a delivery cursor, occurrence token, or change token.
 func (k *Keyring) PublishPreviewToken(orgID, projectID, envID string, encoding []byte) (string, error) {
-	info := appendLP(nil, []byte(publishPreviewInfoLabel))
-	info = appendLP(info, []byte(orgID))
-	info = appendLP(info, []byte(projectID))
-	info = appendLP(info, []byte(envID))
-	key, err := hkdf.Key(sha256.New, k.rootTokenKey(), nil, string(info), KeySize)
+	key, err := k.deriveScopedTokenKey(publishPreviewInfoLabel, orgID, projectID, envID)
 	if err != nil {
-		return "", fmt.Errorf("crypto: derive publish-preview key: %w", err)
+		return "", err
 	}
 	defer Zero(key)
 	return tag(key, encoding), nil
-}
-
-// scopedOccurrenceKey mirrors ScopedTokenKey under its own label, with the same
-// length-prefixed info encoding — load-bearing for the same reason: raw
-// concatenation would let ("a","bc") and ("ab","c") derive the identical key.
-func (k *Keyring) scopedOccurrenceKey(orgID, projectID, envID string) ([]byte, error) {
-	info := appendLP(nil, []byte(occurrenceInfoLabel))
-	info = appendLP(info, []byte(orgID))
-	info = appendLP(info, []byte(projectID))
-	info = appendLP(info, []byte(envID))
-	key, err := hkdf.Key(sha256.New, k.rootTokenKey(), nil, string(info), KeySize)
-	if err != nil {
-		return nil, fmt.Errorf("crypto: derive scoped occurrence key: %w", err)
-	}
-	return key, nil
 }
 
 // rootTokenKey reads the live root token key under the rotation mutex, so a

--- a/internal/crypto/token_test.go
+++ b/internal/crypto/token_test.go
@@ -1,0 +1,65 @@
+package crypto
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestScopedTokenFamiliesPreserveGoldenVectorsAndScopeSeparation(t *testing.T) {
+	t.Parallel()
+
+	// Fixed root, scope and payload make these known-answer vectors protocol
+	// sentinels: changing a label or field encoding changes the literal output.
+	newKeyring := func() *Keyring {
+		return &Keyring{token: keyHandle{key: bytes.Repeat([]byte{0x42}, KeySize)}}
+	}
+	type tokenFn func(*Keyring, string, string, string, []byte) (string, error)
+	tests := []struct {
+		name string
+		tag  tokenFn
+		want string
+	}{
+		{name: "change token", tag: (*Keyring).ChangeToken, want: "v1:poH7aqEWVkpCymIJegWYLoe2hA7Bip7csZ01BkgMyDA"},
+		{name: "delivery cursor", tag: (*Keyring).DeliveryCursor, want: "v1:4_dpQeRHtYsAhf1FiIZWqjKtXvRyY90a90MD8SNuJGE"},
+		{name: "occurrence token", tag: (*Keyring).OccurrenceToken, want: "v1:AMuqmqeGm-zZv8roG7AuxyQyQjcDPr2mswE482p7KtY"},
+		{name: "publish preview", tag: (*Keyring).PublishPreviewToken, want: "v1:wt3UZgkb_Ep1Ehs_GLEZt0PThYFi1Xfk--sft1gdfoI"},
+	}
+	seen := make(map[string]string, len(tests))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kr := newKeyring()
+			got, err := tt.tag(kr, "org_1", "project_1", "production", []byte("canonical payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("golden token = %q, want %q", got, tt.want)
+			}
+			if otherPurpose, ok := seen[got]; ok {
+				t.Errorf("same scope and payload matched %s token", otherPurpose)
+			}
+			seen[got] = tt.name
+
+			otherScope, err := tt.tag(kr, "org_2", "project_1", "production", []byte("canonical payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if otherScope == got {
+				t.Error("different organizations produced the same token")
+			}
+
+			left, err := tt.tag(kr, "a", "bc", "production", []byte("canonical payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			right, err := tt.tag(kr, "ab", "c", "production", []byte("canonical payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if left == right {
+				t.Error("boundary-shifted scopes produced the same token")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- centralize change-token, delivery-cursor, occurrence, and publish-preview key derivation behind one private length-prefixed HKDF primitive
- retire exported ScopedTokenKey so raw scoped token keys remain private
- pin byte-exact outputs plus cross-purpose, cross-scope, and boundary-shift separation for every token family

## Contract and migration

Immutable labels, encodings, root-key locking, and public token bytes are unchanged. Derived keys remain per-use, deferred-zeroed, and uncached. No database migration or generated outputs.

## Validation

- go test -count=1 ./internal/crypto/... — 123 passed
- go test -race -count=1 ./internal/crypto/... — 123 passed
- go test -count=1 ./... — 3066 passed in 57 packages
- git diff --cached --check origin/main — passed
- two-axis Codex review — standards CLEAN; specification CLEAN

Closes #220