### PR TITLE
refactor(service): index key-group validation (#227)

### DIFF
--- a/docs/handoff/227-group-index.md
+++ b/docs/handoff/227-group-index.md
@@ -1,0 +1,64 @@
+# #227 — Transaction-local key-group index
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/227 (parent #204; programme
+#203; audit ID `BE10-B`). Base: `origin/main` at `6dff17c5`.
+
+## Contract
+
+- `groupIndex` is an immutable transaction-local snapshot of catalogue keys,
+  key-group membership, and explicit environment-presence rows. Construction
+  scans each input row once and indexes keys by id, members by group, and
+  presence by key.
+- `validateStaticMembership` owns declaration-time required/forbidden conflicts.
+  `validateResolvedPublish` separately owns publish-time per-key presence,
+  value validation, and all-or-none `(group, environment)` closure.
+- Direct publish builds one full snapshot after selected-environment authority
+  is established, then shares it across closure, freshness detail, and every
+  affected environment materialization. Restore impact preview uses a
+  membership-only snapshot because its proof does not license presence reads.
+- Schema fan-out creates a fresh `groupIndexPhase` after the catalogue mutation.
+  The phase loads only after the first environment publish authorization and is
+  shared across the remaining materializations. Membership writes therefore
+  cannot reuse the pre-mutation static-validation snapshot.
+- Refusal order, public error text, group/key detail, token formats, database
+  schema, and generated output remain unchanged. No process cache exists.
+
+## Regression evidence
+
+- Static membership and resolved `(group, environment)` permutation tables.
+- Exact input-scan and catalogue-read count assertions.
+- Cross-engine conformance scenario: adding an absent member to a group whose
+  existing member is set is refused during same-transaction schema fan-out,
+  and the membership write rolls back; retry succeeds after both members are
+  set.
+- Existing selective-publish closure, cross-owner refusal, required-presence,
+  restore ceremony, and audit coverage remain green.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service/... -run 'Group|Publish|Key'
+                                                    23 passed
+go test -race -count=1 ./internal/service -run '^TestGroup'
+                                                    17 passed
+go test -count=1 ./internal/conformance -run
+  'TestConformanceSQLite/(key_groups_declaration_side|group_membership_rebuilds_publish_index|selective_publish_closes_over_key_groups|required_in_absent_vetoes_publish)'
+                                                     5 passed
+go test -count=1 ./internal/isolation/             1,090 passed
+go test -count=1 ./...                             3,193 passed / 57 packages
+go vet ./...                                       passed
+go build ./...                                     passed
+gofmt -l <changed Go files>                        clean
+git diff --cached --check                          passed
+```
+
+No `HIKYO_TEST_POSTGRES_DSN` was configured. The cross-engine conformance
+scenario is registered in the shared corpus and ran on the available SQLite
+path; PostgreSQL remained environment-skipped.
+
+## Review
+
+Round 1 found duplicate pre-mutation presence reads in `SetGroup`, silent
+broken-index fallbacks, two redundant key-map rebuilds, and retained raw
+presence rows. All were fixed. Round 2 returned `CLEAN` on both Standards and
+issue #227 Spec axes.

--- a/internal/conformance/catalogue_test.go
+++ b/internal/conformance/catalogue_test.go
@@ -764,6 +764,52 @@ func scenarioKeyGroups(t *testing.T, db *store.DB) {
 	}
 }
 
+// scenarioGroupMembershipRebuildsPublishIndex proves a membership write cannot
+// leave the transaction-local group snapshot stale. The second move makes an
+// already-set group partial in the same transaction; publish must see the new
+// member, refuse, and roll the membership back.
+func scenarioGroupMembershipRebuildsPublishIndex(t *testing.T, db *store.DB) {
+	keys := &service.Keys{DB: db, Keyring: sharedKeyring(t, db)}
+	groups := &service.KeyGroups{DB: db, Keyring: sharedKeyring(t, db)}
+	envs := &service.Environments{DB: db, Keyring: sharedKeyring(t, db)}
+	values := &service.Values{DB: db, Keyring: sharedKeyring(t, db)}
+	who, scope := tenantFixture(t, db, "group-index-rebuild")
+	actor := service.LocalPrincipal(who)
+
+	env, err := envs.Create(t.Context(), actor, scope, "prod", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envScope := scope
+	envScope.Env = domain.EnvID(env.ID)
+	group, err := groups.Create(t.Context(), actor, scope, "database", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user := mustKey(t, keys, actor, scope, "DB_USER", string(schema.Config), schema.DefaultPresenceRules())
+	password := mustKey(t, keys, actor, scope, "DB_PASSWORD", string(schema.Config), schema.DefaultPresenceRules())
+	publishValue(t, db, values, actor, envScope, user.Name, "app")
+
+	if _, err := keys.SetGroup(t.Context(), actor, scope, user.ID, group.ID); err != nil {
+		t.Fatalf("moving the set key into an inert group: %v", err)
+	}
+	if _, err := keys.SetGroup(t.Context(), actor, scope, password.ID, group.ID); !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("same-transaction membership snapshot missed a new absent member: %v", err)
+	}
+	afterRefusal, err := keys.Get(t.Context(), actor, scope, password.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterRefusal.GroupID != "" {
+		t.Fatalf("refused membership move committed group %q", afterRefusal.GroupID)
+	}
+
+	publishValue(t, db, values, actor, envScope, password.Name, "pw")
+	if _, err := keys.SetGroup(t.Context(), actor, scope, password.ID, group.ID); err != nil {
+		t.Fatalf("moving the now-set member into the group: %v", err)
+	}
+}
+
 // GateAttemptsPerMinuteForTest mirrors the service's allowance so the loops
 // above scale with it rather than with a number that can drift from it.
 const GateAttemptsPerMinuteForTest = service.GateAttemptsPerMinute

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -89,6 +89,7 @@ var corpus = []scenario{
 	{"secret_rule_change_needs_reveal", scenarioSecretRuleChangeNeedsReveal},
 	{"presence_rules_and_environment_cascade", scenarioPresenceRules},
 	{"key_groups_declaration_side", scenarioKeyGroups},
+	{"group_membership_rebuilds_publish_index", scenarioGroupMembershipRebuildsPublishIndex},
 	{"concurrent_writes_all_succeed", scenarioConcurrent},
 }
 

--- a/internal/service/group_index.go
+++ b/internal/service/group_index.go
@@ -1,0 +1,215 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+type groupIndexInputKind uint8
+
+const (
+	groupIndexCatalogueInput groupIndexInputKind = iota
+	groupIndexPresenceInput
+)
+
+type groupEnvironment struct {
+	groupID       string
+	environmentID string
+}
+
+// groupIndex is one immutable catalogue/presence snapshot. It belongs to one
+// transaction-local validation phase: callers rebuild it after catalogue or
+// membership writes instead of carrying a mutable cache across phases.
+type groupIndex struct {
+	keys           []store.CatalogueKey
+	keyByID        map[string]store.CatalogueKey
+	membersByGroup map[string][]store.CatalogueKey
+	presenceByKey  map[string]schema.PresenceRules
+}
+
+// groupIndexPhase loads one immutable snapshot lazily after the first
+// environment authorization, then shares it across that validation phase.
+// A catalogue mutation starts a new phase by constructing a new value.
+type groupIndexPhase struct {
+	index *groupIndex
+}
+
+func (p *groupIndexPhase) snapshot(ctx context.Context, catalogue store.CatalogueReader, proof authz.Proof) (*groupIndex, error) {
+	if p.index != nil {
+		return p.index, nil
+	}
+	index, err := loadGroupIndex(ctx, catalogue, proof)
+	if err != nil {
+		return nil, err
+	}
+	p.index = index
+	return index, nil
+}
+
+func newGroupIndex(keys []store.CatalogueKey, presence []store.KeyPresence) (*groupIndex, error) {
+	return buildGroupIndex(keys, presence, nil)
+}
+
+// buildGroupIndex has an observation seam only for the required linear-scan
+// invariant test. Production passes nil through newGroupIndex.
+func buildGroupIndex(keys []store.CatalogueKey, presence []store.KeyPresence, observed func(groupIndexInputKind)) (*groupIndex, error) {
+	index := &groupIndex{
+		keys:           slices.Clone(keys),
+		keyByID:        make(map[string]store.CatalogueKey, len(keys)),
+		membersByGroup: make(map[string][]store.CatalogueKey),
+		presenceByKey:  make(map[string]schema.PresenceRules, len(keys)),
+	}
+	for _, key := range index.keys {
+		if observed != nil {
+			observed(groupIndexCatalogueInput)
+		}
+		if _, exists := index.keyByID[key.ID]; exists {
+			return nil, fmt.Errorf("service: group index: duplicate catalogue key %s", key.ID)
+		}
+		index.keyByID[key.ID] = key
+		if key.GroupID != "" {
+			index.membersByGroup[key.GroupID] = append(index.membersByGroup[key.GroupID], key)
+		}
+		index.presenceByKey[key.ID] = schema.PresenceRules{
+			Required:  schema.Presence{Mode: schema.PresenceMode(key.RequiredMode)},
+			Forbidden: schema.Presence{Mode: schema.PresenceMode(key.ForbiddenMode)},
+		}
+	}
+	for _, row := range presence {
+		if observed != nil {
+			observed(groupIndexPresenceInput)
+		}
+		rules, exists := index.presenceByKey[row.KeyID]
+		if !exists {
+			return nil, fmt.Errorf("service: group index: presence row names unknown key %s", row.KeyID)
+		}
+		switch {
+		case row.Rule == store.PresenceRuleRequired && rules.Required.Mode == schema.PresenceExplicit:
+			rules.Required.Environments = append(rules.Required.Environments, row.EnvironmentID)
+		case row.Rule == store.PresenceRuleForbidden && rules.Forbidden.Mode == schema.PresenceExplicit:
+			rules.Forbidden.Environments = append(rules.Forbidden.Environments, row.EnvironmentID)
+		}
+		index.presenceByKey[row.KeyID] = rules
+	}
+	return index, nil
+}
+
+func loadGroupIndex(ctx context.Context, catalogue store.CatalogueReader, proof authz.Proof) (*groupIndex, error) {
+	keys, err := catalogue.List(ctx, proof)
+	if err != nil {
+		return nil, err
+	}
+	presence, err := catalogue.ListPresence(ctx, proof)
+	if err != nil {
+		return nil, err
+	}
+	return newGroupIndex(keys, presence)
+}
+
+// loadGroupMembershipIndex is for closure-only phases such as restore impact
+// preview. Those proofs can read catalogue membership but do not validate
+// environment presence; requiring ListPresence there would widen their store
+// operation set for data the phase never consumes.
+func loadGroupMembershipIndex(ctx context.Context, catalogue store.CatalogueReader, proof authz.Proof) (*groupIndex, error) {
+	keys, err := catalogue.List(ctx, proof)
+	if err != nil {
+		return nil, err
+	}
+	return newGroupIndex(keys, nil)
+}
+
+func (i *groupIndex) catalogueKeys() []store.CatalogueKey {
+	return i.keys
+}
+
+func (i *groupIndex) key(id string) (store.CatalogueKey, bool) {
+	key, ok := i.keyByID[id]
+	return key, ok
+}
+
+func (i *groupIndex) members(groupID string) []store.CatalogueKey {
+	return i.membersByGroup[groupID]
+}
+
+func (i *groupIndex) presenceFor(keyID string) (schema.PresenceRules, error) {
+	rules, exists := i.presenceByKey[keyID]
+	if !exists {
+		return schema.PresenceRules{}, fmt.Errorf("service: group index: key %s is not indexed", keyID)
+	}
+	return rules, nil
+}
+
+// validateStaticMembership is declaration-time authority for the statically
+// decidable required/forbidden conflict between members of one group.
+func (i *groupIndex) validateStaticMembership(groupID, selfID string, self schema.PresenceRules) error {
+	if groupID == "" {
+		return nil
+	}
+	for _, member := range i.members(groupID) {
+		if member.ID == selfID {
+			continue
+		}
+		other, err := i.presenceFor(member.ID)
+		if err != nil {
+			return err
+		}
+		if err := schema.CheckGroupPresence(self, other); err != nil {
+			return fmt.Errorf("%w: %s (with key %q)", domain.ErrInvalid, err, member.Name)
+		}
+	}
+	return nil
+}
+
+// validateResolvedPublish is publish-time authority over resolved values. It
+// keeps per-key presence/value refusals in catalogue order, then evaluates each
+// (group, environment) bucket for all-or-none presence.
+func (i *groupIndex) validateResolvedPublish(cells []resolvedCell, envID string) error {
+	groups := make(map[groupEnvironment][]resolvedCell)
+	for _, cell := range cells {
+		rules, err := i.presenceFor(cell.key.ID)
+		if err != nil {
+			return err
+		}
+		switch {
+		case rules.Required.Covers(envID) && !cell.set:
+			// mvp-boundary C2: required_in absent vetoes by key and env.
+			return invalidDetail("key %q is `required_in` environment %s and resolves to absent: publish is vetoed",
+				cell.key.Name, envID)
+		case rules.Forbidden.Covers(envID) && cell.set:
+			return invalidDetail("key %q is `forbidden_in` environment %s and resolves to set: publish is vetoed",
+				cell.key.Name, envID)
+		}
+		if cell.set {
+			if err := validateValue(cell.key, cell.value); err != nil {
+				return err
+			}
+		}
+		if cell.key.GroupID != "" {
+			bucket := groupEnvironment{groupID: cell.key.GroupID, environmentID: envID}
+			groups[bucket] = append(groups[bucket], cell)
+		}
+	}
+	for bucket, members := range groups {
+		set, absent := []string{}, []string{}
+		for _, member := range members {
+			if member.set {
+				set = append(set, member.key.Name)
+			} else {
+				absent = append(absent, member.key.Name)
+			}
+		}
+		if len(set) > 0 && len(absent) > 0 {
+			slices.Sort(set)
+			slices.Sort(absent)
+			return invalidDetail("key group %s resolves partially in environment %s: set %v, absent %v: a group's presence is all-or-none",
+				bucket.groupID, bucket.environmentID, set, absent)
+		}
+	}
+	return nil
+}

--- a/internal/service/group_index_test.go
+++ b/internal/service/group_index_test.go
@@ -1,0 +1,235 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestGroupIndexStaticPresencePermutations(t *testing.T) {
+	prodRequired := schema.PresenceRules{
+		Required:  schema.Presence{Mode: schema.PresenceExplicit, Environments: []string{"env_prod"}},
+		Forbidden: schema.Presence{Mode: schema.PresenceNone},
+	}
+	prodForbidden := schema.PresenceRules{
+		Required:  schema.Presence{Mode: schema.PresenceNone},
+		Forbidden: schema.Presence{Mode: schema.PresenceExplicit, Environments: []string{"env_prod"}},
+	}
+	defaultPresence := schema.DefaultPresenceRules()
+
+	tests := []struct {
+		name      string
+		groupID   string
+		selfID    string
+		self      schema.PresenceRules
+		wantError bool
+		wantName  string
+	}{
+		{name: "required conflicts with forbidden sibling", groupID: "group_database", selfID: "key_password", self: prodRequired, wantError: true, wantName: "DB_USER"},
+		{name: "forbidden conflicts with required sibling", groupID: "group_database", selfID: "key_user", self: prodForbidden, wantError: true, wantName: "DB_PASSWORD"},
+		{name: "same forbidden rule is compatible", groupID: "group_database", selfID: "key_password", self: prodForbidden},
+		{name: "different group is ignored", groupID: "group_cache", selfID: "key_cache", self: prodRequired},
+		{name: "ungrouped is a no-op", selfID: "key_password", self: prodRequired},
+		{name: "default presence is compatible", groupID: "group_database", selfID: "key_password", self: defaultPresence},
+	}
+
+	index, err := newGroupIndex([]store.CatalogueKey{
+		{ID: "key_user", Name: "DB_USER", GroupID: "group_database", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceExplicit)},
+		{ID: "key_password", Name: "DB_PASSWORD", GroupID: "group_database", RequiredMode: string(schema.PresenceExplicit), ForbiddenMode: string(schema.PresenceNone)},
+		{ID: "key_cache", Name: "CACHE_URL", GroupID: "group_cache", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone)},
+	}, []store.KeyPresence{
+		{KeyID: "key_user", EnvironmentID: "env_prod", Rule: store.PresenceRuleForbidden},
+		{KeyID: "key_password", EnvironmentID: "env_prod", Rule: store.PresenceRuleRequired},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := index.validateStaticMembership(tc.groupID, tc.selfID, tc.self)
+			if got := err != nil; got != tc.wantError {
+				t.Fatalf("validateStaticMembership() error = %v, wantError %t", err, tc.wantError)
+			}
+			if tc.wantName != "" && (err == nil || !errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), tc.wantName)) {
+				t.Fatalf("validateStaticMembership() = %v, want ErrInvalid naming %q", err, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestGroupIndexResolvedEnvironmentPermutations(t *testing.T) {
+	keys := []store.CatalogueKey{
+		{ID: "key_user", Name: "DB_USER", GroupID: "group_database", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone), Declaration: `{"rule":{"type":"string"}}`, Classification: string(schema.Config)},
+		{ID: "key_password", Name: "DB_PASSWORD", GroupID: "group_database", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone), Declaration: `{"rule":{"type":"string"}}`, Classification: string(schema.Config)},
+		{ID: "key_cache", Name: "CACHE_URL", GroupID: "", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone), Declaration: `{"rule":{"type":"string"}}`, Classification: string(schema.Config)},
+	}
+	index, err := newGroupIndex(keys, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		envID     string
+		set       map[string]bool
+		wantError bool
+	}{
+		{name: "all absent", envID: "env_dev", set: map[string]bool{}},
+		{name: "all set", envID: "env_dev", set: map[string]bool{"key_user": true, "key_password": true}},
+		{name: "first member only", envID: "env_dev", set: map[string]bool{"key_user": true}, wantError: true},
+		{name: "second member only", envID: "env_prod", set: map[string]bool{"key_password": true}, wantError: true},
+		{name: "ungrouped value does not affect closure", envID: "env_prod", set: map[string]bool{"key_cache": true}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cells := make([]resolvedCell, 0, len(keys))
+			for _, key := range keys {
+				cells = append(cells, resolvedCell{key: key, set: tc.set[key.ID], value: "value"})
+			}
+			err := index.validateResolvedPublish(cells, tc.envID)
+			if got := err != nil; got != tc.wantError {
+				t.Fatalf("validateResolvedPublish() error = %v, wantError %t", err, tc.wantError)
+			}
+			if tc.wantError && (!errors.Is(err, domain.ErrInvalid) || !strings.Contains(err.Error(), "group_database") || !strings.Contains(err.Error(), tc.envID)) {
+				t.Fatalf("validateResolvedPublish() = %v, want group/environment detail", err)
+			}
+		})
+	}
+}
+
+func TestGroupIndexBuildScansEachInputRowOnce(t *testing.T) {
+	keys := []store.CatalogueKey{
+		{ID: "key_a", GroupID: "group_a", RequiredMode: string(schema.PresenceExplicit), ForbiddenMode: string(schema.PresenceNone)},
+		{ID: "key_b", GroupID: "group_a", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceExplicit)},
+		{ID: "key_c", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone)},
+	}
+	presence := []store.KeyPresence{
+		{KeyID: "key_a", EnvironmentID: "env_dev", Rule: store.PresenceRuleRequired},
+		{KeyID: "key_a", EnvironmentID: "env_prod", Rule: store.PresenceRuleRequired},
+		{KeyID: "key_b", EnvironmentID: "env_prod", Rule: store.PresenceRuleForbidden},
+	}
+	var keyScans, presenceScans int
+	index, err := buildGroupIndex(keys, presence, func(kind groupIndexInputKind) {
+		switch kind {
+		case groupIndexCatalogueInput:
+			keyScans++
+		case groupIndexPresenceInput:
+			presenceScans++
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if keyScans != len(keys) || presenceScans != len(presence) {
+		t.Fatalf("build scans = keys %d/%d, presence %d/%d; want each input row once", keyScans, len(keys), presenceScans, len(presence))
+	}
+	rules, err := index.presenceFor("key_a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rules.Required.Environments; len(got) != 2 {
+		t.Fatalf("indexed explicit presence = %v, want both environments", got)
+	}
+}
+
+func TestGroupIndexRefusesBrokenInputRelationships(t *testing.T) {
+	keys := []store.CatalogueKey{{ID: "key_a"}}
+	if _, err := newGroupIndex(keys, []store.KeyPresence{{KeyID: "key_missing", EnvironmentID: "env_prod", Rule: store.PresenceRuleRequired}}); err == nil {
+		t.Fatal("presence row for an unknown key was silently dropped")
+	}
+	if _, err := newGroupIndex(append(keys, keys[0]), nil); err == nil {
+		t.Fatal("duplicate catalogue key was silently collapsed")
+	}
+	index, err := newGroupIndex(keys, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := index.presenceFor("key_missing"); err == nil {
+		t.Fatal("unknown key presence silently became zero-value rules")
+	}
+}
+
+func TestGroupIndexPhaseReadsCatalogueAndPresenceOnce(t *testing.T) {
+	cat := &countingGroupIndexCatalogue{
+		keys: []store.CatalogueKey{{ID: "key_a", RequiredMode: string(schema.PresenceNone), ForbiddenMode: string(schema.PresenceNone)}},
+	}
+	phase := &groupIndexPhase{}
+	first, err := phase.snapshot(t.Context(), cat, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := phase.snapshot(t.Context(), cat, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("one validation phase returned two different group snapshots")
+	}
+	if cat.listCalls != 1 || cat.presenceCalls != 1 {
+		t.Fatalf("catalogue reads = List %d, ListPresence %d; want one each", cat.listCalls, cat.presenceCalls)
+	}
+}
+
+func TestGroupMembershipIndexDoesNotReadPresence(t *testing.T) {
+	cat := &countingGroupIndexCatalogue{
+		keys: []store.CatalogueKey{{ID: "key_a", GroupID: "group_a"}},
+	}
+	index, err := loadGroupMembershipIndex(t.Context(), cat, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(index.members("group_a")) != 1 {
+		t.Fatal("membership-only snapshot omitted the grouped key")
+	}
+	if cat.listCalls != 1 || cat.presenceCalls != 0 {
+		t.Fatalf("catalogue reads = List %d, ListPresence %d; want membership-only 1/0", cat.listCalls, cat.presenceCalls)
+	}
+}
+
+type countingGroupIndexCatalogue struct {
+	keys          []store.CatalogueKey
+	presence      []store.KeyPresence
+	listCalls     int
+	presenceCalls int
+}
+
+func (c *countingGroupIndexCatalogue) Get(context.Context, authz.Proof, string) (store.CatalogueKey, error) {
+	return store.CatalogueKey{}, errors.New("unexpected Get")
+}
+func (c *countingGroupIndexCatalogue) List(context.Context, authz.Proof) ([]store.CatalogueKey, error) {
+	c.listCalls++
+	return c.keys, nil
+}
+func (c *countingGroupIndexCatalogue) Count(context.Context, authz.Proof) (int64, error) {
+	return 0, errors.New("unexpected Count")
+}
+func (c *countingGroupIndexCatalogue) AdapterPins(context.Context, authz.Proof, string) ([]store.AdapterPin, error) {
+	return nil, errors.New("unexpected AdapterPins")
+}
+func (c *countingGroupIndexCatalogue) GetGroup(context.Context, authz.Proof, string) (store.CatalogueGroup, error) {
+	return store.CatalogueGroup{}, errors.New("unexpected GetGroup")
+}
+func (c *countingGroupIndexCatalogue) ListGroups(context.Context, authz.Proof) ([]store.CatalogueGroup, error) {
+	return nil, errors.New("unexpected ListGroups")
+}
+func (c *countingGroupIndexCatalogue) CountGroups(context.Context, authz.Proof) (int64, error) {
+	return 0, errors.New("unexpected CountGroups")
+}
+func (c *countingGroupIndexCatalogue) ListPresence(context.Context, authz.Proof) ([]store.KeyPresence, error) {
+	c.presenceCalls++
+	return c.presence, nil
+}
+func (c *countingGroupIndexCatalogue) SchemaRevision(context.Context, authz.Proof) (int64, error) {
+	return 0, errors.New("unexpected SchemaRevision")
+}
+
+var _ store.CatalogueReader = (*countingGroupIndexCatalogue)(nil)

--- a/internal/service/hierarchy.go
+++ b/internal/service/hierarchy.go
@@ -877,7 +877,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 		// environment born invalid.
 		newScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(created.ID)}
 		published, err = republish(ctx, r, az, caller, sealer, s.Keyring, newScope,
-			store.CanonTime(time.Now()), "environment-create")
+			store.CanonTime(time.Now()), "environment-create", &groupIndexPhase{})
 		return err
 	})
 	if err != nil {

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -462,7 +462,7 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		// than exposing value_entries that no committed snapshot contains.
 		if len(result.Imported) > 0 {
 			published, err = republish(ctx, r, az, caller, sealer, s.Keyring, scope,
-				store.CanonTime(time.Now()), "import")
+				store.CanonTime(time.Now()), "import", &groupIndexPhase{})
 			if err != nil {
 				return err
 			}

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -312,31 +312,6 @@ func presenceEqual(a, b schema.PresenceRules) bool {
 	return same(a.Required, b.Required) && same(a.Forbidden, b.Forbidden)
 }
 
-// checkGroupPresence enforces the group's all-or-none presence STATICALLY:
-// one member required where another is forbidden can never hold, so the pair
-// is refused at declaration rather than discovered at publish. It runs on both
-// a presence change and a membership change, because either side can create
-// the pair.
-//
-// The closure algorithm and the runtime all-or-none evaluation are publish's
-// (#51); this is only the half that is decidable without any value.
-func checkGroupPresence(groupID, selfID string, self schema.PresenceRules, members []store.CatalogueKey, presence []store.KeyPresence) error {
-	if groupID == "" {
-		return nil
-	}
-	for _, member := range members {
-		if member.ID == selfID || member.GroupID != groupID {
-			continue
-		}
-		other := presenceOf(member.ID, member.RequiredMode, member.ForbiddenMode, presence)
-		if err := schema.CheckGroupPresence(self, other); err != nil {
-			// Rejection messages name groups and key names only, never values.
-			return fmt.Errorf("%w: %s (with key %q)", domain.ErrInvalid, err, member.Name)
-		}
-	}
-	return nil
-}
-
 // cascadeEnvironmentPresence removes a deleted environment's id from every
 // explicit presence set, in the caller's transaction (schema-model ADR
 // § Presence: environment lifecycle and presence rules are one serialized
@@ -687,15 +662,11 @@ func checkGroupMembership(ctx context.Context, r store.Repos, p authz.Proof, gro
 	if _, err := r.Catalogue().GetGroup(ctx, p, groupID); err != nil {
 		return err
 	}
-	members, err := r.Catalogue().List(ctx, p)
+	index, err := loadGroupIndex(ctx, r.Catalogue(), p)
 	if err != nil {
 		return err
 	}
-	rows, err := r.Catalogue().ListPresence(ctx, p)
-	if err != nil {
-		return err
-	}
-	return checkGroupPresence(groupID, selfID, presence, members, rows)
+	return index.validateStaticMembership(groupID, selfID, presence)
 }
 
 // Get reads one key with its presence rules.
@@ -1078,7 +1049,11 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 		if err != nil {
 			return err
 		}
-		if err := checkGroupPresence(before.GroupID, id, u.Presence, members, presence); err != nil {
+		index, err := newGroupIndex(members, presence)
+		if err != nil {
+			return err
+		}
+		if err := index.validateStaticMembership(before.GroupID, id, u.Presence); err != nil {
 			return err
 		}
 		// Re-saving a canonically identical declaration writes NOTHING: it is a
@@ -1375,10 +1350,6 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 		if err != nil {
 			return err
 		}
-		presence, err := r.Catalogue().ListPresence(ctx, p)
-		if err != nil {
-			return err
-		}
 		// Setting the membership a key already has is an IDEMPOTENT SUCCESS,
 		// not a refusal: it writes nothing, moves no revision and emits no
 		// event, exactly as re-saving an identical declaration does. The one
@@ -1386,12 +1357,42 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 		// and only because a ceremony that changed nothing would still write a
 		// disclosure-class audit record.
 		if before.GroupID == groupID {
+			presence, err := r.Catalogue().ListPresence(ctx, p)
+			if err != nil {
+				return err
+			}
 			out, err = keyOf(before, presence)
 			return err
 		}
-		self := presenceOf(id, before.RequiredMode, before.ForbiddenMode, presence)
-		if err := checkGroupMembership(ctx, r, p, groupID, id, self); err != nil {
-			return err
+		var presence []store.KeyPresence
+		if groupID == "" {
+			presence, err = r.Catalogue().ListPresence(ctx, p)
+			if err != nil {
+				return err
+			}
+		} else {
+			if _, err := r.Catalogue().GetGroup(ctx, p, groupID); err != nil {
+				return err
+			}
+			members, err := r.Catalogue().List(ctx, p)
+			if err != nil {
+				return err
+			}
+			presence, err = r.Catalogue().ListPresence(ctx, p)
+			if err != nil {
+				return err
+			}
+			index, err := newGroupIndex(members, presence)
+			if err != nil {
+				return err
+			}
+			self, err := index.presenceFor(id)
+			if err != nil {
+				return err
+			}
+			if err := index.validateStaticMembership(groupID, id, self); err != nil {
+				return err
+			}
 		}
 		if err := r.Catalogue().SetGroup(ctx, p, id, groupID); err != nil {
 			return err

--- a/internal/service/pins.go
+++ b/internal/service/pins.go
@@ -318,7 +318,11 @@ func validatePinnedSnapshot(ctx context.Context, r store.Repos, p authz.Proof, s
 		}
 		cells = append(cells, cell)
 	}
-	return validateResolved(cells, presence, string(scope.Env))
+	index, err := newGroupIndex(keys, presence)
+	if err != nil {
+		return err
+	}
+	return index.validateResolvedPublish(cells, string(scope.Env))
 }
 
 func pinnedHistoricalSecrets(ctx context.Context, r store.Repos, p authz.Proof,

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -312,7 +312,11 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 			proofs[envID] = ep
 		}
 
-		selection, closed, err := selectVersions(ctx, r, p, caller.Principal, selected, byID)
+		groupIndex, err := loadGroupIndex(ctx, r.Catalogue(), p)
+		if err != nil {
+			return err
+		}
+		selection, closed, err := selectVersions(ctx, r, p, caller.Principal, selected, byID, groupIndex)
 		if err != nil {
 			return err
 		}
@@ -396,7 +400,7 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 			envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(envID)}
 			ep := proofs[envID]
 			applies := selection[envID]
-			if err := checkFreshness(ctx, r, ep, applies); err != nil {
+			if err := checkFreshness(ctx, r, ep, applies, groupIndex); err != nil {
 				return err
 			}
 			if s.PublishProbe != nil {
@@ -414,7 +418,7 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 				applies[i].value = string(plain)
 			}
 			published, err := materialize(ctx, r, ep, sealer, s.Keyring, envScope,
-				caller.Principal, now, applies, s.storageLimit())
+				caller.Principal, now, applies, s.storageLimit(), groupIndex)
 			if err != nil {
 				return err
 			}
@@ -531,7 +535,11 @@ func buildImpactPreview(ctx context.Context, r store.Repos, p authz.Proof, seale
 	if err != nil {
 		return ImpactPreview{}, err
 	}
-	selection, _, err := selectVersions(ctx, r, p, caller.Principal, selected, byID)
+	groupIndex, err := loadGroupMembershipIndex(ctx, r.Catalogue(), p)
+	if err != nil {
+		return ImpactPreview{}, err
+	}
+	selection, _, err := selectVersions(ctx, r, p, caller.Principal, selected, byID, groupIndex)
 	if err != nil {
 		return ImpactPreview{}, err
 	}
@@ -550,14 +558,6 @@ func buildImpactPreview(ctx context.Context, r store.Repos, p authz.Proof, seale
 		schemaRevision, err := r.Catalogue().SchemaRevision(ctx, ep)
 		if err != nil {
 			return ImpactPreview{}, err
-		}
-		keys, err := r.Catalogue().List(ctx, ep)
-		if err != nil {
-			return ImpactPreview{}, err
-		}
-		keyByID := make(map[string]store.CatalogueKey, len(keys))
-		for _, key := range keys {
-			keyByID[key.ID] = key
 		}
 		entries, err := r.Values().List(ctx, ep)
 		if err != nil {
@@ -581,7 +581,10 @@ func buildImpactPreview(ctx context.Context, r store.Repos, p authz.Proof, seale
 			Protected: settings.Protected,
 		}
 		for _, apply := range applies {
-			key := keyByID[apply.keyID]
+			key, ok := groupIndex.key(apply.keyID)
+			if !ok {
+				return ImpactPreview{}, fmt.Errorf("service: group index: key %s is not indexed", apply.keyID)
+			}
 			_, beforeSet := entryByKey[apply.keyID]
 			status := "edited"
 			switch {
@@ -691,15 +694,19 @@ func recordPublish(ctx context.Context, r store.Repos, p authz.Proof, principal 
 // a check performed earlier in the same transaction is not that.
 func republish(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity,
 	sealer *crypto.ProjectSealer, kr *crypto.Keyring, scope domain.Scope,
-	now time.Time, trigger string) (PublishedEnvironment, error) {
+	now time.Time, trigger string, groups *groupIndexPhase) (PublishedEnvironment, error) {
 	p, err := az.Authorize(ctx, caller, authz.OpValuePublish, scope)
+	if err != nil {
+		return PublishedEnvironment{}, err
+	}
+	groupIndex, err := groups.snapshot(ctx, r.Catalogue(), p)
 	if err != nil {
 		return PublishedEnvironment{}, err
 	}
 	// republish covers the non-draft payload-advancing paths (declare-into-env,
 	// import, copy, clone, env creation, schema fan-out); each enforces the
 	// production high-water — only the direct publish path is conformance-tunable.
-	published, err := materialize(ctx, r, p, sealer, kr, scope, caller.Principal, now, nil, MaxProjectStorageBytes)
+	published, err := materialize(ctx, r, p, sealer, kr, scope, caller.Principal, now, nil, MaxProjectStorageBytes, groupIndex)
 	if err != nil {
 		return PublishedEnvironment{}, err
 	}
@@ -748,9 +755,10 @@ func fanOutSchemaPublish(ctx context.Context, r store.Repos, az *authz.TxAuthori
 		return nil, err
 	}
 	out := make([]PublishedEnvironment, 0, len(environments))
+	groupPhase := &groupIndexPhase{}
 	for _, env := range environments {
 		envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(env.ID)}
-		published, err := republish(ctx, r, az, caller, sealer, kr, envScope, now, trigger)
+		published, err := republish(ctx, r, az, caller, sealer, kr, envScope, now, trigger, groupPhase)
 		if err != nil {
 			return nil, err
 		}
@@ -791,19 +799,7 @@ func resolveVersions(ctx context.Context, r store.Repos, p authz.Proof,
 }
 
 func selectVersions(ctx context.Context, r store.Repos, p authz.Proof,
-	principal domain.PrincipalID, selected, byID map[string]store.PendingChange) (map[string][]pendingApply, []string, error) {
-	keys, err := r.Catalogue().List(ctx, p)
-	if err != nil {
-		return nil, nil, err
-	}
-	keyByID := make(map[string]store.CatalogueKey, len(keys))
-	groupMembers := map[string][]store.CatalogueKey{}
-	for _, k := range keys {
-		keyByID[k.ID] = k
-		if k.GroupID != "" {
-			groupMembers[k.GroupID] = append(groupMembers[k.GroupID], k)
-		}
-	}
+	principal domain.PrincipalID, selected, byID map[string]store.PendingChange, groups *groupIndex) (map[string][]pendingApply, []string, error) {
 	markers, err := r.Pending().ListMarkers(ctx, p)
 	if err != nil {
 		return nil, nil, err
@@ -823,7 +819,7 @@ func selectVersions(ctx context.Context, r store.Repos, p authz.Proof,
 	for grew := true; grew; {
 		grew = false
 		for _, change := range sortedChanges(selected) {
-			key, ok := keyByID[change.KeyID]
+			key, ok := groups.key(change.KeyID)
 			if !ok {
 				return nil, nil, fmt.Errorf("%w: pending change %s names key %s, which is no longer declared",
 					ErrStalePending, change.ID, change.KeyID)
@@ -831,7 +827,7 @@ func selectVersions(ctx context.Context, r store.Repos, p authz.Proof,
 			if key.GroupID == "" {
 				continue
 			}
-			for _, member := range groupMembers[key.GroupID] {
+			for _, member := range groups.members(key.GroupID) {
 				for _, marker := range markers {
 					if marker.KeyID != member.ID || marker.EnvironmentID != change.EnvironmentID {
 						continue
@@ -916,7 +912,7 @@ func sortedChanges(selected map[string]store.PendingChange) []store.PendingChang
 // The superseded half of the rule needs no code here: a superseded version is
 // collected the moment its successor is staged, so it has no id left to name
 // and the selection lookup already refused it.
-func checkFreshness(ctx context.Context, r store.Repos, p authz.Proof, applies []pendingApply) error {
+func checkFreshness(ctx context.Context, r store.Repos, p authz.Proof, applies []pendingApply, groups *groupIndex) error {
 	entries, err := r.Values().List(ctx, p)
 	if err != nil {
 		return err
@@ -925,20 +921,17 @@ func checkFreshness(ctx context.Context, r store.Repos, p authz.Proof, applies [
 	for _, entry := range entries {
 		published[entry.KeyID] = entry.ID
 	}
-	keys, err := r.Catalogue().List(ctx, p)
-	if err != nil {
-		return err
-	}
-	names := make(map[string]string, len(keys))
-	for _, key := range keys {
-		names[key.ID] = key.Name
-	}
 	for _, apply := range applies {
 		if published[apply.keyID] == apply.stagedFromEntry {
 			continue
 		}
+		key, ok := groups.key(apply.keyID)
+		if !ok {
+			return fmt.Errorf("%w: version %s names key %s, which is no longer declared",
+				ErrStalePending, apply.versionID, apply.keyID)
+		}
 		return fmt.Errorf("%w: version %s targets key %q, whose published value has changed since the draft was staged at revision %d: restage the edit against the current state",
-			ErrStalePending, apply.versionID, names[apply.keyID], apply.stagedFrom)
+			ErrStalePending, apply.versionID, key.Name, apply.stagedFrom)
 	}
 	return nil
 }
@@ -966,15 +959,8 @@ func currentRevision(ctx context.Context, r store.Repos, p authz.Proof) (int64, 
 // and is that legal".
 func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *crypto.ProjectSealer,
 	kr *crypto.Keyring, scope domain.Scope, publisher domain.PrincipalID, now time.Time,
-	applies []pendingApply, storageLimit int64) (PublishedEnvironment, error) {
-	keys, err := r.Catalogue().List(ctx, p)
-	if err != nil {
-		return PublishedEnvironment{}, err
-	}
-	presence, err := r.Catalogue().ListPresence(ctx, p)
-	if err != nil {
-		return PublishedEnvironment{}, err
-	}
+	applies []pendingApply, storageLimit int64, groups *groupIndex) (PublishedEnvironment, error) {
+	keys := groups.catalogueKeys()
 	schemaRevision, err := r.Catalogue().SchemaRevision(ctx, p)
 	if err != nil {
 		return PublishedEnvironment{}, err
@@ -1020,7 +1006,7 @@ func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *cryp
 		cells = append(cells, cell)
 	}
 
-	if err := validateResolved(cells, presence, string(scope.Env)); err != nil {
+	if err := groups.validateResolvedPublish(cells, string(scope.Env)); err != nil {
 		return PublishedEnvironment{}, err
 	}
 
@@ -1215,54 +1201,6 @@ func checkRenderTotal(cells []resolvedCell, envID string) error {
 		if total > MaxRenderBytesPerTarget {
 			return fmt.Errorf("%w: environment %s renders more than the %d-byte per-target limit",
 				domain.ErrLimitExceeded, envID, MaxRenderBytesPerTarget)
-		}
-	}
-	return nil
-}
-
-// validateResolved is publish's authority, run on the RESOLVED values at the
-// current schema revision regardless of any stored draft verdict.
-func validateResolved(cells []resolvedCell, presence []store.KeyPresence, envID string) error {
-	groups := map[string][]resolvedCell{}
-	for _, cell := range cells {
-		rules := presenceOfKey(cell.key, presence)
-		switch {
-		case rules.Required.Covers(envID) && !cell.set:
-			// mvp-boundary C2, verbatim: a `required_in` key left `absent`
-			// vetoes the publish, naming key AND environment.
-			return invalidDetail("key %q is `required_in` environment %s and resolves to absent: publish is vetoed",
-				cell.key.Name, envID)
-		case rules.Forbidden.Covers(envID) && cell.set:
-			return invalidDetail("key %q is `forbidden_in` environment %s and resolves to set: publish is vetoed",
-				cell.key.Name, envID)
-		}
-		if cell.set {
-			if err := validateValue(cell.key, cell.value); err != nil {
-				return err
-			}
-		}
-		if cell.key.GroupID != "" {
-			groups[cell.key.GroupID] = append(groups[cell.key.GroupID], cell)
-		}
-	}
-	// ALL-OR-NONE RESOLVED PRESENCE per environment, always on, no flag: in
-	// each environment either every member of a group resolves to `set` or none
-	// do. Co-publish closure closes the timing hole; this closes the state one.
-	// The message names groups and key names only, never values.
-	for groupID, members := range groups {
-		set, absent := []string{}, []string{}
-		for _, member := range members {
-			if member.set {
-				set = append(set, member.key.Name)
-			} else {
-				absent = append(absent, member.key.Name)
-			}
-		}
-		if len(set) > 0 && len(absent) > 0 {
-			slices.Sort(set)
-			slices.Sort(absent)
-			return invalidDetail("key group %s resolves partially in environment %s: set %v, absent %v: a group's presence is all-or-none",
-				groupID, envID, set, absent)
 		}
 	}
 	return nil

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -712,7 +712,7 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 			// as an immediate write. It therefore materializes each destination
 			// rather than staging: a value that is authorized as delivered and
 			// then does not deliver would be a third state nobody asked for.
-			env, err := republish(ctx, r, az, caller, sealer, s.Keyring, envScope, time.Now().UTC(), "declare")
+			env, err := republish(ctx, r, az, caller, sealer, s.Keyring, envScope, time.Now().UTC(), "declare", &groupIndexPhase{})
 			if err != nil {
 				return declareWriteResult{}, err
 			}
@@ -1160,7 +1160,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 				return copyWriteResult{}, err
 			}
 			published, err := republish(ctx, r, az, caller, sealer, s.Keyring, destScope,
-				store.CanonTime(time.Now()), operation)
+				store.CanonTime(time.Now()), operation, &groupIndexPhase{})
 			if err != nil {
 				return copyWriteResult{}, err
 			}


### PR DESCRIPTION
## Summary

- build one immutable transaction-local group index for catalogue membership and environment presence
- keep static declaration validation separate from resolved publish all-or-none validation
- rebuild after membership writes and share one snapshot across publish closure/materialization phases

## Contract and migration

Refusal ordering and public error detail remain unchanged. Restore preview uses a membership-only snapshot because its proof does not authorize presence reads. No process cache, database migration, API change, token change, or generated output.

## Validation

- `go test -count=1 ./internal/service/... -run 'Group|Publish|Key'` — 23 passed
- `go test -race -count=1 ./internal/service -run '^TestGroup'` — 17 passed
- focused SQLite conformance — 5 passed
- `go test -count=1 ./internal/isolation/` — 1,090 passed
- `go test -count=1 ./...` — 3,193 passed in 57 packages
- `go vet ./...` — passed
- `go build ./...` — passed

No `HIKYO_TEST_POSTGRES_DSN` was configured locally; the shared cross-engine conformance scenario ran on SQLite and remains registered for PostgreSQL CI.

## Review

Three rounds completed. Final Standards: CLEAN. Final Spec: CLEAN.

Closes #227