### PR TITLE
fix(disclose): reserve single-use sinks (#238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,11 +253,15 @@ jobs:
       - name: Upload app build for downstream validation
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
+          # A failed-job rerun reuses successful dependencies from the prior
+          # attempt, so consumers must keep using that run's stable name. A
+          # full rerun rebuilds first and replaces the run-scoped artifact.
+          name: hikyo-app-${{ github.run_id }}
           path: |
             internal/webui/dist/
             ci-artifacts/hikyo-ui
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   # Probe the exact release-shaped binary already built for browser validation.
@@ -276,7 +280,7 @@ jobs:
       - name: Download the exact app build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
+          name: hikyo-app-${{ github.run_id }}
       - name: Prepare the prebuilt app
         run: chmod +x ci-artifacts/hikyo-ui
       - name: Install strace
@@ -553,7 +557,7 @@ jobs:
       - name: Download the exact app build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}
+          name: hikyo-app-${{ github.run_id }}
       # Actions artifacts intentionally normalize file modes. Restore execute
       # permission before the browser harness starts the downloaded binary.
       - name: Prepare the prebuilt app

--- a/docs/handoff/47-first-slice.md
+++ b/docs/handoff/47-first-slice.md
@@ -145,7 +145,7 @@ members keep absent / null / value distinct.
 | [E2E] bootstrap first-admin end to end | `isolation.TestDemoFlow{SQLite,Postgres}`, `human_authentication_flow` |
 | [E2E] local login | same |
 | [E2E] boot refused below the Argon2id floor | `crypto.TestBootFloorRefusesEachShortParameter`, `app.AuthComponents` |
-| [E2E] non-TTY stdout refused | `disclose.TestNonTTYWithNoFlagIsRefused`, `TestPreflightRefusesBeforeAnythingIsMinted`, verified with the real binary |
+| [E2E] non-TTY stdout refused | `disclose.TestNonTTYWithNoFlagIsRefused`, `TestPrepareReservesBeforeAnythingIsMinted`, verified with the real binary |
 | Demo on both engines | `isolation.TestDemoFlow{SQLite,Postgres}` |
 
 ## Verified empirically (real binary, sqlite)
@@ -266,7 +266,8 @@ Recorded because each was found by a check rather than by reading:
   before every authentication.
 - **`admin create` created the administrator before checking it could deliver
   the authority** — leaving an instance bootstrapped with a value nobody saw
-  and a command that refuses to run again. `disclose.Preflight` now runs first.
+  and a command that refuses to run again. Superseded by #238: `disclose.Prepare`
+  now reserves the exact sink before the administrator is created.
 
 ## Cross-model review (Codex `gpt-5.6-sol`, high effort)
 

--- a/docs/handoff/50-flat-values.md
+++ b/docs/handoff/50-flat-values.md
@@ -316,8 +316,8 @@ completion of #4 and the clone-preflight gap — dispositioned below:
 5. **MAJOR — CLI reveal bypassed the print triad.** `values list --reveal` and
    `values diff --reveal` rendered secret plaintext straight to `Render(Stdout)`.
    They now carry the same triad flags `get` has (`--output-file`,
-   `--dangerously-print`); `--reveal` runs `disclose.Preflight` BEFORE the request,
-   renders to a buffer, and delivers via `disclose.Emit` (`emitRendered`).
+   `--dangerously-print`); `--reveal` reserves a `disclose.PreparedSink` BEFORE
+   the request, renders to a buffer, and delivers via `WriteOnce` (`emitRendered`).
    Tests: `cli/TestRevealingDiffIsRefusedBeforeAnyRequestWithoutASink` (pre-request
    refusal on non-TTY, no sink) + `help.txt` golden updated.
 6. **MINOR — spurious `value.cleared` on a no-op.** Clearing an already-absent cell

--- a/docs/handoff/68-import-file-sources.md
+++ b/docs/handoff/68-import-file-sources.md
@@ -202,7 +202,7 @@ artifact, and `cli:definitions` stays `ClassStub`.
 ### Values file (new, minimal, versioned)
 
 `{"format_version":1,"project":…,"environment":…,"entries":[{"key":…,"value":…}]}`.
-Written through `disclose.Emit`'s file leg — the repo's existing secret-file
+Written through `disclose.PreparedSink.WriteOnce`'s file leg — the repo's secret-file
 discipline (dirfd-parent-checked, `O_EXCL`, `0600`, umask-independent). Nothing
 was reimplemented.
 

--- a/docs/handoff/ci-race-fuzz-sharding.md
+++ b/docs/handoff/ci-race-fuzz-sharding.md
@@ -21,6 +21,12 @@ binary. Its standalone workflow was removed, eliminating a second cold module
 download and Go compile. The probe remains a named, fail-closed job in the
 base-controlled validation graph and is explicitly included in `ci-required`.
 
+The artifact name is stable across workflow attempts. GitHub copies successful
+dependency results when only failed jobs are rerun, so an attempt-number suffix
+made the rerun request an artifact that no job had uploaded. Full reruns replace
+the run-scoped artifact after rebuilding it; failed-job reruns reuse the exact
+successful build from the same run and commit.
+
 ## Coverage and trust model
 
 - Race assigns all 56 Go packages except `internal/isolation` exactly once.

--- a/docs/handoff/issue-238-prepared-disclosure-sink.md
+++ b/docs/handoff/issue-238-prepared-disclosure-sink.md
@@ -1,0 +1,50 @@
+# Issue #238: prepared single-use disclosure sink
+
+## Contract
+
+`disclose.Prepare` now selects and owns the exact destination before any
+display-once value is minted or requested. It returns one `PreparedSink`:
+
+- `Destination` reports the already-selected audit delivery mode;
+- `WriteOnce` consumes the sink, writes through the reserved handle, and
+  closes it on success or failure;
+- a second write is refused with `ErrSinkConsumed`;
+- `Abort` is idempotent and closes an unused terminal or removes only the
+  exact empty file reservation owned by the sink;
+- `AbortOnReturn` joins cleanup failures into the caller's returned error, so
+  cancellation and pre-write failures cannot hide failed cleanup.
+
+## Platform ownership
+
+Unix preparation retains the checked parent dirfd and the `O_EXCL`,
+`O_NOFOLLOW`, exactly-`0600` file descriptor. `WriteOnce` fsyncs the file and
+directory. `Abort` requires both an empty open descriptor and the same
+device/inode at the retained dirfd before unlinking. The parent is owner-only
+and not group/world writable, so untrusted UIDs cannot replace the entry.
+
+Windows preparation uses `CREATE_NEW` with no sharing and retains that handle
+until write or abort. Empty abort uses `FileDispositionInfo` so deletion is
+bound to the owned handle. The pre-existing Windows DACL limitation remains;
+Windows is a client platform, not a bootstrap host.
+
+## Migrated callers
+
+All former `Preflight` then `Emit` pairs were removed across local admin and
+backup, account reset/TOTP/recovery, service-account/SCIM/remote credentials,
+definitions export, value reveal/export, and single/multi-environment import
+artifacts. Prepared file reservations are aborted on every early return.
+
+No API, database, migration, or generated output changed.
+
+## Review and validation
+
+- Standards review round 2: CLEAN
+- Issue #238 spec review round 2: CLEAN
+- `go test -count=1 ./internal/disclose/... ./internal/app/... ./internal/cli/...`:
+  280 passed
+- `go test -race -count=1 ./internal/disclose/...`: passed
+- `go vet ./internal/disclose/... ./internal/app/... ./internal/cli/...`: passed
+- `go build ./...`: passed
+- `go test -count=1 ./...`: 3,083 passed in 57 packages
+- Windows `internal/disclose` tests: cross-compiled on macOS; Windows-only
+  lifecycle fixtures are committed for native CI execution

--- a/internal/app/admin.go
+++ b/internal/app/admin.go
@@ -90,7 +90,7 @@ func RunAdmin(ctx context.Context, cfg *config.Config, log *slog.Logger, args []
 	}
 }
 
