### PR TITLE
perf(scan): decode and index acknowledgement tokens once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,6 @@ jobs:
         run: ./scripts/ci/check-trusted-ci-scripts_test.sh
       - name: Build artifact reuse fixture
         run: ./scripts/ci/check-build-artifact-reuse_test.sh
-      - name: No-egress lifecycle fixture
-        run: ./scripts/ci/check-no-egress-lifecycle_test.sh
       - name: Cache policy fixture
         run: ./scripts/ci/check-cache-policy_test.sh
       - name: Fuzz finding classifier fixture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         run: ./scripts/ci/check-trusted-ci-scripts_test.sh
       - name: Build artifact reuse fixture
         run: ./scripts/ci/check-build-artifact-reuse_test.sh
+      - name: No-egress lifecycle fixture
+        run: ./scripts/ci/check-no-egress-lifecycle_test.sh
       - name: Cache policy fixture
         run: ./scripts/ci/check-cache-policy_test.sh
       - name: Fuzz finding classifier fixture

--- a/docs/handoff/229-scan-ack-index.md
+++ b/docs/handoff/229-scan-ack-index.md
@@ -58,5 +58,13 @@ the prior successful dependency artifact; a full rerun safely replaces it with
 `overwrite: true` after the exact-head build succeeds. The policy fixture pins
 both requirements and rejects future attempt-scoped app artifact names.
 
+The fresh exact-head run then reproduced the original shutdown on a second
+hosted runner. `no-egress.sh` was terminating a derived process group after the
+probe; when `setsid` forked, that group could include the runner shell. The
+probe now enables strace's `--kill-on-exit` ownership and kills only the exact
+tracer PID. A lifecycle fixture rejects negative process-group signals, and the
+Ubuntu 24.04 probe completes without leaving the traced server behind.
+
 CI-repair validation: build-artifact reuse, required-jobs, changed-path,
-trusted-script, cache-policy, ShellCheck, and actionlint checks passed locally.
+trusted-script, cache-policy, no-egress lifecycle, ShellCheck, actionlint, and
+the complete Ubuntu 24.04 no-egress probe passed locally.

--- a/docs/handoff/229-scan-ack-index.md
+++ b/docs/handoff/229-scan-ack-index.md
@@ -1,7 +1,7 @@
 # #229 — Decode and index scan acknowledgement tokens once
 
 Status: implemented as a stacked change on PR #290 at
-`ebf6de5f19bc8c51eb1e7d75a884cc7fd64177ea`.
+`9a340d8dce43e6cc1adceaca2c0e70d7c25b42d9`.
 
 ## Contract
 

--- a/docs/handoff/229-scan-ack-index.md
+++ b/docs/handoff/229-scan-ack-index.md
@@ -1,0 +1,45 @@
+# #229 — Decode and index scan acknowledgement tokens once
+
+Status: implemented as a stacked change on PR #290 at
+`ebf6de5f19bc8c51eb1e7d75a884cc7fd64177ea`.
+
+## Contract
+
+Each acknowledgement submission remains a distinct `ackEntry` carrying its
+original index, opaque token, decoded binding or decode error, and used state.
+On first scanner use, `ackSet` opens every presented token exactly once and
+indexes valid bindings by acknowledgement kind, locator, and rule digest.
+
+Matching uses a second per-binding index for snapshot and content digest, with
+input-ordered entry lists and cursors. Duplicate tokens therefore remain
+distinct and are consumed in submission order without token × finding scans.
+Rejection classification builds a first-finding index and walks retained token
+entries in original order, preserving the fixed precedence:
+
+`unreadable → surplus → version-skew → stale → expired`.
+
+Token format, ruleset semantics, public refusal text, and Surface 1/Surface 2
+kind separation are unchanged. No database migration or generated output is
+required.
+
+## Validation
+
+- `go test -count=1 ./internal/service/... -run 'Scan|Ack'`: 16 passed
+- `go test ./internal/service -run '^$' -bench '^BenchmarkAckSetMaximum$'
+  -benchtime 3x -count=1`: maximum-size match and rejection benchmarks passed
+- `go test ./internal/scanning/ -run '^$' -bench BenchmarkScan -benchtime 3x
+  -count=1`: passed
+- `go test -race -count=1 ./internal/service -run
+  '^TestAckSet(OpensEachPresentedTokenOnce|RejectionPrecedenceAndInputOrder|CrossSurfaceReplayRejected|StaleContentAndVersionRejected|SurplusReported)$'`:
+  5 passed
+- `go test -count=1 ./internal/isolation/`: 1,090 passed
+- `go build ./...`: passed
+- `go vet ./...`: passed
+- Exact stacked head on PR #290: `go test -count=1 ./...`: 3,139 passed in
+  57 packages
+
+## Review
+
+- Standards axis: `CLEAN`
+- Spec axis: exact duplicate-token fixture gap fixed; round-2 verification
+  `CLEAN`

