### PR TITLE
refactor(compose): unify live and offline render plans

### DIFF
--- a/docs/handoff/230-compose-render-plan.md
+++ b/docs/handoff/230-compose-render-plan.md
@@ -1,0 +1,48 @@
+# Issue #230: one pure Compose render plan
+
+## Contract
+
+`compose.BuildRenderPlan(RenderInput) (RenderPlan, error)` is the single pure
+decision point for live and offline Compose rendering. Adapters provide ordered
+targets and normalized source rows plus explicit projection and absent-key
+policy. The plan owns exact target bytes, snapshot rows, omissions, and typed
+refusals.
+
+Full live input refuses a configured key absent from the server delivery; full
+offline input refuses a configured key absent from the sealed snapshot.
+Config-only input skips absent keys because projected-out secrets and deleted
+config keys are indistinguishable in that projection. Existing CLI refusal
+text, sorting, all-or-nothing writes, and generation ordering remain unchanged.
+
+`hikyo run` is deliberately excluded. It delivers the full environment, merges
+against the sanitized parent process, performs collision and ARG_MAX checks,
+then execs; it does not select render targets or encode dotenv files.
+
+## What changed
+
+- `internal/compose/renderplan.go` defines the pure input, plan, omission, and
+  refusal model and performs selection, loader-control checks, raw encoding,
+  and snapshot-row collection without filesystem, network, clock, crypto, or
+  secret-fetch work.
+- Live and offline CLI paths now only normalize their source into `RenderInput`,
+  execute the shared plan, and perform source-specific side effects afterward.
+- Pure golden coverage pins plan shape. Adapter tables prove equivalent live
+  and offline inputs produce identical target bytes and refusals, including
+  config-only and refusal cases. Omission provenance remains source-specific:
+  a live unset row is `no-value`; a snapshot that never stored it is `absent`.
+
+## Generated outputs
+
+None.
+
+## Validation
+
+- `go test -count=1 ./internal/compose/... ./internal/cli/...`: 350 passed.
+- `go test -race -count=1 ./internal/compose/... ./internal/cli/...`: 350 passed.
+- `go vet ./internal/compose/... ./internal/cli/...`: passed.
+- `go test -count=1 ./internal/isolation -run '^TestComposeCLI'`: passed.
+- `go build ./...`, `go vet ./...`, and `go test -count=1 ./...`: passed.
+- `./scripts/compose-demo.sh`: passed all 21 byte-exact round trips,
+  refusal atomicity, doctor, and sync/restart checks.
+- `git diff --check` and scoped `gofmt -l`: passed.
+- Standards and issue-spec review axes: CLEAN in round 2.

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -579,66 +579,11 @@ func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, s
 	if _, err := binding.CanonicalAAD(); err != nil {
 		return false, failf(ExitRefused, "compose render: snapshot binding: %v", err)
 	}