-func runAdminCreate(ctx context.Context, cfg *config.Config, log *slog.Logger, args []string, stderr io.Writer) error {
+func runAdminCreate(ctx context.Context, cfg *config.Config, log *slog.Logger, args []string, stderr io.Writer) (returnErr error) {
 	fs := flag.NewFlagSet("admin create", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	username := fs.String("username", "", "the first administrator's login handle")
@@ -104,28 +104,17 @@ func runAdminCreate(ctx context.Context, cfg *config.Config, log *slog.Logger, a
 		return errors.New("--username is required")
 	}
 
-	// The delivery mode is decided BEFORE the authority exists, so it can be
-	// recorded in the mint event. A token that reached a log shipper is a
-	// different event from one written to a root-owned file, and the trail has
-	// to be able to say which.
-	delivery := string(disclose.DestTerminal)
-	switch {
-	case *outputFile != "" && *dangerous:
-		return errors.New("--output-file and --dangerously-print name two destinations; choose one")
-	case *outputFile != "":
-		delivery = string(disclose.DestFile)
-	case *dangerous:
-		delivery = string(disclose.DestStdout)
-	}
-
-	// Check the destination BEFORE anything is created. Minting first and
-	// discovering afterwards that the value has nowhere to go would leave the
-	// instance bootstrapped with an authority nobody ever saw — and running
-	// this again refuses, because the instance now has an account.
+	// Reserve the destination BEFORE anything is created. Minting first would
+	// leave the instance bootstrapped with an authority nobody ever saw.
 	deliveryOpts := disclose.Options{OutputFile: *outputFile, DangerouslyPrint: *dangerous}
-	if err := disclose.Preflight(deliveryOpts); err != nil {
+	sink, err := disclose.Prepare(deliveryOpts)
+	if err != nil {
 		return err
 	}
+	defer sink.AbortOnReturn(&returnErr)
+	// Record the exact prepared delivery mode in the mint event. A value sent
+	// to stdout is a different audit fact from one sent to an owner-only file.
+	delivery := string(sink.Destination())
 
 	auth, closeDB, err := adminAuth(ctx, cfg, log)
 	if err != nil {
@@ -138,10 +127,10 @@ func runAdminCreate(ctx context.Context, cfg *config.Config, log *slog.Logger, a
 		return err
 	}
 
-	dest, err := disclose.Emit(
+	dest, err := sink.WriteOnce(
 		fmt.Sprintf("Credential-establishment authority for %s (expires %s)",
 			result.Username, result.ExpiresAt.Format("2006-01-02 15:04 MST")),
-		result.Authority, deliveryOpts)
+		result.Authority)
 	if err != nil {
 		// The administrator exists and the authority is minted, but nobody
 		// received it. Say so precisely rather than leaving the operator to
@@ -205,7 +194,7 @@ func adminAuth(ctx context.Context, cfg *config.Config, log *slog.Logger) (*serv
 // — on the server's own host under local authority, with no network route. The
 // classification-totality invariant keeps that true: `cli:admin` is ClassSystem,
 // whose probe contract is network unreachability.
-func runAdminReset(ctx context.Context, cfg *config.Config, log *slog.Logger, args []string, stderr io.Writer) error {
+func runAdminReset(ctx context.Context, cfg *config.Config, log *slog.Logger, args []string, stderr io.Writer) (returnErr error) {
 	fs := flag.NewFlagSet("admin reset-credential", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	principal := fs.String("principal", "", "the target principal id to reset")
@@ -218,19 +207,13 @@ func runAdminReset(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 		return errors.New("--principal is required")
 	}
 
-	delivery := string(disclose.DestTerminal)
-	switch {
-	case *outputFile != "" && *dangerous:
-		return errors.New("--output-file and --dangerously-print name two destinations; choose one")
-	case *outputFile != "":
-		delivery = string(disclose.DestFile)
-	case *dangerous:
-		delivery = string(disclose.DestStdout)
-	}
 	deliveryOpts := disclose.Options{OutputFile: *outputFile, DangerouslyPrint: *dangerous}
-	if err := disclose.Preflight(deliveryOpts); err != nil {
+	sink, err := disclose.Prepare(deliveryOpts)
+	if err != nil {
 		return err
 	}
+	defer sink.AbortOnReturn(&returnErr)
+	delivery := string(sink.Destination())
 
 	auth, closeDB, err := adminAuth(ctx, cfg, log)
 	if err != nil {
@@ -242,10 +225,10 @@ func runAdminReset(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 	if err != nil {
 		return err
 	}
-	dest, err := disclose.Emit(
+	dest, err := sink.WriteOnce(
 		fmt.Sprintf("Credential-establishment authority for %s (expires %s)",
 			result.TargetUser, result.ExpiresAt.Format("2006-01-02 15:04 MST")),
-		result.Authority, deliveryOpts)
+		result.Authority)
 	if err != nil {
 		return fmt.Errorf(
 			"the credential for principal %q was reset (its sessions revoked and generation advanced), "+

--- a/internal/app/backup.go
+++ b/internal/app/backup.go
@@ -211,7 +211,7 @@ func readSecretFile(path string) (string, error) {
 	return v, nil
 }
 
-func runBackupKeygen(args []string, stderr io.Writer) error {
+func runBackupKeygen(args []string, stderr io.Writer) (returnErr error) {
 	fs := flag.NewFlagSet("backup keygen", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	outputFile := fs.String("output-file", "", "write the identity to a file this command creates (0600)")
@@ -223,16 +223,18 @@ func runBackupKeygen(args []string, stderr io.Writer) error {
 		return errors.New("--output-file and --dangerously-print name two destinations; choose one")
 	}
 	opts := disclose.Options{OutputFile: *outputFile, DangerouslyPrint: *dangerous}
-	// Check the destination BEFORE the identity exists: minting a key that
+	// Reserve the destination BEFORE the identity exists: minting a key that
 	// has nowhere to go is minting a key nobody has.
-	if err := disclose.Preflight(opts); err != nil {
+	sink, err := disclose.Prepare(opts)
+	if err != nil {
 		return err
 	}
+	defer sink.AbortOnReturn(&returnErr)
 	identity, recipient, err := backup.GenerateIdentity()
 	if err != nil {
 		return err
 	}
-	dest, err := disclose.Emit("Backup identity (PRIVATE - escrow separately from the root key)", identity, opts)
+	dest, err := sink.WriteOnce("Backup identity (PRIVATE - escrow separately from the root key)", identity)
 	if err != nil {
 		return fmt.Errorf("the identity was generated but delivery failed and the value is now unrecoverable; run this again: %w", err)
 	}

--- a/internal/app/disclosure_preparation_test.go
+++ b/internal/app/disclosure_preparation_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/disclose"
+)
+
+func TestLocalMintPreparationFailurePrecedesStateAccess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "already-owned")
+	if err := os.WriteFile(path, []byte("owned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "admin create",
+			run: func() error {
+				return runAdminCreate(t.Context(), nil, nil,
+					[]string{"create", "--username", "alice", "--output-file", path}, io.Discard)
+			},
+		},
+		{
+			name: "admin reset",
+			run: func() error {
+				return runAdminReset(t.Context(), nil, nil,
+					[]string{"reset-credential", "--principal", "usr_1", "--output-file", path}, io.Discard)
+			},
+		},
+		{
+			name: "backup keygen",
+			run: func() error {
+				return runBackupKeygen([]string{"keygen", "--output-file", path}, io.Discard)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Nil app config/logger make any state or mint access fail loudly;
+			// destination refusal must happen before either is touched.
+			if err := tc.run(); !errors.Is(err, disclose.ErrFileExists) {
+				t.Fatalf("error = %v, want ErrFileExists before state access", err)
+			}
+			body, err := os.ReadFile(path)
+			if err != nil || string(body) != "owned" {
+				t.Fatalf("existing destination changed: body=%q err=%v", body, err)
+			}
+		})
+	}
+}

--- a/internal/cli/definitions.go
+++ b/internal/cli/definitions.go
@@ -53,7 +53,7 @@ func asSilentExit(err error, out **silentExit) bool {
 	return errors.As(err, out)
 }
 
-func runDefinitionsVerb(ctx context.Context, ios IO, sub string, args []string) error {
+func runDefinitionsVerb(ctx context.Context, ios IO, sub string, args []string) (returnErr error) {
 	var format, file, outputFile, planID, commit, ref, actor, acknowledge string
 	var portable, allowDelete bool
 	st, flags, err := parseCommon("definitions "+sub, ios, args, func(fs *flag.FlagSet) {
@@ -108,10 +108,13 @@ func runDefinitionsVerb(ctx context.Context, ios IO, sub string, args []string) 
 			return err
 		}
 	}
+	var sink *disclose.PreparedSink
 	if sub == "export" && outputFile != "" {
-		if err := disclose.Preflight(disclose.Options{OutputFile: outputFile}); err != nil {
+		sink, err = disclose.Prepare(disclose.Options{OutputFile: outputFile})
+		if err != nil {
 			return failf(ExitRefused, "writing the definitions bundle: %v", err)
 		}
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
@@ -142,7 +145,7 @@ func runDefinitionsVerb(ctx context.Context, ios IO, sub string, args []string) 
 			_, err = ios.Stdout.Write(raw)
 			return err
 		}
-		if _, err := disclose.Emit("definitions bundle", strings.TrimSuffix(string(raw), "\n"), disclose.Options{OutputFile: outputFile}); err != nil {
+		if _, err := sink.WriteOnce("definitions bundle", strings.TrimSuffix(string(raw), "\n")); err != nil {
 			return failf(ExitRefused, "writing the definitions bundle: %v", err)
 		}
 		if pathInsideGitWorktree(outputFile) {

--- a/internal/cli/identities.go
+++ b/internal/cli/identities.go
@@ -111,7 +111,7 @@ func runServiceAccount(ctx context.Context, ios IO, args []string) error {
 	}
 }
 
-func runServiceAccountCredential(ctx context.Context, ios IO, args []string) error {
+func runServiceAccountCredential(ctx context.Context, ios IO, args []string) (returnErr error) {
 	sub, rest, err := subverb("sa credential", args, "list", "mint", "rotate", "revoke")
 	if err != nil {
 		return err
@@ -182,19 +182,19 @@ func runServiceAccountCredential(ctx context.Context, ios IO, args []string) err
 	// of the predecessor, which is the ADR's overlap-based rotation rather
 	// than a distinct authorization act.
 	//
-	// Preflight runs HERE — before the target is resolved, before any network
-	// call, before the mint. The ordering is the security property: a
-	// credential minted with nowhere to put it has been destroyed and the
-	// side effect performed, because the value is display-once and the server
-	// will never hand it back.
+	// Prepare runs HERE — before target resolution, any network call, or mint.
+	// The reserved destination is the exact destination later written.
 	deliver := disclose.Options{
 		OutputFile: outputFile, DangerouslyPrint: dangerous,
 		Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal,
 	}
+	var sink *disclose.PreparedSink
 	if sub == "mint" || sub == "rotate" {
-		if err := disclose.Preflight(deliver); err != nil {
+		sink, err = disclose.Prepare(deliver)
+		if err != nil {
 			return failf(ExitRefused, "the credential has nowhere to go: %v", err)
 		}
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
@@ -222,7 +222,7 @@ func runServiceAccountCredential(ctx context.Context, ios IO, args []string) err
 	if err := client.Do(ctx, http.MethodPost, credentials, want, &out); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit("hikyo machine credential (shown once)", out.Value, deliver); err != nil {
+	if _, err := sink.WriteOnce("hikyo machine credential (shown once)", out.Value); err != nil {
 		return failf(ExitRefused, "disclosing the credential: %v", err)
 	}
 	if out.Clamped {

--- a/internal/cli/identities_test.go
+++ b/internal/cli/identities_test.go
@@ -1,9 +1,12 @@
 package cli_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/internal/cli"
@@ -13,7 +16,7 @@ import (
 // and the grammar rules the ADR states as absences.
 
 // TestMintDeliveryRefusalMatrix is the closed output-channel set, refusal
-// side. Every case here runs BEFORE any network call, because the preflight
+// side. Every case here runs BEFORE any network call, because preparation
 // deliberately precedes target resolution: a credential minted with nowhere
 // to put it has already been destroyed, and the server will never hand it
 // back.
@@ -83,8 +86,53 @@ func TestMintDeliveryRefusalMatrix(t *testing.T) {
 	}
 }
 
+func TestDisclosurePreparationFailureMakesNoRequest(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	taken := filepath.Join(t.TempDir(), "already-reserved")
+	if err := os.WriteFile(taken, []byte("owned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"service-account mint", []string{"sa", "credential", "mint", "--sa", "sa_1"}},
+		{"account reset", []string{"account", "reset-credential", "usr_1"}},
+		{"TOTP enrolment", []string{"account", "factor", "enrol-totp"}},
+		{"recovery codes", []string{"account", "recovery-codes", "regenerate"}},
+		{"recovery begin", []string{"account", "recovery", "begin", "--as", "alice"}},
+		{"SCIM credential", []string{"scim", "credential", "mint", "scb_1"}},
+		{"remote credential", []string{"remote-credential", "create", "--label", "peer"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests.Store(0)
+			ios, _, stderr := testIO(t, nil)
+			args := append(tc.args,
+				"--output-file", taken,
+				"--instance", server.URL,
+			)
+			got := cli.Run(t.Context(), ios, args)
+			if got != cli.ExitRefused {
+				t.Fatalf("exit %d, want ExitRefused (%d); stderr: %s", got, cli.ExitRefused, stderr)
+			}
+			if requests.Load() != 0 {
+				t.Fatalf("destination preparation failed after %d request(s); want no request", requests.Load())
+			}
+			body, err := os.ReadFile(taken)
+			if err != nil || string(body) != "owned" {
+				t.Fatalf("existing destination changed: body=%q err=%v", body, err)
+			}
+		})
+	}
+}
+
 // TestMintDeliveryAcceptedChannels is the positive side: each permitted
-// destination gets PAST the preflight and fails later, on the network, which
+// destination gets past preparation and fails later, on the network, which
 // is how we know the channel itself was accepted. `--dangerously-print` and
 // `--output-file` are checkable without a terminal; the controlling-terminal
 // leg is the one the refusal matrix above proves by its absence.
@@ -103,14 +151,14 @@ func TestMintDeliveryAcceptedChannels(t *testing.T) {
 			ios, _, stderr := testIO(t, nil)
 			cli.Run(t.Context(), ios, tc.args)
 			if strings.Contains(stderr.String(), "nowhere to go") {
-				t.Fatalf("a permitted destination was refused by the preflight: %s", stderr)
+				t.Fatalf("a permitted destination was refused by preparation: %s", stderr)
 			}
 		})
 	}
-	// The accepted file leg must not have created anything: the preflight
-	// creates nothing, so a failed mint leaves no half-written credential.
+	// Preparation reserves the file, then deferred Abort removes the still-empty
+	// reservation when target resolution fails before the mint.
 	if _, err := os.Lstat(filepath.Join(dir, "token")); !os.IsNotExist(err) {
-		t.Fatalf("the preflight created the output file: %v", err)
+		t.Fatalf("the unused prepared output file remains: %v", err)
 	}
 }
 

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -305,10 +305,10 @@ func (p *terminalPrompter) readLine() (string, error) {
 
 // writeProjectArtifacts emits the three committable artifacts once and one
 // values file per environment that writes anything. Every values path is
-// preflighted before anything is written, and the committable artifacts are
+// reserved before anything is written, and the committable artifacts are
 // created O_EXCL with a cleanup that covers every file this run created — a
 // collision on any artifact must not leave a half-authored migration on disk.
-func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([]string, error) {
+func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) (valuesPaths []string, returnErr error) {
 	if err := os.MkdirAll(outDir, 0o700); err != nil {
 		return nil, failf(ExitRefused, "preparing the output directory: %v", err)
 	}
@@ -317,6 +317,7 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 		path   string
 		file   importer.ValuesFile
 		envRef string
+		sink   *disclose.PreparedSink
 	}
 	var valuesTargets []valuesTarget
 	for _, env := range plan.Envs {
@@ -332,12 +333,17 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 		})
 	}
 
-	// Preflight every values path before writing anything.
-	for _, vt := range valuesTargets {
+	// Reserve every values path before writing anything. If a later
+	// reservation or artifact fails, deferred aborts remove unused empty files.
+	for i := range valuesTargets {
+		vt := &valuesTargets[i]
 		deliver := disclose.Options{OutputFile: vt.path, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-		if err := disclose.Preflight(deliver); err != nil {
+		sink, err := disclose.Prepare(deliver)
+		if err != nil {
 			return nil, failf(ExitRefused, "the values file for %s has nowhere to go: %v", vt.envRef, err)
 		}
+		vt.sink = sink
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	bundleBody, err := definitions.Encode(plan.Bundle)
@@ -389,7 +395,7 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 		}
 	}
 
-	var valuesPaths []string
+	valuesPaths = nil
 	for _, vt := range valuesTargets {
 		body, err := importer.Encode(vt.file)
 		if err != nil {
@@ -402,8 +408,7 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) ([
 				"the values file for %s would be %d bytes, exceeding the %d-byte per-file cap; split the import",
 				vt.envRef, len(body), importer.MaxFileBytes)
 		}
-		deliver := disclose.Options{OutputFile: vt.path, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-		if _, err := disclose.Emit("values for "+vt.envRef, strings.TrimRight(string(body), "\n"), deliver); err != nil {
+		if _, err := vt.sink.WriteOnce("values for "+vt.envRef, strings.TrimRight(string(body), "\n")); err != nil {
 			cleanup()
 			return nil, failf(ExitRefused, "writing the values file for %s: %v", vt.envRef, err)
 		}

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -316,7 +316,7 @@ func wireImportCandidates(in []importer.PlannedCandidate) []apigen.ValueOccurren
 // ordinary files; the values file is NOT committable and goes through the print
 // triad's file leg — dirfd-parent-checked, O_EXCL, 0600 — which is the same
 // discipline every other plaintext-bearing file in this CLI uses.
-func writeArtifacts(ios IO, outDir, envID string, plan *importer.Plan) (string, error) {
+func writeArtifacts(ios IO, outDir, envID string, plan *importer.Plan) (valuesPathResult string, returnErr error) {
 	if err := os.MkdirAll(outDir, 0o700); err != nil {
 		return "", failf(ExitRefused, "preparing the output directory: %v", err)
 	}
@@ -341,14 +341,18 @@ func writeArtifacts(ios IO, outDir, envID string, plan *importer.Plan) (string, 
 		}
 	}
 
-	// The values file is preflighted BEFORE anything is written: a run that
+	// The values file is reserved BEFORE anything is written: a run that
 	// emits a bundle and then discovers it has nowhere to put the plaintext has
 	// left half a migration on disk.
 	deliver := disclose.Options{OutputFile: valuesPath, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
+	var sink *disclose.PreparedSink
 	if valuesPath != "" {
-		if err := disclose.Preflight(deliver); err != nil {
+		prepared, err := disclose.Prepare(deliver)
+		if err != nil {
 			return "", failf(ExitRefused, "the values file has nowhere to go: %v", err)
 		}
+		sink = prepared
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	// The committable artifacts are created O_EXCL, not Lstat-then-write. The
@@ -408,7 +412,7 @@ func writeArtifacts(ios IO, outDir, envID string, plan *importer.Plan) (string, 
 	if valuesPath == "" {
 		return "", nil
 	}
-	if _, err := disclose.Emit("values for "+envID, strings.TrimRight(string(valuesBody), "\n"), deliver); err != nil {
+	if _, err := sink.WriteOnce("values for "+envID, strings.TrimRight(string(valuesBody), "\n")); err != nil {
 		cleanup()
 		return "", failf(ExitRefused, "writing the values file: %v", err)
 	}

--- a/internal/cli/remotes.go
+++ b/internal/cli/remotes.go
@@ -226,7 +226,7 @@ func addRemote(ctx context.Context, ios IO, st *State, flags commonFlags, f Form
 	return Render(ios.Stdout, f, remoteTable(apigen.RemoteList{Items: []apigen.Remote{out}, Count: 1}))
 }
 
-func runRemoteCredential(ctx context.Context, ios IO, args []string) error {
+func runRemoteCredential(ctx context.Context, ios IO, args []string) (returnErr error) {
 	sub, rest, err := subverb("remote-credential", args, "create", "list", "show", "revoke")
 	if err != nil {
 		return err
@@ -293,18 +293,19 @@ func runRemoteCredential(ctx context.Context, ios IO, args []string) error {
 		}
 	}
 
-	// Preflight BEFORE the mint, for the reason every display-once path
-	// preflights: a credential minted with nowhere to put it has been
-	// destroyed and the side effect performed, because the server will never
-	// hand it back.
+	// Reserve the destination BEFORE the mint. The server will never return
+	// this display-once value again.
 	deliver := disclose.Options{
 		OutputFile: outputFile, DangerouslyPrint: dangerous,
 		Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal,
 	}
+	var sink *disclose.PreparedSink
 	if sub == "create" {
-		if err := disclose.Preflight(deliver); err != nil {
+		sink, err = disclose.Prepare(deliver)
+		if err != nil {
 			return failf(ExitRefused, "the credential has nowhere to go: %v", err)
 		}
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	client, _, _, err := authenticatedTarget(st, ios, flags)
@@ -335,7 +336,7 @@ func runRemoteCredential(ctx context.Context, ios IO, args []string) error {
 	if err := client.Do(ctx, http.MethodPost, connectionsPath, want, &out); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit("hikyo directory credential (shown once)", out.Value, deliver); err != nil {
+	if _, err := sink.WriteOnce("hikyo directory credential (shown once)", out.Value); err != nil {
 		return failf(ExitRefused, "disclosing the credential: %v", err)
 	}
 	if out.Clamped {

--- a/internal/cli/scim.go
+++ b/internal/cli/scim.go
@@ -321,7 +321,7 @@ func runSCIMMapping(ctx context.Context, ios IO, args []string) error {
 // credential
 // ---------------------------------------------------------------------------
 
-func runSCIMCredential(ctx context.Context, ios IO, args []string) error {
+func runSCIMCredential(ctx context.Context, ios IO, args []string) (returnErr error) {
 	sub, rest, err := subverb("scim credential", args, "mint", "list", "show", "revoke")
 	if err != nil {
 		return err
@@ -362,16 +362,19 @@ func runSCIMCredential(ctx context.Context, ios IO, args []string) error {
 		return err
 	}
 
-	// The print triad is checked BEFORE the mint, so a credential is never
-	// created and then dropped on the floor for want of somewhere to put it.
+	// Reserve the print-triad destination BEFORE the mint, so a credential is
+	// never created and then dropped on the floor.
 	deliver := disclose.Options{
 		OutputFile: outputFile, DangerouslyPrint: dangerous,
 		Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal,
 	}
+	var sink *disclose.PreparedSink
 	if sub == "mint" {
-		if err := disclose.Preflight(deliver); err != nil {
+		sink, err = disclose.Prepare(deliver)
+		if err != nil {
 			return failf(ExitRefused, "the provisioning credential has nowhere to go: %v", err)
 		}
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
@@ -401,9 +404,9 @@ func runSCIMCredential(ctx context.Context, ios IO, args []string) error {
 		if err := client.Do(ctx, http.MethodPost, path, body, &res); err != nil {
 			return err
 		}
-		if _, err := disclose.Emit(
+		if _, err := sink.WriteOnce(
 			fmt.Sprintf("SCIM provisioning credential %s (display-once)", res.Credential.Id),
-			res.Token, deliver); err != nil {
+			res.Token); err != nil {
 			return failf(ExitRefused, "disclosing the provisioning credential: %v", err)
 		}
 		if res.Rotated {

--- a/internal/cli/values.go
+++ b/internal/cli/values.go
@@ -46,7 +46,7 @@ const valuesSetUsage = "usage: hikyo values set <KEY> (--stdin | --value-file PA
 var valueColumns = []string{"KEY", "CLASS", "PRESENCE", "VALUE"}
 
 // runValues is the `values` family.
-func runValues(ctx context.Context, ios IO, args []string) error {
+func runValues(ctx context.Context, ios IO, args []string) (returnErr error) {
 	sub, rest, err := subverb("values", args,
 		"list", "get", "set", "declare", "diff", "copy", "import", "publish", "export", "pending")
 	if err != nil {
@@ -187,20 +187,22 @@ func runValues(ctx context.Context, ios IO, args []string) error {
 	}
 
 	// A revealing list or diff discloses its ENTIRE rendered output (it may carry
-	// revealed secrets), so the print triad is checked BEFORE the request goes
+	// revealed secrets), so the print-triad destination is reserved BEFORE the request goes
 	// out: a caller with nowhere to put the plaintext is refused before the
-	// server ever reveals it, never after — the same pre-act preflight the
-	// display-once ceremonies use. (`get` preflights per cell after the response,
+	// server ever reveals it. (`get` prepares per cell after the response,
 	// because a config cell prints without the triad; list and diff cannot cheaply
 	// separate the two, so they guard the whole output up front.)
 	deliver := disclose.Options{
 		OutputFile: outputFile, DangerouslyPrint: dangerous,
 		Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal,
 	}
+	var sink *disclose.PreparedSink
 	if reveal && (sub == "list" || sub == "diff" || sub == "export") {
-		if err := disclose.Preflight(deliver); err != nil {
+		sink, err = disclose.Prepare(deliver)
+		if err != nil {
 			return failf(ExitRefused, "the values have nowhere to go: %v", err)
 		}
+		defer sink.AbortOnReturn(&returnErr)
 	}
 
 	client, artifact, resolved, err := authenticatedTarget(st, ios, flags)
@@ -245,7 +247,7 @@ func runValues(ctx context.Context, ios IO, args []string) error {
 			return err
 		}
 		if reveal {
-			return emitRendered(f, valueTable(list), "revealed values", deliver)
+			return emitRendered(f, valueTable(list), "revealed values", sink)
 		}
 		return Render(ios.Stdout, f, valueTable(list))
 
@@ -320,7 +322,7 @@ func runValues(ctx context.Context, ios IO, args []string) error {
 			return err
 		}
 		if reveal {
-			return emitRendered(f, diffTable(out), "revealed value diff", deliver)
+			return emitRendered(f, diffTable(out), "revealed value diff", sink)
 		}
 		return Render(ios.Stdout, f, diffTable(out))
 
@@ -417,10 +419,10 @@ func runValues(ctx context.Context, ios IO, args []string) error {
 			return err
 		}
 		if dotenvExport {
-			return exportDotenv(ios, out, reveal, deliver)
+			return exportDotenv(ios, out, reveal, sink)
 		}
 		if reveal {
-			return emitRendered(f, exportTable(out), "exported values", deliver)
+			return emitRendered(f, exportTable(out), "exported values", sink)
 		}
 		return Render(ios.Stdout, f, exportTable(out))
 	}
@@ -436,7 +438,7 @@ func runValues(ctx context.Context, ios IO, args []string) error {
 // is omitted and their count is reported on stderr. Values are written through
 // internal/dotenv's quoting encoder, so what `values import --from-dotenv`
 // reads back is byte-exact (surrounding whitespace, quotes, `#`, newlines).
-func exportDotenv(ios IO, out apigen.ExportedValues, reveal bool, deliver disclose.Options) error {
+func exportDotenv(ios IO, out apigen.ExportedValues, reveal bool, sink *disclose.PreparedSink) error {
 	var rows []dotenv.Entry
 	omitted := 0
 	for _, item := range out.Items {
@@ -465,7 +467,7 @@ func exportDotenv(ios IO, out apigen.ExportedValues, reveal bool, deliver disclo
 	}
 	body := strings.TrimRight(string(content), "\n")
 	if reveal {
-		if _, err := disclose.Emit("exported values (dotenv)", body, deliver); err != nil {
+		if _, err := sink.WriteOnce("exported values (dotenv)", body); err != nil {
 			return failf(ExitRefused, "disclosing the values: %v", err)
 		}
 	} else if _, err := ios.Stdout.Write(content); err != nil {
@@ -681,15 +683,15 @@ func diffTable(d apigen.ValueDiff) Table {
 
 // emitRendered delivers output that may contain revealed `secret` plaintext
 // through the print triad: it renders to a buffer and hands the whole thing to
-// disclose.Emit, so a revealing list or diff never reaches stdout except under
-// the triad's own rules. Preflight has already run before the request, so a
-// refusal here is the rare check/write race, not the common case.
-func emitRendered(f Format, t Table, label string, deliver disclose.Options) error {
+// PreparedSink.WriteOnce, so a revealing list or diff never reaches stdout
+// except under the triad's own rules. The destination was reserved before the
+// request, so this writes to exactly the destination that admitted the act.
+func emitRendered(f Format, t Table, label string, sink *disclose.PreparedSink) error {
 	var buf bytes.Buffer
 	if err := Render(&buf, f, t); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit(label, strings.TrimRight(buf.String(), "\n"), deliver); err != nil {
+	if _, err := sink.WriteOnce(label, strings.TrimRight(buf.String(), "\n")); err != nil {
 		return failf(ExitRefused, "disclosing the values: %v", err)
 	}
 	return nil
@@ -697,7 +699,7 @@ func emitRendered(f Format, t Table, label string, deliver disclose.Options) err
 
 // renderCell prints one cell. A revealed `secret` goes through the print
 // triad; everything else is ordinary output.
-func renderCell(ios IO, f Format, cell apigen.ValueCell, outputFile string, dangerous bool) error {
+func renderCell(ios IO, f Format, cell apigen.ValueCell, outputFile string, dangerous bool) (returnErr error) {
 	secret := cell.Classification == apigen.KeyClassificationSecret
 	if !secret || !cell.Revealed {
 		return Render(ios.Stdout, f, valueTable(apigen.ValueList{Items: []apigen.ValueCell{cell}, Count: 1}))
@@ -706,10 +708,12 @@ func renderCell(ios IO, f Format, cell apigen.ValueCell, outputFile string, dang
 		OutputFile: outputFile, DangerouslyPrint: dangerous,
 		Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal,
 	}
-	if err := disclose.Preflight(deliver); err != nil {
+	sink, err := disclose.Prepare(deliver)
+	if err != nil {
 		return failf(ExitRefused, "the value has nowhere to go: %v", err)
 	}
-	if _, err := disclose.Emit("value of "+cell.Name, cellValue(cell), deliver); err != nil {
+	defer sink.AbortOnReturn(&returnErr)
+	if _, err := sink.WriteOnce("value of "+cell.Name, cellValue(cell)); err != nil {
 		return failf(ExitRefused, "disclosing the value: %v", err)
 	}
 	return nil

--- a/internal/cli/values_internal_test.go
+++ b/internal/cli/values_internal_test.go
@@ -17,7 +17,7 @@ import (
 // it is refused by the print triad BEFORE the request goes out — never
 // downgraded to stdout, and never after a round-trip that has already disclosed.
 //
-// It reaches no server: the refusal is the "nowhere to go" preflight, which runs
+// It reaches no server: the refusal is destination preparation, which runs
 // ahead of target resolution, so an OpenTerminal that fails (no controlling
 // terminal) is enough to prove the ordering.
 func TestRevealingDiffIsRefusedBeforeAnyRequestWithoutASink(t *testing.T) {
@@ -68,8 +68,8 @@ func TestRollbackTableShowsFullImpactPreview(t *testing.T) {
 	}
 }
 
-// statePathFor gives NewState a writable state dir so the test reaches the
-// preflight rather than failing to open state first.
+// statePathFor gives NewState a writable state dir so the test reaches
+// destination preparation rather than failing to open state first.
 func statePathFor(t *testing.T, key string) string {
 	if key == "HIKYO_STATE_DIR" {
 		return t.TempDir()

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -716,7 +716,7 @@ func runAccount(ctx context.Context, ios IO, args []string) error {
 // and transmitted out of band. An instance-capability target has no network path
 // and is refused uniformly (like a nonexistent target, B2) - break-glass only,
 // via `hikyo admin reset-credential` on the host.
-func runResetCredential(ctx context.Context, ios IO, args []string) error {
+func runResetCredential(ctx context.Context, ios IO, args []string) (returnErr error) {
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
 		return failf(ExitUsage, "usage: hikyo account reset-credential <principal> [--output-file PATH | --dangerously-print]")
 	}
@@ -731,9 +731,11 @@ func runResetCredential(ctx context.Context, ios IO, args []string) error {
 		return err
 	}
 	deliver := disclose.Options{OutputFile: outputFile, DangerouslyPrint: dangerous, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-	if err := disclose.Preflight(deliver); err != nil {
+	sink, err := disclose.Prepare(deliver)
+	if err != nil {
 		return failf(ExitRefused, "the reset authority has nowhere to go: %v", err)
 	}
+	defer sink.AbortOnReturn(&returnErr)
 	client, _, err := authenticatedClient(st, ios, flags)
 	if err != nil {
 		return err
@@ -743,9 +745,9 @@ func runResetCredential(ctx context.Context, ios IO, args []string) error {
 		api.PathPrefix+"/accounts/"+url.PathEscape(principal)+"/credential-reset", nil, &result); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit(
+	if _, err := sink.WriteOnce(
 		fmt.Sprintf("credential-establishment authority for %s (single-use)", principal),
-		result.Authority, deliver); err != nil {
+		result.Authority); err != nil {
 		return failf(ExitRefused, "disclosing the reset authority: %v", err)
 	}
 	fmt.Fprintf(ios.Stderr,
@@ -872,7 +874,7 @@ func runFactor(ctx context.Context, ios IO, args []string) error {
 // runFactorEnrolTOTP stages a pending enrolment and discloses the otpauth URI
 // once through the print triad. It does not reissue the session — confirm-totp
 // does — so it persists no token.
-func runFactorEnrolTOTP(ctx context.Context, ios IO, args []string) error {
+func runFactorEnrolTOTP(ctx context.Context, ios IO, args []string) (returnErr error) {
 	var outputFile string
 	var dangerous bool
 	st, flags, err := parseCommon("account factor enrol-totp", ios, args, func(fs *flag.FlagSet) {
@@ -883,9 +885,11 @@ func runFactorEnrolTOTP(ctx context.Context, ios IO, args []string) error {
 		return err
 	}
 	deliver := disclose.Options{OutputFile: outputFile, DangerouslyPrint: dangerous, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-	if err := disclose.Preflight(deliver); err != nil {
+	sink, err := disclose.Prepare(deliver)
+	if err != nil {
 		return failf(ExitRefused, "the otpauth URI has nowhere to go: %v", err)
 	}
+	defer sink.AbortOnReturn(&returnErr)
 	client, _, err := authenticatedClient(st, ios, flags)
 	if err != nil {
 		return err
@@ -899,7 +903,7 @@ func runFactorEnrolTOTP(ctx context.Context, ios IO, args []string) error {
 		apigen.TotpEnrolStartRequest{Password: password}, &start); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit("otpauth provisioning URI", start.OtpauthUri, deliver); err != nil {
+	if _, err := sink.WriteOnce("otpauth provisioning URI", start.OtpauthUri); err != nil {
 		return failf(ExitRefused, "disclosing the otpauth URI: %v", err)
 	}
 	fmt.Fprintf(ios.Stderr, "TOTP enrolment staged. Scan the URI, then confirm with\n    hikyo account factor confirm-totp\n")
@@ -959,7 +963,7 @@ func runFactorStepUp(ctx context.Context, ios IO, args []string) error {
 	return nil
 }
 
-func runRecoveryCodes(ctx context.Context, ios IO, args []string) error {
+func runRecoveryCodes(ctx context.Context, ios IO, args []string) (returnErr error) {
 	if len(args) == 0 || args[0] != "regenerate" {
 		return failf(ExitUsage, "usage: hikyo account recovery-codes regenerate")
 	}
@@ -973,9 +977,11 @@ func runRecoveryCodes(ctx context.Context, ios IO, args []string) error {
 		return err
 	}
 	deliver := disclose.Options{OutputFile: outputFile, DangerouslyPrint: dangerous, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-	if err := disclose.Preflight(deliver); err != nil {
+	sink, err := disclose.Prepare(deliver)
+	if err != nil {
 		return failf(ExitRefused, "the recovery codes have nowhere to go: %v", err)
 	}
+	defer sink.AbortOnReturn(&returnErr)
 	client, artifact, err := authenticatedClient(st, ios, flags)
 	if err != nil {
 		return err
@@ -989,7 +995,7 @@ func runRecoveryCodes(ctx context.Context, ios IO, args []string) error {
 		apigen.RecoveryProofRequest{Proof: proof}, &result); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit("recovery codes (single-use)", strings.Join(result.RecoveryCodes, "\n"), deliver); err != nil {
+	if _, err := sink.WriteOnce("recovery codes (single-use)", strings.Join(result.RecoveryCodes, "\n")); err != nil {
 		return failf(ExitRefused, "disclosing the recovery codes: %v", err)
 	}
 	if err := persistRotatedSession(st, artifact, result.Login); err != nil {
@@ -1001,7 +1007,7 @@ func runRecoveryCodes(ctx context.Context, ios IO, args []string) error {
 
 // runRecovery is the pre-auth break-in-glass path: consume a code for a
 // credential-establishment authority, then establish a new password with it.
-func runRecovery(ctx context.Context, ios IO, args []string) error {
+func runRecovery(ctx context.Context, ios IO, args []string) (returnErr error) {
 	if len(args) == 0 || args[0] != "begin" {
 		return failf(ExitUsage, "usage: hikyo account recovery begin --instance <url|ref> --as <username>")
 	}
@@ -1031,9 +1037,11 @@ func runRecovery(ctx context.Context, ios IO, args []string) error {
 		return failf(ExitUsage, "--instance <url|ref> is required")
 	}
 	deliver := disclose.Options{OutputFile: outputFile, DangerouslyPrint: dangerous, Stdout: ios.Stdout, OpenTerminal: ios.OpenTerminal}
-	if err := disclose.Preflight(deliver); err != nil {
+	sink, err := disclose.Prepare(deliver)
+	if err != nil {
 		return failf(ExitRefused, "the authority has nowhere to go: %v", err)
 	}
+	defer sink.AbortOnReturn(&returnErr)
 	entry, err := establish(ios, st, target, "", trustFile)
 	if err != nil {
 		return err
@@ -1051,7 +1059,7 @@ func runRecovery(ctx context.Context, ios IO, args []string) error {
 		apigen.RecoveryBeginRequest{Username: as, Code: code}, &result); err != nil {
 		return err
 	}
-	if _, err := disclose.Emit("credential-establishment authority", result.Authority, deliver); err != nil {
+	if _, err := sink.WriteOnce("credential-establishment authority", result.Authority); err != nil {
 		return failf(ExitRefused, "disclosing the authority: %v", err)
 	}
 	fmt.Fprintf(ios.Stderr,

--- a/internal/disclose/disclose.go
+++ b/internal/disclose/disclose.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 )
 
 // ErrNoDestination is the refusal. It names all three options because a
@@ -36,6 +37,16 @@ var ErrNoDestination = errors.New(
 // The file is never overwritten: an existing path may be a symlink into
 // somewhere else, and O_EXCL is what makes that unarguable.
 var ErrFileExists = errors.New("refusing to disclose: --output-file already exists (it is never overwritten)")
+
+// ErrSinkConsumed reports that a prepared destination has already been used
+// or aborted. A prepared sink is deliberately single-use: display-once
+// material must have exactly one disclosure attempt.
+var ErrSinkConsumed = errors.New("refusing to disclose: prepared destination was already consumed")
+
+// ErrReservationChanged reports that Abort found a file reservation that was
+// no longer both empty and the exact file Prepare created. Abort leaves that
+// path untouched rather than risking deletion of somebody else's file.
+var ErrReservationChanged = errors.New("refusing to disclose: prepared file reservation changed; leaving it untouched")
 
 // Options selects the destination.
 type Options struct {
@@ -65,64 +76,60 @@ const (
 	DestStdout   Destination = "stdout"
 )
 
-// Preflight checks that a destination is usable WITHOUT writing anything.
-//
-// It exists because of an ordering hazard the print triad creates on its own:
-// a caller that mints a display-once secret and only then discovers it has
-// nowhere to put it has destroyed the secret and performed the side effect.
-// `admin create` is the sharp case — it would leave an instance bootstrapped
-// with an administrator whose establishment authority nobody ever saw, and
-// re-running it refuses because the instance now has an account.
-//
-// Preflight is necessarily approximate for the file leg: it cannot create the
-// file (that would consume the O_EXCL that makes the real write safe), so it
-// reports what it can — the path is free and the parent is acceptable — and a
-// race between the check and the write still lands on Emit's refusal. It
-// closes the common failure, not every failure, and says so.
-func Preflight(o Options) error {
-	switch {
-	case o.OutputFile != "" && o.DangerouslyPrint:
-		return errors.New("refusing to disclose: --output-file and --dangerously-print name two destinations; choose one")
-	case o.DangerouslyPrint:
-		return nil
-	case o.OutputFile != "":
-		return preflightFile(o.OutputFile)
-	}
-	open := o.OpenTerminal
-	if open == nil {
-		open = openControllingTerminal
-	}
-	tty, err := open()
-	if err != nil {
-		return ErrNoDestination
-	}
-	return tty.Close()
+// PreparedSink owns one already-selected disclosure destination from Prepare
+// until either WriteOnce or Abort consumes it. Keeping the open terminal or
+// exclusively-created file here closes the former check-then-reopen window.
+type PreparedSink struct {
+	mu          sync.Mutex
+	destination Destination
+	consumed    bool
+	write       func(label, value string) error
+	abort       func() error
 }
 
-// Emit writes value to exactly one permitted destination and reports which.
-// label is the human-facing description printed alongside on the interactive
-// path; it is never written to the file, which contains the value and a
-// trailing newline and nothing else, so a script can read it directly.
-func Emit(label, value string, o Options) (Destination, error) {
+// Destination identifies the reserved delivery mode before minting, so audit
+// records can describe the exact sink that will receive the value.
+func (s *PreparedSink) Destination() Destination {
+	if s == nil {
+		return ""
+	}
+	return s.destination
+}
+
+// Prepare selects and reserves exactly one destination before display-once
+// material is minted. File destinations are created exclusively at 0600;
+// terminal destinations are opened now and retained for the eventual write.
+func Prepare(o Options) (*PreparedSink, error) {
 	switch {
 	case o.OutputFile != "" && o.DangerouslyPrint:
-		return "", errors.New("refusing to disclose: --output-file and --dangerously-print name two destinations; choose one")
+		return nil, errors.New("refusing to disclose: --output-file and --dangerously-print name two destinations; choose one")
 
 	case o.OutputFile != "":
-		if err := writeExclusive(o.OutputFile, value+"\n"); err != nil {
-			return "", err
+		file, err := prepareFile(o.OutputFile)
+		if err != nil {
+			return nil, err
 		}
-		return DestFile, nil
+		return &PreparedSink{
+			destination: DestFile,
+			write: func(_ string, value string) error {
+				return file.write(value + "\n")
+			},
+			abort: file.abort,
+		}, nil
 
 	case o.DangerouslyPrint:
 		w := o.Stdout
 		if w == nil {
 			w = os.Stdout
 		}
-		if _, err := fmt.Fprintln(w, value); err != nil {
-			return "", err
-		}
-		return DestStdout, nil
+		return &PreparedSink{
+			destination: DestStdout,
+			write: func(_ string, value string) error {
+				_, err := fmt.Fprintln(w, value)
+				return err
+			},
+			abort: func() error { return nil },
+		}, nil
 	}
 
 	open := o.OpenTerminal
@@ -131,16 +138,64 @@ func Emit(label, value string, o Options) (Destination, error) {
 	}
 	tty, err := open()
 	if err != nil {
-		// No controlling terminal: this is the non-TTY case, and it is
-		// refused rather than downgraded to stdout.
-		return "", ErrNoDestination
+		return nil, ErrNoDestination
 	}
-	defer tty.Close()
-	if _, err := fmt.Fprintf(tty, "\n%s:\n\n    %s\n\nThis value is shown once and is not retrievable afterwards.\n\n",
-		label, value); err != nil {
+	return &PreparedSink{
+		destination: DestTerminal,
+		write: func(label, value string) (writeErr error) {
+			defer func() { writeErr = errors.Join(writeErr, tty.Close()) }()
+			_, writeErr = fmt.Fprintf(tty, "\n%s:\n\n    %s\n\nThis value is shown once and is not retrievable afterwards.\n\n",
+				label, value)
+			return writeErr
+		},
+		abort: tty.Close,
+	}, nil
+}
+
+// WriteOnce consumes the prepared destination even when the write fails. A
+// retry could duplicate a partially-delivered secret, so callers must treat a
+// failed attempt as unrecoverable and mint a replacement where supported.
+func (s *PreparedSink) WriteOnce(label, value string) (Destination, error) {
+	if s == nil {
+		return "", ErrSinkConsumed
+	}
+	s.mu.Lock()
+	if s.consumed {
+		s.mu.Unlock()
+		return "", ErrSinkConsumed
+	}
+	s.consumed = true
+	write := s.write
+	destination := s.destination
+	s.mu.Unlock()
+
+	if err := write(label, value); err != nil {
 		return "", err
 	}
-	return DestTerminal, nil
+	return destination, nil
+}
+
+// Abort closes an unused sink. For a file sink it removes the reservation only
+// when the path still names the exact empty file Prepare created.
+func (s *PreparedSink) Abort() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.consumed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.consumed = true
+	abort := s.abort
+	s.mu.Unlock()
+	return abort()
+}
+
+// AbortOnReturn lets callers defer cleanup without losing an Abort failure.
+// result must point at the caller's named error result.
+func (s *PreparedSink) AbortOnReturn(result *error) {
+	*result = errors.Join(*result, s.Abort())
 }
 
 // Redact renders a value for a log or an error message: never the value.

--- a/internal/disclose/disclose_test.go
+++ b/internal/disclose/disclose_test.go
@@ -13,25 +13,239 @@ import (
 
 type fakeTTY struct {
 	bytes.Buffer
-	closed bool
+	closed     bool
+	closeCount int
 }
 
-func (f *fakeTTY) Close() error { f.closed = true; return nil }
+func (f *fakeTTY) Close() error {
+	f.closed = true
+	f.closeCount++
+	return nil
+}
+
+func TestPreparedFileReservesDestinationAndWritesExactlyOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	sink, err := Prepare(Options{OutputFile: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := sink.Abort(); err != nil {
+			t.Errorf("cleanup prepared sink: %v", err)
+		}
+	})
+	if sink.Destination() != DestFile {
+		t.Fatalf("prepared destination = %q, want %q", sink.Destination(), DestFile)
+	}
+
+	competing, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err == nil {
+		_ = competing.Close()
+		t.Fatal("a competing writer acquired the prepared destination")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("competing create error = %v, want os.ErrExist", err)
+	}
+
+	dest, err := sink.WriteOnce("Token", "hik_1_bs_secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dest != DestFile {
+		t.Fatalf("destination %q, want %q", dest, DestFile)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hik_1_bs_secret\n" {
+		t.Fatalf("file holds %q", body)
+	}
+	if _, err := sink.WriteOnce("Token", "second"); !errors.Is(err, ErrSinkConsumed) {
+		t.Fatalf("second write error = %v, want ErrSinkConsumed", err)
+	}
+	if body, err := os.ReadFile(path); err != nil || string(body) != "hik_1_bs_secret\n" {
+		t.Fatalf("second write changed file: body=%q err=%v", body, err)
+	}
+}
+
+func TestPreparedTerminalClosesAfterWriteAndRefusesSecondWrite(t *testing.T) {
+	tty := &fakeTTY{}
+	sink, err := Prepare(Options{OpenTerminal: func() (io.WriteCloser, error) { return tty, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest, err := sink.WriteOnce("Token", "hik_1_bs_secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dest != DestTerminal {
+		t.Fatalf("destination %q, want %q", dest, DestTerminal)
+	}
+	if tty.closeCount != 1 {
+		t.Fatalf("terminal close count = %d, want 1", tty.closeCount)
+	}
+	if _, err := sink.WriteOnce("Token", "second"); !errors.Is(err, ErrSinkConsumed) {
+		t.Fatalf("second write error = %v, want ErrSinkConsumed", err)
+	}
+	if tty.closeCount != 1 {
+		t.Fatalf("second write closed terminal again: count = %d", tty.closeCount)
+	}
+}
+
+type failingTTY struct {
+	closeCount int
+}
+
+func (*failingTTY) Write([]byte) (int, error) { return 0, errors.New("terminal disappeared") }
+func (f *failingTTY) Close() error {
+	f.closeCount++
+	return nil
+}
+
+func TestPreparedTerminalClosesAfterWriteFailure(t *testing.T) {
+	tty := &failingTTY{}
+	sink, err := Prepare(Options{OpenTerminal: func() (io.WriteCloser, error) { return tty, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sink.WriteOnce("Token", "secret"); err == nil || !strings.Contains(err.Error(), "terminal disappeared") {
+		t.Fatalf("write error = %v, want terminal failure", err)
+	}
+	if tty.closeCount != 1 {
+		t.Fatalf("terminal close count = %d, want 1", tty.closeCount)
+	}
+	if _, err := sink.WriteOnce("Token", "second"); !errors.Is(err, ErrSinkConsumed) {
+		t.Fatalf("second write error = %v, want ErrSinkConsumed", err)
+	}
+}
+
+func TestPreparedTerminalAbortClosesWithoutWriting(t *testing.T) {
+	tty := &fakeTTY{}
+	sink, err := Prepare(Options{OpenTerminal: func() (io.WriteCloser, error) { return tty, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Abort(); err != nil {
+		t.Fatal(err)
+	}
+	if tty.closeCount != 1 {
+		t.Fatalf("terminal close count = %d, want 1", tty.closeCount)
+	}
+	if tty.Len() != 0 {
+		t.Fatalf("abort wrote to terminal: %q", tty.String())
+	}
+	if err := sink.Abort(); err != nil {
+		t.Fatalf("second abort = %v, want idempotent success", err)
+	}
+	if tty.closeCount != 1 {
+		t.Fatalf("second abort closed terminal again: count = %d", tty.closeCount)
+	}
+}
+
+func TestAbortRemovesOnlyOwnedEmptyReservation(t *testing.T) {
+	t.Run("empty reservation", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		sink, err := Prepare(Options{OutputFile: path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.Abort(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("reservation remains after abort: %v", err)
+		}
+		if _, err := sink.WriteOnce("Token", "value"); !errors.Is(err, ErrSinkConsumed) {
+			t.Fatalf("write after abort error = %v, want ErrSinkConsumed", err)
+		}
+	})
+
+	if runtime.GOOS != "windows" {
+		t.Run("non-empty reservation", func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "token")
+			sink, err := Prepare(Options{OutputFile: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("claimed"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := sink.Abort(); !errors.Is(err, ErrReservationChanged) {
+				t.Fatalf("abort error = %v, want ErrReservationChanged", err)
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "claimed" {
+				t.Fatalf("abort changed non-empty reservation: %q", body)
+			}
+		})
+
+		t.Run("replaced reservation", func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "token")
+			sink, err := Prepare(Options{OutputFile: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := sink.Abort(); !errors.Is(err, ErrReservationChanged) {
+				t.Fatalf("abort error = %v, want ErrReservationChanged", err)
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "replacement" {
+				t.Fatalf("abort removed replacement: %q", body)
+			}
+		})
+	}
+}
+
+func TestAbortOnReturnPreservesOperationAndCleanupErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows denies competing writes while the reservation handle is open")
+	}
+	path := filepath.Join(t.TempDir(), "token")
+	sink, err := Prepare(Options{OutputFile: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("claimed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	operationErr := errors.New("operation failed")
+	result := error(operationErr)
+	sink.AbortOnReturn(&result)
+	if !errors.Is(result, operationErr) {
+		t.Fatalf("result = %v, want operation error preserved", result)
+	}
+	if !errors.Is(result, ErrReservationChanged) {
+		t.Fatalf("result = %v, want cleanup error surfaced", result)
+	}
+}
 
 func TestNonTTYWithNoFlagIsRefused(t *testing.T) {
 	// The whole point of the triad: with no controlling terminal and no
 	// explicit destination, the value is refused rather than downgraded to
 	// stdout, where a log shipper would collect it.
 	var out bytes.Buffer
-	dest, err := Emit("Bootstrap token", "hik_1_bs_secret", Options{
+	sink, err := Prepare(Options{
 		Stdout:       &out,
 		OpenTerminal: func() (io.WriteCloser, error) { return nil, errors.New("no controlling terminal") },
 	})
 	if !errors.Is(err, ErrNoDestination) {
 		t.Fatalf("err = %v, want ErrNoDestination", err)
 	}
-	if dest != "" {
-		t.Fatalf("a destination was reported despite the refusal: %q", dest)
+	if sink != nil {
+		t.Fatal("a sink was returned despite the refusal")
 	}
 	if out.Len() != 0 {
 		t.Fatalf("the value reached stdout anyway: %q", out.String())
@@ -44,10 +258,14 @@ func TestNonTTYWithNoFlagIsRefused(t *testing.T) {
 func TestTerminalPathNeverTouchesStdout(t *testing.T) {
 	var out bytes.Buffer
 	tty := &fakeTTY{}
-	dest, err := Emit("Bootstrap token", "hik_1_bs_secret", Options{
+	sink, err := Prepare(Options{
 		Stdout:       &out,
 		OpenTerminal: func() (io.WriteCloser, error) { return tty, nil },
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest, err := sink.WriteOnce("Bootstrap token", "hik_1_bs_secret")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,13 +285,17 @@ func TestTerminalPathNeverTouchesStdout(t *testing.T) {
 
 func TestDangerouslyPrintIsTheOnlyStdoutPath(t *testing.T) {
 	var out bytes.Buffer
-	dest, err := Emit("Token", "hik_1_bs_secret", Options{
+	sink, err := Prepare(Options{
 		Stdout:           &out,
 		DangerouslyPrint: true,
 		// A terminal IS available; the explicit flag still wins, because the
 		// caller asked for the machine-readable path on purpose.
 		OpenTerminal: func() (io.WriteCloser, error) { return &fakeTTY{}, nil },
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest, err := sink.WriteOnce("Token", "hik_1_bs_secret")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +308,7 @@ func TestDangerouslyPrintIsTheOnlyStdoutPath(t *testing.T) {
 }
 
 func TestTwoDestinationsIsARefusal(t *testing.T) {
-	_, err := Emit("Token", "v", Options{OutputFile: filepath.Join(t.TempDir(), "t"), DangerouslyPrint: true})
+	_, err := Prepare(Options{OutputFile: filepath.Join(t.TempDir(), "t"), DangerouslyPrint: true})
 	if err == nil {
 		t.Fatal("naming two destinations was accepted")
 	}
@@ -94,7 +316,11 @@ func TestTwoDestinationsIsARefusal(t *testing.T) {
 
 func TestOutputFileIsCreatedFreshAt0600(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "token")
-	dest, err := Emit("Token", "hik_1_bs_secret", Options{OutputFile: path})
+	sink, err := Prepare(Options{OutputFile: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest, err := sink.WriteOnce("Token", "hik_1_bs_secret")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +350,7 @@ func TestOutputFileIsNeverOverwritten(t *testing.T) {
 	if err := os.WriteFile(path, []byte("previous"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Emit("Token", "new", Options{OutputFile: path}); !errors.Is(err, ErrFileExists) {
+	if _, err := Prepare(Options{OutputFile: path}); !errors.Is(err, ErrFileExists) {
 		t.Fatalf("err = %v, want ErrFileExists", err)
 	}
 	body, _ := os.ReadFile(path)
@@ -146,7 +372,7 @@ func TestOutputFileRefusesASymlinkedTarget(t *testing.T) {
 	if err := os.Symlink(real, link); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Emit("Token", "v", Options{OutputFile: link}); err == nil {
+	if _, err := Prepare(Options{OutputFile: link}); err == nil {
 		t.Fatal("a symlinked target was written through")
 	}
 	body, _ := os.ReadFile(real)
@@ -167,7 +393,7 @@ func TestOutputFileRefusesAWorldWritableParent(t *testing.T) {
 	if err := os.Chmod(dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	_, err := Emit("Token", "v", Options{OutputFile: filepath.Join(dir, "token")})
+	_, err := Prepare(Options{OutputFile: filepath.Join(dir, "token")})
 	if err == nil {
 		t.Fatal("a world-writable parent was accepted — someone else could win the create race")
 	}
@@ -176,41 +402,58 @@ func TestOutputFileRefusesAWorldWritableParent(t *testing.T) {
 	}
 }
 
-func TestPreflightRefusesBeforeAnythingIsMinted(t *testing.T) {
+func TestPrepareReservesBeforeAnythingIsMinted(t *testing.T) {
 	// The ordering hazard the triad creates: a caller that mints a
 	// display-once secret and only then finds it has nowhere to put it has
-	// destroyed the secret and performed the side effect. Preflight is what
-	// lets `admin create` refuse before it creates an administrator.
+	// destroyed the secret and performed the side effect. Prepare refuses or
+	// reserves before `admin create` creates an administrator.
 	noTerminal := func() (io.WriteCloser, error) { return nil, errors.New("no controlling terminal") }
-	if err := Preflight(Options{OpenTerminal: noTerminal}); !errors.Is(err, ErrNoDestination) {
+	if _, err := Prepare(Options{OpenTerminal: noTerminal}); !errors.Is(err, ErrNoDestination) {
 		t.Fatalf("err = %v, want ErrNoDestination", err)
 	}
-	if err := Preflight(Options{DangerouslyPrint: true, OpenTerminal: noTerminal}); err != nil {
+	stdoutSink, err := Prepare(Options{DangerouslyPrint: true, OpenTerminal: noTerminal})
+	if err != nil {
 		t.Fatalf("--dangerously-print refused: %v", err)
 	}
-	if err := Preflight(Options{OpenTerminal: func() (io.WriteCloser, error) { return &fakeTTY{}, nil }}); err != nil {
+	if err := stdoutSink.Abort(); err != nil {
+		t.Fatal(err)
+	}
+	terminalSink, err := Prepare(Options{OpenTerminal: func() (io.WriteCloser, error) { return &fakeTTY{}, nil }})
+	if err != nil {
 		t.Fatalf("an available terminal refused: %v", err)
+	}
+	if err := terminalSink.Abort(); err != nil {
+		t.Fatal(err)
 	}
 
 	dir := t.TempDir()
 	fresh := filepath.Join(dir, "fresh")
-	if err := Preflight(Options{OutputFile: fresh, OpenTerminal: noTerminal}); err != nil {
+	fileSink, err := Prepare(Options{OutputFile: fresh, OpenTerminal: noTerminal})
+	if err != nil {
 		t.Fatalf("a free path refused: %v", err)
 	}
-	// Preflight creates nothing — the O_EXCL that makes the real write safe
-	// must still be available to it.
+	info, err := os.Stat(fresh)
+	if err != nil {
+		t.Fatalf("Prepare did not reserve the file: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("prepared reservation size = %d, want 0", info.Size())
+	}
+	if err := fileSink.Abort(); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := os.Stat(fresh); !errors.Is(err, os.ErrNotExist) {
-		t.Fatal("Preflight created the file")
+		t.Fatalf("Abort left the reservation behind: %v", err)
 	}
 	taken := filepath.Join(dir, "taken")
 	if err := os.WriteFile(taken, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := Preflight(Options{OutputFile: taken, OpenTerminal: noTerminal}); !errors.Is(err, ErrFileExists) {
-		t.Fatalf("an occupied path passed preflight: %v", err)
+	if _, err := Prepare(Options{OutputFile: taken, OpenTerminal: noTerminal}); !errors.Is(err, ErrFileExists) {
+		t.Fatalf("an occupied path passed preparation: %v", err)
 	}
-	if err := Preflight(Options{OutputFile: fresh, DangerouslyPrint: true}); err == nil {
-		t.Fatal("two destinations passed preflight")
+	if _, err := Prepare(Options{OutputFile: fresh, DangerouslyPrint: true}); err == nil {
+		t.Fatal("two destinations passed preparation")
 	}
 }
 

--- a/internal/disclose/file_unix.go
+++ b/internal/disclose/file_unix.go
@@ -12,144 +12,143 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// writeExclusive creates the output file the way the ADR fixes it, and the
-// order is the security property:
-//
-//  1. open the PARENT directory with O_DIRECTORY|O_NOFOLLOW and check it —
-//     owned by the invoking user, not world- or group-writable;
-//  2. create the final component RELATIVE TO THAT DIRECTORY FD with
-//     O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, so the path cannot be swapped
-//     between the check and the create;
-//  3. fchmod to exactly 0600 (umask-independent — a permissive umask must not
-//     be able to widen a file holding a credential);
-//  4. fstat the written descriptor and confirm a regular file.
-//
-// Symlinked or shared-writable parents are refused by these checks rather
-// than delegated to caller judgment. Ancestry ABOVE the checked parent stays
-// the caller's path choice, which the docs state rather than pretending
-// otherwise.
-func writeExclusive(path, content string) error {
+type preparedFile struct {
+	f       *os.File
+	dirFD   int
+	name    string
+	path    string
+	created unix.Stat_t
+}
+
+func prepareFile(path string) (*preparedFile, error) {
 	dir, name := filepath.Split(path)
 	if dir == "" {
 		dir = "."
 	}
 	if name == "" {
-		return fmt.Errorf("refusing to disclose: %q names a directory, not a file", path)
+		return nil, fmt.Errorf("refusing to disclose: %q names a directory, not a file", path)
 	}
 
 	dirFD, err := unix.Open(dir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
-		return fmt.Errorf("refusing to disclose: cannot open the parent directory %q safely: %w", dir, err)
+		return nil, fmt.Errorf("refusing to disclose: cannot open the parent directory %q safely: %w", dir, err)
 	}
-	defer unix.Close(dirFD)
+	fail := func(err error) (*preparedFile, error) {
+		_ = unix.Close(dirFD)
+		return nil, err
+	}
 
 	var dirStat unix.Stat_t
 	if err := unix.Fstat(dirFD, &dirStat); err != nil {
-		return fmt.Errorf("refusing to disclose: cannot stat the parent directory %q: %w", dir, err)
+		return fail(fmt.Errorf("refusing to disclose: cannot stat the parent directory %q: %w", dir, err))
 	}
 	if uint32(dirStat.Uid) != uint32(os.Getuid()) {
-		return fmt.Errorf("refusing to disclose: the parent directory %q is owned by uid %d, not by you (uid %d)",
-			dir, dirStat.Uid, os.Getuid())
+		return fail(fmt.Errorf("refusing to disclose: the parent directory %q is owned by uid %d, not by you (uid %d)",
+			dir, dirStat.Uid, os.Getuid()))
 	}
-	// Group- or world-writable parents let someone else win the create race
-	// or replace the file after it is written.
 	if dirStat.Mode&0o022 != 0 {
-		return fmt.Errorf("refusing to disclose: the parent directory %q is writable by group or others (mode %04o)",
-			dir, dirStat.Mode&0o777)
+		return fail(fmt.Errorf("refusing to disclose: the parent directory %q is writable by group or others (mode %04o)",
+			dir, dirStat.Mode&0o777))
 	}
 
 	fd, err := unix.Openat(dirFD, name,
 		unix.O_CREAT|unix.O_EXCL|unix.O_WRONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		if errors.Is(err, unix.EEXIST) {
-			return ErrFileExists
+			return fail(ErrFileExists)
 		}
-		return fmt.Errorf("refusing to disclose: cannot create %q: %w", path, err)
+		return fail(fmt.Errorf("refusing to disclose: cannot create %q: %w", path, err))
 	}
 	f := os.NewFile(uintptr(fd), path)
-	// Any failure from here on removes the file. Leaving it behind is worse
-	// than either outcome it could represent: a partial write is a truncated
-	// secret the operator may not notice is truncated, and a complete write
-	// whose fsync failed is a secret on disk that Emit told the caller it had
-	// failed to deliver — so the caller mints another and the first is
-	// orphaned plaintext.
-	committed := false
-	defer func() {
-		f.Close()
-		if !committed {
-			_ = unix.Unlinkat(dirFD, name, 0)
-		}
-	}()
-
-	// Umask-independent: 0600 exactly, whatever the process umask was when
-	// the file came into existence.
+	cleanup := func(err error) (*preparedFile, error) {
+		_ = f.Close()
+		_ = unix.Unlinkat(dirFD, name, 0)
+		_ = unix.Close(dirFD)
+		return nil, err
+	}
 	if err := f.Chmod(0o600); err != nil {
-		return fmt.Errorf("refusing to disclose: cannot set 0600 on %q: %w", path, err)
+		return cleanup(fmt.Errorf("refusing to disclose: cannot set 0600 on %q: %w", path, err))
 	}
 	var fileStat unix.Stat_t
 	if err := unix.Fstat(int(f.Fd()), &fileStat); err != nil {
-		return fmt.Errorf("refusing to disclose: cannot stat %q: %w", path, err)
+		return cleanup(fmt.Errorf("refusing to disclose: cannot stat %q: %w", path, err))
 	}
 	if fileStat.Mode&unix.S_IFMT != unix.S_IFREG {
-		return fmt.Errorf("refusing to disclose: %q is not a regular file", path)
+		return cleanup(fmt.Errorf("refusing to disclose: %q is not a regular file", path))
 	}
 
-	if _, err := io.WriteString(f, content); err != nil {
-		return err
+	return &preparedFile{f: f, dirFD: dirFD, name: name, path: path, created: fileStat}, nil
+}
+
+func (p *preparedFile) pathStillOwned() bool {
+	var current unix.Stat_t
+	if err := unix.Fstatat(p.dirFD, p.name, &current, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return false
 	}
-	// The value must be on disk before the caller is told it was delivered:
-	// a crash between write and fsync would leave the operator holding a
-	// receipt for a token that does not exist.
-	if err := f.Sync(); err != nil {
-		return err
+	return current.Dev == p.created.Dev && current.Ino == p.created.Ino
+}
+
+func (p *preparedFile) removeOwned() error {
+	// The parent was opened without following symlinks and rejected unless it
+	// is owned by this uid and not writable by group/others. Therefore an
+	// untrusted uid cannot replace this entry between the identity check and
+	// unlink; a same-uid process is already inside the owner boundary for this
+	// 0600 disclosure file. The inode comparison still prevents stale cleanup
+	// from removing a replacement made before Abort starts.
+	if !p.pathStillOwned() {
+		return ErrReservationChanged
 	}
-	if err := f.Close(); err != nil {
-		return err
+	if err := unix.Unlinkat(p.dirFD, p.name, 0); err != nil {
+		return fmt.Errorf("remove unused disclosure reservation %q: %w", p.path, err)
 	}
-	// Syncing the file is not enough: the directory ENTRY is what makes it
-	// findable, and on a crash an unsynced entry can leave a durable file
-	// with no name pointing at it.
-	if err := unix.Fsync(dirFD); err != nil {
-		return fmt.Errorf("refusing to disclose: cannot commit the directory entry for %q: %w", path, err)
-	}
-	committed = true
 	return nil
 }
 
-// preflightFile reports whether writeExclusive would plausibly succeed: the
-// target is free and its parent passes the ownership and permission checks.
-// It creates nothing.
-func preflightFile(path string) error {
-	if _, err := os.Lstat(path); err == nil {
-		return ErrFileExists
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("refusing to disclose: cannot inspect %q: %w", path, err)
+func (p *preparedFile) write(content string) error {
+	_, writeErr := io.WriteString(p.f, content)
+	if writeErr == nil {
+		writeErr = p.f.Sync()
 	}
-	dir, name := filepath.Split(path)
-	if dir == "" {
-		dir = "."
+	writeErr = errors.Join(writeErr, p.f.Close())
+	p.f = nil
+	if writeErr == nil {
+		if err := unix.Fsync(p.dirFD); err == nil {
+			_ = unix.Close(p.dirFD)
+			p.dirFD = -1
+			return nil
+		} else {
+			writeErr = fmt.Errorf("refusing to disclose: cannot commit the directory entry for %q: %w", p.path, err)
+		}
 	}
-	if name == "" {
-		return fmt.Errorf("refusing to disclose: %q names a directory, not a file", path)
+
+	cleanupErr := p.removeOwned()
+	if cleanupErr == nil {
+		cleanupErr = unix.Fsync(p.dirFD)
 	}
-	dirFD, err := unix.Open(dir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return fmt.Errorf("refusing to disclose: cannot open the parent directory %q safely: %w", dir, err)
+	_ = unix.Close(p.dirFD)
+	p.dirFD = -1
+	return errors.Join(writeErr, cleanupErr)
+}
+
+func (p *preparedFile) abort() error {
+	var current unix.Stat_t
+	if err := unix.Fstat(int(p.f.Fd()), &current); err != nil || current.Size != 0 || !p.pathStillOwned() {
+		closeErr := p.f.Close()
+		p.f = nil
+		_ = unix.Close(p.dirFD)
+		p.dirFD = -1
+		return errors.Join(ErrReservationChanged, err, closeErr)
 	}
-	defer unix.Close(dirFD)
-	var st unix.Stat_t
-	if err := unix.Fstat(dirFD, &st); err != nil {
-		return fmt.Errorf("refusing to disclose: cannot stat the parent directory %q: %w", dir, err)
+
+	removeErr := p.removeOwned()
+	closeErr := p.f.Close()
+	p.f = nil
+	if removeErr == nil {
+		removeErr = unix.Fsync(p.dirFD)
 	}
-	if uint32(st.Uid) != uint32(os.Getuid()) {
-		return fmt.Errorf("refusing to disclose: the parent directory %q is owned by uid %d, not by you (uid %d)",
-			dir, st.Uid, os.Getuid())
-	}
-	if st.Mode&0o022 != 0 {
-		return fmt.Errorf("refusing to disclose: the parent directory %q is writable by group or others (mode %04o)",
-			dir, st.Mode&0o777)
-	}
-	return nil
+	_ = unix.Close(p.dirFD)
+	p.dirFD = -1
+	return errors.Join(removeErr, closeErr)
 }
 
 // openControllingTerminal opens /dev/tty — the controlling terminal, which is

--- a/internal/disclose/file_windows.go
+++ b/internal/disclose/file_windows.go
@@ -7,45 +7,75 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
-// The Windows leg of the triad. CREATE_NEW is expressed as O_CREATE|O_EXCL,
-// which the runtime maps to it, so the never-overwrite property holds.
-//
-// Stated limitation, not a silent one: the owner-only DACL and the
-// dirfd-relative create the unix path uses have no direct equivalent here,
-// so this leg gives exclusivity but not the parent-directory ownership check.
-// Windows is a CLIENT platform for Hikyo — the server, and therefore every
-// bootstrap and reset disclosure, runs on unix — so the weaker leg is not on
-// the bootstrap path. Closing it needs the Windows security APIs and belongs
-// with the ticket that ships a supported Windows client.
-func writeExclusive(path, content string) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return ErrFileExists
-		}
-		return fmt.Errorf("refusing to disclose: cannot create %q: %w", path, err)
-	}
-	defer f.Close()
-	if _, err := io.WriteString(f, content); err != nil {
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		return err
-	}
-	return f.Close()
+type preparedFile struct {
+	f    *os.File
+	path string
 }
 
-// preflightFile reports whether the target is free. The parent-ownership
-// half has no Windows equivalent here, as documented above.
-func preflightFile(path string) error {
-	if _, err := os.Lstat(path); err == nil {
-		return ErrFileExists
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("refusing to disclose: cannot inspect %q: %w", path, err)
+// prepareFile uses CREATE_NEW with no sharing, so the reserved handle cannot
+// be reopened, replaced, or deleted before WriteOnce/Abort consumes it. The
+// owner-only DACL and dirfd-relative parent checks used on Unix still have no
+// equivalent here; Windows remains a client platform, not a bootstrap host.
+func prepareFile(path string) (*preparedFile, error) {
+	pathp, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("refusing to disclose: invalid output path %q: %w", path, err)
+	}
+	handle, err := windows.CreateFile(
+		pathp,
+		windows.GENERIC_WRITE|windows.DELETE,
+		0,
+		nil,
+		windows.CREATE_NEW,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_FILE_EXISTS) || errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			return nil, ErrFileExists
+		}
+		return nil, fmt.Errorf("refusing to disclose: cannot create %q: %w", path, err)
+	}
+	return &preparedFile{f: os.NewFile(uintptr(handle), path), path: path}, nil
+}
+
+func (p *preparedFile) deleteOnClose() error {
+	deleteFile := byte(1)
+	if err := windows.SetFileInformationByHandle(
+		windows.Handle(p.f.Fd()), windows.FileDispositionInfo, &deleteFile, 1,
+	); err != nil {
+		return fmt.Errorf("remove disclosure reservation %q: %w", p.path, err)
 	}
 	return nil
+}
+
+func (p *preparedFile) write(content string) error {
+	_, writeErr := io.WriteString(p.f, content)
+	if writeErr == nil {
+		writeErr = p.f.Sync()
+	}
+	if writeErr != nil {
+		writeErr = errors.Join(writeErr, p.deleteOnClose())
+	}
+	writeErr = errors.Join(writeErr, p.f.Close())
+	p.f = nil
+	return writeErr
+}
+
+func (p *preparedFile) abort() error {
+	info, err := p.f.Stat()
+	if err != nil || info.Size() != 0 {
+		closeErr := p.f.Close()
+		p.f = nil
+		return errors.Join(ErrReservationChanged, err, closeErr)
+	}
+	err = errors.Join(p.deleteOnClose(), p.f.Close())
+	p.f = nil
+	return err
 }
 
 // openControllingTerminal opens the console output device, the Windows

--- a/internal/disclose/file_windows_test.go
+++ b/internal/disclose/file_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package disclose
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsPreparedFileOwnsHandleUntilAbort(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	sink, err := Prepare(Options{OutputFile: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	competing, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err == nil {
+		_ = competing.Close()
+		t.Fatal("a competing writer opened the prepared Windows destination")
+	}
+	if err := sink.Abort(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unused Windows reservation remains after Abort: %v", err)
+	}
+}
+
+func TestWindowsPreparedFileWritesThroughReservedHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	sink, err := Prepare(Options{OutputFile: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sink.WriteOnce("Token", "hik_1_bs_secret"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hik_1_bs_secret\n" {
+		t.Fatalf("Windows disclosure file = %q", body)
+	}
+}

--- a/internal/isolation/scim_demo_e2e_test.go
+++ b/internal/isolation/scim_demo_e2e_test.go
@@ -83,7 +83,7 @@ func runSCIMDemo(t *testing.T, db *store.DB, ios func() cli.IO, baseURL, orgID s
 	}
 
 	// 2. Mint the display-once credential through the print triad. The
-	//    preflight runs BEFORE the mint, so a credential is never created and
+	//    destination preparation runs BEFORE the mint, so a credential is never created and
 	//    then dropped for want of somewhere to put it (the refusal leg itself
 	//    is #54's fixture; this demo has a terminal available, which is the
 	//    triad's third leg).

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -32,14 +32,22 @@ printf '%s\n' "$app_block" | grep -F 'run: ./scripts/ci/build-spa.sh --verify' >
 	fail 'app-build does not verify and build the SPA through the shared script'
 printf '%s\n' "$app_block" | grep -F 'go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo' >/dev/null ||
 	fail 'app-build does not produce the release-shaped CI binary'
-printf '%s\n' "$app_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
-	fail 'app-build artifact is not scoped to this run attempt'
+printf '%s\n' "$app_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
+	fail 'app-build artifact is not scoped to this run'
+if printf '%s\n' "$app_block" | grep -F 'github.run_attempt' >/dev/null; then
+	fail 'app-build artifact name changes when failed jobs are rerun'
+fi
+printf '%s\n' "$app_block" | grep -F 'overwrite: true' >/dev/null ||
+	fail 'app-build artifact cannot be replaced by a full workflow rerun'
 
 [ -n "$no_egress_block" ] || fail 'no-egress job is missing'
 printf '%s\n' "$no_egress_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
 	fail 'no-egress does not depend on app-build'
-printf '%s\n' "$no_egress_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
+printf '%s\n' "$no_egress_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
 	fail 'no-egress does not consume the exact app-build artifact'
+if printf '%s\n' "$no_egress_block" | grep -F 'github.run_attempt' >/dev/null; then
+	fail 'no-egress changes artifact names when failed jobs are rerun'
+fi
 printf '%s\n' "$no_egress_block" | grep -F 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1' >/dev/null ||
 	fail 'no-egress does not use the repository-pinned download-artifact action'
 printf '%s\n' "$no_egress_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev/null ||
@@ -53,8 +61,11 @@ fi
 
 printf '%s\n' "$web_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
 	fail 'web does not depend on app-build'
-printf '%s\n' "$web_block" | grep -F 'name: hikyo-app-${{ github.run_id }}-${{ github.run_attempt }}' >/dev/null ||
+printf '%s\n' "$web_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
 	fail 'web does not consume the exact app-build artifact'
+if printf '%s\n' "$web_block" | grep -F 'github.run_attempt' >/dev/null; then
+	fail 'web changes artifact names when failed jobs are rerun'
+fi
 printf '%s\n' "$web_block" | grep -F 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1' >/dev/null ||
 	fail 'web does not use the repository-pinned download-artifact action'
 printf '%s\n' "$web_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev/null ||


### PR DESCRIPTION
## Summary

- prepare and reserve the exact disclosure destination before minting or requesting sensitive material
- expose a single-use PreparedSink with WriteOnce, idempotent Abort, and AbortOnReturn
- retain Unix parent directory identity and use CREATE_NEW with exclusive sharing on Windows
- migrate existing Preflight and Emit callers to the prepared-sink lifecycle

## Stack

- stacked on #289
- base branch: t3code/implement-issue-1
- base head at creation: e0d8b68480dd55f53bb4f0eb79b88886a0767057

## Contract and migration

- Prepare reserves the destination before secret-producing work begins
- successful paths call WriteOnce exactly once
- all early returns clean up through AbortOnReturn
- no generated outputs changed

## Validation

- go test -count=1 ./internal/disclose/... ./internal/app/... ./internal/cli/... — 281 passed
- go test -race -count=1 ./internal/disclose/... — 21 passed
- go vet ./...
- go build ./...
- go test -count=1 ./... — 3,137 passed in 57 packages
- Windows cross-compilation passed; native Windows fixture included
- Standards and Spec review round 2: clean

Closes #238