--- a/docs/handoff/229-scan-ack-index.md
+++ b/docs/handoff/229-scan-ack-index.md
@@ -43,3 +43,20 @@ required.
 - Standards axis: `CLEAN`
 - Spec axis: exact duplicate-token fixture gap fixed; round-2 verification
   `CLEAN`
+
+## CI repair
+
+The first PR run's `no-egress` job was terminated by its hosted runner with
+exit 143. A failed-job rerun then exposed a separate workflow defect: GitHub
+reuses successful dependency jobs from the original attempt, while
+`github.run_attempt` advances for the rerun. `app-build` therefore remained at
+artifact `hikyo-app-<run>-1`, but rerun consumers requested
+`hikyo-app-<run>-2`.
+
+App artifacts are now scoped to `github.run_id` only. A partial rerun consumes
+the prior successful dependency artifact; a full rerun safely replaces it with
+`overwrite: true` after the exact-head build succeeds. The policy fixture pins
+both requirements and rejects future attempt-scoped app artifact names.
+
+CI-repair validation: build-artifact reuse, required-jobs, changed-path,
+trusted-script, cache-policy, ShellCheck, and actionlint checks passed locally.

--- a/internal/service/scan.go
+++ b/internal/service/scan.go
@@ -207,15 +207,79 @@ func ackRef(token string) string {
 	return base64.RawURLEncoding.EncodeToString(h[:])
 }
 
-// ackSet tracks the tokens a resubmission presented, consuming each as it
-// matches a current finding so surplus tokens can be rejected by name (ADR §4).
+type ackBindingIndexKey struct {
+	kind       string
+	locator    string
+	ruleDigest string
+}
+
+type ackMatchIndexKey struct {
+	snapshot   string
+	contentSHA [32]byte
+}
+
+type ackEntry struct {
+	originalIndex int
+	token         string
+	binding       ackBinding
+	decodeErr     error
+	used          bool
+}
+
+type ackBindingBucket struct {
+	byMatch map[ackMatchIndexKey][]int
+	cursors map[ackMatchIndexKey]int
+}
+
+// ackSet decodes each presented token once, retains its original position and
+// indexes valid bindings for linear matching. Entries remain distinct so
+// duplicate tokens cannot collapse into one map value and rejection reporting
+// stays in submission order (ADR §4).
 type ackSet struct {
-	tokens []string
-	used   []bool
+	entries      []ackEntry
+	bindingIndex map[ackBindingIndexKey]*ackBindingBucket
+	decoded      bool
+	open         func(*crypto.Keyring, string) (ackBinding, error)
 }
 
 func newAckSet(tokens []string) *ackSet {
-	return &ackSet{tokens: tokens, used: make([]bool, len(tokens))}
+	entries := make([]ackEntry, len(tokens))
+	for i, token := range tokens {
+		entries[i] = ackEntry{originalIndex: i, token: token}
+	}
+	return &ackSet{entries: entries, open: openAck}
+}
+
+// decode opens every token on first use. Both matching and rejection
+// classification share the retained result, so neither can repeat crypto work.
+func (a *ackSet) decode(kr *crypto.Keyring) {
+	if a.decoded {
+		return
+	}
+	a.decoded = true
+	a.bindingIndex = make(map[ackBindingIndexKey]*ackBindingBucket, len(a.entries))
+	for i := range a.entries {
+		entry := &a.entries[i]
+		entry.binding, entry.decodeErr = a.open(kr, entry.token)
+		if entry.decodeErr != nil {
+			continue
+		}
+		bindingKey := ackBindingIndexKey{
+			kind:       entry.binding.kind,
+			locator:    entry.binding.locator,
+			ruleDigest: entry.binding.ruleDigest,
+		}
+		bucket := a.bindingIndex[bindingKey]
+		if bucket == nil {
+			bucket = &ackBindingBucket{
+				byMatch: make(map[ackMatchIndexKey][]int),
+				cursors: make(map[ackMatchIndexKey]int),
+			}
+			a.bindingIndex[bindingKey] = bucket
+		}
+		matchKey := ackMatchIndexKey{snapshot: entry.binding.snapshot, contentSHA: entry.binding.contentSHA}
+		bucket.byMatch[matchKey] = append(bucket.byMatch[matchKey], i)
+	}
 }
 
 // match finds one unconsumed token that binds exactly this finding under this
