### PR TITLE
Make definitions encoding closed over validated canonical bundles

### DIFF
--- a/docs/handoff/228-canonical-definitions-bundle.md
+++ b/docs/handoff/228-canonical-definitions-bundle.md
@@ -1,0 +1,43 @@
+# Handoff: #228 canonical definitions bundle
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/228 (parent #204; programme
+#203; audit ID `BE11-A`). Implemented from `origin/main` at `6dff17c5`.
+
+## Contract
+
+- `definitions.Bundle` is the mutable wire/import DTO. Production encoders take
+  only `CanonicalBundle`, whose state is private and whose zero value fails
+  loudly.
+- `Parse` and `Canonicalize` are the only canonical constructors. Both enforce
+  format version, entry and encoded-byte limits, additive-ID rules,
+  classification/declaration validity, presence rules, and deterministic
+  ordering before a value becomes encodable. Strict parsing continues to reject
+  unknown and duplicate members and trailing content.
+- `Encode` and `Digest` accept only `CanonicalBundle`. Every successful encoded
+  result therefore parses to the same canonical model and remains byte-stable.
+- `WireBundle` returns a detached DTO for review, diffing, and scanning;
+  mutating it cannot change the canonical snapshot.
+- Import plans now carry the canonical type. Service export, plan persistence,
+  apply pin checks, CLI scaffold/read paths, and all test/conformance callers
+  canonicalize or parse before encoding.
+- External bundle JSON and digest spelling are unchanged. Generated outputs:
+  none.
+
+## Review
+
+Two-axis review against repository standards and issue #228 found one initial
+fail-loud gap: zero-value observation could look like an empty additive bundle.
+Zero-value observers now panic, the detached accessor is explicitly named, and
+the obsolete `Normalize` alias is removed. Round 2: `CLEAN` / `CLEAN`.
+
+## Validation
+
+```text
+go test -count=1 ./internal/definitions/... ./internal/importer/... \
+  ./internal/service/... ./internal/cli/... ./internal/conformance/...  649 passed
+go test -run '^$' -fuzz '^FuzzCanonicalBundleRoundTrip$' \
+  -fuzztime=10s ./internal/definitions                              passed
+go test -count=1 ./...                                               3186 passed / 57 packages
+go vet ./...                                                         passed
+git diff --check                                                     clean
+```

--- a/internal/cli/definitions.go
+++ b/internal/cli/definitions.go
@@ -237,7 +237,7 @@ func runDefinitionsScaffold(ios IO, args []string) error {
 		return failf(ExitRefused, "%v", err)
 	}
 
-	bundle := definitions.Bundle{Keys: make([]definitions.Key, 0, len(entries))}
+	bundle := definitions.Bundle{FormatVersion: definitions.FormatVersion, Keys: make([]definitions.Key, 0, len(entries))}
 	for _, e := range entries {
 		bundle.Keys = append(bundle.Keys, definitions.Key{
 			Name:           e.Key,
@@ -248,11 +248,11 @@ func runDefinitionsScaffold(ios IO, args []string) error {
 			ForbiddenIn:    definitions.Presence{Mode: string(schema.PresenceNone)},
 		})
 	}
-	normalized, err := definitions.Normalize(bundle)
+	canonical, err := definitions.Canonicalize(bundle)
 	if err != nil {
 		return failf(ExitInternal, "%v", err)
 	}
-	out, err := definitions.Encode(normalized)
+	out, err := definitions.Encode(canonical)
 	if err != nil {
 		return failf(ExitInternal, "%v", err)
 	}

--- a/internal/cli/importer_internal_test.go
+++ b/internal/cli/importer_internal_test.go
@@ -262,7 +262,7 @@ func TestWriteArtifactsRefusesValuesFilePhaseTwoCannotRead(t *testing.T) {
 }
 
 func TestWriteArtifactsEmitsCanonicalDefinitionsBundle(t *testing.T) {
-	bundle, err := definitions.Normalize(definitions.Bundle{
+	bundle, err := definitions.Canonicalize(definitions.Bundle{
 		FormatVersion: definitions.FormatVersion,
 		Environments:  []definitions.Environment{},
 		KeyGroups:     []definitions.KeyGroup{},
@@ -293,7 +293,8 @@ func TestWriteArtifactsEmitsCanonicalDefinitionsBundle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emitted definitions-bundle.json is not canonical bundle input: %v\n%s", err, raw)
 	}
-	if !parsed.Additive() || len(parsed.Keys) != 1 || parsed.Keys[0].Name != "DATABASE_URL" {
+	model := parsed.WireBundle()
+	if !parsed.Additive() || len(model.Keys) != 1 || model.Keys[0].Name != "DATABASE_URL" {
 		t.Fatalf("emitted bundle = %+v", parsed)
 	}
 	want, err := definitions.Encode(bundle)

--- a/internal/conformance/import_test.go
+++ b/internal/conformance/import_test.go
@@ -113,7 +113,7 @@ users:
 			if plan.Template.Scope.FileDigest != "" {
 				t.Fatalf("live template recorded a file digest: %q", plan.Template.Scope.FileDigest)
 			}
-			for _, key := range plan.Bundle.Keys {
+			for _, key := range plan.Bundle.WireBundle().Keys {
 				if key.Classification != string(schema.Secret) {
 					t.Fatalf("live key %s defaulted to %s, want secret", key.Name, key.Classification)
 				}
@@ -123,8 +123,8 @@ users:
 			if err != nil {
 				t.Fatalf("phase 2 refused live fixture: %v", err)
 			}
-			if len(imported.Imported) != len(plan.Bundle.Keys) {
-				t.Fatalf("imported = %v, bundle keys = %d", imported.Imported, len(plan.Bundle.Keys))
+			if len(imported.Imported) != len(plan.Bundle.WireBundle().Keys) {
+				t.Fatalf("imported = %v, bundle keys = %d", imported.Imported, len(plan.Bundle.WireBundle().Keys))
 			}
 		})
 	}
@@ -532,12 +532,12 @@ func scenarioImportPerSourceE2E(t *testing.T, db *store.DB) {
 			if strings.Join(plan.New, ",") != strings.Join(tc.wantKeys, ",") {
 				t.Fatalf("new bucket = %v, want %v", plan.New, tc.wantKeys)
 			}
-			if len(plan.Bundle.Keys) != len(tc.wantKeys) {
-				t.Fatalf("bundle declares %d keys, want %d", len(plan.Bundle.Keys), len(tc.wantKeys))
+			if len(plan.Bundle.WireBundle().Keys) != len(tc.wantKeys) {
+				t.Fatalf("bundle declares %d keys, want %d", len(plan.Bundle.WireBundle().Keys), len(tc.wantKeys))
 			}
 			// Classification matrix: EVERY imported key defaults `secret`, from
 			// every source, with no exception and no downgrade.
-			for _, k := range plan.Bundle.Keys {
+			for _, k := range plan.Bundle.WireBundle().Keys {
 				if k.Classification != string(schema.Secret) {
 					t.Errorf("%s declared %s; every imported key defaults secret", k.Name, k.Classification)
 				}
@@ -565,7 +565,7 @@ func scenarioImportPerSourceE2E(t *testing.T, db *store.DB) {
 			// definitions revision: applying the bundle bumps that revision, so
 			// a run that silently re-planned in between would pass here while
 			// the product's documented flow failed.
-			for _, k := range plan.Bundle.Keys {
+			for _, k := range plan.Bundle.WireBundle().Keys {
 				mustKey(t, keys, actor, scope, k.Name, k.Classification, schema.DefaultPresenceRules())
 			}
 			imported, err := values.Import(t.Context(), actor, prod, importRequestFrom(plan))
@@ -620,9 +620,9 @@ func scenarioMultiEnvImportE2E(t *testing.T, db *store.DB) {
 	wantKeys := []string{"API_KEY", "DB_HOST", "DB_PASSWORD", "DB_PORT"}
 
 	plan := mustProjectPlan(t, "k8s", result, values, actor, scope, raw, staging, prod)
-	if len(plan.Bundle.Keys) != len(wantKeys) {
+	if len(plan.Bundle.WireBundle().Keys) != len(wantKeys) {
 		t.Fatalf("bundle declares %d keys, want ONE project-wide declaration per key (%d)",
-			len(plan.Bundle.Keys), len(wantKeys))
+			len(plan.Bundle.WireBundle().Keys), len(wantKeys))
 	}
 	if len(plan.Envs) != 2 || len(plan.Manifest.Target.Environments) != 2 {
 		t.Fatalf("plan does not span both environments: envs=%d manifest=%v",
@@ -631,7 +631,7 @@ func scenarioMultiEnvImportE2E(t *testing.T, db *store.DB) {
 
 	// Apply the one bundle by hand (definitions plan|apply is #70), then import
 	// each environment's values file against the original manifest.
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		mustKey(t, keys, actor, scope, k.Name, k.Classification, schema.DefaultPresenceRules())
 	}
 	for _, env := range []domain.Scope{staging, prod} {
@@ -724,8 +724,8 @@ func scenarioImportUndeclaredTransition(t *testing.T, db *store.DB) {
 		Folder: []string{"source"}, SourceName: "NEW_KEY", Value: "value", Type: schema.TypeString,
 	}}}
 	plan := mustPlan(t, "k8s", result, values, actor, scope, prod, []byte("fixture"), "")
-	if len(plan.Bundle.Keys) != 1 {
-		t.Fatalf("phase 1 emitted %d bundle keys, want one", len(plan.Bundle.Keys))
+	if len(plan.Bundle.WireBundle().Keys) != 1 {
+		t.Fatalf("phase 1 emitted %d bundle keys, want one", len(plan.Bundle.WireBundle().Keys))
 	}
 	created := mustKey(t, keys, actor, scope, "NEW_KEY", string(schema.Secret), schema.DefaultPresenceRules())
 	if _, _, err := keys.Reclassify(t.Context(), actor, scope, created.ID, string(schema.Config)); err != nil {

--- a/internal/definitions/bundle.go
+++ b/internal/definitions/bundle.go
@@ -14,6 +14,7 @@
 package definitions
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/Hikyo-Org/hikyo/internal/domain"
@@ -76,8 +77,10 @@ type Key struct {
 	ForbiddenIn     Presence           `json:"forbidden_in"`
 }
 
-// Bundle is the canonical definitions bundle. BaseRevision is a pointer so its
-// absence — which makes the bundle *additive* (ADR § Additive bundles) — is
+// Bundle is the mutable definitions wire/import DTO. Construct it only at an
+// import or test boundary, then immediately pass it to Canonicalize. Application
+// paths encode CanonicalBundle instead. BaseRevision is a pointer so its absence
+// — which makes the bundle *additive* (ADR § Additive bundles) — is
 // distinguishable from a zero base revision.
 type Bundle struct {
 	FormatVersion int           `json:"format_version"`
@@ -85,6 +88,38 @@ type Bundle struct {
 	Environments  []Environment `json:"environments"`
 	KeyGroups     []KeyGroup    `json:"key_groups"`
 	Keys          []Key         `json:"keys"`
+}
+
+// CanonicalBundle is a validated, normalized bundle snapshot. Its fields stay
+// private so only Parse and Canonicalize can create an encodable value.
+// WireBundle returns a detached copy for review and for non-encoding domain
+// operations; mutating that copy cannot alter this canonical snapshot.
+type CanonicalBundle struct {
+	encoded  []byte
+	additive bool
+	valid    bool
+}
+
+// WireBundle returns a detached copy of the canonical wire model.
+func (b CanonicalBundle) WireBundle() Bundle {
+	b.requireValid()
+	var out Bundle
+	if err := json.Unmarshal(b.encoded, &out); err != nil {
+		panic(fmt.Sprintf("definitions: corrupt canonical bundle invariant: %v", err))
+	}
+	return out
+}
+
+// Additive reports whether the canonical bundle has no base revision.
+func (b CanonicalBundle) Additive() bool {
+	b.requireValid()
+	return b.additive
+}
+
+func (b CanonicalBundle) requireValid() {
+	if !b.valid {
+		panic("definitions: canonical bundle was not produced by Parse or Canonicalize")
+	}
 }
 
 // Additive reports whether the bundle carries no base revision, in which case

--- a/internal/definitions/bundle_test.go
+++ b/internal/definitions/bundle_test.go
@@ -47,9 +47,9 @@ func sampleBundle() Bundle {
 }
 
 func TestEncodeParseRoundTrip(t *testing.T) {
-	norm, err := Normalize(sampleBundle())
+	norm, err := Canonicalize(sampleBundle())
 	if err != nil {
-		t.Fatalf("normalize: %v", err)
+		t.Fatalf("canonicalize: %v", err)
 	}
 	canonical, err := Encode(norm)
 	if err != nil {
@@ -77,8 +77,8 @@ func TestEncodeParseRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if !reflect.DeepEqual(parsed, norm) {
-		t.Fatalf("Parse(Encode(b)) != b\n got: %+v\nwant: %+v", parsed, norm)
+	if !reflect.DeepEqual(parsed.WireBundle(), norm.WireBundle()) {
+		t.Fatalf("Parse(Encode(b)) != b\n got: %+v\nwant: %+v", parsed.WireBundle(), norm.WireBundle())
 	}
 	reEncoded, err := Encode(parsed)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestEncodeParseRoundTrip(t *testing.T) {
 }
 
 func TestParseCompiledCarriesClassifiedDeclarations(t *testing.T) {
-	norm := mustNormalize(t, sampleBundle())
+	norm := mustCanonicalize(t, sampleBundle())
 	raw, err := Encode(norm)
 	if err != nil {
 		t.Fatal(err)
@@ -99,8 +99,8 @@ func TestParseCompiledCarriesClassifiedDeclarations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(parsed.Bundle, norm) {
-		t.Fatalf("ParseCompiled bundle differs\n got: %+v\nwant: %+v", parsed.Bundle, norm)
+	if !reflect.DeepEqual(parsed.WireBundle(), norm.WireBundle()) {
+		t.Fatalf("ParseCompiled bundle differs\n got: %+v\nwant: %+v", parsed.WireBundle(), norm.WireBundle())
 	}
 	compiled, ok := parsed.CompiledDeclaration("DB_URL")
 	if !ok {
@@ -115,7 +115,7 @@ func TestParseCompiledCarriesClassifiedDeclarations(t *testing.T) {
 }
 
 func TestDigestStableOverCanonical(t *testing.T) {
-	norm, _ := Normalize(sampleBundle())
+	norm, _ := Canonicalize(sampleBundle())
 	d1, err := Digest(norm)
 	if err != nil {
 		t.Fatal(err)
@@ -155,14 +155,124 @@ func TestParseBaseFieldRejectedByName(t *testing.T) {
 func TestParseIDsWithoutBaseRejected(t *testing.T) {
 	b := sampleBundle()
 	b.BaseRevision = nil // ids remain
-	canonical, err := Encode(mustNormalize(t, b))
+	_, err := Canonicalize(b)
+	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "ids without base revision") {
+		t.Fatalf("ids-without-base canonicalization must be rejected: %v", err)
+	}
+}
+
+func TestCanonicalizeRunsEveryPreEncodeBundleValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Bundle)
+		want error
+	}{
+		{
+			name: "wrong format version",
+			edit: func(b *Bundle) { b.FormatVersion = FormatVersion + 1 },
+			want: domain.ErrInvalid,
+		},
+		{
+			name: "too many entries",
+			edit: func(b *Bundle) {
+				b.Environments = make([]Environment, MaxBundleEntries+1)
+			},
+			want: domain.ErrLimitExceeded,
+		},
+		{
+			name: "canonical bytes exceed parse limit",
+			edit: func(b *Bundle) {
+				b.Keys[0].Description = strings.Repeat("x", MaxBundleBytes)
+			},
+			want: domain.ErrLimitExceeded,
+		},
+		{
+			name: "invalid classification",
+			edit: func(b *Bundle) { b.Keys[0].Classification = "public" },
+			want: domain.ErrInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := sampleBundle()
+			tt.edit(&b)
+			_, err := Canonicalize(b)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Canonicalize error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalBundleReturnsDetachedModel(t *testing.T) {
+	bundle := mustCanonicalize(t, sampleBundle())
+	want, err := Encode(bundle)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Parse(canonical)
-	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "ids without base revision") {
-		t.Fatalf("ids-without-base must be rejected: %v", err)
+
+	detached := bundle.WireBundle()
+	detached.Keys[0].Name = "MUTATED"
+	detached.Keys[0].Declaration.Rule.Type = schema.TypeInteger
+	got, err := Encode(bundle)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutating Bundle() copy changed canonical bytes\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestCanonicalBundleZeroValueRejected(t *testing.T) {
+	zero := CanonicalBundle{}
+	if _, err := Encode(zero); !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("Encode zero CanonicalBundle error = %v, want ErrInvalid", err)
+	}
+	for _, tt := range []struct {
+		name string
+		call func()
+	}{
+		{name: "WireBundle", call: func() { zero.WireBundle() }},
+		{name: "Additive", call: func() { zero.Additive() }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			panicked := false
+			func() {
+				defer func() { panicked = recover() != nil }()
+				tt.call()
+			}()
+			if !panicked {
+				t.Fatalf("%s accepted zero CanonicalBundle", tt.name)
+			}
+		})
+	}
+}
+
+func FuzzCanonicalBundleRoundTrip(f *testing.F) {
+	seed, err := Encode(mustCanonicalize(f, sampleBundle()))
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		first, err := Parse(raw)
+		if err != nil {
+			return
+		}
+		encoded, err := Encode(first)
+		if err != nil {
+			t.Fatalf("Encode(Parse(raw)): %v", err)
+		}
+		second, err := Parse(encoded)
+		if err != nil {
+			t.Fatalf("Parse(Encode(Parse(raw))): %v\n%s", err, encoded)
+		}
+		if !reflect.DeepEqual(second.WireBundle(), first.WireBundle()) {
+			t.Fatalf("canonical model changed across round trip\n got: %+v\nwant: %+v", second.WireBundle(), first.WireBundle())
+		}
+	})
 }
 
 func TestParseDuplicateMemberRejected(t *testing.T) {
@@ -187,22 +297,18 @@ func TestParseRefusesNestedLiteralOnSecretKey(t *testing.T) {
 		Type:       schema.TypeJSON,
 		JSONSchema: []byte(`{"properties":{"password":{"const":"live-value"}}}`),
 	}}
-	raw, err := Encode(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = Parse(raw)
+	_, err := Canonicalize(b)
 	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "DB_URL") ||
 		!strings.Contains(err.Error(), "use `pattern`, or declassify the key") {
-		t.Fatalf("secret literal parse refusal = %v", err)
+		t.Fatalf("secret literal canonicalization refusal = %v", err)
 	}
 }
 
-func mustNormalize(t *testing.T, b Bundle) Bundle {
+func mustCanonicalize(t testing.TB, b Bundle) CanonicalBundle {
 	t.Helper()
-	n, err := Normalize(b)
+	n, err := Canonicalize(b)
 	if err != nil {
-		t.Fatalf("normalize: %v", err)
+		t.Fatalf("canonicalize: %v", err)
 	}
 	return n
 }

--- a/internal/definitions/encode.go
+++ b/internal/definitions/encode.go
@@ -8,18 +8,19 @@ import (
 	"fmt"
 )
 
-// Encode renders a normalized bundle canonically: sorted object keys at every
+// Encode renders a validated canonical bundle: sorted object keys at every
 // depth (including any JSON Schema document embedded in a declaration),
 // two-space indentation, HTML escaping off, and exactly one trailing newline.
 // Byte-stability is what makes the digest a meaningful apply pin and a PR diff
 // legible.
 //
-// Encode assumes its input is normalized — Parse is the sole producer of a
-// normalized bundle, so `Encode(Parse(bytes)) == canonical(bytes)` and
-// `Parse(Encode(b)) == b`. A bundle built by hand (the importer, a test) must
-// pass through Normalize first.
-func Encode(b Bundle) ([]byte, error) {
-	return canonicalize(b)
+// Parse and Canonicalize are the only producers of an encodable bundle, so
+// every successful result parses back to the same canonical model.
+func Encode(b CanonicalBundle) ([]byte, error) {
+	if !b.valid {
+		return nil, invalidDetail("canonical bundle was not produced by Parse or Canonicalize")
+	}
+	return bytes.Clone(b.encoded), nil
 }
 
 // canonicalize serializes any value with sorted keys and stable integers. The
@@ -67,7 +68,7 @@ func marshalNoEscape(v any) ([]byte, error) {
 // whitespace-only edit does not move the apply pin while any content change
 // does. (This deliberately differs from internal/importer.Digest, whose
 // "sha256:"-prefixed form is a template-reference spelling.)
-func Digest(b Bundle) (string, error) {
+func Digest(b CanonicalBundle) (string, error) {
 	canonical, err := Encode(b)
 	if err != nil {
 		return "", err

--- a/internal/definitions/parse.go
+++ b/internal/definitions/parse.go
@@ -14,21 +14,28 @@ import (
 // before it can drive any work. A parsed bundle is normalized (entries sorted by
 // name, declarations in schema-canonical form, presence lists sorted), so it is
 // the sole producer of the canonical form Encode assumes.
-func Parse(raw []byte) (Bundle, error) {
+func Parse(raw []byte) (CanonicalBundle, error) {
 	parsed, err := ParseCompiled(raw)
 	if err != nil {
-		return Bundle{}, err
+		return CanonicalBundle{}, err
 	}
-	return parsed.Bundle, nil
+	return parsed.Canonical(), nil
 }
 
 // CompiledBundle keeps parsed wire data separate from the classified
 // declaration artifacts built from it. Apply paths consume both so a
 // declaration is not compiled again after parsing.
 type CompiledBundle struct {
-	Bundle       Bundle
+	canonical    CanonicalBundle
 	declarations map[string]*schema.Compiled
 }
+
+// Canonical returns the validated canonical bundle retained with the compiled
+// declaration artifacts.
+func (b CompiledBundle) Canonical() CanonicalBundle { return b.canonical }
+
+// WireBundle returns a detached wire-model copy of the canonical bundle.
+func (b CompiledBundle) WireBundle() Bundle { return b.canonical.WireBundle() }
 
 // CompiledDeclaration returns the artifact for a normalized key name.
 func (b CompiledBundle) CompiledDeclaration(keyName string) (*schema.Compiled, bool) {
@@ -48,21 +55,11 @@ func ParseCompiled(raw []byte) (CompiledBundle, error) {
 		return CompiledBundle{}, mapDecodeError(err)
 	}
 
-	if b.FormatVersion != FormatVersion {
-		return CompiledBundle{}, invalidDetail(
-			"bundle format_version %d is not this build's %d: version mismatch", b.FormatVersion, FormatVersion)
+	if err := validateBundle(b); err != nil {
+		return CompiledBundle{}, err
 	}
 
-	entries := len(b.Keys) + len(b.Environments) + len(b.KeyGroups)
-	if entries > MaxBundleEntries {
-		return CompiledBundle{}, limitDetail("bundle holds %d entries, over the %d entry limit", entries, MaxBundleEntries)
-	}
-
-	if b.Additive() && hasIDs(b) {
-		return CompiledBundle{}, invalidDetail("malformed template: ids without base revision")
-	}
-
-	return normalizeCompiled(b)
+	return compileCanonical(b)
 }
 
 // mapDecodeError translates the neutral strict-decode errors into caller-safe
@@ -108,17 +105,35 @@ func hasIDs(b Bundle) bool {
 	return false
 }
 
-// Normalize sorts and canonicalizes a bundle. Import and tests that build a
-// bundle by hand call it before Encode; Parse calls it on decode.
-func Normalize(b Bundle) (Bundle, error) {
-	compiled, err := normalizeCompiled(b)
-	if err != nil {
-		return Bundle{}, err
+// Canonicalize validates, sorts, and canonicalizes a raw wire-model bundle.
+// Import and test boundaries use it immediately after constructing Bundle.
+func Canonicalize(b Bundle) (CanonicalBundle, error) {
+	if err := validateBundle(b); err != nil {
+		return CanonicalBundle{}, err
 	}
-	return compiled.Bundle, nil
+	compiled, err := compileCanonical(b)
+	if err != nil {
+		return CanonicalBundle{}, err
+	}
+	return compiled.Canonical(), nil
 }
 
-func normalizeCompiled(b Bundle) (CompiledBundle, error) {
+func validateBundle(b Bundle) error {
+	if b.FormatVersion != FormatVersion {
+		return invalidDetail(
+			"bundle format_version %d is not this build's %d: version mismatch", b.FormatVersion, FormatVersion)
+	}
+	entries := len(b.Keys) + len(b.Environments) + len(b.KeyGroups)
+	if entries > MaxBundleEntries {
+		return limitDetail("bundle holds %d entries, over the %d entry limit", entries, MaxBundleEntries)
+	}
+	if b.Additive() && hasIDs(b) {
+		return invalidDetail("malformed template: ids without base revision")
+	}
+	return nil
+}
+
+func compileCanonical(b Bundle) (CompiledBundle, error) {
 	out := Bundle{
 		FormatVersion: FormatVersion,
 		BaseRevision:  b.BaseRevision,
@@ -163,7 +178,15 @@ func normalizeCompiled(b Bundle) (CompiledBundle, error) {
 		out.Keys[i] = k
 		declarations[k.Name] = compiled
 	}
-	return CompiledBundle{Bundle: out, declarations: declarations}, nil
+	encoded, err := canonicalize(out)
+	if err != nil {
+		return CompiledBundle{}, err
+	}
+	if len(encoded) > MaxBundleBytes {
+		return CompiledBundle{}, limitDetail("bundle is %d bytes, over the %d byte limit", len(encoded), MaxBundleBytes)
+	}
+	canonical := CanonicalBundle{encoded: encoded, additive: out.Additive(), valid: true}
+	return CompiledBundle{canonical: canonical, declarations: declarations}, nil
 }
 
 // normalizePresence validates a bundle presence rule's mode/shape and returns

--- a/internal/definitions/resolve_test.go
+++ b/internal/definitions/resolve_test.go
@@ -36,7 +36,7 @@ func TestResolveIDFirstThenBareCreate(t *testing.T) {
 		Environments: []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("id-1", "B", "config"), bKey("", "A", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	res, err := Resolve(b, cur)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +62,7 @@ func TestResolveSwapRename(t *testing.T) {
 		Environments: []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("id-a", "B", "config"), bKey("id-b", "A", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	res, err := Resolve(b, cur)
 	if err != nil {
 		t.Fatalf("swap must resolve: %v", err)
@@ -79,7 +79,7 @@ func TestResolveStaleIDIsHardError(t *testing.T) {
 		Environments: []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("id-ghost", "A", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	_, err := Resolve(b, cur)
 	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "stale file") {
 		t.Fatalf("stale id must be a hard error: %v", err)
@@ -95,7 +95,7 @@ func TestResolveDuplicateFinalNameNamesBoth(t *testing.T) {
 		Environments: []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("id-1", "SAME", "config"), bKey("id-2", "SAME", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	_, err := Resolve(b, cur)
 	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "SAME") {
 		t.Fatalf("duplicate final name must name it: %v", err)
@@ -113,7 +113,7 @@ func TestResolvePortableMatchesByName(t *testing.T) {
 		Environments:  []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("", "A", "config"), bKey("", "B", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	res, err := Resolve(b, cur)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +133,7 @@ func TestResolveAdditiveModificationRefused(t *testing.T) {
 	mod := bKey("", "A", "config")
 	mod.Declaration = schema.Declaration{Rule: &schema.Rule{Type: schema.TypeInteger}}
 	b := Bundle{FormatVersion: FormatVersion, Environments: []Environment{}, KeyGroups: []KeyGroup{}, Keys: []Key{mod}}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	_, err := Resolve(b, cur)
 	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "additive bundle may not modify") {
 		t.Fatalf("additive modification must be refused naming the key: %v", err)
@@ -149,7 +149,7 @@ func TestResolveDeletionByAbsence(t *testing.T) {
 		Environments: []Environment{}, KeyGroups: []KeyGroup{},
 		Keys: []Key{bKey("id-1", "KEEP", "config")},
 	}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	res, err := Resolve(b, cur)
 	if err != nil {
 		t.Fatal(err)
@@ -171,7 +171,7 @@ func TestResolveRevealOnSecretRuleChange(t *testing.T) {
 	changed := bKey("id-1", "TOKEN", "secret")
 	changed.Declaration = schema.Declaration{Rule: &schema.Rule{Type: schema.TypeInteger}}
 	b := Bundle{FormatVersion: FormatVersion, BaseRevision: rev(2), Environments: []Environment{}, KeyGroups: []KeyGroup{}, Keys: []Key{changed}}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	res, err := Resolve(b, cur)
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func TestResolveDanglingPresenceRejected(t *testing.T) {
 	k := bKey("", "A", "config")
 	k.RequiredIn = Presence{Mode: "explicit", Environments: []string{"ghost"}}
 	b := Bundle{FormatVersion: FormatVersion, Environments: []Environment{}, KeyGroups: []KeyGroup{}, Keys: []Key{k}}
-	b, _ = Normalize(b)
+	b = mustCanonicalize(t, b).WireBundle()
 	_, err := Resolve(b, cur)
 	if !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "ghost") {
 		t.Fatalf("dangling presence env must be rejected naming it: %v", err)
@@ -197,8 +197,7 @@ func TestClassifyDrift(t *testing.T) {
 	cur := CurrentState{SchemaRevision: 10, Keys: []CurrentKey{curKey("id-1", "A", "config")}}
 	equalBundle := func(base int64, keys ...Key) Bundle {
 		b := Bundle{FormatVersion: FormatVersion, BaseRevision: rev(base), Environments: []Environment{}, KeyGroups: []KeyGroup{}, Keys: keys}
-		b, _ = Normalize(b)
-		return b
+		return mustCanonicalize(t, b).WireBundle()
 	}
 	cases := []struct {
 		name string

--- a/internal/importer/plan.go
+++ b/internal/importer/plan.go
@@ -92,7 +92,7 @@ type PlanInput struct {
 type Plan struct {
 	Template Template
 	Manifest Manifest
-	Bundle   definitions.Bundle
+	Bundle   definitions.CanonicalBundle
 	Values   ValuesFile
 
 	// Renames is every source-name → target-name mapping. Nothing is renamed
@@ -326,7 +326,7 @@ type EnvPlan struct {
 type ProjectPlan struct {
 	Template Template
 	Manifest Manifest
-	Bundle   definitions.Bundle
+	Bundle   definitions.CanonicalBundle
 	Envs     []EnvPlan
 
 	Renames         []Rename
@@ -447,7 +447,7 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 		Renames:         renames,
 		PlaintextHints:  plaintextHints,
 	}
-	plan.Bundle = definitions.Bundle{
+	bundle := definitions.Bundle{
 		FormatVersion: definitions.FormatVersion,
 		Environments:  []definitions.Environment{},
 		KeyGroups:     []definitions.KeyGroup{},
@@ -462,7 +462,7 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 			plan.AlreadyDeclared = append(plan.AlreadyDeclared, target)
 		} else {
 			rule := schema.Rule{Type: d.declType}
-			plan.Bundle.Keys = append(plan.Bundle.Keys, definitions.Key{
+			bundle.Keys = append(bundle.Keys, definitions.Key{
 				Name:           target,
 				FolderPath:     d.folder,
 				Classification: d.class,
@@ -552,11 +552,11 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 	}
 	slices.Sort(created)
 	for _, name := range created {
-		plan.Bundle.Environments = append(plan.Bundle.Environments, definitions.Environment{Name: name})
+		bundle.Environments = append(bundle.Environments, definitions.Environment{Name: name})
 	}
-	plan.Bundle, err = definitions.Normalize(plan.Bundle)
+	plan.Bundle, err = definitions.Canonicalize(bundle)
 	if err != nil {
-		return nil, fmt.Errorf("import: normalizing definitions bundle: %w", err)
+		return nil, fmt.Errorf("import: canonicalizing definitions bundle: %w", err)
 	}
 	return plan, nil
 }

--- a/internal/importer/plan_test.go
+++ b/internal/importer/plan_test.go
@@ -171,8 +171,8 @@ func TestProjectPlanFansOutAcrossEnvironments(t *testing.T) {
 
 	// One project-wide bundle: the three undeclared keys declared once each;
 	// DB_PASSWORD is already declared in both environments and not re-declared.
-	if len(plan.Bundle.Keys) != 3 {
-		t.Fatalf("bundle keys = %d, want one project-wide declaration per undeclared key", len(plan.Bundle.Keys))
+	if len(plan.Bundle.WireBundle().Keys) != 3 {
+		t.Fatalf("bundle keys = %d, want one project-wide declaration per undeclared key", len(plan.Bundle.WireBundle().Keys))
 	}
 	if strings.Join(plan.AlreadyDeclared, ",") != "DB_PASSWORD" {
 		t.Errorf("already declared = %v, want DB_PASSWORD once project-wide", plan.AlreadyDeclared)
@@ -360,7 +360,7 @@ func TestEveryImportedKeyDefaultsSecret(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.Classification != string(schema.Secret) {
 			t.Errorf("%s declared %s; every imported key defaults secret", k.Name, k.Classification)
 		}
@@ -388,10 +388,11 @@ func TestBundleIsCanonicalAdditiveAndApplicable(t *testing.T) {
 		t.Fatalf("canonical definitions bundle carries importer project field:\n%s", raw)
 	}
 
-	bundle, err := definitions.Parse(raw)
+	canonical, err := definitions.Parse(raw)
 	if err != nil {
 		t.Fatalf("importer bundle does not parse through definitions.Parse: %v\n%s", err, raw)
 	}
+	bundle := canonical.WireBundle()
 	if !bundle.Additive() || len(bundle.Environments) != 0 || len(bundle.KeyGroups) != 0 {
 		t.Fatalf("bundle is not project-wide additive: %+v", bundle)
 	}
@@ -426,7 +427,7 @@ func TestTemplateDowngradeAndTypesAreRecorded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.Name != "DB_PORT" {
 			continue
 		}
@@ -530,7 +531,7 @@ func TestIncompatibleExistingDeclarationIsRefusedByName(t *testing.T) {
 	if strings.Join(plan.AlreadyDeclared, ",") != "ALPHA" {
 		t.Errorf("already-declared = %v", plan.AlreadyDeclared)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.Name == "ALPHA" {
 			t.Error("an already-declared key was re-declared")
 		}
@@ -605,7 +606,7 @@ func TestRootCollapseIsTheK8sProvisionOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.FolderPath != "only" {
 			t.Errorf("%s landed at %q; a SOPS map level is folder structure the source stated", k.Name, k.FolderPath)
 		}
@@ -625,7 +626,7 @@ func TestTemplateFolderChoicesAreHonouredOnReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := map[string]string{}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		got[k.Name] = k.FolderPath
 	}
 	if got["DB_HOST"] != "databases/primary" || got["API_KEY"] != "services/api" {
@@ -746,7 +747,7 @@ func TestSingleSecretMayTargetTheEnvironmentRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.FolderPath != "" {
 			t.Errorf("%s landed in folder %q; a single-Secret import targets the root", k.Name, k.FolderPath)
 		}
@@ -756,7 +757,7 @@ func TestSingleSecretMayTargetTheEnvironmentRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	seen := map[string]string{}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		seen[k.Name] = k.FolderPath
 	}
 	if seen["API_KEY"] != "app-api" || seen["DB_HOST"] != "app-db" {
@@ -771,7 +772,7 @@ func TestExistingDeclarationIsNotRedeclared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range plan.Bundle.Keys {
+	for _, k := range plan.Bundle.WireBundle().Keys {
 		if k.Name == "ALPHA" {
 			t.Error("an already-declared key was re-declared; an additive bundle may not modify one")
 		}

--- a/internal/importer/wizard_test.go
+++ b/internal/importer/wizard_test.go
@@ -247,13 +247,13 @@ func TestWizardCreatesEnvironment(t *testing.T) {
 
 	// The bundle carries the create-environment line.
 	foundEnv := false
-	for _, e := range wiz.Bundle.Environments {
+	for _, e := range wiz.Bundle.WireBundle().Environments {
 		if e.Name == "staging" {
 			foundEnv = true
 		}
 	}
 	if !foundEnv {
-		t.Errorf("bundle environments = %+v, want a `staging` create line", wiz.Bundle.Environments)
+		t.Errorf("bundle environments = %+v, want a `staging` create line", wiz.Bundle.WireBundle().Environments)
 	}
 
 	// The manifest names it under created_environments, with no occurrence rows.

--- a/internal/isolation/definitions_e2e_test.go
+++ b/internal/isolation/definitions_e2e_test.go
@@ -1,6 +1,7 @@
 package isolation
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -88,7 +89,11 @@ func definitionsRoundTrip(t *testing.T, db *store.DB) {
 	svc := definitionsService(t, db)
 	raw := exportDefinitions(t, svc, f)
 	bundle := parseDefinitions(t, raw)
-	digest, err := definitions.Digest(bundle)
+	canonical, err := definitions.Canonicalize(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := definitions.Digest(canonical)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +483,7 @@ func definitionsSecretDeclarationBoundary(t *testing.T, db *store.DB) {
 		bundle := parseDefinitions(t, exportDefinitions(t, svc, f))
 		bundle.Keys[0].Declaration = schema.Declaration{Rule: &schema.Rule{Type: schema.TypeJSON,
 			JSONSchema: []byte(`{"properties":{"nested":{"const":"live-value"}}}`)}}
-		raw, err := definitions.Encode(bundle)
+		raw, err := json.Marshal(bundle)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -684,16 +689,16 @@ func parseDefinitions(t *testing.T, raw []byte) definitions.Bundle {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return bundle
+	return bundle.WireBundle()
 }
 
 func encodeDefinitions(t *testing.T, bundle definitions.Bundle) []byte {
 	t.Helper()
-	normalized, err := definitions.Normalize(bundle)
+	canonical, err := definitions.Canonicalize(bundle)
 	if err != nil {
 		t.Fatal(err)
 	}
-	raw, err := definitions.Encode(normalized)
+	raw, err := definitions.Encode(canonical)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -180,8 +180,7 @@ func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scop
 		if err != nil {
 			return err
 		}
-		bundle := bundleFromState(cur, !portable)
-		bundle, err = definitions.Normalize(bundle)
+		bundle, err := definitions.Canonicalize(bundleFromState(cur, !portable))
 		if err != nil {
 			return err
 		}
@@ -213,10 +212,11 @@ func (s *Definitions) Check(ctx context.Context, actor Actor, scope domain.Scope
 		if err != nil {
 			return err
 		}
-		bundle, err := definitions.Parse(raw)
+		canonical, err := definitions.Parse(raw)
 		if err != nil {
 			return err
 		}
+		bundle := canonical.WireBundle()
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)
 		if err != nil {
 			return err

--- a/internal/service/definitions_apply.go
+++ b/internal/service/definitions_apply.go
@@ -82,10 +82,11 @@ func (s *Definitions) Plan(ctx context.Context, actor Actor, scope domain.Scope,
 		if err := r.Projects().Lock(ctx, p); err != nil {
 			return err
 		}
-		bundle, err := definitions.Parse(raw)
+		canonical, err := definitions.Parse(raw)
 		if err != nil {
 			return err
 		}
+		bundle := canonical.WireBundle()
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)
 		if err != nil {
 			return err
@@ -135,7 +136,7 @@ func (s *Definitions) Plan(ctx context.Context, actor Actor, scope domain.Scope,
 			return fmt.Errorf("%w: project already holds %d open definitions plans (max %d)",
 				domain.ErrLimitExceeded, open, MaxOpenPlansPerProject)
 		}
-		view, err = s.persistPlan(ctx, r, az, caller, p, scope, bundle, cur, res)
+		view, err = s.persistPlan(ctx, r, az, caller, p, scope, canonical, cur, res)
 		return err
 	})
 	return view, err
@@ -223,7 +224,7 @@ func definitionLimit(format string, args ...any) error {
 // persistPlan enriches the diff with live-occurrence impact, computes the pins,
 // writes the plan row, and audits it.
 func (s *Definitions) persistPlan(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity,
-	p authz.Proof, scope domain.Scope, bundle definitions.Bundle, cur definitions.CurrentState,
+	p authz.Proof, scope domain.Scope, bundle definitions.CanonicalBundle, cur definitions.CurrentState,
 	res definitions.Resolution) (PlanView, error) {
 	now := s.now()
 	envNameByID := make(map[string]string, len(cur.Environments))
@@ -327,7 +328,7 @@ func (s *Definitions) persistPlan(ctx context.Context, r store.Repos, az *authz.
 	}
 
 	return PlanView{
-		ID: planID, Digest: digest, BaseRevision: bundle.BaseRevision, CurrentRevision: cur.SchemaRevision,
+		ID: planID, Digest: digest, BaseRevision: bundle.WireBundle().BaseRevision, CurrentRevision: cur.SchemaRevision,
 		Additive: bundle.Additive(), ExpiresAt: now.Add(PlanTTL),
 		ProtectedEnvironments: protectedPinNames(protectedSet),
 		Diff:                  planDiff, DeletionsPresent: res.DeletionsPresent(), RevealRequired: res.RevealKeys,

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -87,13 +87,14 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 		} else {
 			compiledBundle = *precompiled
 		}
-		bundle := compiledBundle.Bundle
+		canonical := compiledBundle.Canonical()
+		bundle := canonical.WireBundle()
 		cur, err := buildCurrentState(ctx, r.Catalogue(), r.Environments(), p)
 		if err != nil {
 			return err
 		}
 
-		if err := s.recheckPins(ctx, r, az, caller, p, scope, plan, bundle, cur, opts); err != nil {
+		if err := s.recheckPins(ctx, r, az, caller, p, scope, plan, canonical, cur, opts); err != nil {
 			return err
 		}
 
@@ -230,7 +231,7 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 		if plan.ScanSnapshot == s.Scan.SnapshotVersion() {
 			return nil // no skew: a same-version apply adds no second scan
 		}
-		res, err := scanDeclaration(ctx, s.Keyring, s.Scan, bundleLeaves(parsed.Bundle), newAckSet(acks), s.now(), ingressApply)
+		res, err := scanDeclaration(ctx, s.Keyring, s.Scan, bundleLeaves(parsed.WireBundle()), newAckSet(acks), s.now(), ingressApply)
 		if err != nil {
 			return err
 		}
@@ -257,7 +258,7 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 // since the plan (#70, ADR § Plan and apply). Each refusal names what moved and
 // records the rollback-surviving apply_rejected_stale event.
 func (s *Definitions) recheckPins(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity,
-	p authz.Proof, scope domain.Scope, plan store.DefinitionsPlan, bundle definitions.Bundle, cur definitions.CurrentState, opts ApplyOptions) error {
+	p authz.Proof, scope domain.Scope, plan store.DefinitionsPlan, bundle definitions.CanonicalBundle, cur definitions.CurrentState, opts ApplyOptions) error {
 	moved := func(what string) error {
 		ev, evErr := newAuditEvent(ctx, audit.EventDefinitionsApplyRejectedStale, caller.Principal,
 			audit.Object{Type: "definitions-plan", ID: plan.ID}, audit.OutcomeDenied, "",


### PR DESCRIPTION
# Handoff: #228 canonical definitions bundle

Issue: https://github.com/Hikyo-Org/Hikyo/issues/228 (parent #204; programme
#203; audit ID `BE11-A`). Implemented from `origin/main` at `6dff17c5`.

## Contract

- `definitions.Bundle` is the mutable wire/import DTO. Production encoders take
  only `CanonicalBundle`, whose state is private and whose zero value fails
  loudly.
- `Parse` and `Canonicalize` are the only canonical constructors. Both enforce
  format version, entry and encoded-byte limits, additive-ID rules,
  classification/declaration validity, presence rules, and deterministic
  ordering before a value becomes encodable. Strict parsing continues to reject
  unknown and duplicate members and trailing content.
- `Encode` and `Digest` accept only `CanonicalBundle`. Every successful encoded
  result therefore parses to the same canonical model and remains byte-stable.
- `WireBundle` returns a detached DTO for review, diffing, and scanning;
  mutating it cannot change the canonical snapshot.
- Import plans now carry the canonical type. Service export, plan persistence,
  apply pin checks, CLI scaffold/read paths, and all test/conformance callers
  canonicalize or parse before encoding.
- External bundle JSON and digest spelling are unchanged. Generated outputs:
  none.

## Review

Two-axis review against repository standards and issue #228 found one initial
fail-loud gap: zero-value observation could look like an empty additive bundle.
Zero-value observers now panic, the detached accessor is explicitly named, and
the obsolete `Normalize` alias is removed. Round 2: `CLEAN` / `CLEAN`.

## Validation

```text
go test -count=1 ./internal/definitions/... ./internal/importer/... \
  ./internal/service/... ./internal/cli/... ./internal/conformance/...  649 passed
go test -run '^$' -fuzz '^FuzzCanonicalBundleRoundTrip$' \
  -fuzztime=10s ./internal/definitions                              passed
go test -count=1 ./...                                               3186 passed / 57 packages
go vet ./...                                                         passed
git diff --check                                                     clean
```