-	byID := deliveredByID(resp.Keys)
-
-	type rendered struct {
-		name    string
-		content []byte
-		rows    []compose.SnapshotRow
+	plan, err := compose.BuildRenderPlan(liveRenderInput(cfg, configOnly, resp.Keys))
+	if err != nil {
+		return false, failf(ExitInternal, "compose render: %v", err)
 	}
-	var results []rendered
-	var refusals []string
-
-	for _, name := range cfg.TargetNames() {
-		tgt := cfg.Targets[name]
-		var rows []compose.Row
-		var srows []compose.SnapshotRow
-		var names []string
-		for _, id := range tgt.Keys {
-			k, ok := byID[id]
-			if !ok {
-				// Under --config-only the server OMITS secrets ENTIRELY — from the
-				// delivery and from the manifest (#64's locked rule) — so a
-				// projected-out secret is indistinguishable from a deleted config
-				// id. A configured id that is not delivered is therefore a SKIP in
-				// config-only, not a refusal; `compose doctor`'s drift checks are the
-				// compensating control that surface a genuinely deleted key. Under the
-				// FULL projection every configured id must be delivered, so an absent
-				// one refuses the target.
-				if configOnly {
-					continue
-				}
-				refusals = append(refusals, fmt.Sprintf("%s: %s: key id was not delivered by the server", name, id))
-				continue
-			}
-			if !configOnly && isUnrevealedSecret(k) {
-				refusals = append(refusals, fmt.Sprintf("%s: %s: secret has no value — %s", name, k.Name, machineRevealOptIn))
-				continue
-			}
-			// A delivered row with no value is genuinely unset / projected-out:
-			// never emit NAME= for a nil value (finding 7).
-			if k.Value == nil {
-				continue
-			}
-			rows = append(rows, compose.Row{Name: k.Name, Value: *k.Value})
-			srows = append(srows, compose.SnapshotRow{Name: k.Name, KeyID: k.KeyId, Classification: string(k.Classification), Value: *k.Value})
-			names = append(names, k.Name)
-		}
-		for _, ln := range compose.RefuseUnacknowledged(names, tgt.AcknowledgeLoaderControl) {
-			refusals = append(refusals, fmt.Sprintf("%s: %s: loader-control key not acknowledged (add it to this target's acknowledge_loader_control)", name, ln))
-		}
-		content, encRefusals, err := compose.EncodeRaw(rows)
-		if err != nil {
-			return false, failf(ExitInternal, "compose render: encode %s: %v", name, err)
-		}
-		for _, r := range encRefusals {
-			refusals = append(refusals, fmt.Sprintf("%s: %s: %s", name, r.Key, r.Reason))
-		}
-		results = append(results, rendered{name: name, content: content, rows: srows})
-	}
-
-	if len(refusals) > 0 {
-		sort.Strings(refusals)
+	if refusals := renderRefusalMessages(plan.Refusals); len(refusals) > 0 {
 		return false, failf(ExitRefused, "hikyo compose render refused; no generation written, cursor not advanced:\n  %s", strings.Join(refusals, "\n  "))
 	}
 
@@ -651,20 +596,20 @@ func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, s
 	var allRows []compose.SnapshotRow
 	var lines []string
 	moved := false
-	for _, r := range results {
-		allRows = append(allRows, r.rows...)
-		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, r.name, r.content)
+	for _, target := range plan.Targets {
+		allRows = append(allRows, target.SnapshotRows...)
+		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, target.Name, target.Content)
 		if err != nil {
-			return false, failf(ExitInternal, "compose render: write generation %s: %v", r.name, err)
+			return false, failf(ExitInternal, "compose render: write generation %s: %v", target.Name, err)
 		}
-		finalStamps[r.name] = stamp
+		finalStamps[target.Name] = stamp
 		// moved when the stamp changed OR the generation had to be re-materialised
 		// (the tmpfs copy was lost): either way sync must re-apply (R1-10).
-		if currentStamps[r.name] != stamp || materialized {
+		if currentStamps[target.Name] != stamp || materialized {
 			moved = true
-			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", r.name, stamp, filepath.Join(runtimeDir, stamp, r.name+".env")))
+			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", target.Name, stamp, filepath.Join(runtimeDir, stamp, target.Name+".env")))
 		} else {
-			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", r.name, stamp))
+			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", target.Name, stamp))
 		}
 	}
 	if err := lock.CommitStamps(finalStamps); err != nil {
@@ -711,80 +656,32 @@ func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock,
 	if err != nil {
 		return false, failf(ExitInternal, "compose render: reading offline snapshot binding: %v", err)
 	}
-	byID := map[string]compose.SnapshotRow{}
-	for _, r := range payload.Rows {
-		if r.KeyID != "" {
-			byID[r.KeyID] = r
-		}
+	plan, err := compose.BuildRenderPlan(offlineRenderInput(cfg, configOnly, payload.Rows))
+	if err != nil {
+		return false, failf(ExitInternal, "compose render: %v", err)
 	}
-
-	type rendered struct {
-		name    string
-		stamp   string
-		content []byte
-		rows    []compose.SnapshotRow
-	}
-	var results []rendered
-	var refusals []string
-	for _, name := range cfg.TargetNames() {
-		tgt := cfg.Targets[name]
-		var rows []compose.Row
-		var srows []compose.SnapshotRow
-		var names []string
-		for _, id := range tgt.Keys {
-			r, ok := byID[id]
-			if !ok {
-				// Under the FULL projection every configured target key id must be
-				// present in the sealed payload rows — the render-target set check at
-				// key granularity (R1-3), an absent id is a genuinely deleted key and
-				// refuses. Under --config-only the snapshot never held secrets (the
-				// server omits them entirely, #64's locked rule), so an absent id is
-				// indistinguishable from a projected-out secret and is a SKIP, not a
-				// refusal — `compose doctor`'s drift checks are the compensating
-				// control. This mirrors the live-fetch config-only skip.
-				if configOnly {
-					continue
-				}
-				refusals = append(refusals, fmt.Sprintf("%s: %s: not present in the last snapshot", name, id))
-				continue
-			}
-			rows = append(rows, compose.Row{Name: r.Name, Value: r.Value})
-			srows = append(srows, r)
-			names = append(names, r.Name)
-		}
-		// Loader-control BEFORE any offline record or write (finding 6).
-		for _, ln := range compose.RefuseUnacknowledged(names, tgt.AcknowledgeLoaderControl) {
-			refusals = append(refusals, fmt.Sprintf("%s: %s: loader-control key not acknowledged (add it to this target's acknowledge_loader_control)", name, ln))
-		}
-		content, encRefusals, err := compose.EncodeRaw(rows)
-		if err != nil {
-			return false, failf(ExitInternal, "compose render: encode %s: %v", name, err)
-		}
-		for _, rr := range encRefusals {
-			refusals = append(refusals, fmt.Sprintf("%s: %s: %s", name, rr.Key, rr.Reason))
-		}
-		// The stamp is bound to the target name (finding 5); it must match the
-		// stamp WriteGeneration will compute below.
-		results = append(results, rendered{name: name, stamp: compose.TargetStamp(keys, name, content), content: content, rows: srows})
-	}
-	if len(refusals) > 0 {
-		sort.Strings(refusals)
+	if refusals := renderRefusalMessages(plan.Refusals); len(refusals) > 0 {
 		return false, failf(ExitRefused, "hikyo compose render (offline) refused; no generation written:\n  %s", strings.Join(refusals, "\n  "))
 	}
 
 	// One offline record per served key, fsynced BEFORE any generation is
 	// written, then the generations, then the stamp commit and GC.
 	var records []compose.OfflineRecord
-	for _, r := range results {
-		for _, sr := range r.rows {
+	stamps := make(map[string]string, len(plan.Targets))
+	for _, target := range plan.Targets {
+		// The stamp is bound to the target name and must match the value
+		// WriteGeneration computes after the disclosure record is durable.
+		stamp := compose.TargetStamp(keys, target.Name, target.Content)
+		stamps[target.Name] = stamp
+		for _, row := range target.SnapshotRows {
 			id, err := compose.NewRecordID()
 			if err != nil {
 				return false, failf(ExitInternal, "compose render: record id: %v", err)
 			}
 			records = append(records, compose.OfflineRecord{
-				RecordID: id, KeyID: sr.KeyID, KeyName: sr.Name, Classification: sr.Classification,
+				RecordID: id, KeyID: row.KeyID, KeyName: row.Name, Classification: row.Classification,
 				OccurredAt: ios.now().UTC().Format(time.RFC3339), CredentialID: aad.CredentialID,
-				Generation: r.stamp, ServedFrom: aad.IssuedAt,
+				Generation: stamp, ServedFrom: aad.IssuedAt,
 			})
 		}
 	}
@@ -799,20 +696,23 @@ func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock,
 	finalStamps := map[string]string{}
 	var lines []string
 	moved := false
-	for _, r := range results {
-		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, r.name, r.content)
+	for _, target := range plan.Targets {
+		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, target.Name, target.Content)
 		if err != nil {
-			return false, failf(ExitInternal, "compose render: write generation %s: %v", r.name, err)
+			return false, failf(ExitInternal, "compose render: write generation %s: %v", target.Name, err)
 		}
-		finalStamps[r.name] = stamp
+		if stamp != stamps[target.Name] {
+			return false, failf(ExitInternal, "compose render: target %s stamp changed between planning and write", target.Name)
+		}
+		finalStamps[target.Name] = stamp
 		fmt.Fprintf(ios.Stderr, "serving stale from %s, generation %s\n", aad.IssuedAt, stamp)
 		// moved when the stamp changed OR the generation had to be re-materialised
 		// (the tmpfs copy was lost): either way sync must re-apply (R1-10).
-		if currentStamps[r.name] != stamp || materialized {
+		if currentStamps[target.Name] != stamp || materialized {
 			moved = true
-			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", r.name, stamp, filepath.Join(runtimeDir, stamp, r.name+".env")))
+			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", target.Name, stamp, filepath.Join(runtimeDir, stamp, target.Name+".env")))
 		} else {
-			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", r.name, stamp))
+			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", target.Name, stamp))
 		}
 	}
 	if err := lock.CommitStamps(finalStamps); err != nil {
@@ -1890,6 +1790,70 @@ func isUnrevealedSecret(k apigen.DeliveredKey) bool {
 		k.Classification == apigen.KeyClassificationSecret && k.Value == nil
 }
 
+func liveRenderInput(cfg *compose.Config, configOnly bool, keys []apigen.DeliveredKey) compose.RenderInput {
+	rows := make([]compose.RenderSourceRow, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, compose.RenderSourceRow{
+			KeyID: key.KeyId, Name: key.Name, Classification: string(key.Classification), Value: key.Value,
+			UnrevealedSecret: !configOnly && isUnrevealedSecret(key),
+		})
+	}
+	return renderInput(cfg, configOnly, compose.AbsentKeyRefuseNotDelivered, rows)
+}
+
+func offlineRenderInput(cfg *compose.Config, configOnly bool, rows []compose.SnapshotRow) compose.RenderInput {
+	sourceRows := make([]compose.RenderSourceRow, 0, len(rows))
+	for _, row := range rows {
+		value := row.Value
+		sourceRows = append(sourceRows, compose.RenderSourceRow{
+			KeyID: row.KeyID, Name: row.Name, Classification: row.Classification, Value: &value,
+		})
+	}
+	return renderInput(cfg, configOnly, compose.AbsentKeyRefuseNotInSnapshot, sourceRows)
+}
+
+func renderInput(cfg *compose.Config, configOnly bool, fullProjectionPolicy compose.AbsentKeyPolicy, rows []compose.RenderSourceRow) compose.RenderInput {
+	projection := compose.RenderProjectionFull
+	absentKeys := fullProjectionPolicy
+	if configOnly {
+		projection = compose.RenderProjectionConfigOnly
+		absentKeys = compose.AbsentKeySkip
+	}
+	targets := make([]compose.RenderTarget, 0, len(cfg.Targets))
+	for _, name := range cfg.TargetNames() {
+		target := cfg.Targets[name]
+		targets = append(targets, compose.RenderTarget{
+			Name: name, KeyIDs: append([]string(nil), target.Keys...),
+			AcknowledgeLoaderControl: append([]string(nil), target.AcknowledgeLoaderControl...),
+		})
+	}
+	return compose.RenderInput{Projection: projection, AbsentKeys: absentKeys, Targets: targets, Rows: rows}
+}
+
+func renderRefusalMessages(refusals []compose.RenderRefusal) []string {
+	messages := make([]string, 0, len(refusals))
+	for _, refusal := range refusals {
+		var detail string
+		switch refusal.Kind {
+		case compose.RenderRefusalKeyNotDelivered:
+			detail = "key id was not delivered by the server"
+		case compose.RenderRefusalKeyNotInSnapshot:
+			detail = "not present in the last snapshot"
+		case compose.RenderRefusalSecretUnrevealed:
+			detail = "secret has no value — " + machineRevealOptIn
+		case compose.RenderRefusalLoaderControl:
+			detail = "loader-control key not acknowledged (add it to this target's acknowledge_loader_control)"
+		case compose.RenderRefusalEncoding:
+			detail = refusal.Reason
+		default:
+			detail = fmt.Sprintf("unknown render refusal %q", refusal.Kind)
+		}
+		messages = append(messages, fmt.Sprintf("%s: %s: %s", refusal.Target, refusal.Key, detail))
+	}
+	sort.Strings(messages)
+	return messages
+}
+
 func deliveredValues(keys []apigen.DeliveredKey) map[string]string {
 	out := map[string]string{}
 	for _, k := range keys {
@@ -1918,14 +1882,6 @@ func rowNames(rows []compose.SnapshotRow) []string {
 		out = append(out, r.Name)
 	}
 	return out
-}
-
-func deliveredByID(keys []apigen.DeliveredKey) map[string]apigen.DeliveredKey {
-	m := make(map[string]apigen.DeliveredKey, len(keys))
-	for _, k := range keys {
-		m[k.KeyId] = k
-	}
-	return m
 }
 
 func rowsToValues(rows []compose.SnapshotRow) map[string]string {

--- a/internal/cli/compose_internal_test.go
+++ b/internal/cli/compose_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -918,6 +919,70 @@ func TestSnapshotBindingLiveAndOfflineRenderPathsAreEquivalent(t *testing.T) {
 	}
 	if !bytes.Equal(liveAAD, offlineAAD) {
 		t.Fatalf("live/offline binding mismatch:\n live %s\noffline %s", liveAAD, offlineAAD)
+	}
+}
+
+func TestLiveAndOfflineRenderAdaptersAreEquivalent(t *testing.T) {
+	tests := []struct {
+		name       string
+		configOnly bool
+		target     compose.Target
+		live       []apigen.DeliveredKey
+		offline    []compose.SnapshotRow
+	}{
+		{
+			name:   "selected values preserve bytes and row order",
+			target: compose.Target{Keys: []string{"key_url", "key_mode"}},
+			live: []apigen.DeliveredKey{
+				{KeyId: "key_mode", Name: "APP_MODE", Classification: apigen.KeyClassificationConfig, Value: strPtr("production")},
+				{KeyId: "key_url", Name: "DATABASE_URL", Classification: apigen.KeyClassificationSecret, Value: strPtr("postgres://db")},
+			},
+			offline: []compose.SnapshotRow{
+				{Name: "APP_MODE", KeyID: "key_mode", Classification: "config", Value: "production"},
+				{Name: "DATABASE_URL", KeyID: "key_url", Classification: "secret", Value: "postgres://db"},
+			},
+		},
+		{
+			name:   "loader and encoding refusals match",
+			target: compose.Target{Keys: []string{"key_path", "key_bad"}},
+			live: []apigen.DeliveredKey{
+				{KeyId: "key_path", Name: "PATH", Classification: apigen.KeyClassificationConfig, Value: strPtr("/srv/bin")},
+				{KeyId: "key_bad", Name: "MULTILINE", Classification: apigen.KeyClassificationConfig, Value: strPtr("a\nb")},
+			},
+			offline: []compose.SnapshotRow{
+				{Name: "PATH", KeyID: "key_path", Classification: "config", Value: "/srv/bin"},
+				{Name: "MULTILINE", KeyID: "key_bad", Classification: "config", Value: "a\nb"},
+			},
+		},
+		{
+			name:       "config-only projected and unset rows render identically",
+			configOnly: true,
+			target:     compose.Target{Keys: []string{"key_cfg", "key_unset", "key_secret"}},
+			live: []apigen.DeliveredKey{
+				{KeyId: "key_cfg", Name: "APP_MODE", Classification: apigen.KeyClassificationConfig, Value: strPtr("production")},
+				{KeyId: "key_unset", Name: "OPTIONAL", Classification: apigen.KeyClassificationConfig},
+			},
+			offline: []compose.SnapshotRow{{Name: "APP_MODE", KeyID: "key_cfg", Classification: "config", Value: "production"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &compose.Config{Targets: map[string]compose.Target{"api": tt.target}}
+			live, err := compose.BuildRenderPlan(liveRenderInput(cfg, tt.configOnly, tt.live))
+			if err != nil {
+				t.Fatal(err)
+			}
+			offline, err := compose.BuildRenderPlan(offlineRenderInput(cfg, tt.configOnly, tt.offline))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(live.Targets, offline.Targets) {
+				t.Fatalf("target plans differ:\n live: %#v\noffline: %#v", live.Targets, offline.Targets)
+			}
+			if !reflect.DeepEqual(live.Refusals, offline.Refusals) {
+				t.Fatalf("refusals differ:\n live: %#v\noffline: %#v", live.Refusals, offline.Refusals)
+			}
+		})
 	}
 }
 

--- a/internal/compose/renderplan.go
+++ b/internal/compose/renderplan.go
@@ -1,0 +1,185 @@
+package compose
+
+import "fmt"
+
+// RenderProjection is the delivery projection being planned. It is explicit so
+// config-only absence semantics cannot be inferred from row contents.
+type RenderProjection string
+
+const (
+	RenderProjectionFull       RenderProjection = "full"
+	RenderProjectionConfigOnly RenderProjection = "config-only"
+)
+
+// AbsentKeyPolicy tells the pure planner what a configured key missing from the
+// source means. Live and snapshot adapters name their refusal independently;
+// config-only adapters skip because projected-out secrets are absent entirely.
+type AbsentKeyPolicy string
+
+const (
+	AbsentKeySkip                AbsentKeyPolicy = "skip"
+	AbsentKeyRefuseNotDelivered  AbsentKeyPolicy = "refuse-not-delivered"
+	AbsentKeyRefuseNotInSnapshot AbsentKeyPolicy = "refuse-not-in-snapshot"
+)
+
+// RenderTarget is one ordered target selection supplied by an adapter.
+type RenderTarget struct {
+	Name                     string
+	KeyIDs                   []string
+	AcknowledgeLoaderControl []string
+}
+
+// RenderSourceRow is one adapter-normalized delivery row. Value nil means the
+// key was delivered without plaintext; UnrevealedSecret distinguishes the
+// all-or-nothing secret refusal from a genuinely unset value.
+type RenderSourceRow struct {
+	KeyID            string
+	Name             string
+	Classification   string
+	Value            *string
+	UnrevealedSecret bool
+}
+
+// RenderInput contains every policy and datum needed to build a render plan.
+// BuildRenderPlan performs no I/O and retains no reference to these slices.
+type RenderInput struct {
+	Projection RenderProjection
+	AbsentKeys AbsentKeyPolicy
+	Targets    []RenderTarget
+	Rows       []RenderSourceRow
+}
+
+type RenderOmissionKind string
+
+const (
+	RenderOmissionAbsent  RenderOmissionKind = "absent"
+	RenderOmissionNoValue RenderOmissionKind = "no-value"
+)
+
+// RenderOmission records a configured row intentionally omitted from output.
+type RenderOmission struct {
+	Target string             `json:"target"`
+	KeyID  string             `json:"key_id"`
+	Name   string             `json:"name,omitempty"`
+	Kind   RenderOmissionKind `json:"kind"`
+}
+
+type RenderRefusalKind string
+
+const (
+	RenderRefusalKeyNotDelivered  RenderRefusalKind = "key-not-delivered"
+	RenderRefusalKeyNotInSnapshot RenderRefusalKind = "key-not-in-snapshot"
+	RenderRefusalSecretUnrevealed RenderRefusalKind = "secret-unrevealed"
+	RenderRefusalLoaderControl    RenderRefusalKind = "loader-control"
+	RenderRefusalEncoding         RenderRefusalKind = "encoding"
+)
+
+// RenderRefusal is a typed, source-stable refusal owned by the plan. CLI
+// adapters add command-specific framing without re-running policy.
+type RenderRefusal struct {
+	Target string            `json:"target"`
+	Key    string            `json:"key"`
+	Kind   RenderRefusalKind `json:"kind"`
+	Reason string            `json:"reason,omitempty"`
+}
+
+// RenderTargetPlan is one target's exact bytes and snapshot rows.
+type RenderTargetPlan struct {
+	Name         string        `json:"name"`
+	Content      []byte        `json:"content"`
+	SnapshotRows []SnapshotRow `json:"snapshot_rows"`
+}
+
+// RenderPlan is the complete pure decision for one render attempt.
+type RenderPlan struct {
+	Targets   []RenderTargetPlan `json:"targets"`
+	Omissions []RenderOmission   `json:"omissions"`
+	Refusals  []RenderRefusal    `json:"refusals"`
+}
+
+// BuildRenderPlan applies target selection, projection/absence policy,
+// loader-control checks, raw-dotenv encoding, and snapshot-row collection.
+func BuildRenderPlan(in RenderInput) (RenderPlan, error) {
+	var plan RenderPlan
+	if err := validateRenderInput(in); err != nil {
+		return plan, err
+	}
+
+	byID := make(map[string]RenderSourceRow, len(in.Rows))
+	for _, row := range in.Rows {
+		if row.UnrevealedSecret && row.Value != nil {
+			return RenderPlan{}, fmt.Errorf("compose: render row %q is both unrevealed and valued", row.KeyID)
+		}
+		byID[row.KeyID] = row
+	}
+
+	for _, target := range in.Targets {
+		var rows []Row
+		var snapshotRows []SnapshotRow
+		var names []string
+		for _, keyID := range target.KeyIDs {
+			row, ok := byID[keyID]
+			if !ok {
+				if in.AbsentKeys == AbsentKeySkip {
+					plan.Omissions = append(plan.Omissions, RenderOmission{Target: target.Name, KeyID: keyID, Kind: RenderOmissionAbsent})
+				} else {
+					kind := RenderRefusalKeyNotDelivered
+					if in.AbsentKeys == AbsentKeyRefuseNotInSnapshot {
+						kind = RenderRefusalKeyNotInSnapshot
+					}
+					plan.Refusals = append(plan.Refusals, RenderRefusal{Target: target.Name, Key: keyID, Kind: kind})
+				}
+				continue
+			}
+			if row.UnrevealedSecret {
+				plan.Refusals = append(plan.Refusals, RenderRefusal{Target: target.Name, Key: row.Name, Kind: RenderRefusalSecretUnrevealed})
+				continue
+			}
+			if row.Value == nil {
+				plan.Omissions = append(plan.Omissions, RenderOmission{Target: target.Name, KeyID: keyID, Name: row.Name, Kind: RenderOmissionNoValue})
+				continue
+			}
+			rows = append(rows, Row{Name: row.Name, Value: *row.Value})
+			snapshotRows = append(snapshotRows, SnapshotRow{
+				Name: row.Name, KeyID: row.KeyID, Classification: row.Classification, Value: *row.Value,
+			})
+			names = append(names, row.Name)
+		}
+
+		for _, name := range RefuseUnacknowledged(names, target.AcknowledgeLoaderControl) {
+			plan.Refusals = append(plan.Refusals, RenderRefusal{Target: target.Name, Key: name, Kind: RenderRefusalLoaderControl})
+		}
+		content, encodingRefusals, err := EncodeRaw(rows)
+		if err != nil {
+			return RenderPlan{}, fmt.Errorf("compose: render target %s: %w", target.Name, err)
+		}
+		for _, refusal := range encodingRefusals {
+			plan.Refusals = append(plan.Refusals, RenderRefusal{
+				Target: target.Name, Key: refusal.Key, Kind: RenderRefusalEncoding, Reason: refusal.Reason,
+			})
+		}
+		plan.Targets = append(plan.Targets, RenderTargetPlan{Name: target.Name, Content: content, SnapshotRows: snapshotRows})
+	}
+	return plan, nil
+}
+
+func validateRenderInput(in RenderInput) error {
+	switch in.Projection {
+	case RenderProjectionFull:
+		if in.AbsentKeys == AbsentKeySkip {
+			return fmt.Errorf("compose: full render projection cannot skip absent keys")
+		}
+	case RenderProjectionConfigOnly:
+		if in.AbsentKeys != AbsentKeySkip {
+			return fmt.Errorf("compose: config-only render projection must skip absent keys")
+		}
+	default:
+		return fmt.Errorf("compose: unknown render projection %q", in.Projection)
+	}
+	switch in.AbsentKeys {
+	case AbsentKeySkip, AbsentKeyRefuseNotDelivered, AbsentKeyRefuseNotInSnapshot:
+		return nil
+	default:
+		return fmt.Errorf("compose: unknown absent-key policy %q", in.AbsentKeys)
+	}
+}

--- a/internal/compose/renderplan_test.go
+++ b/internal/compose/renderplan_test.go
@@ -1,0 +1,101 @@
+package compose
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func renderValue(value string) *string { return &value }
+
+func TestBuildRenderPlanLiveOfflineEquivalence(t *testing.T) {
+	targets := []RenderTarget{
+		{Name: "api", KeyIDs: []string{"key_url", "key_mode"}},
+		{Name: "worker", KeyIDs: []string{"key_mode"}},
+	}
+	rows := []RenderSourceRow{
+		{KeyID: "key_url", Name: "DATABASE_URL", Classification: "secret", Value: renderValue("postgres://db")},
+		{KeyID: "key_mode", Name: "APP_MODE", Classification: "config", Value: renderValue("production")},
+	}
+
+	live, err := BuildRenderPlan(RenderInput{
+		Projection: RenderProjectionFull,
+		AbsentKeys: AbsentKeyRefuseNotDelivered,
+		Targets:    targets,
+		Rows:       rows,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	offline, err := BuildRenderPlan(RenderInput{
+		Projection: RenderProjectionFull,
+		AbsentKeys: AbsentKeyRefuseNotInSnapshot,
+		Targets:    targets,
+		Rows:       append([]RenderSourceRow(nil), rows...),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(live, offline) {
+		t.Fatalf("equivalent live/offline plans differ:\n live: %#v\noffline: %#v", live, offline)
+	}
+}
+
+func TestBuildRenderPlanGolden(t *testing.T) {
+	plan, err := BuildRenderPlan(RenderInput{
+		Projection: RenderProjectionConfigOnly,
+		AbsentKeys: AbsentKeySkip,
+		Targets: []RenderTarget{
+			{Name: "api", KeyIDs: []string{"key_url", "key_unset", "key_projected", "key_path"}},
+			{Name: "worker", KeyIDs: []string{"key_bad_name", "key_multiline"}},
+		},
+		Rows: []RenderSourceRow{
+			{KeyID: "key_url", Name: "DATABASE_URL", Classification: "config", Value: renderValue("postgres://db")},
+			{KeyID: "key_unset", Name: "OPTIONAL", Classification: "config"},
+			{KeyID: "key_path", Name: "PATH", Classification: "config", Value: renderValue("/srv/bin")},
+			{KeyID: "key_bad_name", Name: "BAD-NAME", Classification: "config", Value: renderValue("x")},
+			{KeyID: "key_multiline", Name: "MULTILINE", Classification: "config", Value: renderValue("a\nb")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = append(got, '\n')
+	want, err := os.ReadFile("testdata/renderplan/config-only.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("render plan golden mismatch:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func TestBuildRenderPlanModelsFullProjectionRefusals(t *testing.T) {
+	plan, err := BuildRenderPlan(RenderInput{
+		Projection: RenderProjectionFull,
+		AbsentKeys: AbsentKeyRefuseNotDelivered,
+		Targets: []RenderTarget{{
+			Name: "api", KeyIDs: []string{"key_missing", "key_secret"},
+		}},
+		Rows: []RenderSourceRow{{
+			KeyID: "key_secret", Name: "DB_PASSWORD", Classification: "secret", UnrevealedSecret: true,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []RenderRefusal{
+		{Target: "api", Key: "key_missing", Kind: RenderRefusalKeyNotDelivered},
+		{Target: "api", Key: "DB_PASSWORD", Kind: RenderRefusalSecretUnrevealed},
+	}
+	if !reflect.DeepEqual(plan.Refusals, want) {
+		t.Fatalf("refusals = %#v, want %#v", plan.Refusals, want)
+	}
+}

--- a/internal/compose/testdata/renderplan/config-only.json
+++ b/internal/compose/testdata/renderplan/config-only.json
@@ -1,0 +1,72 @@
+{
+  "targets": [
+    {
+      "name": "api",
+      "content": "REFUQUJBU0VfVVJMPXBvc3RncmVzOi8vZGIKUEFUSD0vc3J2L2Jpbgo=",
+      "snapshot_rows": [
+        {
+          "name": "DATABASE_URL",
+          "key_id": "key_url",
+          "classification": "config",
+          "value": "postgres://db"
+        },
+        {
+          "name": "PATH",
+          "key_id": "key_path",
+          "classification": "config",
+          "value": "/srv/bin"
+        }
+      ]
+    },
+    {
+      "name": "worker",
+      "content": null,
+      "snapshot_rows": [
+        {
+          "name": "BAD-NAME",
+          "key_id": "key_bad_name",
+          "classification": "config",
+          "value": "x"
+        },
+        {
+          "name": "MULTILINE",
+          "key_id": "key_multiline",
+          "classification": "config",
+          "value": "a\nb"
+        }
+      ]
+    }
+  ],
+  "omissions": [
+    {
+      "target": "api",
+      "key_id": "key_unset",
+      "name": "OPTIONAL",
+      "kind": "no-value"
+    },
+    {
+      "target": "api",
+      "key_id": "key_projected",
+      "kind": "absent"
+    }
+  ],
+  "refusals": [
+    {
+      "target": "api",
+      "key": "PATH",
+      "kind": "loader-control"
+    },
+    {
+      "target": "worker",
+      "key": "BAD-NAME",
+      "kind": "encoding",
+      "reason": "invalid name"
+    },
+    {
+      "target": "worker",
+      "key": "MULTILINE",
+      "kind": "encoding",
+      "reason": "embedded newline"
+    }
+  ]
+}


### PR DESCRIPTION
# Issue #230: one pure Compose render plan

## Contract

`compose.BuildRenderPlan(RenderInput) (RenderPlan, error)` is the single pure
decision point for live and offline Compose rendering. Adapters provide ordered
targets and normalized source rows plus explicit projection and absent-key
policy. The plan owns exact target bytes, snapshot rows, omissions, and typed
refusals.

Full live input refuses a configured key absent from the server delivery; full
offline input refuses a configured key absent from the sealed snapshot.
Config-only input skips absent keys because projected-out secrets and deleted
config keys are indistinguishable in that projection. Existing CLI refusal
text, sorting, all-or-nothing writes, and generation ordering remain unchanged.

`hikyo run` is deliberately excluded. It delivers the full environment, merges
against the sanitized parent process, performs collision and ARG_MAX checks,
then execs; it does not select render targets or encode dotenv files.

## What changed

- `internal/compose/renderplan.go` defines the pure input, plan, omission, and
  refusal model and performs selection, loader-control checks, raw encoding,
  and snapshot-row collection without filesystem, network, clock, crypto, or
  secret-fetch work.
- Live and offline CLI paths now only normalize their source into `RenderInput`,
  execute the shared plan, and perform source-specific side effects afterward.
- Pure golden coverage pins plan shape. Adapter tables prove equivalent live
  and offline inputs produce identical target bytes and refusals, including
  config-only and refusal cases. Omission provenance remains source-specific:
  a live unset row is `no-value`; a snapshot that never stored it is `absent`.

## Generated outputs

None.

## Validation

- `go test -count=1 ./internal/compose/... ./internal/cli/...`: 350 passed.
- `go test -race -count=1 ./internal/compose/... ./internal/cli/...`: 350 passed.
- `go vet ./internal/compose/... ./internal/cli/...`: passed.
- `go test -count=1 ./internal/isolation -run '^TestComposeCLI'`: passed.
- `go build ./...`, `go vet ./...`, and `go test -count=1 ./...`: passed.
- `./scripts/compose-demo.sh`: passed all 21 byte-exact round trips,
  refusal atomicity, doctor, and sync/restart checks.
- `git diff --check` and scoped `gofmt -l`: passed.
- Standards and issue-spec review axes: CLEAN in round 2.