@@ -224,28 +288,24 @@ func newAckSet(tokens []string) *ackSet {
 // a stale content digest is left UNCONSUMED and surfaced as a stale rejection by
 // the caller's surplus sweep.
 func (a *ackSet) match(kr *crypto.Keyring, kind, locator, ruleDigest, snapshot string, cSHA [32]byte, now time.Time) (string, bool) {
-	for i, tok := range a.tokens {
-		if a.used[i] {
+	a.decode(kr)
+	bucket := a.bindingIndex[ackBindingIndexKey{kind: kind, locator: locator, ruleDigest: ruleDigest}]
+	if bucket == nil {
+		return "", false
+	}
+	matchKey := ackMatchIndexKey{snapshot: snapshot, contentSHA: cSHA}
+	indices := bucket.byMatch[matchKey]
+	for cursor := bucket.cursors[matchKey]; cursor < len(indices); cursor++ {
+		bucket.cursors[matchKey] = cursor + 1
+		entry := &a.entries[indices[cursor]]
+		if entry.used {
 			continue
 		}
-		b, err := openAck(kr, tok)
-		if err != nil {
-			continue
+		if now.Sub(time.Unix(0, entry.binding.mintNano)) > ackTTL {
+			continue // expired; retained for rejection classification
 		}
-		if b.kind != kind || b.locator != locator || b.ruleDigest != ruleDigest {
-			continue
-		}
-		if b.snapshot != snapshot {
-			continue // version skew: rejected by the surplus sweep
-		}
-		if b.contentSHA != cSHA {
-			continue // stale: content changed since minting
-		}
-		if now.Sub(time.Unix(0, b.mintNano)) > ackTTL {
-			continue // expired
-		}
-		a.used[i] = true
-		return tok, true
+		entry.used = true
+		return entry.token, true
 	}
 	return "", false
 }
@@ -255,8 +315,8 @@ func (a *ackSet) match(kr *crypto.Keyring, kind, locator, ruleDigest, snapshot s
 // standing pre-authorization is structurally impossible).
 func (a *ackSet) unconsumed() int {
 	n := 0
-	for _, u := range a.used {
-		if !u {
+	for _, entry := range a.entries {
+		if !entry.used {
 			n++
 		}
 	}
@@ -270,35 +330,40 @@ func (a *ackSet) unconsumed() int {
 // is surplus; otherwise the mismatch that kept it from matching its finding is
 // the reason — version-skew before stale before expired.
 func (a *ackSet) classifyRejections(kr *crypto.Keyring, findings []declFinding, snapshot string, now time.Time) []scanRejection {
+	a.decode(kr)
+	findingsByBinding := make(map[ackBindingIndexKey]declFinding, len(findings))
+	for _, finding := range findings {
+		key := ackBindingIndexKey{kind: ackKindDecl, locator: finding.locator, ruleDigest: finding.ruleDigest}
+		if _, exists := findingsByBinding[key]; !exists {
+			findingsByBinding[key] = finding
+		}
+	}
 	var out []scanRejection
-	for i, tok := range a.tokens {
-		if a.used[i] {
+	for i := range a.entries {
+		entry := &a.entries[i]
+		if entry.used {
 			continue
 		}
-		rej := scanRejection{Index: i}
-		b, err := openAck(kr, tok)
-		if err != nil || b.kind != ackKindDecl {
+		rej := scanRejection{Index: entry.originalIndex}
+		if entry.decodeErr != nil || entry.binding.kind != ackKindDecl {
 			rej.Reason = rejectUnreadable
 			out = append(out, rej)
 			continue
 		}
-		rej.Locator = b.locator
-		var match *declFinding
-		for j := range findings {
-			if findings[j].locator == b.locator && findings[j].ruleDigest == b.ruleDigest {
-				match = &findings[j]
-				break
-			}
-		}
+		binding := entry.binding
+		rej.Locator = binding.locator
+		match, matched := findingsByBinding[ackBindingIndexKey{
+			kind: ackKindDecl, locator: binding.locator, ruleDigest: binding.ruleDigest,
+		}]
 		switch {
-		case match == nil:
+		case !matched:
 			// No current finding shares this token's locator+rule.
 			rej.Reason = rejectSurplus
-		case b.snapshot != snapshot:
+		case binding.snapshot != snapshot:
 			rej.Reason, rej.RuleID = rejectVersionSkew, match.ruleID
-		case b.contentSHA != match.cSHA:
+		case binding.contentSHA != match.cSHA:
 			rej.Reason, rej.RuleID = rejectStale, match.ruleID
-		case now.Sub(time.Unix(0, b.mintNano)) > ackTTL:
+		case now.Sub(time.Unix(0, binding.mintNano)) > ackTTL:
 			rej.Reason, rej.RuleID = rejectExpired, match.ruleID
 		default:
 			// Binds an exact current finding yet stayed unconsumed: a second token

--- a/internal/service/scan_ack_test.go
+++ b/internal/service/scan_ack_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,7 +20,7 @@ import (
 // unforgeable, it binds one surface/locator/rule/content/snapshot, it expires,
 // and a tampered or foreign token opens to nothing.
 
-func ackTestKeyring(t *testing.T) *crypto.Keyring {
+func ackTestKeyring(t testing.TB) *crypto.Keyring {
 	t.Helper()
 	cfg := store.Config{Engine: store.EngineSQLite, Path: filepath.Join(t.TempDir(), "ack.db")}
 	if err := migrate.Run(t.Context(), cfg); err != nil {
@@ -205,6 +206,148 @@ func TestAckSetSurplusReported(t *testing.T) {
 	if n := set.unconsumed(); n != 0 {
 		t.Fatalf("unconsumed = %d, want 0 after match", n)
 	}
+}
+
+func TestAckSetOpensEachPresentedTokenOnce(t *testing.T) {
+	kr := ackTestKeyring(t)
+	now := time.Unix(1_700_000_100, 0)
+	const tokenCount = 8
+	tokens := make([]string, 0, tokenCount)
+	for i := range tokenCount - 1 {
+		tok, err := sealAck(kr, ackBinding{
+			kind:       ackKindDecl,
+			locator:    fmt.Sprintf("token-locator-%d", i),
+			ruleDigest: fmt.Sprintf("token-rule-%d", i),
+			contentSHA: contentDigest([]byte(fmt.Sprintf("token-content-%d", i))),
+			snapshot:   "snap",
+			mintNano:   now.Add(-time.Minute).UnixNano(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		tokens = append(tokens, tok)
+	}
+	tokens = append(tokens, "unreadable-token")
+
+	set := newAckSet(tokens)
+	openCount := 0
+	set.open = func(kr *crypto.Keyring, token string) (ackBinding, error) {
+		openCount++
+		return openAck(kr, token)
+	}
+
+	findings := make([]declFinding, tokenCount)
+	for i := range findings {
+		findings[i] = declFinding{
+			locator:    fmt.Sprintf("finding-locator-%d", i),
+			ruleID:     fmt.Sprintf("finding-rule-id-%d", i),
+			ruleDigest: fmt.Sprintf("finding-rule-%d", i),
+			cSHA:       contentDigest([]byte(fmt.Sprintf("finding-content-%d", i))),
+		}
+		set.match(kr, ackKindDecl, findings[i].locator, findings[i].ruleDigest, "snap", findings[i].cSHA, now)
+	}
+	set.classifyRejections(kr, findings, "snap", now)
+
+	if openCount != len(tokens) {
+		t.Fatalf("openAck calls = %d, want %d (once per presented token)", openCount, len(tokens))
+	}
+}
+
+func TestAckSetRejectionPrecedenceAndInputOrder(t *testing.T) {
+	kr := ackTestKeyring(t)
+	now := time.Unix(1_700_000_100, 0)
+	currentSHA := contentDigest([]byte("AKIAIOSFODNN7EXAMPLE"))
+	staleSHA := contentDigest([]byte("AKIAI44QH8DHBEXAMPLE"))
+	const digest = "sha256:rule-digest"
+	findings := []declFinding{{
+		locator: locDeclPattern, ruleID: "aws-access-key-id", ruleDigest: digest, cSHA: currentSHA,
+	}}
+	mint := func(kind, locator, snapshot string, cSHA [32]byte, age time.Duration) string {
+		t.Helper()
+		tok, err := sealAck(kr, ackBinding{
+			kind: kind, locator: locator, ruleDigest: digest, contentSHA: cSHA,
+			snapshot: snapshot, mintNano: now.Add(-age).UnixNano(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tok
+	}
+
+	valid := mint(ackKindDecl, locDeclPattern, "snap", currentSHA, time.Minute)
+	tokens := []string{
+		valid,
+		"unreadable-token",
+		valid,
+		mint(ackKindDecl, "missing-locator", "old-snap", staleSHA, ackTTL+time.Minute),
+		mint(ackKindDecl, locDeclPattern, "old-snap", staleSHA, ackTTL+time.Minute),
+		mint(ackKindDecl, locDeclPattern, "snap", staleSHA, ackTTL+time.Minute),
+		mint(ackKindDecl, locDeclPattern, "snap", currentSHA, ackTTL+time.Minute),
+		mint(ackKindValue, locDeclPattern, "snap", currentSHA, time.Minute),
+	}
+	set := newAckSet(tokens)
+	if got, matched := set.match(kr, ackKindDecl, locDeclPattern, digest, "snap", currentSHA, now); !matched || got != valid {
+		t.Fatal("first exact token did not match in original input order")
+	}
+
+	got := set.classifyRejections(kr, findings, "snap", now)
+	want := []struct {
+		index  int
+		reason string
+	}{
+		{1, rejectUnreadable},
+		{2, rejectSurplus},
+		{3, rejectSurplus},
+		{4, rejectVersionSkew},
+		{5, rejectStale},
+		{6, rejectExpired},
+		{7, rejectUnreadable},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("rejections = %d, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Index != want[i].index || got[i].Reason != want[i].reason {
+			t.Errorf("rejection[%d] = {Index:%d Reason:%q}, want {Index:%d Reason:%q}",
+				i, got[i].Index, got[i].Reason, want[i].index, want[i].reason)
+		}
+	}
+}
+
+func BenchmarkAckSetMaximum(b *testing.B) {
+	kr := ackTestKeyring(b)
+	now := time.Unix(1_700_000_100, 0)
+	tokens := make([]string, maxRequestFindings)
+	findings := make([]declFinding, maxRequestFindings)
+	for i := range maxRequestFindings {
+		locator := fmt.Sprintf("locator-%03d", i)
+		digest := fmt.Sprintf("digest-%03d", i)
+		cSHA := contentDigest([]byte(fmt.Sprintf("content-%03d", i)))
+		tok, err := sealAck(kr, ackBinding{
+			kind: ackKindDecl, locator: locator, ruleDigest: digest, contentSHA: cSHA,
+			snapshot: "snap", mintNano: now.Add(-time.Minute).UnixNano(),
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		tokens[i] = tok
+		findings[i] = declFinding{locator: locator, ruleID: fmt.Sprintf("rule-%03d", i), ruleDigest: digest, cSHA: cSHA}
+	}
+
+	b.Run("match", func(b *testing.B) {
+		for b.Loop() {
+			set := newAckSet(tokens)
+			for _, finding := range findings {
+				set.match(kr, ackKindDecl, finding.locator, finding.ruleDigest, "snap", finding.cSHA, now)
+			}
+		}
+	})
+	b.Run("reject", func(b *testing.B) {
+		for b.Loop() {
+			set := newAckSet(tokens)
+			set.classifyRejections(kr, findings[1:], "snap", now)
+		}
+	})
 }
 
 // TestScanRejectionsNamedByClass proves a resubmitted token that no current

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -32,8 +32,8 @@ printf '%s\n' "$app_block" | grep -F 'run: ./scripts/ci/build-spa.sh --verify' >
 	fail 'app-build does not verify and build the SPA through the shared script'
 printf '%s\n' "$app_block" | grep -F 'go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo' >/dev/null ||
 	fail 'app-build does not produce the release-shaped CI binary'
-printf '%s\n' "$app_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
-	fail 'app-build artifact is not scoped to this run'
+printf '%s\n' "$app_block" | grep -Fx '          name: hikyo-app-${{ github.run_id }}' >/dev/null ||
+	fail 'app-build artifact is not scoped to this workflow run'
 if printf '%s\n' "$app_block" | grep -F 'github.run_attempt' >/dev/null; then
 	fail 'app-build artifact name changes when failed jobs are rerun'
 fi
@@ -43,7 +43,7 @@ printf '%s\n' "$app_block" | grep -F 'overwrite: true' >/dev/null ||
 [ -n "$no_egress_block" ] || fail 'no-egress job is missing'
 printf '%s\n' "$no_egress_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
 	fail 'no-egress does not depend on app-build'
-printf '%s\n' "$no_egress_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
+printf '%s\n' "$no_egress_block" | grep -Fx '          name: hikyo-app-${{ github.run_id }}' >/dev/null ||
 	fail 'no-egress does not consume the exact app-build artifact'
 if printf '%s\n' "$no_egress_block" | grep -F 'github.run_attempt' >/dev/null; then
 	fail 'no-egress changes artifact names when failed jobs are rerun'
@@ -61,7 +61,7 @@ fi
 
 printf '%s\n' "$web_block" | grep -F 'needs: [changes, app-build]' >/dev/null ||
 	fail 'web does not depend on app-build'
-printf '%s\n' "$web_block" | grep -F 'name: hikyo-app-${{ github.run_id }}' >/dev/null ||
+printf '%s\n' "$web_block" | grep -Fx '          name: hikyo-app-${{ github.run_id }}' >/dev/null ||
 	fail 'web does not consume the exact app-build artifact'
 if printf '%s\n' "$web_block" | grep -F 'github.run_attempt' >/dev/null; then
 	fail 'web changes artifact names when failed jobs are rerun'
@@ -74,6 +74,10 @@ printf '%s\n' "$web_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev
 if printf '%s\n' "$web_block" |
 	grep -E 'pnpm run (typecheck|test|build)|pnpm build' >/dev/null; then
 	fail 'a browser shard repeats app-build frontend work'
+fi
+if printf '%s\n' "$app_block$no_egress_block$web_block" |
+	grep -F 'github.run_attempt' >/dev/null; then
+	fail 'app-build artifact changes name across partial rerun attempts'
 fi
 printf '%s\n' "$release_block" | grep -F 'needs: changes' >/dev/null ||
 	fail 'release snapshot is serialized behind app-build'

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -119,4 +119,6 @@ if grep -Eq 'gh release|action-gh-release' "$workflow"; then
 	fail 'ordinary CI publishes a GitHub Release and bypasses the signing ceremony'
 fi
 
+"$repo_root/scripts/ci/check-no-egress-lifecycle_test.sh"
+
 printf 'build artifact reuse fixture: one app build feeds browser shards and no-egress while release downloads stay parallel\n'

--- a/scripts/ci/check-no-egress-lifecycle_test.sh
+++ b/scripts/ci/check-no-egress-lifecycle_test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Shell variables below are literal fixture text.
+# shellcheck disable=SC2016
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+probe="$script_dir/no-egress.sh"
+
+fail() {
+	printf 'no-egress lifecycle fixture failed: %s\n' "$1" >&2
+	exit 1
+}
+
+grep -F -- 'strace --kill-on-exit -f' "$probe" >/dev/null ||
+	fail 'strace does not own tracee cleanup when the tracer exits'
+grep -F -- 'kill -KILL "$child"' "$probe" >/dev/null ||
+	fail 'the probe does not stop the tracer by its exact PID'
+if grep -Eq 'kill[[:space:]][^#]*"?-\$\{?[[:alnum:]_]+' "$probe"; then
+	fail 'the probe can signal an inherited process group'
+fi
+if grep -Eq '^[[:space:]]*pgid=' "$probe"; then
+	fail 'the probe still derives a process group for teardown'
+fi
+
+printf 'no-egress lifecycle fixture: tracer-owned cleanup cannot signal the runner process group\n'

--- a/scripts/ci/no-egress.sh
+++ b/scripts/ci/no-egress.sh
@@ -12,8 +12,15 @@ set -euo pipefail
 command -v strace >/dev/null || { echo "no-egress: strace is required"; exit 2; }
 
 work="$(mktemp -d)"
-pgid=""
-trap 'rm -rf "$work"; [ -n "$pgid" ] && kill -TERM "-${pgid}" 2>/dev/null || true' EXIT
+child=""
+cleanup() {
+	if [ -n "$child" ]; then
+		kill -KILL "$child" 2>/dev/null || true
+		wait "$child" 2>/dev/null || true
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT
 
 if [ -n "${HIKYO_NO_EGRESS_BIN:-}" ]; then
 	bin="$HIKYO_NO_EGRESS_BIN"
@@ -46,10 +53,14 @@ fi
 
 # Trace TCP connect(2) AND UDP sendto/sendmsg(2): both are outbound paths, and a
 # UDP send needs no connect(), so tracing connect alone would miss it.
-setsid strace -f -e trace=connect,sendto,sendmsg -o "$trace" \
+# --kill-on-exit makes strace terminate every tracee when the tracer exits. Stop
+# only strace's exact PID below: a negative process-group signal can also reach
+# the GitHub runner when setsid forks before exec on a hosted runner. SIGKILL is
+# intentional: strace defers SIGTERM while tracing, whereas PTRACE_O_EXITKILL
+# guarantees that a killed tracer cannot leave the server behind.
+strace --kill-on-exit -f -e trace=connect,sendto,sendmsg -o "$trace" \
 	"$bin" server --dev --listen "127.0.0.1:${port}" >"$serverlog" 2>&1 &
 child=$!
-pgid="$(ps -o pgid= "$child" | tr -d ' ')"
 
 # Boots AND serves with outbound unavailable (CI invariant 4): both liveness
 # (/healthz) and readiness (/readyz = DB reachable + keyring loaded + migrations
@@ -78,9 +89,9 @@ fi
 sleep 3
 curl -sf "${origin}/readyz" >/dev/null 2>&1 || true
 
-kill -TERM "-${pgid}" 2>/dev/null || true
-pgid=""
+kill -KILL "$child" 2>/dev/null || true
 wait "$child" 2>/dev/null || true
+child=""
 
 # strace must actually have traced — a missing file or an attach error means we
 # proved nothing about egress and must not report a green result.


### PR DESCRIPTION
## Stack

- Base: #290 (`9a340d8dce43e6cc1adceaca2c0e70d7c25b42d9`)
- This PR is intentionally stacked; merge #290 first.

## Summary

- Decode each presented scan acknowledgement token at most once.
- Index bindings by kind, locator, and rule digest, with exact-match queues preserving duplicate entries and original input order.
- Classify retained invalid/unused entries in linear time while preserving unreadable → surplus → version-skew → stale → expired precedence.
- Add open-count instrumentation, exact-duplicate/order regression coverage, and 100-token match/rejection benchmarks.

## CI repair

The first `no-egress` job received a hosted-runner shutdown (exit 143). Its failed-job rerun exposed a workflow bug: GitHub reused successful attempt-1 `app-build`, while consumers requested an attempt-2 artifact. #290 now carries stable run-scoped app artifact names and safe full-rerun replacement; this child preserves stricter per-consumer regression assertions.

A fresh run reproduced the shutdown on a second runner and isolated the original cause: the probe's negative process-group signal could terminate the hosted runner shell when `setsid` forked. The probe now enables strace-owned tracee cleanup and kills only the exact tracer PID. The existing trusted artifact fixture invokes a lifecycle regression check that rejects process-group signaling.

## Contract and migration

Token format, ruleset semantics, public refusal text, and Surface 1/Surface 2 kind separation are unchanged. No database migration is required.

Generated outputs: none.

## Validation

- `go test -count=1 ./internal/service/... -run "Scan|Ack"`: 16 passed
- focused acknowledgement race tests: 16 passed
- maximum-size acknowledgement match/rejection benchmarks: passed
- `BenchmarkScan -benchtime 3x`: passed
- rebased head: `go test -count=1 ./...`: 3,154 passed in 57 packages
- rebased head: `go build ./...` and `go vet ./...`: passed
- artifact-reuse, no-egress lifecycle, required-jobs, trusted-script, cache-policy, ShellCheck, and actionlint checks: passed
- Ubuntu 24.04 full no-egress probe: passed with tracer and tracee cleanup before rebase; lifecycle code is patch-equivalent after rebase
- exact head `176039ee`: [trusted CI](https://github.com/Hikyo-Org/Hikyo/actions/runs/32575297264), CodeQL, and Snyk passed
- standards review: CLEAN
- spec review: CLEAN after exact-duplicate fixture fix

Closes #229
