### PR TITLE
refactor(compose): unify snapshot binding

### DIFF
--- a/docs/handoff/issue-221-snapshot-binding.md
+++ b/docs/handoff/issue-221-snapshot-binding.md
@@ -1,0 +1,32 @@
+# Issue #221 — validated offline snapshot binding
+
+## Outcome
+
+Offline snapshot scope, storage location, credential binding, delivery identity,
+projection, targets, and issuance window now travel as one immutable
+`crypto.SnapshotBinding`. Live fetch completes the locally constructed binding
+once; offline load validates the same scope before key or snapshot filesystem
+work and returns the stored delivery-complete binding.
+
+## Contract choices
+
+- `HKS1` framing and `SnapshotAAD` JSON field names/order are unchanged.
+- `StorageDir` belongs to the validated binding but is not serialized or
+  authenticated; moving local state does not change snapshot cryptographic
+  identity.
+- Targets, projection, and RFC3339 timestamps canonicalize before live save.
+- Scope-only bindings are valid offline locators. Save requires a
+  delivery-complete binding; mixed/partial delivery fields cannot be built.
+- Existing snapshots need no migration. A literal pre-change HKS1 fixture loads
+  with the new representation.
+
+## Generated outputs
+
+None.
+
+## Validation
+
+- `go test -count=1 ./internal/cli/... ./internal/crypto/... ./internal/compose/...` — 479 passed.
+- `go vet ./internal/cli/... ./internal/crypto/... ./internal/compose/...` — passed.
+- `go test -count=1 ./...` — 3,092 passed across 57 packages.
+- Two-axis review (standards/security and issue #221 spec), round 2 — CLEAN / CLEAN.

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -135,12 +135,17 @@ func runRun(ctx context.Context, ios IO, args []string) error {
 	// The state dir exists only when a config file names this stack; run with no
 	// config file writes nothing and holds nothing pending by construction.
 	stateDir := ""
+	var snapshotBinding crypto.SnapshotBinding
 	if cfg != nil {
 		slug, serr := composeSlug(cfg, org, project, env)
 		if serr != nil {
 			return serr
 		}
 		stateDir = composeStateDir(st, slug)
+		snapshotBinding, serr = newSnapshotBinding(stateDir, entry, org, project, env, token, configOnly, []string{runGenerationKey})
+		if serr != nil {
+			return failf(ExitRefused, "hikyo run: snapshot binding: %v", serr)
+		}
 		// Flush-before-fetch (ops-spec § 6 ordering rule): pending offline
 		// records reconcile BEFORE the fetch proceeds; a failure refuses the
 		// fetch.
@@ -165,12 +170,18 @@ func runRun(ctx context.Context, ios IO, args []string) error {
 		live    bool
 	)
 	if ferr != nil {
-		f, herr := serveRunOffline(ios, cfg, stateDir, entry, org, project, env, token, configOnly, ack, ferr)
+		f, herr := serveRunOffline(ios, cfg, stateDir, snapshotBinding, ack, ferr)
 		if herr != nil {
 			return herr
 		}
 		fetched = f
 	} else {
+		if cfg != nil {
+			snapshotBinding, err = bindSnapshotDelivery(snapshotBinding, resp)
+			if err != nil {
+				return failf(ExitRefused, "hikyo run: snapshot binding: %v", err)
+			}
+		}
 		// All-or-nothing (compose ADR § "Authorization"): a secret the principal
 		// cannot reveal makes the whole delivery refuse BEFORE anything else. Not
 		// reached under --config-only, whose projection carries no secrets.
@@ -210,7 +221,7 @@ func runRun(ctx context.Context, ios IO, args []string) error {
 	// Opt-in governs SERVING, not saving — a silent save failure is the silent
 	// fallback the house forbids, so it is a hard error.
 	if live && cfg != nil {
-		if err := saveRunSnapshot(cfg, stateDir, entry, org, project, env, token, configOnly, resp); err != nil {
+		if err := saveRunSnapshot(stateDir, snapshotBinding, resp); err != nil {
 			return failf(ExitInternal, "hikyo run: saving offline snapshot: %v", err)
 		}
 	}
@@ -367,7 +378,7 @@ func runLoaderControlAck(cfg *compose.Config) []string {
 // stale line, and returns them. Any other failure (or no opt-in) is surfaced
 // unchanged. The snapshot is bound to run's identity: TargetNames ["__run__"],
 // so a render snapshot cannot be served here (finding 3).
-func serveRunOffline(ios IO, cfg *compose.Config, stateDir string, entry TrustEntry, org, project, env, token string, configOnly bool, ack []string, fetchErr error) (map[string]string, error) {
+func serveRunOffline(ios IO, cfg *compose.Config, stateDir string, binding crypto.SnapshotBinding, ack []string, fetchErr error) (map[string]string, error) {
 	if !isUnavailable(fetchErr) {
 		return nil, fetchErr
 	}
@@ -375,7 +386,7 @@ func serveRunOffline(ios IO, cfg *compose.Config, stateDir string, entry TrustEn
 		fmt.Fprintln(ios.Stderr, "hikyo run: offline serve is not enabled for this stack; set snapshot.offline_serve: true in hikyo-compose.yaml to serve stale values during an outage")
 		return nil, fetchErr
 	}
-	payload, aad, err := loadOfflineSnapshot(ios, cfg, stateDir, entry, org, project, env, token, configOnly, []string{runGenerationKey})
+	payload, binding, err := loadOfflineSnapshot(ios, cfg, binding)
 	if err != nil {
 		return nil, err
 	}
@@ -386,8 +397,12 @@ func serveRunOffline(ios IO, cfg *compose.Config, stateDir string, entry TrustEn
 			strings.Join(refused, ", "))
 	}
 	stamp := payload.GenerationStamps[runGenerationKey]
-	if err := appendOfflineRecords(ios, stateDir, payload.Rows, aad, stamp); err != nil {
+	if err := appendOfflineRecords(ios, stateDir, payload.Rows, binding, stamp); err != nil {
 		return nil, failf(ExitInternal, "hikyo run: recording offline disclosure: %v", err)
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		return nil, failf(ExitInternal, "hikyo run: reading offline snapshot binding: %v", err)
 	}
 	fmt.Fprintf(ios.Stderr, "serving stale from %s, generation %s\n", aad.IssuedAt, stamp)
 	return rowsToValues(payload.Rows), nil
@@ -398,7 +413,10 @@ func serveRunOffline(ios IO, cfg *compose.Config, stateDir string, entry TrustEn
 // ContextMatches refuses a render snapshot for run and vice versa (finding 3),
 // and its credential binding is the fingerprint of the presented token (R1-3),
 // authenticated in the header — no separate credential record on disk.
-func saveRunSnapshot(cfg *compose.Config, stateDir string, entry TrustEntry, org, project, env, token string, configOnly bool, resp apigen.DeliveryResponse) error {
+func saveRunSnapshot(stateDir string, binding crypto.SnapshotBinding, resp apigen.DeliveryResponse) error {
+	if _, err := binding.CanonicalAAD(); err != nil {
+		return err
+	}
 	keys, err := loadLocalKeys(stateDir)
 	if err != nil {
 		return err
@@ -409,8 +427,7 @@ func saveRunSnapshot(cfg *compose.Config, stateDir string, entry TrustEntry, org
 	// WriteGeneration does — so the __run__ sentinel is legal here).
 	stamp := compose.TargetStamp(keys, runGenerationKey, canonicalRows(rows))
 	payload := compose.SnapshotPayload{Rows: rows, GenerationStamps: map[string]string{runGenerationKey: stamp}}
-	aad := buildDeliveryAAD(entry, org, project, env, resp, token, configOnly, []string{runGenerationKey})
-	return saveSnapshot(stateDir, keys, aad, payload)
+	return saveSnapshot(keys, binding, payload)
 }
 
 // ---------------------------------------------------------------------------
@@ -485,6 +502,10 @@ func composeRenderCore(ctx context.Context, ios IO, st *State, flags commonFlags
 	}
 	stateDir := composeStateDir(st, slug)
 	rp := renderPaths{cfgDir: cfgDir, stateDir: stateDir}
+	snapshotBinding, err := newSnapshotBinding(stateDir, entry, org, project, env, token, configOnly, cfg.TargetNames())
+	if err != nil {
+		return false, rp, failf(ExitRefused, "compose render: snapshot binding: %v", err)
+	}
 	runtimeDir, explicitRuntime, err := composeRuntimeDir(ios, cfg, slug)
 	if err != nil {
 		return false, rp, err
@@ -535,7 +556,7 @@ func composeRenderCore(ctx context.Context, ios IO, st *State, flags commonFlags
 	// filters nothing; per-target refusal below stays client-side authoritative.
 	resp, ferr := fetchDelivery(ctx, client, org, project, env, configOnly, renderAcknowledged(cfg), present)
 	if ferr != nil {
-		moved, err := composeRenderOffline(ctx, ios, lock, cfg, cfgDir, stateDir, runtimeDir, keys, entry, org, project, env, token, configOnly, ferr)
+		moved, err := composeRenderOffline(ctx, ios, lock, cfg, cfgDir, stateDir, runtimeDir, keys, snapshotBinding, configOnly, ferr)
 		return moved, rp, err
 	}
 	if resp.Current {
@@ -544,13 +565,20 @@ func composeRenderCore(ctx context.Context, ios IO, st *State, flags commonFlags
 		}
 		return false, rp, nil
 	}
-	moved, err := composeRenderApply(ios, lock, cfg, stateDir, runtimeDir, keys, entry, org, project, env, token, configOnly, resp, currentStamps)
+	snapshotBinding, err = bindSnapshotDelivery(snapshotBinding, resp)
+	if err != nil {
+		return false, rp, failf(ExitRefused, "compose render: snapshot binding: %v", err)
+	}
+	moved, err := composeRenderApply(ios, lock, cfg, stateDir, runtimeDir, keys, snapshotBinding, token, env, configOnly, resp, currentStamps)
 	return moved, rp, err
 }
 
 // composeRenderApply renders each target from a live full delivery. On ANY
 // refusal it writes no generation and does not advance the cursor.
-func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, stateDir, runtimeDir string, keys *crypto.LocalKeys, entry TrustEntry, org, project, env, token string, configOnly bool, resp apigen.DeliveryResponse, currentStamps map[string]string) (bool, error) {
+func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, stateDir, runtimeDir string, keys *crypto.LocalKeys, binding crypto.SnapshotBinding, token, env string, configOnly bool, resp apigen.DeliveryResponse, currentStamps map[string]string) (bool, error) {
+	if _, err := binding.CanonicalAAD(); err != nil {
+		return false, failf(ExitRefused, "compose render: snapshot binding: %v", err)
+	}
 	byID := deliveredByID(resp.Keys)
 
 	type rendered struct {
@@ -650,8 +678,7 @@ func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, s
 	// without a snapshot could read "current" after a reboot with nothing to
 	// serve. If the cursor save fails the snapshot still stands and the next
 	// render does a full fetch.
-	aad := buildDeliveryAAD(entry, org, project, env, resp, token, configOnly, cfg.TargetNames())
-	if err := saveSnapshot(stateDir, keys, aad, compose.SnapshotPayload{Rows: allRows, GenerationStamps: finalStamps}); err != nil {
+	if err := saveSnapshot(keys, binding, compose.SnapshotPayload{Rows: allRows, GenerationStamps: finalStamps}); err != nil {
 		return false, failf(ExitInternal, "compose render: save snapshot: %v", err)
 	}
 	if err := saveCursor(stateDir, cfg, resp, token, env, configOnly, finalStamps); err != nil {
@@ -667,7 +694,7 @@ func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, s
 // composeRenderOffline renders each target from the last snapshot when the
 // server is unreachable and the stack opted in. Row→key_id now comes from the
 // sealed payload's rows (finding 3: no cleartext sidecar).
-func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock, cfg *compose.Config, cfgDir, stateDir, runtimeDir string, keys *crypto.LocalKeys, entry TrustEntry, org, project, env, token string, configOnly bool, fetchErr error) (bool, error) {
+func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock, cfg *compose.Config, cfgDir, stateDir, runtimeDir string, keys *crypto.LocalKeys, binding crypto.SnapshotBinding, configOnly bool, fetchErr error) (bool, error) {
 	_ = ctx
 	if !isUnavailable(fetchErr) {
 		return false, fetchErr
@@ -676,9 +703,13 @@ func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock,
 		fmt.Fprintln(ios.Stderr, "hikyo compose render: offline serve is not enabled for this stack; set snapshot.offline_serve: true to render from the last snapshot during an outage")
 		return false, fetchErr
 	}
-	payload, aad, err := loadOfflineSnapshot(ios, cfg, stateDir, entry, org, project, env, token, configOnly, cfg.TargetNames())
+	payload, binding, err := loadOfflineSnapshot(ios, cfg, binding)
 	if err != nil {
 		return false, err
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		return false, failf(ExitInternal, "compose render: reading offline snapshot binding: %v", err)
 	}
 	byID := map[string]compose.SnapshotRow{}
 	for _, r := range payload.Rows {
@@ -1383,56 +1414,61 @@ func toAPIRecords(recs []compose.OfflineRecord) []apigen.OfflineDeliveryRecord {
 // snapshot / cursor helpers (thin wrappers over internal/compose)
 // ---------------------------------------------------------------------------
 
-func saveSnapshot(stateDir string, keys *crypto.LocalKeys, aad crypto.SnapshotAAD, payload compose.SnapshotPayload) error {
-	return compose.SaveSnapshot(stateDir, keys, aad, payload)
+func saveSnapshot(keys *crypto.LocalKeys, binding crypto.SnapshotBinding, payload compose.SnapshotPayload) error {
+	return compose.SaveSnapshot(keys, binding, payload)
 }
 
-// loadOfflineSnapshot opens the persisted snapshot for offline serve under the
-// SnapshotContext the box can reconstruct offline: origin/org/project/env from
-// the invocation, config_only, the mode's target set (["__run__"] for run, the
-// configured targets for render), and the LOCAL fingerprint of the presented
-// token (R1-3 — a rotated token refuses the old snapshot by name, offline, with
-// nothing mutable on disk supplying the expectation). ContextMatches refuses a
-// transplanted snapshot BY NAME before any crypto.
-func loadOfflineSnapshot(ios IO, cfg *compose.Config, stateDir string, entry TrustEntry, org, project, env, token string, configOnly bool, targetNames []string) (compose.SnapshotPayload, crypto.SnapshotAAD, error) {
+// loadOfflineSnapshot opens the persisted snapshot under the validated binding
+// the box constructed before the fetch: origin/org/project/env, config_only,
+// mode target set, and the LOCAL fingerprint of the presented token. A rotated
+// token refuses the old snapshot by name before decrypt work.
+func loadOfflineSnapshot(ios IO, cfg *compose.Config, binding crypto.SnapshotBinding) (compose.SnapshotPayload, crypto.SnapshotBinding, error) {
 	var zeroP compose.SnapshotPayload
-	var zeroA crypto.SnapshotAAD
+	var zeroB crypto.SnapshotBinding
+	if err := binding.ValidateScope(); err != nil {
+		return zeroP, zeroB, err
+	}
+	stateDir, err := binding.StorageDir()
+	if err != nil {
+		return zeroP, zeroB, err
+	}
 	keys, err := loadLocalKeys(stateDir)
 	if err != nil {
-		return zeroP, zeroA, err
+		return zeroP, zeroB, err
 	}
-	ctx := snapshotContext(entry, org, project, env, token, configOnly, targetNames)
-	payload, aad, err := compose.LoadSnapshot(stateDir, keys, ctx, ios.now(), cfg.SnapshotMaxAge())
+	payload, storedBinding, err := compose.LoadSnapshot(keys, binding, ios.now(), cfg.SnapshotMaxAge())
 	if err != nil {
 		if errors.Is(err, compose.ErrSnapshotContext) {
-			return zeroP, zeroA, failf(ExitRefused, "offline snapshot belongs to a different context and will not be served: %v", err)
+			return zeroP, zeroB, failf(ExitRefused, "offline snapshot belongs to a different context and will not be served: %v", err)
 		}
 		if errors.Is(err, os.ErrNotExist) {
-			return zeroP, zeroA, failf(ExitRefused, "offline serve is enabled but no snapshot has been saved for this stack yet")
+			return zeroP, zeroB, failf(ExitRefused, "offline serve is enabled but no snapshot has been saved for this stack yet")
 		}
 		if errors.Is(err, compose.ErrSnapshotExpired) || errors.Is(err, compose.ErrSnapshotRollback) || errors.Is(err, crypto.ErrDecrypt) {
-			return zeroP, zeroA, failf(ExitRefused,
+			aad, aadErr := storedBinding.AAD()
+			if aadErr != nil {
+				return zeroP, zeroB, failf(ExitRefused, "offline serve refused: snapshot binding is unusable (%v)", err)
+			}
+			return zeroP, zeroB, failf(ExitRefused,
 				"offline serve refused: snapshot issued %s, expires %s — past the maximum stale age (%s) or otherwise unusable (%v)",
 				aad.IssuedAt, aad.ExpiresAt, cfg.SnapshotMaxAge(), err)
 		}
-		return zeroP, zeroA, failf(ExitRefused, "offline serve: %v", err)
+		return zeroP, zeroB, failf(ExitRefused, "offline serve: %v", err)
 	}
-	return payload, aad, nil
+	return payload, storedBinding, nil
 }
 
-// snapshotContext assembles the offline-known SnapshotContext (crypto ADR
-// § "AAD binds the container to its context"). The credential is bound by the
-// LOCAL fingerprint of the presented token (R1-3), the SAME helper the cursor
-// uses, so both refuse a rotated token without reaching the server.
-func snapshotContext(entry TrustEntry, org, project, env, token string, configOnly bool, targetNames []string) crypto.SnapshotContext {
-	names := append([]string(nil), targetNames...)
-	sort.Strings(names)
-	return crypto.SnapshotContext{
+// newSnapshotBinding validates and owns the offline-known scope before any
+// snapshot filesystem work. The same value is completed from a live delivery
+// or matched against the stored delivery fields on an offline path.
+func newSnapshotBinding(stateDir string, entry TrustEntry, org, project, env, token string, configOnly bool, targetNames []string) (crypto.SnapshotBinding, error) {
+	return crypto.NewSnapshotBinding(crypto.SnapshotBindingScope{
+		StorageDir:     stateDir,
 		InstanceOrigin: entry.Origin,
 		OrgID:          org, ProjectID: project, EnvironmentID: env,
 		CredentialFingerprint: credentialFingerprint(token), ConfigOnly: configOnly,
-		TargetNames: names,
-	}
+		TargetNames: targetNames,
+	})
 }
 
 // cursorBinding builds the eligibility binding. The credential identity is the
@@ -1492,9 +1528,13 @@ func eligibleCursor(stateDir string, cfg *compose.Config, currentStamps map[stri
 // appendOfflineRecords writes one durable, fsynced disclosure record per served
 // row BEFORE the plaintext is released (compose ADR § "Audit during offline
 // serve"). KeyID travels inside the sealed payload's rows now.
-func appendOfflineRecords(ios IO, stateDir string, rows []compose.SnapshotRow, aad crypto.SnapshotAAD, generation string) error {
+func appendOfflineRecords(ios IO, stateDir string, rows []compose.SnapshotRow, binding crypto.SnapshotBinding, generation string) error {
 	if len(rows) == 0 {
 		return nil
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		return err
 	}
 	recs := make([]compose.OfflineRecord, 0, len(rows))
 	for _, r := range rows {
@@ -1937,29 +1977,19 @@ func targetKeyIDs(cfg *compose.Config) map[string][]string {
 	return out
 }
 
-// buildDeliveryAAD assembles the snapshot header AAD. PinnedRevision is the
-// resolved pin when the server served a pin, else 0 (unpinned "current") — it is
-// NOT the schema revision. ChangeToken is the server's keyed manifest token
-// binding content identity into the header (findings 7/8, on the wire).
-func buildDeliveryAAD(entry TrustEntry, org, project, env string, resp apigen.DeliveryResponse, token string, configOnly bool, targetNames []string) crypto.SnapshotAAD {
+// bindSnapshotDelivery completes the already-validated local snapshot scope
+// with one live response. PinnedRevision is the resolved pin when the server
+// served a pin, else 0 (unpinned "current") — it is NOT schema revision.
+func bindSnapshotDelivery(binding crypto.SnapshotBinding, resp apigen.DeliveryResponse) (crypto.SnapshotBinding, error) {
 	pinned := int64(0)
 	if resp.PinnedRevision != nil {
 		pinned = *resp.PinnedRevision
 	}
-	names := append([]string(nil), targetNames...)
-	sort.Strings(names)
-	return crypto.SnapshotAAD{
-		InstanceOrigin: entry.Origin,
-		OrgID:          org, ProjectID: project, EnvironmentID: env,
-		// CredentialID is authenticated server-asserted metadata (returned to the
-		// caller for the offline records' credential_id); CredentialFingerprint is
-		// the LOCAL binding ContextMatches actually compares (R1-3).
-		CredentialID:          resp.CredentialId,
-		CredentialFingerprint: credentialFingerprint(token),
-		PinnedRevision:        pinned,
-		ChangeToken:           resp.ChangeToken,
-		Projection:            deliveryProjection(resp.Keys), ConfigOnly: configOnly,
-		TargetNames: names,
+	return binding.WithDelivery(crypto.SnapshotBindingDelivery{
+		CredentialID:   resp.CredentialId,
+		PinnedRevision: pinned,
+		ChangeToken:    resp.ChangeToken,
+		Projection:     deliveryProjection(resp.Keys),
 		// RFC3339Nano (not RFC3339): the server issues at sub-second precision, and
 		// second-truncation would make two fetches within the same wall-clock
 		// second collide on the snapshot high-water mark (equal issuance, different
@@ -1970,7 +2000,7 @@ func buildDeliveryAAD(entry TrustEntry, org, project, env string, resp apigen.De
 		// (fractional seconds are permitted), so the stale-line spelling holds.
 		IssuedAt:  resp.IssuedAt.UTC().Format(time.RFC3339Nano),
 		ExpiresAt: resp.SnapshotExpiresAt.UTC().Format(time.RFC3339Nano),
-	}
+	})
 }
 
 // deliveryProjection is the authorized projection recorded in the snapshot AAD,

--- a/internal/cli/compose_internal_test.go
+++ b/internal/cli/compose_internal_test.go
@@ -854,6 +854,73 @@ func TestOfflineRenderSnapshotRefusedForRun(t *testing.T) {
 	}
 }
 
+func TestSnapshotBindingLiveAndOfflineRenderPathsAreEquivalent(t *testing.T) {
+	issued := time.Date(2026, 8, 19, 10, 0, 0, 123, time.UTC)
+	server := deliveryServer(t, apigen.DeliveryResponse{
+		ChangeToken: "v1:tok", CredentialId: "cred_1", Current: false, Cursor: "v1:c1",
+		IssuedAt: issued, SnapshotExpiresAt: issued.Add(7 * 24 * time.Hour),
+		SchemaRevision: 1,
+		Keys: []apigen.DeliveredKey{{
+			KeyId: "key_1", Name: "DATABASE_URL", Classification: apigen.KeyClassificationConfig,
+			Presence: apigen.DeliveredKeyPresenceSet, Value: strPtr("postgres://live"),
+		}},
+	})
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	projectDir := t.TempDir()
+	content := "version: 1\ninstance: " + server.URL + "\norg: org_1\nproject: prj_1\nenvironment: env_1\n" +
+		"slug: acme\nruntime_dir: " + runtimeDir + "\nsnapshot:\n  offline_serve: true\n" +
+		"targets:\n  api:\n    keys: [key_1]\n    services: [api]\n"
+	if err := os.WriteFile(filepath.Join(projectDir, composeConfigName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stateRoot := machineState(t, server.URL)
+	now := func() time.Time { return issued.Add(time.Hour) }
+
+	liveIO, _, liveStderr := composeIO(stateRoot, projectDir, "wl_token", nil)
+	liveIO.Now = now
+	if code := Run(t.Context(), liveIO, []string{"compose", "render"}); code != ExitOK {
+		t.Fatalf("live render exit=%d; stderr=%s", code, liveStderr)
+	}
+	stateDir := filepath.Join(stateRoot, "compose", "acme")
+	cfg, err := compose.ParseConfig([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := newSnapshotBinding(stateDir, TrustEntry{Origin: server.URL}, "org_1", "prj_1", "env_1", "wl_token", false, []string{"api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, liveBinding, err := loadOfflineSnapshot(liveIO, cfg, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveAAD, err := liveBinding.CanonicalAAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server.Close()
+	offlineIO, _, offlineStderr := composeIO(stateRoot, projectDir, "wl_token", nil)
+	offlineIO.Now = now
+	if code := Run(t.Context(), offlineIO, []string{"compose", "render"}); code != ExitOK {
+		t.Fatalf("offline render exit=%d; stderr=%s", code, offlineStderr)
+	}
+	if !strings.Contains(offlineStderr.String(), "serving stale from 2026-08-19T10:00:00.000000123Z") {
+		t.Fatalf("offline render did not use stored issuance: %s", offlineStderr)
+	}
+	_, offlineBinding, err := loadOfflineSnapshot(offlineIO, cfg, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offlineAAD, err := offlineBinding.CanonicalAAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(liveAAD, offlineAAD) {
+		t.Fatalf("live/offline binding mismatch:\n live %s\noffline %s", liveAAD, offlineAAD)
+	}
+}
+
 // seedRenderSnapshot writes a render-mode snapshot (TargetNames [target]) with
 // the given rows, bound to the fingerprint of `token`, so an offline render that
 // presents the SAME token can open it (R1-3 — no server-credential record).
@@ -875,7 +942,15 @@ func seedRenderSnapshot(t *testing.T, stateDir, origin, token, target string, ro
 		IssuedAt:    issued.Format(time.RFC3339), ExpiresAt: issued.Add(7 * 24 * time.Hour).Format(time.RFC3339),
 	}
 	payload := compose.SnapshotPayload{Rows: rows, GenerationStamps: map[string]string{target: "v1-00000000000000000000000000000000"}}
-	if err := compose.SaveSnapshot(stateDir, keys, aad, payload); err != nil {
+	header, err := aad.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := crypto.ParseSnapshotBinding(stateDir, header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compose.SaveSnapshot(keys, binding, payload); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -954,7 +1029,15 @@ func seedRunSnapshot(t *testing.T, stateDir, origin, token string) {
 		IssuedAt: issued.Format(time.RFC3339), ExpiresAt: issued.Add(7 * 24 * time.Hour).Format(time.RFC3339),
 	}
 	payload := compose.SnapshotPayload{Rows: rows, GenerationStamps: map[string]string{runGenerationKey: stamp}}
-	if err := compose.SaveSnapshot(stateDir, keys, aad, payload); err != nil {
+	header, err := aad.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := crypto.ParseSnapshotBinding(stateDir, header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compose.SaveSnapshot(keys, binding, payload); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/compose/snapshot.go
+++ b/internal/compose/snapshot.go
@@ -27,14 +27,14 @@ import (
 // exists for — the server is unreachable, so the box cannot reconstruct the
 // full AAD tuple (revision, projection, issuance, expiry). The container
 // therefore stores that tuple as a cleartext, AEAD-authenticated header and the
-// caller supplies only the SnapshotContext it knows offline (identity, org,
-// project, environment, credential fingerprint of the presented token,
-// config-only mode, target set).
+// caller supplies one validated scope-only SnapshotBinding containing what it
+// knows offline (identity, org, project, environment, credential fingerprint of
+// the presented token, config-only mode, target set).
 //
 //	container = "HKS1" ‖ uint32-BE(len(header)) ‖ header ‖ sealed-payload
 //
-// where `header` is crypto.SnapshotAAD.Canonical() and the sealed payload's AAD
-// IS those exact header bytes, so tampering the header fails the open.
+// where `header` is SnapshotBinding.CanonicalAAD() and the sealed payload's AAD
+// IS those exact legacy-compatible bytes, so tampering the header fails the open.
 //
 // Two guards beyond the AEAD:
 //   - a high-water mark of (issuance, header-digest): an older issuance is
@@ -88,18 +88,26 @@ type hwm struct {
 	Digest   string `json:"digest"`
 }
 
-// SaveSnapshot seals payload under keys with the AAD's canonical header, frames
+// SaveSnapshot seals payload under keys with the binding's canonical AAD, frames
 // the self-describing container, and writes snapshot.bin atomically (0600). It
 // advances snapshot.hwm to (issued_at, header-digest) and REFUSES to save an
 // issuance older than the current high-water mark (a rollback attempt).
-func SaveSnapshot(stateDir string, keys *crypto.LocalKeys, aad crypto.SnapshotAAD, payload SnapshotPayload) error {
+func SaveSnapshot(keys *crypto.LocalKeys, binding crypto.SnapshotBinding, payload SnapshotPayload) error {
+	stateDir, err := binding.StorageDir()
+	if err != nil {
+		return err
+	}
+	header, err := binding.CanonicalAAD()
+	if err != nil {
+		return err
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		return err
+	}
 	issued, err := time.Parse(time.RFC3339, aad.IssuedAt)
 	if err != nil {
 		return fmt.Errorf("compose: snapshot issued_at %q is not RFC3339: %w", aad.IssuedAt, err)
-	}
-	header, err := aad.Canonical()
-	if err != nil {
-		return err
 	}
 	// The container writes the header length as a 4-byte prefix, so a header
 	// beyond uint32 range cannot be framed. It never happens (the AAD is a
@@ -150,55 +158,65 @@ func SaveSnapshot(stateDir string, keys *crypto.LocalKeys, aad crypto.SnapshotAA
 	return nil
 }
 
-// LoadSnapshot reads snapshot.bin, parses its self-describing header, checks the
-// offline-known context against `expect`, enforces rollback and expiry, then
-// decrypts. It returns the payload and the full header (revision, projection,
-// issuance and expiry are taken FROM the header, not reconstructed). maxAge is
-// the per-stack downward override; the effective expiry is the earlier bound.
-func LoadSnapshot(stateDir string, keys *crypto.LocalKeys, expect crypto.SnapshotContext, now time.Time, maxAge time.Duration) (SnapshotPayload, crypto.SnapshotAAD, error) {
+// LoadSnapshot validates the expected binding before reading snapshot.bin,
+// parses its self-describing header into a delivery-complete binding, checks the
+// offline-known scope, enforces rollback and expiry, then decrypts. maxAge is the
+// per-stack downward override; the effective expiry is the earlier bound.
+func LoadSnapshot(keys *crypto.LocalKeys, expect crypto.SnapshotBinding, now time.Time, maxAge time.Duration) (SnapshotPayload, crypto.SnapshotBinding, error) {
 	var zeroP SnapshotPayload
-	var zeroA crypto.SnapshotAAD
+	var zeroB crypto.SnapshotBinding
+	if err := expect.ValidateScope(); err != nil {
+		return zeroP, zeroB, err
+	}
+	stateDir, err := expect.StorageDir()
+	if err != nil {
+		return zeroP, zeroB, err
+	}
 
 	record, err := os.ReadFile(filepath.Join(stateDir, snapshotFile))
 	if err != nil {
-		return zeroP, zeroA, fmt.Errorf("compose: read snapshot: %w", err)
+		return zeroP, zeroB, fmt.Errorf("compose: read snapshot: %w", err)
 	}
 	header, sealed, err := unframeSnapshot(record)
 	if err != nil {
-		return zeroP, zeroA, err
+		return zeroP, zeroB, err
 	}
-	aad, err := crypto.ParseSnapshotHeader(header)
+	binding, err := crypto.ParseSnapshotBinding(stateDir, header)
 	if err != nil {
-		return zeroP, zeroA, err
+		return zeroP, zeroB, err
 	}
 	// Refuse a transplanted snapshot by name before any crypto work.
-	if err := aad.ContextMatches(expect); err != nil {
-		return zeroP, zeroA, fmt.Errorf("%w: %v", ErrSnapshotContext, err)
+	if err := binding.ContextMatches(expect); err != nil {
+		return zeroP, zeroB, fmt.Errorf("%w: %v", ErrSnapshotContext, err)
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		return zeroP, zeroB, err
 	}
 
 	issued, err := time.Parse(time.RFC3339, aad.IssuedAt)
 	if err != nil {
-		return zeroP, zeroA, fmt.Errorf("compose: snapshot issued_at %q is not RFC3339: %w", aad.IssuedAt, err)
+		return zeroP, binding, fmt.Errorf("compose: snapshot issued_at %q is not RFC3339: %w", aad.IssuedAt, err)
 	}
 	expires, err := time.Parse(time.RFC3339, aad.ExpiresAt)
 	if err != nil {
-		return zeroP, zeroA, fmt.Errorf("compose: snapshot expires_at %q is not RFC3339: %w", aad.ExpiresAt, err)
+		return zeroP, binding, fmt.Errorf("compose: snapshot expires_at %q is not RFC3339: %w", aad.ExpiresAt, err)
 	}
 
 	mark, err := readHWM(stateDir)
 	if err != nil {
-		return zeroP, zeroA, err
+		return zeroP, binding, err
 	}
 	if mark != nil {
 		markTime, err := time.Parse(time.RFC3339, mark.IssuedAt)
 		if err != nil {
-			return zeroP, zeroA, fmt.Errorf("compose: high-water mark %q is not RFC3339: %w", mark.IssuedAt, err)
+			return zeroP, binding, fmt.Errorf("compose: high-water mark %q is not RFC3339: %w", mark.IssuedAt, err)
 		}
 		if issued.Before(markTime) {
-			return zeroP, zeroA, fmt.Errorf("%w (issued %s < hwm %s)", ErrSnapshotRollback, issued, markTime)
+			return zeroP, binding, fmt.Errorf("%w (issued %s < hwm %s)", ErrSnapshotRollback, issued, markTime)
 		}
 		if issued.Equal(markTime) && headerDigest(header) != mark.Digest {
-			return zeroP, zeroA, fmt.Errorf("%w (issued %s equals hwm but header identity differs)", ErrSnapshotRollback, issued)
+			return zeroP, binding, fmt.Errorf("%w (issued %s equals hwm but header identity differs)", ErrSnapshotRollback, issued)
 		}
 	}
 
@@ -208,20 +226,20 @@ func LoadSnapshot(stateDir string, keys *crypto.LocalKeys, expect crypto.Snapsho
 		effective = capped
 	}
 	if now.After(effective) {
-		return zeroP, zeroA, fmt.Errorf("%w (expired at %s, now %s)", ErrSnapshotExpired, effective, now)
+		return zeroP, binding, fmt.Errorf("%w (expired at %s, now %s)", ErrSnapshotExpired, effective, now)
 	}
 
 	plaintext, err := keys.OpenSnapshot(header, sealed)
 	if err != nil {
-		return zeroP, zeroA, err // crypto.ErrDecrypt on any tamper/AEAD failure
+		return zeroP, binding, err // crypto.ErrDecrypt on any tamper/AEAD failure
 	}
 	var payload SnapshotPayload
 	dec := json.NewDecoder(bytes.NewReader(plaintext))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&payload); err != nil {
-		return zeroP, zeroA, fmt.Errorf("compose: parse snapshot payload: %w", err)
+		return zeroP, binding, fmt.Errorf("compose: parse snapshot payload: %w", err)
 	}
-	return payload, aad, nil
+	return payload, binding, nil
 }
 
 func headerDigest(header []byte) string {

--- a/internal/compose/snapshot_test.go
+++ b/internal/compose/snapshot_test.go
@@ -1,7 +1,9 @@
 package compose
 
 import (
+	"encoding/base64"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,14 +22,43 @@ func snapAAD(issued, expires string) crypto.SnapshotAAD {
 	}
 }
 
-// snapCtx is the offline-known context matching snapAAD.
-func snapCtx() crypto.SnapshotContext {
-	return crypto.SnapshotContext{
+func snapBinding(t *testing.T, stateDir string, aad crypto.SnapshotAAD) crypto.SnapshotBinding {
+	t.Helper()
+	binding, err := crypto.NewSnapshotBinding(crypto.SnapshotBindingScope{
+		StorageDir:     stateDir,
+		InstanceOrigin: aad.InstanceOrigin,
+		OrgID:          aad.OrgID, ProjectID: aad.ProjectID, EnvironmentID: aad.EnvironmentID,
+		CredentialFingerprint: aad.CredentialFingerprint, ConfigOnly: aad.ConfigOnly,
+		TargetNames: aad.TargetNames,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err = binding.WithDelivery(crypto.SnapshotBindingDelivery{
+		CredentialID: aad.CredentialID, PinnedRevision: aad.PinnedRevision,
+		ChangeToken: aad.ChangeToken, Projection: aad.Projection,
+		IssuedAt: aad.IssuedAt, ExpiresAt: aad.ExpiresAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding
+}
+
+// snapScope is the offline-known binding matching snapAAD.
+func snapScope(t *testing.T, stateDir, environment string) crypto.SnapshotBinding {
+	t.Helper()
+	binding, err := crypto.NewSnapshotBinding(crypto.SnapshotBindingScope{
+		StorageDir:     stateDir,
 		InstanceOrigin: "https://hikyo.example",
-		OrgID:          "org_1", ProjectID: "prj_1", EnvironmentID: "env_1",
+		OrgID:          "org_1", ProjectID: "prj_1", EnvironmentID: environment,
 		CredentialFingerprint: "fp_1", ConfigOnly: false,
 		TargetNames: []string{"api"},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+	return binding
 }
 
 func snapState(t *testing.T) (string, *crypto.LocalKeys) {
@@ -50,11 +81,11 @@ func TestSnapshotSaveLoadRoundTrip(t *testing.T) {
 		Rows:             []SnapshotRow{{Name: "API_KEY", KeyID: "key_api", Classification: "secret", Value: "s3cr3t"}},
 		GenerationStamps: map[string]string{"api": "v1-" + hex32()},
 	}
-	if err := SaveSnapshot(state, keys, aad, payload); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, aad), payload); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
-	got, hdr, err := LoadSnapshot(state, keys, snapCtx(), now, DefaultSnapshotMaxAge)
+	got, binding, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, DefaultSnapshotMaxAge)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -66,19 +97,85 @@ func TestSnapshotSaveLoadRoundTrip(t *testing.T) {
 		t.Errorf("KeyID not round-tripped inside the sealed payload: %+v", got.Rows[0])
 	}
 	// Server-asserted fields come back from the header, not reconstructed.
+	hdr, err := binding.AAD()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if hdr.PinnedRevision != 3 || hdr.IssuedAt != "2026-08-19T10:00:00Z" || hdr.ExpiresAt != "2026-08-26T10:00:00Z" {
 		t.Errorf("header not returned intact: %+v", hdr)
+	}
+}
+
+func TestSnapshotLegacyContainerStillLoads(t *testing.T) {
+	// Fixture was produced by the pre-#221 HKS1 writer with a 32-byte zero local
+	// key. It is literal so framing, HKDF/AAD, or payload drift cannot update both
+	// producer and consumer and leave this test falsely green.
+	const legacyContainer = "SEtTMQAAAWt7Imluc3RhbmNlX29yaWdpbiI6Imh0dHBzOi8vaGlreW8uZXhhbXBsZSIsIm9yZ19pZCI6Im9yZ18xIiwicHJvamVjdF9pZCI6InByal8xIiwiZW52aXJvbm1lbnRfaWQiOiJlbnZfMSIsImNyZWRlbnRpYWxfaWQiOiJjcmVkXzEiLCJjcmVkZW50aWFsX2ZpbmdlcnByaW50IjoiZnBfMSIsImNvbmZpZ19vbmx5IjpmYWxzZSwidGFyZ2V0X25hbWVzIjpbImFwaSJdLCJwaW5uZWRfcmV2aXNpb24iOjMsImNoYW5nZV90b2tlbiI6InYxOm1hbmlmZXN0LXRva2VuIiwicHJvamVjdGlvbiI6WyJyZWFkIiwicmV2ZWFsIl0sImlzc3VlZF9hdCI6IjIwMjYtMDgtMTlUMTA6MDA6MDBaIiwiZXhwaXJlc19hdCI6IjIwMjYtMDgtMjZUMTA6MDA6MDBaIn0BBwEAAAAZaGlreW8vY29tcG9zZS9zbmFwc2hvdC92MQAAAAEAAAAYDeYH5jDyXMo1MwLNyoquSIzQTHV357AoAcpN2Ld9fsU+q91qqmmocnWELkWj7TX4fHvrd/qd2Sn4AtkelDf4xIStV4Q9oHhgA7Ra8SA865fBMfrVRWFCj8GNy3bmCk2O3NQYGIhWwnEyBLCIk5hwMC/aJDYuqBq+B+2kPO3kpJlMiZIpL6gMQavnDVQomnw="
+	const legacyHeader = `{"instance_origin":"https://hikyo.example","org_id":"org_1","project_id":"prj_1","environment_id":"env_1","credential_id":"cred_1","credential_fingerprint":"fp_1","config_only":false,"target_names":["api"],"pinned_revision":3,"change_token":"v1:manifest-token","projection":["read","reveal"],"issued_at":"2026-08-19T10:00:00Z","expires_at":"2026-08-26T10:00:00Z"}`
+
+	state := filepath.Join(t.TempDir(), "state")
+	if err := os.Mkdir(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(state, "local.key"), make([]byte, crypto.KeySize), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := crypto.LoadOrCreateLocalKey(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := base64.StdEncoding.DecodeString(legacyContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(filepath.Join(state, snapshotFile), record, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	got, binding, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, DefaultSnapshotMaxAge)
+	if err != nil {
+		t.Fatalf("load legacy container: %v", err)
+	}
+	if len(got.Rows) != 1 || got.Rows[0].Value != "legacy" {
+		t.Fatalf("legacy payload = %+v", got)
+	}
+	canonical, err := binding.CanonicalAAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(canonical) != legacyHeader {
+		t.Fatalf("legacy header changed:\n got %s\nwant %s", canonical, legacyHeader)
+	}
+}
+
+func TestSnapshotInvalidBindingFailsBeforeFilesystemWork(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "must-not-exist")
+	keys := testKeys(t)
+	incomplete := snapScope(t, state, "env_1")
+
+	if err := SaveSnapshot(keys, incomplete, SnapshotPayload{}); err == nil {
+		t.Fatal("save accepted a scope-only binding")
+	}
+	if _, err := os.Stat(state); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid save touched state dir: %v", err)
+	}
+
+	var invalid crypto.SnapshotBinding
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	if _, _, err := LoadSnapshot(keys, invalid, now, DefaultSnapshotMaxAge); err == nil || errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid load reached filesystem: %v", err)
 	}
 }
 
 func TestSnapshotExpiryServerBound(t *testing.T) {
 	state, keys := snapState(t)
 	aad := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, aad, SnapshotPayload{}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, aad), SnapshotPayload{}); err != nil {
 		t.Fatal(err)
 	}
 	past := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC) // after expires_at
-	_, _, err := LoadSnapshot(state, keys, snapCtx(), past, DefaultSnapshotMaxAge)
+	_, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), past, DefaultSnapshotMaxAge)
 	if !errors.Is(err, ErrSnapshotExpired) {
 		t.Fatalf("err = %v, want ErrSnapshotExpired", err)
 	}
@@ -88,16 +185,16 @@ func TestSnapshotExpiryDownwardMaxAge(t *testing.T) {
 	state, keys := snapState(t)
 	// Server expiry 7 d out, but a per-stack 1h cap bites first.
 	aad := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, aad, SnapshotPayload{}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, aad), SnapshotPayload{}); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC) // 2h after issue
-	_, _, err := LoadSnapshot(state, keys, snapCtx(), now, time.Hour)
+	_, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, time.Hour)
 	if !errors.Is(err, ErrSnapshotExpired) {
 		t.Fatalf("err = %v, want ErrSnapshotExpired (downward max_age)", err)
 	}
 	within := time.Date(2026, 8, 19, 10, 30, 0, 0, time.UTC)
-	if _, _, err := LoadSnapshot(state, keys, snapCtx(), within, time.Hour); err != nil {
+	if _, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), within, time.Hour); err != nil {
 		t.Fatalf("within cap: %v", err)
 	}
 }
@@ -105,11 +202,11 @@ func TestSnapshotExpiryDownwardMaxAge(t *testing.T) {
 func TestSnapshotHWMRollbackRefusedOnSave(t *testing.T) {
 	state, keys := snapState(t)
 	newer := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, newer, SnapshotPayload{}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, newer), SnapshotPayload{}); err != nil {
 		t.Fatal(err)
 	}
 	older := snapAAD("2026-08-18T10:00:00Z", "2026-08-25T10:00:00Z")
-	if err := SaveSnapshot(state, keys, older, SnapshotPayload{}); !errors.Is(err, ErrSnapshotRollback) {
+	if err := SaveSnapshot(keys, snapBinding(t, state, older), SnapshotPayload{}); !errors.Is(err, ErrSnapshotRollback) {
 		t.Fatalf("save older err = %v, want ErrSnapshotRollback", err)
 	}
 }
@@ -117,7 +214,7 @@ func TestSnapshotHWMRollbackRefusedOnSave(t *testing.T) {
 func TestSnapshotHWMRollbackRefusedOnLoad(t *testing.T) {
 	state, keys := snapState(t)
 	newer := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, newer, SnapshotPayload{}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, newer), SnapshotPayload{}); err != nil {
 		t.Fatal(err)
 	}
 	// Overwrite snapshot.bin with an older sealed container (file rollback);
@@ -135,7 +232,7 @@ func TestSnapshotHWMRollbackRefusedOnLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
-	if _, _, err := LoadSnapshot(state, keys, snapCtx(), now, DefaultSnapshotMaxAge); !errors.Is(err, ErrSnapshotRollback) {
+	if _, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, DefaultSnapshotMaxAge); !errors.Is(err, ErrSnapshotRollback) {
 		t.Fatalf("load rolled-back err = %v, want ErrSnapshotRollback", err)
 	}
 }
@@ -151,7 +248,7 @@ func TestSnapshotSameIssuanceRollback(t *testing.T) {
 	issued := "2026-08-19T10:00:00Z"
 	first := snapAAD(issued, "2026-08-26T10:00:00Z")
 	first.PinnedRevision = 0
-	if err := SaveSnapshot(state, keys, first, SnapshotPayload{Rows: []SnapshotRow{{Name: "A", Value: "1"}}}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, first), SnapshotPayload{Rows: []SnapshotRow{{Name: "A", Value: "1"}}}); err != nil {
 		t.Fatal(err)
 	}
 	// A different current snapshot sharing the timestamp: same (unpinned) revision,
@@ -172,7 +269,7 @@ func TestSnapshotSameIssuanceRollback(t *testing.T) {
 	}
 	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
 	// context still matches (revision is not part of the offline context).
-	if _, _, err := LoadSnapshot(state, keys, snapCtx(), now, DefaultSnapshotMaxAge); !errors.Is(err, ErrSnapshotRollback) {
+	if _, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, DefaultSnapshotMaxAge); !errors.Is(err, ErrSnapshotRollback) {
 		t.Fatalf("same-issuance swap err = %v, want ErrSnapshotRollback", err)
 	}
 }
@@ -180,13 +277,11 @@ func TestSnapshotSameIssuanceRollback(t *testing.T) {
 func TestSnapshotContextMismatchRefused(t *testing.T) {
 	state, keys := snapState(t)
 	aad := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, aad, SnapshotPayload{}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, aad), SnapshotPayload{}); err != nil {
 		t.Fatal(err)
 	}
-	wrong := snapCtx()
-	wrong.EnvironmentID = "env_2"
 	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
-	_, _, err := LoadSnapshot(state, keys, wrong, now, DefaultSnapshotMaxAge)
+	_, _, err := LoadSnapshot(keys, snapScope(t, state, "env_2"), now, DefaultSnapshotMaxAge)
 	if !errors.Is(err, ErrSnapshotContext) {
 		t.Fatalf("err = %v, want ErrSnapshotContext (refused by name, not ErrDecrypt)", err)
 	}
@@ -195,7 +290,7 @@ func TestSnapshotContextMismatchRefused(t *testing.T) {
 func TestSnapshotTamperedContainerFailsAEAD(t *testing.T) {
 	state, keys := snapState(t)
 	aad := snapAAD("2026-08-19T10:00:00Z", "2026-08-26T10:00:00Z")
-	if err := SaveSnapshot(state, keys, aad, SnapshotPayload{Rows: []SnapshotRow{{Name: "A", Value: "1"}}}); err != nil {
+	if err := SaveSnapshot(keys, snapBinding(t, state, aad), SnapshotPayload{Rows: []SnapshotRow{{Name: "A", Value: "1"}}}); err != nil {
 		t.Fatal(err)
 	}
 	path := filepath.Join(state, snapshotFile)
@@ -209,7 +304,7 @@ func TestSnapshotTamperedContainerFailsAEAD(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
-	if _, _, err := LoadSnapshot(state, keys, snapCtx(), now, DefaultSnapshotMaxAge); !errors.Is(err, crypto.ErrDecrypt) {
+	if _, _, err := LoadSnapshot(keys, snapScope(t, state, "env_1"), now, DefaultSnapshotMaxAge); !errors.Is(err, crypto.ErrDecrypt) {
 		t.Fatalf("tampered container err = %v, want ErrDecrypt", err)
 	}
 }

--- a/internal/crypto/client.go
+++ b/internal/crypto/client.go
@@ -113,9 +113,10 @@ func ParseStamp(s string) error {
 	return nil
 }
 
-// SnapshotAAD binds an offline snapshot to its full context (compose ADR
-// § "AAD binds the container to its context"). A snapshot is therefore not
-// transplantable across environments, projects, principals, or projections.
+// SnapshotAAD is the stable serialized form derived from SnapshotBinding. Its
+// field names and declaration order are persisted protocol data for HKS1
+// containers. Runtime save/load code accepts SnapshotBinding instead, so this
+// mutable serialization DTO cannot bypass binding validation.
 //
 // The list fields (Projection, TargetNames) are sorted and deduplicated INSIDE
 // Canonical(), so a caller-visible ordering choice or an accidental duplicate
@@ -134,8 +135,8 @@ type SnapshotAAD struct {
 	EnvironmentID  string `json:"environment_id"`
 	// CredentialID is the server-asserted credential id. It is authenticated
 	// metadata (bound into the AAD, returned to the caller for the offline
-	// records' credential_id) but is NOT part of SnapshotContext: it is a mutable
-	// on-disk value the box could rewrite, so it supplies no offline expectation.
+	// records' credential_id) but is not locally knowable: it is a mutable on-disk
+	// value the box could rewrite, so it supplies no offline expectation.
 	CredentialID string `json:"credential_id"`
 	// CredentialFingerprint is the LOCAL, offline-derivable identity of the
 	// credential the snapshot was fetched with — hex(sha256(domain ‖ token)). The
@@ -159,31 +160,13 @@ type SnapshotAAD struct {
 	// current snapshots with the same issuance but different content. Binding the
 	// token into the header makes the header — and therefore the HWM digest over
 	// it — differ whenever the delivered content differs (compose ADR § Expiry,
-	// clocks and rollback). It is NOT part of SnapshotContext: the offline box
-	// cannot reconstruct it without the server.
+	// clocks and rollback). The offline box cannot reconstruct it without the
+	// server; ParseSnapshotBinding recovers it from the authenticated header.
 	ChangeToken string `json:"change_token"`
 	// Projection is the authorized delivery capability list.
 	Projection []string `json:"projection"`
 	IssuedAt   string   `json:"issued_at"`
 	ExpiresAt  string   `json:"expires_at"`
-}
-
-// SnapshotContext is the offline-known subset of the AAD: the identity, org,
-// project, environment, credential FINGERPRINT, config-only mode, and target set
-// the box can reconstruct WITHOUT reaching the server. The credential is bound
-// by its local fingerprint (recomputed from the presented token), NOT by the
-// server-asserted credential id, which is mutable on disk. LoadSnapshot compares
-// it against the stored header; the remaining fields
-// (revision/projection/issued/expires) are taken from the header and returned to
-// the caller.
-type SnapshotContext struct {
-	InstanceOrigin        string
-	OrgID                 string
-	ProjectID             string
-	EnvironmentID         string
-	CredentialFingerprint string
-	ConfigOnly            bool
-	TargetNames           []string
 }
 
 // Canonical is the deterministic header-bytes encoding of the full AAD tuple:
@@ -209,41 +192,6 @@ func ParseSnapshotHeader(b []byte) (SnapshotAAD, error) {
 		return SnapshotAAD{}, fmt.Errorf("crypto: parse snapshot header: %w", err)
 	}
 	return a, nil
-}
-
-// ContextMatches checks the offline-known local context against the header,
-// field by field, comparing the target set as a sorted/deduplicated set. A
-// mismatch is refused BY NAME (not as a decrypt failure) so the operator sees
-// which coordinate a transplanted snapshot disagrees on.
-func (a SnapshotAAD) ContextMatches(expect SnapshotContext) error {
-	for _, f := range []struct {
-		name     string
-		got, exp string
-	}{
-		{"instance", a.InstanceOrigin, expect.InstanceOrigin},
-		{"org", a.OrgID, expect.OrgID},
-		{"project", a.ProjectID, expect.ProjectID},
-		{"environment", a.EnvironmentID, expect.EnvironmentID},
-		{"credential", a.CredentialFingerprint, expect.CredentialFingerprint},
-	} {
-		if f.got != f.exp {
-			return fmt.Errorf("crypto: snapshot %s %q does not match local context %q", f.name, f.got, f.exp)
-		}
-	}
-	if a.ConfigOnly != expect.ConfigOnly {
-		return fmt.Errorf("crypto: snapshot config_only=%v does not match local context config_only=%v", a.ConfigOnly, expect.ConfigOnly)
-	}
-	got := CanonicalStringSet(a.TargetNames)
-	exp := CanonicalStringSet(expect.TargetNames)
-	if len(got) != len(exp) {
-		return fmt.Errorf("crypto: snapshot target set %v does not match local context %v", got, exp)
-	}
-	for i := range got {
-		if got[i] != exp[i] {
-			return fmt.Errorf("crypto: snapshot target set %v does not match local context %v", got, exp)
-		}
-	}
-	return nil
 }
 
 // SealSnapshot encrypts plaintext under the snapshot key with headerCanonical as

--- a/internal/crypto/client_test.go
+++ b/internal/crypto/client_test.go
@@ -270,29 +270,3 @@ func TestSnapshotWrongKeyFails(t *testing.T) {
 		t.Errorf("cross-key open err = %v, want ErrDecrypt", err)
 	}
 }
-
-func TestSnapshotContextMatches(t *testing.T) {
-	base := baseSnapshotAAD()
-	ctx := SnapshotContext{
-		InstanceOrigin: base.InstanceOrigin, OrgID: base.OrgID, ProjectID: base.ProjectID,
-		EnvironmentID: base.EnvironmentID, CredentialFingerprint: base.CredentialFingerprint,
-		ConfigOnly: base.ConfigOnly, TargetNames: []string{"worker", "api"}, // unsorted set
-	}
-	if err := base.ContextMatches(ctx); err != nil {
-		t.Errorf("matching context rejected: %v", err)
-	}
-	for _, bad := range []func(*SnapshotContext){
-		func(c *SnapshotContext) { c.EnvironmentID = "env_2" },
-		func(c *SnapshotContext) { c.CredentialFingerprint = "fp_2" },
-		func(c *SnapshotContext) { c.ConfigOnly = true },
-		func(c *SnapshotContext) { c.TargetNames = []string{"api"} },
-		func(c *SnapshotContext) { c.TargetNames = []string{"api", "worker", "extra"} },
-	} {
-		bc := ctx
-		bc.TargetNames = append([]string(nil), ctx.TargetNames...)
-		bad(&bc)
-		if err := base.ContextMatches(bc); err == nil {
-			t.Error("mismatched context accepted")
-		}
-	}
-}

--- a/internal/crypto/snapshot_binding.go
+++ b/internal/crypto/snapshot_binding.go
@@ -1,0 +1,283 @@
+package crypto
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SnapshotBindingScope is the locally known identity of one offline snapshot.
+// It is validated and copied by NewSnapshotBinding before it can be used for a
+// filesystem lookup or compared with an authenticated snapshot header.
+type SnapshotBindingScope struct {
+	StorageDir            string
+	InstanceOrigin        string
+	OrgID                 string
+	ProjectID             string
+	EnvironmentID         string
+	CredentialFingerprint string
+	ConfigOnly            bool
+	TargetNames           []string
+}
+
+// SnapshotBindingDelivery is the server-asserted remainder of a snapshot
+// binding. WithDelivery adds it atomically: callers cannot construct a binding
+// containing only some revision, projection, or issuance fields.
+type SnapshotBindingDelivery struct {
+	CredentialID   string
+	PinnedRevision int64
+	ChangeToken    string
+	Projection     []string
+	IssuedAt       string
+	ExpiresAt      string
+}
+
+// SnapshotBinding carries one validated snapshot identity through both live
+// and offline paths. Its scope-only state is valid for locating and checking an
+// offline snapshot. Its delivery-complete state additionally owns every field
+// required to derive the serialized SnapshotAAD.
+//
+// Fields are private so list canonicalization and issuance-window validation
+// cannot be bypassed by mutation after construction.
+type SnapshotBinding struct {
+	scope    SnapshotBindingScope
+	delivery *SnapshotBindingDelivery
+}
+
+// NewSnapshotBinding validates and owns the locally derivable snapshot scope.
+func NewSnapshotBinding(scope SnapshotBindingScope) (SnapshotBinding, error) {
+	canonical, err := canonicalSnapshotScope(scope)
+	if err != nil {
+		return SnapshotBinding{}, err
+	}
+	return SnapshotBinding{scope: canonical}, nil
+}
+
+// WithDelivery returns a delivery-complete binding. A binding can be completed
+// once only, preventing accidental reconstruction with a second response.
+func (b SnapshotBinding) WithDelivery(delivery SnapshotBindingDelivery) (SnapshotBinding, error) {
+	if err := b.validateScope(); err != nil {
+		return SnapshotBinding{}, err
+	}
+	if b.delivery != nil {
+		return SnapshotBinding{}, fmt.Errorf("crypto: snapshot binding already has delivery fields")
+	}
+	canonical, err := canonicalSnapshotDelivery(delivery)
+	if err != nil {
+		return SnapshotBinding{}, err
+	}
+	b.delivery = &canonical
+	return b, nil
+}
+
+// CanonicalAAD derives the stable serialized AAD bytes from a complete binding.
+func (b SnapshotBinding) CanonicalAAD() ([]byte, error) {
+	aad, err := b.AAD()
+	if err != nil {
+		return nil, err
+	}
+	return aad.Canonical()
+}
+
+// AAD derives a detached serialization value from a complete binding. Slices
+// are copied, so mutating the returned DTO cannot mutate the binding.
+func (b SnapshotBinding) AAD() (SnapshotAAD, error) {
+	if err := b.validateComplete(); err != nil {
+		return SnapshotAAD{}, err
+	}
+	delivery := *b.delivery
+	return SnapshotAAD{
+		InstanceOrigin:        b.scope.InstanceOrigin,
+		OrgID:                 b.scope.OrgID,
+		ProjectID:             b.scope.ProjectID,
+		EnvironmentID:         b.scope.EnvironmentID,
+		CredentialID:          delivery.CredentialID,
+		CredentialFingerprint: b.scope.CredentialFingerprint,
+		ConfigOnly:            b.scope.ConfigOnly,
+		TargetNames:           append([]string(nil), b.scope.TargetNames...),
+		PinnedRevision:        delivery.PinnedRevision,
+		ChangeToken:           delivery.ChangeToken,
+		Projection:            append([]string(nil), delivery.Projection...),
+		IssuedAt:              delivery.IssuedAt,
+		ExpiresAt:             delivery.ExpiresAt,
+	}, nil
+}
+
+// StorageDir returns the validated local storage locator owned by the binding.
+// It is intentionally absent from SnapshotAAD: moving a state directory does
+// not change cryptographic or serialized snapshot identity.
+func (b SnapshotBinding) StorageDir() (string, error) {
+	if err := b.validateScope(); err != nil {
+		return "", err
+	}
+	return b.scope.StorageDir, nil
+}
+
+// ParseSnapshotBinding validates an existing serialized AAD header without
+// changing its field names, ordering, or timestamp spellings.
+func ParseSnapshotBinding(storageDir string, header []byte) (SnapshotBinding, error) {
+	aad, err := ParseSnapshotHeader(header)
+	if err != nil {
+		return SnapshotBinding{}, err
+	}
+	binding, err := NewSnapshotBinding(SnapshotBindingScope{
+		StorageDir:            storageDir,
+		InstanceOrigin:        aad.InstanceOrigin,
+		OrgID:                 aad.OrgID,
+		ProjectID:             aad.ProjectID,
+		EnvironmentID:         aad.EnvironmentID,
+		CredentialFingerprint: aad.CredentialFingerprint,
+		ConfigOnly:            aad.ConfigOnly,
+		TargetNames:           aad.TargetNames,
+	})
+	if err != nil {
+		return SnapshotBinding{}, err
+	}
+	return binding.WithDelivery(SnapshotBindingDelivery{
+		CredentialID:   aad.CredentialID,
+		PinnedRevision: aad.PinnedRevision,
+		ChangeToken:    aad.ChangeToken,
+		Projection:     aad.Projection,
+		IssuedAt:       aad.IssuedAt,
+		ExpiresAt:      aad.ExpiresAt,
+	})
+}
+
+// ContextMatches compares the locally knowable scope of two validated
+// bindings. Server-only delivery fields are intentionally not expectations on
+// an offline box.
+func (b SnapshotBinding) ContextMatches(expect SnapshotBinding) error {
+	if err := b.validateComplete(); err != nil {
+		return err
+	}
+	if err := expect.validateScope(); err != nil {
+		return err
+	}
+	for _, field := range []struct {
+		name     string
+		got, exp string
+	}{
+		{"instance", b.scope.InstanceOrigin, expect.scope.InstanceOrigin},
+		{"org", b.scope.OrgID, expect.scope.OrgID},
+		{"project", b.scope.ProjectID, expect.scope.ProjectID},
+		{"environment", b.scope.EnvironmentID, expect.scope.EnvironmentID},
+		{"credential", b.scope.CredentialFingerprint, expect.scope.CredentialFingerprint},
+	} {
+		if field.got != field.exp {
+			return fmt.Errorf("crypto: snapshot %s %q does not match local context %q", field.name, field.got, field.exp)
+		}
+	}
+	if b.scope.ConfigOnly != expect.scope.ConfigOnly {
+		return fmt.Errorf("crypto: snapshot config_only=%v does not match local context config_only=%v", b.scope.ConfigOnly, expect.scope.ConfigOnly)
+	}
+	if !equalStrings(b.scope.TargetNames, expect.scope.TargetNames) {
+		return fmt.Errorf("crypto: snapshot target set %v does not match local context %v", b.scope.TargetNames, expect.scope.TargetNames)
+	}
+	return nil
+}
+
+// ValidateScope reports whether the binding can safely identify an offline
+// snapshot. Both scope-only and delivery-complete bindings are valid locators.
+func (b SnapshotBinding) ValidateScope() error {
+	return b.validateScope()
+}
+
+func (b SnapshotBinding) validateScope() error {
+	_, err := canonicalSnapshotScope(b.scope)
+	return err
+}
+
+func (b SnapshotBinding) validateComplete() error {
+	if err := b.validateScope(); err != nil {
+		return err
+	}
+	if b.delivery == nil {
+		return fmt.Errorf("crypto: snapshot binding has no delivery fields")
+	}
+	_, err := canonicalSnapshotDelivery(*b.delivery)
+	return err
+}
+
+func canonicalSnapshotScope(scope SnapshotBindingScope) (SnapshotBindingScope, error) {
+	for _, field := range []struct {
+		name, value string
+	}{
+		{"storage dir", scope.StorageDir},
+		{"instance origin", scope.InstanceOrigin},
+		{"org id", scope.OrgID},
+		{"project id", scope.ProjectID},
+		{"environment id", scope.EnvironmentID},
+		{"credential fingerprint", scope.CredentialFingerprint},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return SnapshotBindingScope{}, fmt.Errorf("crypto: snapshot binding %s is required", field.name)
+		}
+	}
+	targets, err := canonicalRequiredSet("target", scope.TargetNames)
+	if err != nil {
+		return SnapshotBindingScope{}, err
+	}
+	scope.TargetNames = targets
+	return scope, nil
+}
+
+func canonicalSnapshotDelivery(delivery SnapshotBindingDelivery) (SnapshotBindingDelivery, error) {
+	for _, field := range []struct {
+		name, value string
+	}{
+		{"credential id", delivery.CredentialID},
+		{"change token", delivery.ChangeToken},
+		{"issued at", delivery.IssuedAt},
+		{"expires at", delivery.ExpiresAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return SnapshotBindingDelivery{}, fmt.Errorf("crypto: snapshot binding %s is required", field.name)
+		}
+	}
+	if delivery.PinnedRevision < 0 {
+		return SnapshotBindingDelivery{}, fmt.Errorf("crypto: snapshot binding pinned revision must not be negative")
+	}
+	projection, err := canonicalRequiredSet("projection", delivery.Projection)
+	if err != nil {
+		return SnapshotBindingDelivery{}, err
+	}
+	issued, err := time.Parse(time.RFC3339, delivery.IssuedAt)
+	if err != nil {
+		return SnapshotBindingDelivery{}, fmt.Errorf("crypto: snapshot binding issued_at %q is not RFC3339: %w", delivery.IssuedAt, err)
+	}
+	expires, err := time.Parse(time.RFC3339, delivery.ExpiresAt)
+	if err != nil {
+		return SnapshotBindingDelivery{}, fmt.Errorf("crypto: snapshot binding expires_at %q is not RFC3339: %w", delivery.ExpiresAt, err)
+	}
+	if !expires.After(issued) {
+		return SnapshotBindingDelivery{}, fmt.Errorf("crypto: snapshot binding expires_at %q must be after issued_at %q", delivery.ExpiresAt, delivery.IssuedAt)
+	}
+	delivery.IssuedAt = issued.UTC().Format(time.RFC3339Nano)
+	delivery.ExpiresAt = expires.UTC().Format(time.RFC3339Nano)
+	delivery.Projection = projection
+	return delivery, nil
+}
+
+func canonicalRequiredSet(name string, items []string) ([]string, error) {
+	if len(items) == 0 {
+		return nil, fmt.Errorf("crypto: snapshot binding %s set is required", name)
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item) == "" {
+			return nil, fmt.Errorf("crypto: snapshot binding %s set contains an empty value", name)
+		}
+	}
+	return CanonicalStringSet(items), nil
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/crypto/snapshot_binding_test.go
+++ b/internal/crypto/snapshot_binding_test.go
@@ -1,0 +1,184 @@
+package crypto
+
+import (
+	"strings"
+	"testing"
+)
+
+func baseSnapshotScope() SnapshotBindingScope {
+	return SnapshotBindingScope{
+		StorageDir:            "/state/compose/acme",
+		InstanceOrigin:        "https://hikyo.example.internal",
+		OrgID:                 "org_1",
+		ProjectID:             "prj_1",
+		EnvironmentID:         "env_1",
+		CredentialFingerprint: "fp_1",
+		ConfigOnly:            false,
+		TargetNames:           []string{"worker", "api", "api"},
+	}
+}
+
+func baseSnapshotDelivery() SnapshotBindingDelivery {
+	return SnapshotBindingDelivery{
+		CredentialID:   "cred_1",
+		PinnedRevision: 7,
+		ChangeToken:    "v1:manifest-token-1",
+		Projection:     []string{"reveal", "read", "reveal"},
+		IssuedAt:       "2026-08-19T10:00:00Z",
+		ExpiresAt:      "2026-08-26T10:00:00Z",
+	}
+}
+
+func completeSnapshotBinding(t *testing.T) SnapshotBinding {
+	t.Helper()
+	binding, err := NewSnapshotBinding(baseSnapshotScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err = binding.WithDelivery(baseSnapshotDelivery())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding
+}
+
+func TestSnapshotBindingConstructorRejectsImpossibleStates(t *testing.T) {
+	for name, mutate := range map[string]func(*SnapshotBindingScope){
+		"instance":               func(s *SnapshotBindingScope) { s.InstanceOrigin = "" },
+		"storage":                func(s *SnapshotBindingScope) { s.StorageDir = "" },
+		"org":                    func(s *SnapshotBindingScope) { s.OrgID = "" },
+		"project":                func(s *SnapshotBindingScope) { s.ProjectID = "" },
+		"environment":            func(s *SnapshotBindingScope) { s.EnvironmentID = "" },
+		"credential fingerprint": func(s *SnapshotBindingScope) { s.CredentialFingerprint = "" },
+		"targets":                func(s *SnapshotBindingScope) { s.TargetNames = nil },
+		"empty target":           func(s *SnapshotBindingScope) { s.TargetNames = []string{"api", ""} },
+	} {
+		t.Run("scope/"+name, func(t *testing.T) {
+			scope := baseSnapshotScope()
+			mutate(&scope)
+			if _, err := NewSnapshotBinding(scope); err == nil {
+				t.Fatal("constructor accepted invalid scope")
+			}
+		})
+	}
+
+	base, err := NewSnapshotBinding(baseSnapshotScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*SnapshotBindingDelivery){
+		"credential":       func(d *SnapshotBindingDelivery) { d.CredentialID = "" },
+		"revision":         func(d *SnapshotBindingDelivery) { d.PinnedRevision = -1 },
+		"change token":     func(d *SnapshotBindingDelivery) { d.ChangeToken = "" },
+		"projection":       func(d *SnapshotBindingDelivery) { d.Projection = nil },
+		"empty projection": func(d *SnapshotBindingDelivery) { d.Projection = []string{"read", ""} },
+		"issued at":        func(d *SnapshotBindingDelivery) { d.IssuedAt = "not-a-time" },
+		"expires at":       func(d *SnapshotBindingDelivery) { d.ExpiresAt = "not-a-time" },
+		"window":           func(d *SnapshotBindingDelivery) { d.ExpiresAt = d.IssuedAt },
+	} {
+		t.Run("delivery/"+name, func(t *testing.T) {
+			delivery := baseSnapshotDelivery()
+			mutate(&delivery)
+			if _, err := base.WithDelivery(delivery); err == nil {
+				t.Fatal("constructor accepted invalid delivery binding")
+			}
+		})
+	}
+}
+
+func TestSnapshotBindingCanonicalAADMatchesLegacyGolden(t *testing.T) {
+	scope := baseSnapshotScope()
+	binding := completeSnapshotBinding(t)
+
+	// Existing HKS1 headers depend on this field order and spelling.
+	const golden = `{"instance_origin":"https://hikyo.example.internal","org_id":"org_1","project_id":"prj_1","environment_id":"env_1","credential_id":"cred_1","credential_fingerprint":"fp_1","config_only":false,"target_names":["api","worker"],"pinned_revision":7,"change_token":"v1:manifest-token-1","projection":["read","reveal"],"issued_at":"2026-08-19T10:00:00Z","expires_at":"2026-08-26T10:00:00Z"}`
+	got, err := binding.CanonicalAAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != golden {
+		t.Fatalf("canonical AAD changed:\n got %s\nwant %s", got, golden)
+	}
+
+	parsed, err := ParseSnapshotBinding("/state/compose/acme", []byte(golden))
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTrip, err := parsed.CanonicalAAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(roundTrip) != golden {
+		t.Fatalf("parsed AAD changed: %s", roundTrip)
+	}
+
+	// Constructor owns copies and canonical order; caller mutation cannot alter it.
+	scope.TargetNames[0] = "mutated"
+	if strings.Contains(string(got), "mutated") {
+		t.Fatal("binding retained caller-owned target slice")
+	}
+}
+
+func TestSnapshotBindingCanonicalizesEquivalentTimestamps(t *testing.T) {
+	base, err := NewSnapshotBinding(baseSnapshotScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivery := baseSnapshotDelivery()
+	delivery.IssuedAt = "2026-08-19T12:00:00+02:00"
+	delivery.ExpiresAt = "2026-08-26T12:00:00+02:00"
+	binding, err := base.WithDelivery(delivery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aad, err := binding.AAD()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aad.IssuedAt != "2026-08-19T10:00:00Z" || aad.ExpiresAt != "2026-08-26T10:00:00Z" {
+		t.Fatalf("timestamps not canonical UTC: issued=%q expires=%q", aad.IssuedAt, aad.ExpiresAt)
+	}
+}
+
+func TestSnapshotBindingContextMatchesCanonicalScope(t *testing.T) {
+	complete := completeSnapshotBinding(t)
+	for name, mutate := range map[string]func(*SnapshotBindingScope){
+		"instance":    func(s *SnapshotBindingScope) { s.InstanceOrigin = "https://other.example" },
+		"org":         func(s *SnapshotBindingScope) { s.OrgID = "org_2" },
+		"project":     func(s *SnapshotBindingScope) { s.ProjectID = "prj_2" },
+		"environment": func(s *SnapshotBindingScope) { s.EnvironmentID = "env_2" },
+		"credential":  func(s *SnapshotBindingScope) { s.CredentialFingerprint = "fp_2" },
+		"mode":        func(s *SnapshotBindingScope) { s.ConfigOnly = true },
+		"targets":     func(s *SnapshotBindingScope) { s.TargetNames = []string{"api"} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			scope := baseSnapshotScope()
+			mutate(&scope)
+			expect, err := NewSnapshotBinding(scope)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := complete.ContextMatches(expect); err == nil {
+				t.Fatal("mismatched scope accepted")
+			}
+		})
+	}
+
+	expect, err := NewSnapshotBinding(baseSnapshotScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := complete.ContextMatches(expect); err != nil {
+		t.Fatalf("matching canonical scope rejected: %v", err)
+	}
+}
+
+func TestSnapshotBindingScopeCannotProduceAAD(t *testing.T) {
+	binding, err := NewSnapshotBinding(baseSnapshotScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := binding.CanonicalAAD(); err == nil {
+		t.Fatal("scope-only binding produced cryptographic AAD")
+	}
+}


### PR DESCRIPTION
## Summary

- introduce one validated `SnapshotBinding` for live and offline snapshot identity
- derive stable `SnapshotAAD` bytes and local storage locator from the binding
- reject incomplete bindings before snapshot filesystem or decrypt work
- preserve legacy `HKS1` framing and AAD serialization

## Stack

- stacked on #285 (`t3code/implement-ticket-220`)
- implements and closes #221

## Contract and migration

No snapshot migration. Existing `HKS1` containers and AAD JSON field names/order remain byte-compatible. Targets, projection, and timestamps canonicalize before new saves. `StorageDir` is local-only and is not serialized or authenticated.

## Generated outputs

None.

## Validation

- `go test -count=1 ./internal/cli/... ./internal/crypto/... ./internal/compose/...` — 483 passed on stacked head
- `go test -count=1 ./...` — 3,096 passed across 57 packages on stacked head
- two-axis standards/security + #221 spec review — CLEAN / CLEAN

Closes #221