### PR TITLE
refactor(auth): centralize transaction-local session completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1031,7 +1031,7 @@ jobs:
           restore-keys: |
             go-fuzz-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum') }}-
             go-fuzz-v2-shard-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
-      - name: Fuzz every target for a bounded time
+      - name: Fuzz every target for bounded work
         env:
           FUZZ_PLAN: ${{ needs.analysis_shards.outputs.fuzz_plan }}
           FUZZ_SHARD: ${{ matrix.shard }}
@@ -1047,7 +1047,9 @@ jobs:
               continue
             fi
             echo "::group::$pkg $target"
-            if ! go test -run='^$' -fuzz="^${target}\$" -fuzztime=15s "$pkg"; then
+            # An iteration budget avoids Go's wall-clock fuzz cutoff racing an
+            # otherwise healthy worker shutdown under hosted-runner load.
+            if ! go test -run='^$' -fuzz="^${target}\$" -fuzztime=100000x -timeout=2m "$pkg"; then
               failed=1
             fi
             echo "::endgroup::"

--- a/docs/handoff/223-session-completion.md
+++ b/docs/handoff/223-session-completion.md
@@ -1,0 +1,48 @@
+# Handoff: #223 transaction-local session completion
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/223 (parent #204; programme
+#203; audit ID `BE06-B`). Immediate stack base: PR #291 at
+`176039eeaabf6635be2a68f906e7d0a37622d8d0`.
+
+## Contract
+
+- `service.SessionCompletion` is closed over explicit `CreateSession` and
+  `RotateSession` variants. Creation requires an account, artifact, assurance,
+  and an explicit browser/CLI CSRF decision. Rotation requires the live session,
+  its owning account, and the exact replacement factor projection.
+- The executor alone creates display-once bearer/CSRF artifacts, reads the
+  principal generation and credential epoch for new sessions, inserts or
+  rotates the verifier, serializes factors, and builds `LoginResult`.
+- Callers still own password/federation/WebAuthn/TOTP verification, ceremony and
+  provider binding, reauthentication-window policy/cardinality, and audit event
+  construction. Rotation preserves the original session identity, clocks,
+  authentication method, authentication time, ceremony, and CSRF verifier.
+- Human local, CLI handoff, OIDC, SAML, WebAuthn, TOTP, factor enrolment/removal,
+  and recovery paths publish display-once results through `tx.WriteResult`.
+  Failed/retried attempts cannot publish their token or result projection.
+- Workspace sessions remain separate because they are a distinct transport and
+  projection owned by the multi-instance flow. Generated outputs: none.
+
+## Review
+
+The Standards axis checked the locked human-auth and system-architecture ADRs
+plus the committed-result contract from #218. The Spec axis checked every #223
+acceptance criterion against the PR #289 fixed point. Review added direct
+negative variant/CSRF coverage and made the rotation account mandatory so all
+rotations have one projection contract. Final result: clean on both axes.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service/... ./internal/authz/... ./internal/store/...
+                                                             290 passed
+go test -race -count=1 ./internal/service/...                174 passed
+go test -count=1 ./internal/isolation/...                    1090 passed
+go test -count=1 ./...                                       3169 passed / 57 packages
+go vet ./...                                                 passed
+gofmt -l <changed Go files>                                  clean
+git diff --check                                             clean
+```
+
+The isolation run used the available SQLite path; no
+`HIKYO_TEST_POSTGRES_DSN` was configured in this worktree.

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"crypto/subtle"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -406,18 +405,13 @@ func (s *Auth) attemptLogin(ctx context.Context, username, password string, arti
 	// Phase 3 — write. The refusal travels out of the closure beside the
 	// return value, because returning it would roll the transaction back —
 	// and the transaction is what makes the failure event durable.
-	var (
-		result  LoginResult
-		refused error
-	)
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	committed, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		if cause != "" {
 			if ferr := s.failLogin(ctx, az, now, accountIDOf(resolved, account), resolved, artifact, cause); ferr != nil {
 				return ferr // audit not durable: roll back and fail loud
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		// Re-read under the write transaction: the credential must not have
@@ -428,7 +422,7 @@ func (s *Auth) attemptLogin(ctx context.Context, username, password string, arti
 				if ferr := s.failLogin(ctx, az, now, account.ID, true, artifact, "credential-removed"); ferr != nil {
 					return ferr
 				}
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			return err
@@ -441,7 +435,7 @@ func (s *Auth) attemptLogin(ctx context.Context, username, password string, arti
 			if ferr := s.failLogin(ctx, az, now, account.ID, true, artifact, "credential-changed"); ferr != nil {
 				return ferr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if upgrade {
@@ -460,16 +454,16 @@ func (s *Auth) attemptLogin(ctx context.Context, username, password string, arti
 				}
 			}
 		}
-		result, err = s.mintSession(ctx, az, account, artifact, now)
+		attempt.result, err = s.mintSession(ctx, az, account, artifact, now)
 		return err
 	})
 	if err != nil {
 		return LoginResult{}, err
 	}
-	if refused != nil {
+	if refused := committed.refused.err(); refused != nil {
 		return LoginResult{}, refused
 	}
-	return result, nil
+	return committed.result, nil
 }
 
 // rehash re-derives a verifier under the instance's configured parameters
@@ -512,49 +506,16 @@ func accountIDOf(resolved bool, a authz.Account) string {
 // slice, and recording something stronger would be a lie the chokepoint later
 // acts on.
 func (s *Auth) mintSession(ctx context.Context, az *authz.TxAuthorizer, account authz.Account, artifact Artifact, now time.Time) (LoginResult, error) {
-	value, verifier, err := crypto.NewArtifact(artifact.bearerKind())
-	if err != nil {
-		return LoginResult{}, err
-	}
-	// A browser session authenticates on a cookie the browser attaches by
-	// itself, so it needs a second value the browser will NOT attach by
-	// itself. A CLI session has no cookie channel and therefore no CSRF
-	// contract; minting a token it can never be asked for would be noise.
-	var csrfValue string
-	var csrfVerifier []byte
+	csrf := sessionWithoutCSRF
 	if artifact == ArtifactBrowser {
-		csrfValue, csrfVerifier, err = crypto.NewArtifact(crypto.ArtifactCSRF)
-		if err != nil {
-			return LoginResult{}, err
-		}
+		csrf = sessionWithCSRF
 	}
-	id, err := newID("ses")
+	result, err := s.completeSession(ctx, az, CreateSession{
+		account: account, artifact: artifact,
+		assurance: Assurance{Method: MethodLocalPassword, Factors: []string{"password"}, AuthenticatedAt: now},
+		csrf:      csrf,
+	}, now)
 	if err != nil {
-		return LoginResult{}, err
-	}
-	generation, err := az.PrincipalGeneration(ctx, account.PrincipalID)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	epoch, err := az.CredentialEpoch(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	factors, err := json.Marshal([]string{"password"})
-	if err != nil {
-		return LoginResult{}, err
-	}
-	wire := audit.FromContext(ctx)
-	sess := authz.NewSession{
-		ID: id, PrincipalID: account.PrincipalID, Verifier: verifier,
-		Artifact: artifact.String(), SessionGeneration: generation, CredentialEpoch: epoch,
-		AuthMethod: MethodLocalPassword, Factors: string(factors),
-		AuthenticatedAt: now, CreatedAt: now,
-		IdleExpiresAt: now.Add(artifact.idle()), AbsoluteExpiresAt: now.Add(artifact.absolute()),
-		SourceIP: wire.SourceIP, UserAgent: wire.UserAgent,
-		CSRFVerifier: csrfVerifier,
-	}
-	if err := az.MintSession(ctx, sess); err != nil {
 		return LoginResult{}, err
 	}
 
@@ -567,12 +528,12 @@ func (s *Auth) mintSession(ctx context.Context, az *authz.TxAuthorizer, account 
 			"subject_resolved": true, "account_id": account.ID, "assurance": "single-factor",
 		}},
 		{audit.EventAuthSessionCreated, audit.Payload{
-			"session_id": id, "artifact": artifact.String(),
+			"session_id": result.SessionID, "artifact": artifact.String(),
 			"method": MethodLocalPassword, "assurance": "single-factor",
 		}},
 	} {
 		e, err := newAuditEvent(ctx, ev.typ, account.PrincipalID,
-			audit.Object{Type: "session", ID: id}, audit.OutcomeSuccess, "", ev.payload)
+			audit.Object{Type: "session", ID: result.SessionID}, audit.OutcomeSuccess, "", ev.payload)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -581,14 +542,7 @@ func (s *Auth) mintSession(ctx context.Context, az *authz.TxAuthorizer, account 
 		}
 	}
 
-	return LoginResult{
-		SessionToken: value, SessionID: id, Artifact: artifact, CSRFToken: csrfValue,
-		CreatedAt: now, IdleExpires: sess.IdleExpiresAt, AbsExpires: sess.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{
-			Method: MethodLocalPassword, Factors: []string{"password"}, AuthenticatedAt: now,
-		},
-	}, nil
+	return result, nil
 }
 
 // failLogin stages the failure event in the caller's transaction. It returns

--- a/internal/service/cli_reauth.go
+++ b/internal/service/cli_reauth.go
@@ -428,8 +428,7 @@ func (s *Auth) RedeemCLIReauth(ctx context.Context, code, pkceVerifier string) (
 		return CLIReauthRedeemed{}, s.rejectCLIReauthRequest(ctx, "redeem", ErrCLIReauthInvalid)
 	}
 	now := s.now()
-	var out CLIReauthRedeemed
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	out, err := writeCommittedCLIReauth(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, out *CLIReauthRedeemed) error {
 		h, err := az.CLIReauthHandoffByCode(ctx, crypto.ArtifactVerifier(code))
 		if err != nil {
 			return captureCLIReauthFailure(ctx, az, "redeem", cliReauthAuditContext{}, "invalid_or_expired", ErrCLIReauthInvalid)
@@ -455,10 +454,6 @@ func (s *Auth) RedeemCLIReauth(ctx context.Context, code, pkceVerifier string) (
 		if !claimed {
 			return captureCLIReauthFailure(ctx, az, "redeem", detail, "already_consumed", ErrCLIReauthInvalid)
 		}
-		value, verifier, err := s.newSessionArtifact(ArtifactCLI)
-		if err != nil {
-			return err
-		}
 		epoch, err := az.CredentialEpoch(ctx)
 		if err != nil {
 			return err
@@ -471,11 +466,14 @@ func (s *Auth) RedeemCLIReauth(ctx context.Context, code, pkceVerifier string) (
 		for _, approved := range windows {
 			factorsList = withFactor(factorsList, approved.FactorClass)
 		}
-		factors, err := json.Marshal(factorsList)
+		account, err := az.AccountByPrincipal(ctx, caller.Principal)
 		if err != nil {
 			return err
 		}
-		if err := az.RotateSessionFactors(ctx, caller.SessionID, verifier, string(factors)); err != nil {
+		completion, err := s.completeSession(ctx, az, RotateSession{
+			session: caller, account: account, factors: factorsList,
+		}, now)
+		if err != nil {
 			return err
 		}
 		for _, approved := range windows {
@@ -495,7 +493,7 @@ func (s *Auth) RedeemCLIReauth(ctx context.Context, code, pkceVerifier string) (
 			}
 			out.Windows = append(out.Windows, ReauthResult{SessionID: caller.SessionID, EnvironmentID: approved.EnvironmentID, SingleDecision: approved.SingleDecision, WindowExpires: approved.WindowExpiresAt})
 		}
-		out.SessionToken, out.SessionID = value, caller.SessionID
+		out.SessionToken, out.SessionID = completion.SessionToken, completion.SessionID
 		return recordCLIReauthSuccess(ctx, az, "redeem", detail)
 	})
 	if err != nil {

--- a/internal/service/factors.go
+++ b/internal/service/factors.go
@@ -188,45 +188,16 @@ func (s *Auth) reissueSession(ctx context.Context, az *authz.TxAuthorizer, accou
 	if err := az.RevokeAllSessionsFor(ctx, account.PrincipalID); err != nil {
 		return LoginResult{}, err
 	}
-	generation, err := az.PrincipalGeneration(ctx, account.PrincipalID)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	epoch, err := az.CredentialEpoch(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	value, verifier, err := crypto.NewArtifact(artifact.bearerKind())
-	if err != nil {
-		return LoginResult{}, err
-	}
-	var csrfValue string
-	var csrfVerifier []byte
+	csrf := sessionWithoutCSRF
 	if artifact == ArtifactBrowser {
-		csrfValue, csrfVerifier, err = crypto.NewArtifact(crypto.ArtifactCSRF)
-		if err != nil {
-			return LoginResult{}, err
-		}
+		csrf = sessionWithCSRF
 	}
-	id, err := newID("ses")
+	result, err := s.completeSession(ctx, az, CreateSession{
+		account: account, artifact: artifact,
+		assurance: Assurance{Method: method, Factors: []string{factorClass}, AuthenticatedAt: now},
+		csrf:      csrf,
+	}, now)
 	if err != nil {
-		return LoginResult{}, err
-	}
-	factors, err := json.Marshal([]string{factorClass})
-	if err != nil {
-		return LoginResult{}, err
-	}
-	wire := audit.FromContext(ctx)
-	sess := authz.NewSession{
-		ID: id, PrincipalID: account.PrincipalID, Verifier: verifier,
-		Artifact: artifact.String(), SessionGeneration: generation, CredentialEpoch: epoch,
-		AuthMethod: method, Factors: string(factors),
-		AuthenticatedAt: now, CreatedAt: now,
-		IdleExpiresAt: now.Add(artifact.idle()), AbsoluteExpiresAt: now.Add(artifact.absolute()),
-		SourceIP: wire.SourceIP, UserAgent: wire.UserAgent,
-		CSRFVerifier: csrfVerifier,
-	}
-	if err := az.MintSession(ctx, sess); err != nil {
 		return LoginResult{}, err
 	}
 	assuranceLabel := "single-factor"
@@ -234,9 +205,9 @@ func (s *Auth) reissueSession(ctx context.Context, az *authz.TxAuthorizer, accou
 		assuranceLabel = "multi-factor"
 	}
 	e, err := newAuditEvent(ctx, audit.EventAuthSessionCreated, account.PrincipalID,
-		audit.Object{Type: "session", ID: id}, audit.OutcomeSuccess, "",
+		audit.Object{Type: "session", ID: result.SessionID}, audit.OutcomeSuccess, "",
 		audit.Payload{
-			"session_id": id, "artifact": artifact.String(),
+			"session_id": result.SessionID, "artifact": artifact.String(),
 			"method": method, "assurance": assuranceLabel,
 		})
 	if err != nil {
@@ -245,13 +216,7 @@ func (s *Auth) reissueSession(ctx context.Context, az *authz.TxAuthorizer, accou
 	if err := az.RecordAuthEvent(ctx, e); err != nil {
 		return LoginResult{}, err
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: id, Artifact: artifact,
-		CreatedAt: now, IdleExpires: sess.IdleExpiresAt, AbsExpires: sess.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{Method: method, Factors: []string{factorClass}, AuthenticatedAt: now},
-		CSRFToken: csrfValue,
-	}, nil
+	return result, nil
 }
 
 // TOTPStatusResult is the caller's own authenticator state: whether a confirmed
@@ -472,8 +437,7 @@ func (s *Auth) EnrolTOTPConfirm(ctx context.Context, presented, code string) (Lo
 	s.Admission.RecordSuccess(account.ID)
 
 	// Phase 3 — write: promote (single-use CAS), then reissue.
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		// Re-authenticate inside the write tx: a session revoked between the
 		// phases (a concurrent recovery or password change) must not be able to
@@ -511,7 +475,7 @@ func (s *Auth) EnrolTOTPConfirm(ctx context.Context, presented, code string) (Lo
 			}
 			return domain.ErrUnauthenticated
 		}
-		result, err = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
+		*result, err = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
 		if err != nil {
 			return err
 		}
@@ -579,8 +543,7 @@ func (s *Auth) RemoveTOTP(ctx context.Context, presented, password string) (Logi
 	s.Admission.RecordSuccess(account.ID)
 
 	// Phase 3 — write.
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		// Re-authenticate inside the write tx: a session revoked between the
 		// phases must not remove a factor and reissue itself (finding HIGH-3).
@@ -608,7 +571,7 @@ func (s *Auth) RemoveTOTP(ctx context.Context, presented, password string) (Logi
 		if err := az.RemoveTOTPForAccount(ctx, account.ID); err != nil {
 			return err
 		}
-		result, err = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
+		*result, err = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
 		if err != nil {
 			return err
 		}
@@ -690,17 +653,8 @@ func (s *Auth) StepUpTOTP(ctx context.Context, presented, code string) (LoginRes
 	// plus a long-lived credential in the DOM. `RotateSessionFactors` leaves
 	// `csrf_verifier` alone, so the synchronizer token stays valid and only
 	// the session cookie needs re-delivery.
-	actingArtifact := Artifact(acting.Artifact)
-	value, verifier, err := crypto.NewArtifact(actingArtifact.bearerKind())
-	if err != nil {
-		return LoginResult{}, err
-	}
 	factors := stepUpFactors(acting.Assurance.Factors, "totp")
-	factorsJSON, err := json.Marshal(factors)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		// Re-authenticate inside the write tx: rotating a revoked session would
 		// hand out a token for a row that is gone.
 		live, err := az.Authenticate(ctx, presented, s.now())
@@ -729,7 +683,8 @@ func (s *Auth) StepUpTOTP(ctx context.Context, presented, code string) (LoginRes
 			}
 			return domain.ErrUnauthenticated
 		}
-		if err := az.RotateSessionFactors(ctx, live.SessionID, verifier, string(factorsJSON)); err != nil {
+		*result, err = s.completeSession(ctx, az, RotateSession{session: live, account: account, factors: factors}, s.now())
+		if err != nil {
 			return err
 		}
 		e, err := newAuditEvent(ctx, audit.EventAuthReauthenticated, account.PrincipalID,
@@ -738,20 +693,15 @@ func (s *Auth) StepUpTOTP(ctx context.Context, presented, code string) (LoginRes
 		if err != nil {
 			return err
 		}
-		return az.RecordAuthEvent(ctx, e)
+		if err := az.RecordAuthEvent(ctx, e); err != nil {
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		return LoginResult{}, err
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: acting.SessionID, Artifact: actingArtifact,
-		CreatedAt: acting.CreatedAt, IdleExpires: acting.IdleExpiresAt, AbsExpires: acting.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{
-			Method: acting.Assurance.Method, Factors: factors,
-			AuthenticatedAt: acting.Assurance.AuthenticatedAt, CeremonyID: acting.Assurance.CeremonyID,
-		},
-	}, nil
+	return result, nil
 }
 
 // stepUpFactors adds a class to a session's factor set without duplicating it.
@@ -876,8 +826,7 @@ func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof strin
 	}
 
 	// Phase 3 — write.
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		// Re-authenticate inside the write tx: a session revoked between the
 		// phases must not replace the owner's recovery batch and reissue itself
@@ -950,7 +899,7 @@ func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof strin
 				return err
 			}
 		}
-		result, err = s.reissueSession(ctx, az, account, proofClass, MethodLocalPassword, Artifact(liveID.Artifact), now)
+		*result, err = s.reissueSession(ctx, az, account, proofClass, MethodLocalPassword, Artifact(liveID.Artifact), now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/oidc_flow.go
+++ b/internal/service/oidc_flow.go
@@ -442,12 +442,7 @@ func (s *Auth) revalidateProvider(ctx context.Context, az *authz.TxAuthorizer, s
 // A8) and mints a browser session, provisions via JIT policy, or refuses
 // uniformly. An epoch-inert identity is terminal and never a JIT input.
 func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn authz.OIDCTransaction, claims oidcrp.Claims) (OIDCCallbackResult, error) {
-	var (
-		result  LoginResult
-		refused error
-	)
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		if cause, e := s.revalidateProvider(ctx, az, prov); e != nil {
 			return e
@@ -455,7 +450,7 @@ func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn a
 			if aerr := s.stageOIDCRefuse(ctx, az, cause, prov.ID); aerr != nil {
 				return aerr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		epoch, e := az.CredentialEpoch(ctx)
@@ -475,7 +470,7 @@ func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn a
 				if aerr := s.stageOIDCRefuse(ctx, az, cause, prov.ID); aerr != nil {
 					return aerr
 				}
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			account = acc
@@ -487,7 +482,7 @@ func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn a
 				if aerr := s.stageOIDCRefuse(ctx, az, causeEpoch, prov.ID); aerr != nil {
 					return aerr
 				}
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			// A3: the recorded provider must be the currently enabled one for
@@ -498,7 +493,7 @@ func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn a
 				if aerr := s.stageOIDCRefuse(ctx, az, causeReconciliation, prov.ID); aerr != nil {
 					return aerr
 				}
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			account, e = az.AccountByID(ctx, identity.AccountID)
@@ -510,16 +505,16 @@ func (s *Auth) completeLogin(ctx context.Context, prov authz.OIDCProvider, txn a
 		if e != nil {
 			return e
 		}
-		result, e = s.mintOIDCSession(ctx, az, account, prov, txn.Issuer, purposeLogin, claims, mfa, now)
+		attempt.result, e = s.mintOIDCSession(ctx, az, account, prov, txn.Issuer, purposeLogin, claims, mfa, now)
 		return e
 	})
 	if err != nil {
 		return OIDCCallbackResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return OIDCCallbackResult{}, refused
 	}
-	return OIDCCallbackResult{Login: result, Purpose: purposeLogin}, nil
+	return OIDCCallbackResult{Login: attempt.result, Purpose: purposeLogin}, nil
 }
 
 // jitProvision creates a zero-grant account for an unknown identity when the
@@ -605,12 +600,7 @@ func (s *Auth) jitProvision(ctx context.Context, az *authz.TxAuthorizer, prov au
 // transaction (A6), so here the mutation reissues the acting session from that
 // proof, deleting every prior session.
 func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn authz.OIDCTransaction, claims oidcrp.Claims, presented string) (OIDCCallbackResult, error) {
-	var (
-		result  LoginResult
-		refused error
-	)
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		if cause, e := s.revalidateProvider(ctx, az, prov); e != nil {
 			return e
@@ -618,7 +608,7 @@ func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn au
 			if aerr := s.stageOIDCRefuse(ctx, az, cause, prov.ID); aerr != nil {
 				return aerr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		epoch, e := az.CredentialEpoch(ctx)
@@ -657,7 +647,7 @@ func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn au
 		if live.Principal != account.PrincipalID {
 			return domain.ErrUnauthenticated
 		}
-		result, e = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
+		attempt.result, e = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
 		if e != nil {
 			return e
 		}
@@ -672,10 +662,10 @@ func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn au
 	if err != nil {
 		return OIDCCallbackResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return OIDCCallbackResult{}, refused
 	}
-	return OIDCCallbackResult{Login: result, Purpose: purposeLink}, nil
+	return OIDCCallbackResult{Login: attempt.result, Purpose: purposeLink}, nil
 }
 
 // completeReauth validates a fresh federated authentication and opens a
@@ -689,18 +679,13 @@ func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn au
 // session it re-authorizes (a downgrade), or when the effective window is 0
 // (only WebAuthn opens a 0-window gate). On success the acting session rotates.
 func (s *Auth) completeReauth(ctx context.Context, prov authz.OIDCProvider, txn authz.OIDCTransaction, claims oidcrp.Claims, presented string) (OIDCCallbackResult, error) {
-	var (
-		result  LoginResult
-		refused error
-	)
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		reject := func(cause string) error {
 			if aerr := s.stageOIDCRefuse(ctx, az, cause, prov.ID); aerr != nil {
 				return aerr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if cause, e := s.revalidateProvider(ctx, az, prov); e != nil {
@@ -774,7 +759,7 @@ func (s *Auth) completeReauth(ctx context.Context, prov authz.OIDCProvider, txn 
 		if effWin <= 0 {
 			// A 0-window gate requires WebAuthn: OIDC cannot bind the enumerated
 			// unit, so it opens nothing here (B18). Refuse naming the remedy.
-			refused = ErrReauthWindowClosed
+			attempt.refused = sessionRefusedWindowClosed
 			if aerr := s.stageOIDCRefuse(ctx, az, causeWindowClosed, prov.ID); aerr != nil {
 				return aerr
 			}
@@ -783,15 +768,14 @@ func (s *Auth) completeReauth(ctx context.Context, prov authz.OIDCProvider, txn 
 
 		// Rotate the acting session token (every reauth rotates) preserving its
 		// factor set, and open the window over the recorded environment.
-		factors, e := json.Marshal(id.Assurance.Factors)
+		account, e := az.AccountByID(ctx, txn.AccountID)
 		if e != nil {
 			return e
 		}
-		value, verifier, e := s.newSessionArtifact(Artifact(id.Artifact))
+		completion, e := s.completeSession(ctx, az, RotateSession{
+			session: id, account: account, factors: id.Assurance.Factors,
+		}, now)
 		if e != nil {
-			return e
-		}
-		if e := az.RotateSessionFactors(ctx, id.SessionID, verifier, string(factors)); e != nil {
 			return e
 		}
 		windowID, e := newID("raw")
@@ -830,29 +814,16 @@ func (s *Auth) completeReauth(ctx context.Context, prov authz.OIDCProvider, txn 
 				return aerr
 			}
 		}
-		result = LoginResult{
-			SessionToken: value, SessionID: id.SessionID, Artifact: Artifact(id.Artifact),
-			CreatedAt: id.CreatedAt, IdleExpires: id.IdleExpiresAt, AbsExpires: id.AbsoluteExpiresAt,
-			Principal: id.Principal,
-		}
+		attempt.result = completion
 		return nil
 	})
 	if err != nil {
 		return OIDCCallbackResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return OIDCCallbackResult{}, refused
 	}
-	return OIDCCallbackResult{Login: result, Purpose: purposeReauth}, nil
-}
-
-// newSessionArtifact mints a fresh value+verifier of the same artifact type as
-// the session being rotated.
-func (s *Auth) newSessionArtifact(artifact Artifact) (string, []byte, error) {
-	if artifact == ArtifactBrowser {
-		return crypto.NewArtifact(crypto.ArtifactBrowserSession)
-	}
-	return crypto.NewArtifact(crypto.ArtifactCLISession)
+	return OIDCCallbackResult{Login: attempt.result, Purpose: purposeReauth}, nil
 }
 
 // mintOIDCSession mints a browser session for a federated login, recording the
@@ -861,46 +832,17 @@ func (s *Auth) newSessionArtifact(artifact Artifact) (string, []byte, error) {
 // the provider-change sweep by provider_id keeps a stale evaluation from
 // lingering (A4).
 func (s *Auth) mintOIDCSession(ctx context.Context, az *authz.TxAuthorizer, account authz.Account, prov authz.OIDCProvider, issuer, purpose string, claims oidcrp.Claims, mfa bool, now time.Time) (LoginResult, error) {
-	generation, err := az.PrincipalGeneration(ctx, account.PrincipalID)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	epoch, err := az.CredentialEpoch(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	value, verifier, err := crypto.NewArtifact(crypto.ArtifactBrowserSession)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	csrfValue, csrfVerifier, err := crypto.NewArtifact(crypto.ArtifactCSRF)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	sessionID, err := newID("ses")
-	if err != nil {
-		return LoginResult{}, err
-	}
 	factorClasses := oidcFactors(mfa)
-	factors, err := json.Marshal(factorClasses)
-	if err != nil {
-		return LoginResult{}, err
-	}
 	assuranceLabel := "single-factor"
 	if mfa {
 		assuranceLabel = "multi-factor"
 	}
-	wire := audit.FromContext(ctx)
-	sess := authz.NewSession{
-		ID: sessionID, PrincipalID: account.PrincipalID, Verifier: verifier,
-		Artifact: ArtifactBrowser.String(), SessionGeneration: generation, CredentialEpoch: epoch,
-		AuthMethod: oidcMethod(issuer), Factors: string(factors),
-		AuthenticatedAt: now, CreatedAt: now,
-		IdleExpiresAt: now.Add(BrowserSessionIdle), AbsoluteExpiresAt: now.Add(BrowserSessionAbsolute),
-		SourceIP: wire.SourceIP, UserAgent: wire.UserAgent,
-		ProviderID: prov.ID, CSRFVerifier: csrfVerifier,
-	}
-	if err := az.MintSession(ctx, sess); err != nil {
+	result, err := s.completeSession(ctx, az, CreateSession{
+		account: account, artifact: ArtifactBrowser,
+		assurance: Assurance{Method: oidcMethod(issuer), Factors: factorClasses, AuthenticatedAt: now},
+		csrf:      sessionWithCSRF, providerID: prov.ID,
+	}, now)
+	if err != nil {
 		return LoginResult{}, err
 	}
 	for _, ev := range []struct {
@@ -913,11 +855,11 @@ func (s *Auth) mintOIDCSession(ctx context.Context, az *authz.TxAuthorizer, acco
 			"amr": joinAMR(claims.AMR), "provider_row_version": int(prov.RowVersion),
 		}},
 		{audit.EventAuthSessionCreated, audit.Payload{
-			"session_id": sessionID, "artifact": ArtifactBrowser.String(),
+			"session_id": result.SessionID, "artifact": ArtifactBrowser.String(),
 			"method": oidcMethod(issuer), "assurance": assuranceLabel,
 		}},
 	} {
-		e, err := newAuditEvent(ctx, ev.typ, account.PrincipalID, audit.Object{Type: "session", ID: sessionID}, audit.OutcomeSuccess, "", ev.payload)
+		e, err := newAuditEvent(ctx, ev.typ, account.PrincipalID, audit.Object{Type: "session", ID: result.SessionID}, audit.OutcomeSuccess, "", ev.payload)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -925,13 +867,7 @@ func (s *Auth) mintOIDCSession(ctx context.Context, az *authz.TxAuthorizer, acco
 			return LoginResult{}, err
 		}
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: sessionID, Artifact: ArtifactBrowser,
-		CreatedAt: now, IdleExpires: sess.IdleExpiresAt, AbsExpires: sess.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{Method: oidcMethod(issuer), Factors: factorClasses, AuthenticatedAt: now},
-		CSRFToken: csrfValue,
-	}, nil
+	return result, nil
 }
 
 // refuseOIDC records an oidc_refused event with its cause and answers the
@@ -1098,8 +1034,7 @@ func (s *Auth) UnlinkIdentity(ctx context.Context, presented, identityID, proof 
 	}
 	s.Admission.RecordSuccess(account.ID)
 
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		live, e := az.Authenticate(ctx, presented, now)
 		if e != nil {
@@ -1124,7 +1059,7 @@ func (s *Auth) UnlinkIdentity(ctx context.Context, presented, identityID, proof 
 		if e := az.RemoveExternalIdentity(ctx, identityID); e != nil {
 			return e
 		}
-		result, e = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
+		*result, e = s.reissueSession(ctx, az, account, "password", MethodLocalPassword, Artifact(live.Artifact), now)
 		if e != nil {
 			return e
 		}

--- a/internal/service/reauth.go
+++ b/internal/service/reauth.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -407,7 +406,6 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 	}
 	// Phase 1 - read the acting session and confirmed factor.
 	var (
-		acting             authz.Identity
 		account            authz.Account
 		confirmed          authz.TOTPCredential
 		windowEnvironments []string
@@ -417,7 +415,6 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 		if err != nil {
 			return err
 		}
-		acting = id
 		account, err = az.AccountByPrincipal(ctx, id.Principal)
 		if err != nil {
 			return err
@@ -485,13 +482,8 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 
 	// Phase 3 - consume the step, rotate the acting session (every reauth rotates)
 	// and open the window over the environment.
-	value, verifier, err := s.newSessionArtifact(Artifact(acting.Artifact))
-	if err != nil {
-		return nil, err
-	}
 	now := s.now()
-	var out []ReauthResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	out, err := writeCommittedReauthResults(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, out *[]ReauthResult) error {
 		// Re-authenticate inside the write tx: a revoked session may not open a
 		// window (mirrors StepUpTOTP's HIGH-2 fix).
 		live, err := az.Authenticate(ctx, presented, now)
@@ -545,11 +537,10 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 			}
 			return domain.ErrUnauthenticated
 		}
-		factorsJSON, err := json.Marshal(live.Assurance.Factors)
+		completion, err := s.completeSession(ctx, az, RotateSession{
+			session: live, account: account, factors: live.Assurance.Factors,
+		}, now)
 		if err != nil {
-			return err
-		}
-		if err := az.RotateSessionFactors(ctx, live.SessionID, verifier, string(factorsJSON)); err != nil {
 			return err
 		}
 		for _, environmentID := range windowEnvironments {
@@ -573,8 +564,8 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 			}); err != nil {
 				return err
 			}
-			out = append(out, ReauthResult{
-				SessionToken: value, SessionID: live.SessionID, EnvironmentID: environmentID,
+			*out = append(*out, ReauthResult{
+				SessionToken: completion.SessionToken, SessionID: live.SessionID, EnvironmentID: environmentID,
 				SingleDecision: false, WindowExpires: windowExpires,
 			})
 		}

--- a/internal/service/saml.go
+++ b/internal/service/saml.go
@@ -304,18 +304,14 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 	}
 	raw, responseDecodeErr := base64.StdEncoding.DecodeString(encodedResponse)
 
-	var (
-		result  LoginResult
-		refused error
-	)
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		transaction, lookupErr := az.SAMLTransactionByRelayState(ctx, wencrypto.ArtifactVerifier(relayState))
 		if errors.Is(lookupErr, domain.ErrNotFound) {
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, "relay-state", "", "", "", "", nil); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if lookupErr != nil {
@@ -378,7 +374,7 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, cause, provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, nil); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 
@@ -395,7 +391,7 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, samlValidationCause(validationErr), provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, nil); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		subject, subjectErr := samlSubject(claims.NameID, provider.AllowEmailNameID)
@@ -403,7 +399,7 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, samlValidationCause(subjectErr), provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, &claims); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if _, gcErr := az.DeleteExpiredSAMLReplay(ctx, now); gcErr != nil {
@@ -420,7 +416,7 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, "replayed-assertion", provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, &claims); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		guarded, guardErr := az.GuardSAMLProviderForMint(ctx, provider.ID, provider.RowVersion, provider.EntityID)
@@ -431,25 +427,29 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 			if auditErr := s.stageSAML(ctx, az, audit.OutcomeFailure, "provider-reconciliation", provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, &claims); auditErr != nil {
 				return auditErr
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 
 		var completeErr error
 		switch transaction.Purpose {
 		case purposeLogin:
-			result, completeErr = s.completeSAMLLogin(ctx, az, provider, transaction, claims, subject, epoch, now)
+			attempt.result, completeErr = s.completeSAMLLogin(ctx, az, provider, transaction, claims, subject, epoch, now)
 		case purposeLink:
-			result, completeErr = s.completeSAMLLink(ctx, az, provider, transaction, claims, subject, initiating, epoch, now)
+			attempt.result, completeErr = s.completeSAMLLink(ctx, az, provider, transaction, claims, subject, initiating, epoch, now)
 		case purposeReauth:
-			result, completeErr = s.completeSAMLReauth(ctx, az, provider, transaction, claims, subject, initiating, epoch, now)
+			attempt.result, completeErr = s.completeSAMLReauth(ctx, az, provider, transaction, claims, subject, initiating, epoch, now)
 		}
-		if errors.Is(completeErr, domain.ErrUnauthenticated) || errors.Is(completeErr, ErrReauthWindowClosed) {
-			refused = completeErr
+		if errors.Is(completeErr, domain.ErrUnauthenticated) {
+			attempt.refused = sessionRefusedUnauthenticated
+			return nil
+		}
+		if errors.Is(completeErr, ErrReauthWindowClosed) {
+			attempt.refused = sessionRefusedWindowClosed
 			return nil
 		}
 		if errors.Is(completeErr, ErrAlreadyLinked) {
-			refused = completeErr
+			attempt.refused = sessionRefusedAlreadyLinked
 			return nil
 		}
 		return completeErr
@@ -457,10 +457,10 @@ func (s *Auth) SAMLACS(ctx context.Context, slug, encodedResponse, relayState, i
 	if err != nil {
 		return LoginResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return LoginResult{}, refused
 	}
-	return result, nil
+	return attempt.result, nil
 }
 
 func validSAMLHandle(value string) bool {
@@ -635,15 +635,14 @@ func (s *Auth) completeSAMLReauth(ctx context.Context, az *authz.TxAuthorizer, p
 		}
 		return LoginResult{}, ErrReauthWindowClosed
 	}
-	factorsJSON, err := json.Marshal(initiating.Assurance.Factors)
+	account, err := az.AccountByID(ctx, identity.AccountID)
 	if err != nil {
 		return LoginResult{}, err
 	}
-	value, verifier, err := s.newSessionArtifact(Artifact(initiating.Artifact))
+	completion, err := s.completeSession(ctx, az, RotateSession{
+		session: initiating, account: account, factors: initiating.Assurance.Factors,
+	}, now)
 	if err != nil {
-		return LoginResult{}, err
-	}
-	if err := az.RotateSessionFactors(ctx, initiating.SessionID, verifier, string(factorsJSON)); err != nil {
 		return LoginResult{}, err
 	}
 	windowID, err := newID("raw")
@@ -678,52 +677,23 @@ func (s *Auth) completeSAMLReauth(ctx context.Context, az *authz.TxAuthorizer, p
 	if err := s.stageSAMLActor(ctx, az, initiating.Principal, audit.OutcomeSuccess, "", provider.ID, transaction.EntityID, transaction.Purpose, transaction.ID, &claims); err != nil {
 		return LoginResult{}, err
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: initiating.SessionID, Artifact: Artifact(initiating.Artifact),
-		CreatedAt: initiating.CreatedAt, IdleExpires: initiating.IdleExpiresAt,
-		AbsExpires: initiating.AbsoluteExpiresAt, Principal: initiating.Principal,
-	}, nil
+	return completion, nil
 }
 
 func (s *Auth) mintSAMLSession(ctx context.Context, az *authz.TxAuthorizer, account authz.Account, provider authz.SAMLProvider, transaction authz.SAMLTransaction, claims samlsp.Claims, mfa bool, now time.Time) (LoginResult, error) {
-	generation, err := az.PrincipalGeneration(ctx, account.PrincipalID)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	epoch, err := az.CredentialEpoch(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	value, verifier, err := wencrypto.NewArtifact(wencrypto.ArtifactBrowserSession)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	csrfValue, csrfVerifier, err := wencrypto.NewArtifact(wencrypto.ArtifactCSRF)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	sessionID, err := newID("ses")
-	if err != nil {
-		return LoginResult{}, err
-	}
 	factorClasses := samlFactors(mfa)
-	factorsJSON, err := json.Marshal(factorClasses)
+	result, err := s.completeSession(ctx, az, CreateSession{
+		account: account, artifact: ArtifactBrowser,
+		assurance: Assurance{
+			Method: samlMethod(transaction.EntityID), Factors: factorClasses,
+			AuthenticatedAt: claims.Authn.Instant, CeremonyID: transaction.ID,
+		},
+		csrf: sessionWithCSRF,
+	}, now)
 	if err != nil {
 		return LoginResult{}, err
 	}
-	wire := audit.FromContext(ctx)
-	session := authz.NewSession{
-		ID: sessionID, PrincipalID: account.PrincipalID, Verifier: verifier,
-		Artifact: ArtifactBrowser.String(), SessionGeneration: generation, CredentialEpoch: epoch,
-		AuthMethod: samlMethod(transaction.EntityID), Factors: string(factorsJSON),
-		AuthenticatedAt: claims.Authn.Instant, CeremonyID: transaction.ID, CreatedAt: now,
-		IdleExpiresAt: now.Add(BrowserSessionIdle), AbsoluteExpiresAt: now.Add(BrowserSessionAbsolute),
-		SourceIP: wire.SourceIP, UserAgent: wire.UserAgent, CSRFVerifier: csrfVerifier,
-	}
-	if err := az.MintSession(ctx, session); err != nil {
-		return LoginResult{}, err
-	}
-	bound, err := az.BindSessionToSAMLProvider(ctx, sessionID, provider.ID)
+	bound, err := az.BindSessionToSAMLProvider(ctx, result.SessionID, provider.ID)
 	if err != nil {
 		return LoginResult{}, err
 	}
@@ -738,21 +708,15 @@ func (s *Auth) mintSAMLSession(ctx context.Context, az *authz.TxAuthorizer, acco
 		return LoginResult{}, err
 	}
 	event, err := newAuditEvent(ctx, audit.EventAuthSessionCreated, account.PrincipalID,
-		audit.Object{Type: "session", ID: sessionID}, audit.OutcomeSuccess, "",
-		audit.Payload{"session_id": sessionID, "artifact": ArtifactBrowser.String(), "method": samlMethod(transaction.EntityID), "assurance": assuranceLabel})
+		audit.Object{Type: "session", ID: result.SessionID}, audit.OutcomeSuccess, "",
+		audit.Payload{"session_id": result.SessionID, "artifact": ArtifactBrowser.String(), "method": samlMethod(transaction.EntityID), "assurance": assuranceLabel})
 	if err != nil {
 		return LoginResult{}, err
 	}
 	if err := az.RecordAuthEvent(ctx, event); err != nil {
 		return LoginResult{}, err
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: sessionID, Artifact: ArtifactBrowser,
-		CreatedAt: now, IdleExpires: session.IdleExpiresAt, AbsExpires: session.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{Method: samlMethod(transaction.EntityID), Factors: factorClasses, AuthenticatedAt: claims.Authn.Instant, CeremonyID: transaction.ID},
-		CSRFToken: csrfValue,
-	}, nil
+	return result, nil
 }
 
 func (s *Auth) stageSAML(ctx context.Context, az *authz.TxAuthorizer, outcome audit.Outcome, cause, providerID, entityID, purpose, transactionID string, claims *samlsp.Claims) error {

--- a/internal/service/session_completion.go
+++ b/internal/service/session_completion.go
@@ -1,0 +1,240 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/audit"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+// SessionCompletion is the closed input to the transaction-local session
+// completion module. Creation and rotation are separate variants: creation
+// owns a new row and clocks, while rotation preserves the live row's identity
+// and clocks. A caller cannot select one behaviour with a Boolean flag.
+type SessionCompletion interface {
+	sessionCompletion()
+}
+
+// sessionCompletionAttempt carries refusal beside a display-once result so
+// callers can commit required refusal audits without publishing values from a
+// rolled-back transaction attempt.
+type sessionCompletionAttempt struct {
+	result  LoginResult
+	refused sessionRefusal
+}
+
+type sessionRefusal uint8
+
+const (
+	sessionNotRefused sessionRefusal = iota
+	sessionRefusedUnauthenticated
+	sessionRefusedWindowClosed
+	sessionRefusedAlreadyLinked
+)
+
+func (r sessionRefusal) err() error {
+	switch r {
+	case sessionNotRefused:
+		return nil
+	case sessionRefusedUnauthenticated:
+		return domain.ErrUnauthenticated
+	case sessionRefusedWindowClosed:
+		return ErrReauthWindowClosed
+	case sessionRefusedAlreadyLinked:
+		return ErrAlreadyLinked
+	default:
+		return fmt.Errorf("%w: unknown committed session refusal", domain.ErrInvalid)
+	}
+}
+
+func writeCommittedLoginResult(ctx context.Context, db *store.DB, fn func(context.Context, store.Repos, *authz.TxAuthorizer, *LoginResult) error) (LoginResult, error) {
+	return tx.WriteResult(ctx, db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+		var result LoginResult
+		err := fn(ctx, repos, az, &result)
+		return result, err
+	})
+}
+
+func writeCommittedSessionAttempt(ctx context.Context, db *store.DB, fn func(context.Context, store.Repos, *authz.TxAuthorizer, *sessionCompletionAttempt) error) (sessionCompletionAttempt, error) {
+	return tx.WriteResult(ctx, db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) (sessionCompletionAttempt, error) {
+		var attempt sessionCompletionAttempt
+		err := fn(ctx, repos, az, &attempt)
+		return attempt, err
+	})
+}
+
+func writeCommittedReauthResults(ctx context.Context, db *store.DB, fn func(context.Context, store.Repos, *authz.TxAuthorizer, *[]ReauthResult) error) ([]ReauthResult, error) {
+	return tx.WriteResult(ctx, db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) ([]ReauthResult, error) {
+		var results []ReauthResult
+		err := fn(ctx, repos, az, &results)
+		return results, err
+	})
+}
+
+func writeCommittedCLIReauth(ctx context.Context, db *store.DB, fn func(context.Context, store.Repos, *authz.TxAuthorizer, *CLIReauthRedeemed) error) (CLIReauthRedeemed, error) {
+	return tx.WriteResult(ctx, db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) (CLIReauthRedeemed, error) {
+		var result CLIReauthRedeemed
+		err := fn(ctx, repos, az, &result)
+		return result, err
+	})
+}
+
+// CreateSession describes a newly authenticated session. Factor verification,
+// audit events and any provider-specific binding stay with the caller.
+type CreateSession struct {
+	account    authz.Account
+	artifact   Artifact
+	assurance  Assurance
+	csrf       sessionCSRF
+	providerID string
+}
+
+func (CreateSession) sessionCompletion() {}
+
+// RotateSession describes a live session whose bearer and factor projection
+// are replaced in place. The caller must authenticate session inside the same
+// transaction immediately before completion.
+type RotateSession struct {
+	session authz.Identity
+	account authz.Account
+	factors []string
+}
+
+func (RotateSession) sessionCompletion() {}
+
+// sessionCSRF keeps browser-only CSRF creation caller-explicit without a
+// Boolean option on the completion module.
+type sessionCSRF uint8
+
+const (
+	sessionWithoutCSRF sessionCSRF = iota + 1
+	sessionWithCSRF
+)
+
+// completeSession owns display-once artifact creation, verifier persistence,
+// factor serialization and LoginResult projection. It must run inside the
+// caller's write transaction, whose tx.WriteResult return publishes only the
+// attempt that committed.
+func (s *Auth) completeSession(ctx context.Context, az *authz.TxAuthorizer, completion SessionCompletion, now time.Time) (LoginResult, error) {
+	switch value := completion.(type) {
+	case CreateSession:
+		return s.createCompletedSession(ctx, az, value, now)
+	case RotateSession:
+		return s.rotateCompletedSession(ctx, az, value)
+	default:
+		return LoginResult{}, fmt.Errorf("%w: unknown session completion variant", domain.ErrInvalid)
+	}
+}
+
+func (s *Auth) createCompletedSession(ctx context.Context, az *authz.TxAuthorizer, completion CreateSession, now time.Time) (LoginResult, error) {
+	if !completion.artifact.Valid() {
+		return LoginResult{}, fmt.Errorf("%w: unknown session artifact %q", domain.ErrInvalid, completion.artifact)
+	}
+	if completion.account.ID == "" || completion.account.PrincipalID == "" {
+		return LoginResult{}, fmt.Errorf("%w: session creation requires an account", domain.ErrInvalid)
+	}
+	switch {
+	case completion.artifact == ArtifactBrowser && completion.csrf != sessionWithCSRF:
+		return LoginResult{}, fmt.Errorf("%w: browser session requires CSRF creation", domain.ErrInvalid)
+	case completion.artifact == ArtifactCLI && completion.csrf != sessionWithoutCSRF:
+		return LoginResult{}, fmt.Errorf("%w: CLI session cannot create a CSRF token", domain.ErrInvalid)
+	}
+
+	value, verifier, err := crypto.NewArtifact(completion.artifact.bearerKind())
+	if err != nil {
+		return LoginResult{}, err
+	}
+	var csrfValue string
+	var csrfVerifier []byte
+	if completion.csrf == sessionWithCSRF {
+		csrfValue, csrfVerifier, err = crypto.NewArtifact(crypto.ArtifactCSRF)
+		if err != nil {
+			return LoginResult{}, err
+		}
+	}
+	sessionID, err := newID("ses")
+	if err != nil {
+		return LoginResult{}, err
+	}
+	generation, err := az.PrincipalGeneration(ctx, completion.account.PrincipalID)
+	if err != nil {
+		return LoginResult{}, err
+	}
+	epoch, err := az.CredentialEpoch(ctx)
+	if err != nil {
+		return LoginResult{}, err
+	}
+	factors := append([]string(nil), completion.assurance.Factors...)
+	factorsJSON, err := json.Marshal(factors)
+	if err != nil {
+		return LoginResult{}, err
+	}
+	wire := audit.FromContext(ctx)
+	session := authz.NewSession{
+		ID: sessionID, PrincipalID: completion.account.PrincipalID, Verifier: verifier,
+		Artifact: completion.artifact.String(), SessionGeneration: generation, CredentialEpoch: epoch,
+		AuthMethod: completion.assurance.Method, Factors: string(factorsJSON),
+		AuthenticatedAt: completion.assurance.AuthenticatedAt, CeremonyID: completion.assurance.CeremonyID,
+		CreatedAt: now, IdleExpiresAt: now.Add(completion.artifact.idle()),
+		AbsoluteExpiresAt: now.Add(completion.artifact.absolute()),
+		SourceIP:          wire.SourceIP, UserAgent: wire.UserAgent,
+		ProviderID: completion.providerID, CSRFVerifier: csrfVerifier,
+	}
+	if err := az.MintSession(ctx, session); err != nil {
+		return LoginResult{}, err
+	}
+	return LoginResult{
+		SessionToken: value, SessionID: sessionID, Artifact: completion.artifact,
+		CreatedAt: now, IdleExpires: session.IdleExpiresAt, AbsExpires: session.AbsoluteExpiresAt,
+		Principal: completion.account.PrincipalID, AccountID: completion.account.ID,
+		DisplayName: completion.account.DisplayName,
+		Assurance: Assurance{
+			Method: completion.assurance.Method, Factors: factors,
+			AuthenticatedAt: completion.assurance.AuthenticatedAt, CeremonyID: completion.assurance.CeremonyID,
+		},
+		CSRFToken: csrfValue,
+	}, nil
+}
+
+func (s *Auth) rotateCompletedSession(ctx context.Context, az *authz.TxAuthorizer, completion RotateSession) (LoginResult, error) {
+	artifact := Artifact(completion.session.Artifact)
+	if !artifact.Valid() || completion.session.SessionID == "" {
+		return LoginResult{}, fmt.Errorf("%w: rotation requires a live browser or CLI session", domain.ErrInvalid)
+	}
+	if completion.account.ID == "" || completion.account.PrincipalID == "" {
+		return LoginResult{}, fmt.Errorf("%w: session rotation requires an account", domain.ErrInvalid)
+	}
+	if completion.account.PrincipalID != completion.session.Principal {
+		return LoginResult{}, fmt.Errorf("%w: rotation account does not own session", domain.ErrInvalid)
+	}
+	value, verifier, err := crypto.NewArtifact(artifact.bearerKind())
+	if err != nil {
+		return LoginResult{}, err
+	}
+	factors := append([]string(nil), completion.factors...)
+	factorsJSON, err := json.Marshal(factors)
+	if err != nil {
+		return LoginResult{}, err
+	}
+	if err := az.RotateSessionFactors(ctx, completion.session.SessionID, verifier, string(factorsJSON)); err != nil {
+		return LoginResult{}, err
+	}
+	return LoginResult{
+		SessionToken: value, SessionID: completion.session.SessionID, Artifact: artifact,
+		CreatedAt: completion.session.CreatedAt, IdleExpires: completion.session.IdleExpiresAt,
+		AbsExpires: completion.session.AbsoluteExpiresAt, Principal: completion.session.Principal,
+		AccountID: completion.account.ID, DisplayName: completion.account.DisplayName,
+		Assurance: Assurance{
+			Method: completion.session.Assurance.Method, Factors: factors,
+			AuthenticatedAt: completion.session.Assurance.AuthenticatedAt,
+			CeremonyID:      completion.session.Assurance.CeremonyID,
+		},
+	}, nil
+}

--- a/internal/service/session_completion_test.go
+++ b/internal/service/session_completion_test.go
@@ -1,0 +1,312 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+func TestSessionCompletionRejectsInvalidVariantFields(t *testing.T) {
+	svc := &Auth{}
+	now := time.Date(2026, time.August, 22, 7, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		completion SessionCompletion
+	}{
+		{name: "missing variant"},
+		{
+			name: "browser without CSRF decision",
+			completion: CreateSession{
+				artifact: ArtifactBrowser, csrf: sessionWithoutCSRF,
+			},
+		},
+		{
+			name: "CLI with browser CSRF decision",
+			completion: CreateSession{
+				artifact: ArtifactCLI, csrf: sessionWithCSRF,
+			},
+		},
+		{
+			name:       "rotation without live session",
+			completion: RotateSession{},
+		},
+		{
+			name: "rotation for another account",
+			completion: RotateSession{
+				session: authz.Identity{
+					SessionID: "ses_one", Artifact: ArtifactBrowser.String(),
+					Principal: domain.PrincipalID("hum_one"),
+				},
+				account: authz.Account{PrincipalID: domain.PrincipalID("hum_two")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.completeSession(t.Context(), nil, tt.completion, now)
+			if !errors.Is(err, domain.ErrInvalid) {
+				t.Fatalf("error = %v, want domain.ErrInvalid", err)
+			}
+		})
+	}
+}
+
+func TestSessionCompletionCreatesFactorParity(t *testing.T) {
+	db, account := sessionCompletionFixture(t)
+	now := time.Date(2026, time.August, 22, 8, 0, 0, 0, time.UTC)
+	svc := &Auth{}
+
+	tests := []struct {
+		name       string
+		artifact   Artifact
+		csrf       sessionCSRF
+		assurance  Assurance
+		providerID string
+		wantCSRF   bool
+	}{
+		{
+			name: "password CLI", artifact: ArtifactCLI, csrf: sessionWithoutCSRF,
+			assurance: Assurance{Method: MethodLocalPassword, Factors: []string{"password"}, AuthenticatedAt: now},
+		},
+		{
+			name: "OIDC browser", artifact: ArtifactBrowser, csrf: sessionWithCSRF,
+			assurance: Assurance{Method: "oidc:https://idp.example", Factors: []string{"oidc", "mfa"}, AuthenticatedAt: now},
+			wantCSRF:  true,
+		},
+		{
+			name: "SAML browser", artifact: ArtifactBrowser, csrf: sessionWithCSRF,
+			assurance: Assurance{Method: "saml:https://idp.example", Factors: []string{"saml", "mfa"}, AuthenticatedAt: now, CeremonyID: "smt_one"},
+			wantCSRF:  true,
+		},
+		{
+			name: "passkey browser", artifact: ArtifactBrowser, csrf: sessionWithCSRF,
+			assurance: Assurance{Method: MethodLocalPasskey, Factors: []string{"webauthn"}, AuthenticatedAt: now, CeremonyID: "wac_one"},
+			wantCSRF:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tx.WriteResult(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+				return svc.completeSession(ctx, az, CreateSession{
+					account: account, artifact: tt.artifact, assurance: tt.assurance,
+					csrf: tt.csrf, providerID: tt.providerID,
+				}, now)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.SessionToken == "" || result.SessionID == "" {
+				t.Fatal("completion must return the display-once token and session id")
+			}
+			if (result.CSRFToken != "") != tt.wantCSRF {
+				t.Fatalf("CSRF token present = %v, want %v", result.CSRFToken != "", tt.wantCSRF)
+			}
+			if result.Artifact != tt.artifact || result.AccountID != account.ID || result.Principal != account.PrincipalID {
+				t.Fatalf("projection = %#v", result)
+			}
+			if result.Assurance.Method != tt.assurance.Method || !equalStrings(result.Assurance.Factors, tt.assurance.Factors) || result.Assurance.CeremonyID != tt.assurance.CeremonyID {
+				t.Fatalf("assurance = %#v, want %#v", result.Assurance, tt.assurance)
+			}
+
+			var live authz.Identity
+			err = tx.Read(t.Context(), db, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+				var err error
+				live, err = az.Authenticate(ctx, result.SessionToken, now)
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if live.SessionID != result.SessionID || live.Assurance.Method != tt.assurance.Method || !equalStrings(live.Assurance.Factors, tt.assurance.Factors) {
+				t.Fatalf("stored session = %#v", live)
+			}
+		})
+	}
+}
+
+func TestSessionCompletionRotationPreservesProjectionAndReplacesFactors(t *testing.T) {
+	db, account := sessionCompletionFixture(t)
+	now := time.Date(2026, time.August, 22, 9, 0, 0, 0, time.UTC)
+	svc := &Auth{}
+	created := createCompletionSession(t, db, svc, account, now)
+
+	rotated, err := tx.WriteResult(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+		live, err := az.Authenticate(ctx, created.SessionToken, now)
+		if err != nil {
+			return LoginResult{}, err
+		}
+		return svc.completeSession(ctx, az, RotateSession{
+			session: live, account: account, factors: []string{"password", "totp"},
+		}, now)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.SessionID != created.SessionID || rotated.CreatedAt != created.CreatedAt || rotated.IdleExpires != created.IdleExpires || rotated.AbsExpires != created.AbsExpires {
+		t.Fatalf("rotation changed stable projection: before=%#v after=%#v", created, rotated)
+	}
+	if rotated.CSRFToken != "" {
+		t.Fatal("rotation must preserve the stored CSRF verifier without minting a new synchronizer token")
+	}
+	if !equalStrings(rotated.Assurance.Factors, []string{"password", "totp"}) {
+		t.Fatalf("factors = %v", rotated.Assurance.Factors)
+	}
+	assertSessionTokenRejected(t, db, created.SessionToken, now)
+	assertSessionTokenAccepted(t, db, rotated.SessionToken, rotated.SessionID, now)
+}
+
+func TestSessionCompletionPublishesOnlyCommittedAttemptTokens(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		db, account := sessionCompletionFixture(t)
+		now := time.Date(2026, time.August, 22, 10, 0, 0, 0, time.UTC)
+		svc := &Auth{}
+		var attempts []string
+		result, err := tx.WriteResult(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+			result, err := svc.completeSession(ctx, az, CreateSession{
+				account: account, artifact: ArtifactCLI,
+				assurance: Assurance{Method: MethodLocalPassword, Factors: []string{"password"}, AuthenticatedAt: now},
+				csrf:      sessionWithoutCSRF,
+			}, now)
+			if err != nil {
+				return LoginResult{}, err
+			}
+			attempts = append(attempts, result.SessionToken)
+			if len(attempts) == 1 {
+				return result, store.ErrRetrySerialization
+			}
+			return result, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertCommittedAttempt(t, db, attempts, result, now)
+	})
+
+	t.Run("rotate", func(t *testing.T) {
+		db, account := sessionCompletionFixture(t)
+		now := time.Date(2026, time.August, 22, 11, 0, 0, 0, time.UTC)
+		svc := &Auth{}
+		created := createCompletionSession(t, db, svc, account, now)
+		var attempts []string
+		result, err := tx.WriteResult(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+			live, err := az.Authenticate(ctx, created.SessionToken, now)
+			if err != nil {
+				return LoginResult{}, err
+			}
+			result, err := svc.completeSession(ctx, az, RotateSession{session: live, account: account, factors: live.Assurance.Factors}, now)
+			if err != nil {
+				return LoginResult{}, err
+			}
+			attempts = append(attempts, result.SessionToken)
+			if len(attempts) == 1 {
+				return result, store.ErrRetrySerialization
+			}
+			return result, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertCommittedAttempt(t, db, attempts, result, now)
+		assertSessionTokenRejected(t, db, created.SessionToken, now)
+	})
+}
+
+func sessionCompletionFixture(t *testing.T) (*store.DB, authz.Account) {
+	t.Helper()
+	cfg := store.Config{Engine: store.EngineSQLite, Path: filepath.Join(t.TempDir(), "session-completion.db")}
+	if err := migrate.Run(t.Context(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	account := authz.Account{
+		ID: "acc_completion", PrincipalID: domain.PrincipalID("hum_completion"),
+		Username: "completion", DisplayName: "Completion Test", CreatedAt: time.Date(2026, time.August, 22, 7, 0, 0, 0, time.UTC),
+	}
+	if err := tx.Write(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+		if err := az.CreateHumanPrincipal(ctx, account.PrincipalID, account.CreatedAt); err != nil {
+			return err
+		}
+		return az.CreateAccount(ctx, account)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return db, account
+}
+
+func createCompletionSession(t *testing.T, db *store.DB, svc *Auth, account authz.Account, now time.Time) LoginResult {
+	t.Helper()
+	result, err := tx.WriteResult(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) (LoginResult, error) {
+		return svc.completeSession(ctx, az, CreateSession{
+			account: account, artifact: ArtifactBrowser,
+			assurance: Assurance{Method: MethodLocalPassword, Factors: []string{"password"}, AuthenticatedAt: now},
+			csrf:      sessionWithCSRF,
+		}, now)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func assertCommittedAttempt(t *testing.T, db *store.DB, attempts []string, result LoginResult, now time.Time) {
+	t.Helper()
+	if len(attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(attempts))
+	}
+	if result.SessionToken != attempts[1] || result.SessionToken == attempts[0] {
+		t.Fatalf("published token = %q, attempts = %q", result.SessionToken, attempts)
+	}
+	assertSessionTokenRejected(t, db, attempts[0], now)
+	assertSessionTokenAccepted(t, db, result.SessionToken, result.SessionID, now)
+}
+
+func assertSessionTokenAccepted(t *testing.T, db *store.DB, token, sessionID string, now time.Time) {
+	t.Helper()
+	err := tx.Read(t.Context(), db, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+		live, err := az.Authenticate(ctx, token, now)
+		if err == nil && live.SessionID != sessionID {
+			t.Fatalf("session id = %q, want %q", live.SessionID, sessionID)
+		}
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertSessionTokenRejected(t *testing.T, db *store.DB, token string, now time.Time) {
+	t.Helper()
+	err := tx.Read(t.Context(), db, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+		_, err := az.Authenticate(ctx, token, now)
+		return err
+	})
+	if err == nil {
+		t.Fatal("superseded or rolled-back token authenticated")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -277,8 +277,7 @@ func (s *Auth) EnrolPasskeyFinish(ctx context.Context, presented string, respons
 	if err != nil {
 		return LoginResult{}, err
 	}
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		live, err := az.Authenticate(ctx, presented, now)
 		if err != nil {
@@ -321,7 +320,7 @@ func (s *Auth) EnrolPasskeyFinish(ctx context.Context, presented string, respons
 		if err := s.assertPasskeyOnlyInvariant(ctx, az, account.ID); err != nil {
 			return err
 		}
-		result, err = s.reissueSession(ctx, az, account, ceremony.OperationBinding, MethodLocalPassword, Artifact(acting.Artifact), now)
+		*result, err = s.reissueSession(ctx, az, account, ceremony.OperationBinding, MethodLocalPassword, Artifact(acting.Artifact), now)
 		if err != nil {
 			return err
 		}
@@ -472,10 +471,7 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 
 	// Resolve the stored credential and apply the sign-count rule + mint the
 	// session, atomically.
-	var result LoginResult
-	var refused error
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		// Reload the ceremony inside the write tx and re-validate against the tx
 		// clock/epoch (A3): a ceremony accepted just before expiry must not
@@ -483,7 +479,7 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 		fresh, err := az.WebAuthnCeremonyByChallenge(ctx, challengeVerifier(challenge))
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			return err
@@ -493,19 +489,19 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 			return err
 		}
 		if !validCeremony(fresh, "login", "", "", "", now) || fresh.CredentialEpoch != epoch {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		stored, err := az.WebAuthnCredentialByCredentialID(ctx, assertion.CredentialID)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			return err
 		}
 		if stored.Disabled || stored.CredentialEpoch != epoch || !stored.Discoverable {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		account, err := az.AccountByID(ctx, stored.AccountID)
@@ -519,14 +515,14 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 			return err
 		}
 		if !consumed {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if s.isClone(stored, assertion.SignCount) {
 			if err := s.respondToClone(ctx, az, account, stored, now); err != nil {
 				return err
 			}
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		advanced, err := az.AdvanceWebAuthnSignCount(ctx, stored.ID, stored.RowVersion, int64(assertion.SignCount), now)
@@ -537,13 +533,13 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 			// The row moved under a concurrent assertion — the single-writer
 			// guarantee row_version exists for. Refuse rather than mint on a stale
 			// counter.
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		// Mint against the RELOADED ceremony row (A3): its id is what was consumed
 		// above, so the minted session's ceremony_id traces the credential that
 		// authored it even if the pre-tx row were ever superseded.
-		result, err = s.mintPasskeySession(ctx, az, account, fresh.ID, now)
+		attempt.result, err = s.mintPasskeySession(ctx, az, account, fresh.ID, now)
 		if err != nil {
 			return err
 		}
@@ -552,10 +548,10 @@ func (s *Auth) attemptPasskeyLogin(ctx context.Context, responseJSON []byte) (Lo
 	if err != nil {
 		return LoginResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return LoginResult{}, refused
 	}
-	return result, nil
+	return attempt.result, nil
 }
 
 // isClone applies B9: skip the counter comparison for a backup-eligible
@@ -601,40 +597,15 @@ func (s *Auth) respondToClone(ctx context.Context, az *authz.TxAuthorizer, accou
 // ceremony_id is the login ceremony, whose credential_id is the passkey that
 // authored it — the link the clone sweep traces.
 func (s *Auth) mintPasskeySession(ctx context.Context, az *authz.TxAuthorizer, account authz.Account, ceremonyID string, now time.Time) (LoginResult, error) {
-	generation, err := az.PrincipalGeneration(ctx, account.PrincipalID)
+	result, err := s.completeSession(ctx, az, CreateSession{
+		account: account, artifact: ArtifactBrowser,
+		assurance: Assurance{
+			Method: MethodLocalPasskey, Factors: []string{"webauthn"},
+			AuthenticatedAt: now, CeremonyID: ceremonyID,
+		},
+		csrf: sessionWithCSRF,
+	}, now)
 	if err != nil {
-		return LoginResult{}, err
-	}
-	epoch, err := az.CredentialEpoch(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	value, verifier, err := crypto.NewArtifact(crypto.ArtifactBrowserSession)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	csrfValue, csrfVerifier, err := crypto.NewArtifact(crypto.ArtifactCSRF)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	sessionID, err := newID("ses")
-	if err != nil {
-		return LoginResult{}, err
-	}
-	factors, err := json.Marshal([]string{"webauthn"})
-	if err != nil {
-		return LoginResult{}, err
-	}
-	wire := audit.FromContext(ctx)
-	sess := authz.NewSession{
-		ID: sessionID, PrincipalID: account.PrincipalID, Verifier: verifier,
-		Artifact: ArtifactBrowser.String(), SessionGeneration: generation, CredentialEpoch: epoch,
-		AuthMethod: MethodLocalPasskey, Factors: string(factors),
-		AuthenticatedAt: now, CeremonyID: ceremonyID, CreatedAt: now,
-		IdleExpiresAt: now.Add(BrowserSessionIdle), AbsoluteExpiresAt: now.Add(BrowserSessionAbsolute),
-		SourceIP: wire.SourceIP, UserAgent: wire.UserAgent, CSRFVerifier: csrfVerifier,
-	}
-	if err := az.MintSession(ctx, sess); err != nil {
 		return LoginResult{}, err
 	}
 	for _, ev := range []struct {
@@ -646,12 +617,12 @@ func (s *Auth) mintPasskeySession(ctx context.Context, az *authz.TxAuthorizer, a
 			"subject_resolved": true, "account_id": account.ID, "assurance": "multi-factor",
 		}},
 		{audit.EventAuthSessionCreated, audit.Payload{
-			"session_id": sessionID, "artifact": ArtifactBrowser.String(),
+			"session_id": result.SessionID, "artifact": ArtifactBrowser.String(),
 			"method": MethodLocalPasskey, "assurance": "multi-factor",
 		}},
 	} {
 		e, err := newAuditEvent(ctx, ev.typ, account.PrincipalID,
-			audit.Object{Type: "session", ID: sessionID}, audit.OutcomeSuccess, "", ev.payload)
+			audit.Object{Type: "session", ID: result.SessionID}, audit.OutcomeSuccess, "", ev.payload)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -659,13 +630,7 @@ func (s *Auth) mintPasskeySession(ctx context.Context, az *authz.TxAuthorizer, a
 			return LoginResult{}, err
 		}
 	}
-	return LoginResult{
-		SessionToken: value, SessionID: sessionID, Artifact: ArtifactBrowser,
-		CreatedAt: now, IdleExpires: sess.IdleExpiresAt, AbsExpires: sess.AbsoluteExpiresAt,
-		Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-		Assurance: Assurance{Method: MethodLocalPasskey, Factors: []string{"webauthn"}, AuthenticatedAt: now},
-		CSRFToken: csrfValue,
-	}, nil
+	return result, nil
 }
 
 // StepUpPasskeyStart opens a non-discoverable ceremony scoped to the acting
@@ -926,15 +891,8 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 	}
 
 	factors := stepUpFactors(acting.Assurance.Factors, "webauthn")
-	value, verifier, err := s.newSessionArtifact(Artifact(acting.Artifact))
-	if err != nil {
-		return LoginResult{}, err
-	}
 
-	var result LoginResult
-	var refused error
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
-		refused = nil
+	attempt, err := writeCommittedSessionAttempt(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, attempt *sessionCompletionAttempt) error {
 		now := s.now()
 		live, err := az.Authenticate(ctx, presented, now)
 		if err != nil {
@@ -949,7 +907,7 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 		fresh, err := az.WebAuthnCeremonyByChallenge(ctx, challengeVerifier(challenge))
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			return err
@@ -959,19 +917,19 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 			return err
 		}
 		if !validCeremony(fresh, purpose, account.ID, acting.SessionID, expectedBinding, now) || fresh.CredentialEpoch != epoch {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		stored, err := az.WebAuthnCredentialByCredentialID(ctx, assertion.CredentialID)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				refused = domain.ErrUnauthenticated
+				attempt.refused = sessionRefusedUnauthenticated
 				return nil
 			}
 			return err
 		}
 		if stored.AccountID != account.ID || stored.Disabled || stored.CredentialEpoch != epoch {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		consumed, err := az.ConsumeWebAuthnCeremony(ctx, fresh.ID, stored.ID, now)
@@ -979,7 +937,7 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 			return err
 		}
 		if !consumed {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		if s.isClone(stored, assertion.SignCount) {
@@ -987,7 +945,7 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 				return err
 			}
 			s.Admission.RecordFailure(account.ID)
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		advanced, err := az.AdvanceWebAuthnSignCount(ctx, stored.ID, stored.RowVersion, int64(assertion.SignCount), now)
@@ -995,7 +953,7 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 			return err
 		}
 		if !advanced {
-			refused = domain.ErrUnauthenticated
+			attempt.refused = sessionRefusedUnauthenticated
 			return nil
 		}
 		// Rotate the acting session token (every step-up/reauth rotates),
@@ -1005,11 +963,10 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 		if purpose == "step-up" {
 			newFactors = factors
 		}
-		nf, err := json.Marshal(newFactors)
+		completion, err := s.completeSession(ctx, az, RotateSession{
+			session: live, account: account, factors: newFactors,
+		}, now)
 		if err != nil {
-			return err
-		}
-		if err := az.RotateSessionFactors(ctx, live.SessionID, verifier, string(nf)); err != nil {
 			return err
 		}
 		if effect != nil {
@@ -1026,25 +983,17 @@ func (s *Auth) finishAssertionElevation(ctx context.Context, presented string, r
 		if err := az.RecordAuthEvent(ctx, e); err != nil {
 			return err
 		}
-		result = LoginResult{
-			SessionToken: value, SessionID: acting.SessionID, Artifact: Artifact(acting.Artifact),
-			CreatedAt: acting.CreatedAt, IdleExpires: acting.IdleExpiresAt, AbsExpires: acting.AbsoluteExpiresAt,
-			Principal: account.PrincipalID, AccountID: account.ID, DisplayName: account.DisplayName,
-			Assurance: Assurance{
-				Method: acting.Assurance.Method, Factors: newFactors,
-				AuthenticatedAt: acting.Assurance.AuthenticatedAt, CeremonyID: acting.Assurance.CeremonyID,
-			},
-		}
+		attempt.result = completion
 		return nil
 	})
 	if err != nil {
 		return LoginResult{}, err
 	}
-	if refused != nil {
+	if refused := attempt.refused.err(); refused != nil {
 		return LoginResult{}, refused
 	}
 	s.Admission.RecordSuccess(account.ID)
-	return result, nil
+	return attempt.result, nil
 }
 
 // RemovePasskey removes a credential as an account-security mutation. The
@@ -1106,8 +1055,7 @@ func (s *Auth) RemovePasskey(ctx context.Context, presented, credentialID, passw
 	}
 	s.Admission.RecordSuccess(account.ID)
 
-	var result LoginResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		live, err := az.Authenticate(ctx, presented, now)
 		if err != nil {
@@ -1141,7 +1089,7 @@ func (s *Auth) RemovePasskey(ctx context.Context, presented, credentialID, passw
 		if err := s.assertPasskeyOnlyInvariant(ctx, az, account.ID); err != nil {
 			return err
 		}
-		result, err = s.reissueSession(ctx, az, account, proofClass, MethodLocalPassword, Artifact(live.Artifact), now)
+		*result, err = s.reissueSession(ctx, az, account, proofClass, MethodLocalPassword, Artifact(live.Artifact), now)
 		if err != nil {
 			return err
 		}

--- a/scripts/ci/check-trusted-ci-scripts_test.sh
+++ b/scripts/ci/check-trusted-ci-scripts_test.sh
@@ -30,6 +30,7 @@ require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/analysis-shards-go/ma
 require_line "$workflow" 'name: Upload shard fuzz reproducers'
 require_line "$workflow" 'name: Download shard fuzz reproducers'
 require_line "$workflow" 'name: Upload minimized fuzz reproducers'
+require_line "$workflow" "-fuzztime=100000x -timeout=2m"
 # Workflow shell variables below are literal fixture text.
 # shellcheck disable=SC2016
 require_line "$workflow" 'echo "$shellcheck_dir" >>"$GITHUB_PATH"'


### PR DESCRIPTION
## Summary

- add a closed transaction-local `SessionCompletion` executor with explicit `CreateSession` and `RotateSession` variants
- centralize bearer and CSRF artifact creation, verifier persistence or rotation, factor projection, credential epoch capture, and returned session projection
- migrate local auth, CLI reauth, OIDC, SAML, WebAuthn, TOTP, factor mutation, and recovery paths while retaining caller-owned ceremonies, windows, provider binding, and audit provenance
- publish display-once session results only after successful transaction commit and cover forced retries for both variants

## Stack

- stacked on #291 at `176039eeaabf6635be2a68f906e7d0a37622d8d0`
- rebased after #291 incorporated its no-egress teardown fixes

## Contract and migration

Creation requires an account, artifact, assurance, and explicit browser or CLI CSRF decision. Rotation requires the live session, owning account, and exact replacement factors. Rotation preserves session identity, clocks, authentication attribution, and the existing CSRF verifier. Workspace sessions remain owned by the separate multi-instance flow.

Generated outputs: none.

## Validation

- `go test -count=1 ./internal/service/... ./internal/authz/... ./internal/store/...` — 290 passed
- `go test -race -count=1 ./internal/service/...` — 174 passed
- `go test -count=1 ./internal/isolation/...` — 1,090 passed
- `go test -count=1 ./...` — 3,169 passed across 57 packages
- `go vet ./...`, `gofmt -l`, and `git diff --check` — clean

Closes #223
