### PR TITLE
refactor(remotefetch): close fan-out result set

### DIFF
--- a/docs/handoff/234-remote-fetch-results.md
+++ b/docs/handoff/234-remote-fetch-results.md
@@ -1,0 +1,70 @@
+# Handoff: #234 closed remote-fetch results
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/234 (subissue of #204;
+programme #203; audit `BE17-B`). Implemented from fresh `origin/main` at
+`709b2b0ca32b906b95a9ae7149664328ca823b97`.
+
+## Contract
+
+- `remotefetch.Result` is a sealed union: `Attempted` carries the listing,
+  remote outcome, and diagnostic error; `NotAttempted` carries only target id
+  and `context_cancelled` or `slot_not_acquired`.
+- `FetchAll` returns exactly one result per input target in input order. The
+  scheduler starts requests under the existing fan-out semaphore. Cancellation
+  while the next target waits for a full slot records `slot_not_acquired`; later
+  targets record `context_cancelled`. Cancellation seen after slot acquisition
+  but before `Directory` also records `context_cancelled`.
+- A request that reached `Directory` remains `Attempted` even when transport,
+  TLS, HTTP, or cancellation makes it fail. No response body enters either
+  result variant.
+- Service settlement, identity-conflict detection, and fetch-gate coverage use
+  the same attempted-variant check. `NotAttempted` serves the last snapshot and
+  cannot update remote health, write `remote.fetch_failed`, contribute an
+  identity conflict, or make a coalesced round cover that target.
+
+No persisted schema, API wire format, or generated output changed.
+
+## Tests
+
+- Mid-queue cancellation proves result cardinality, input order, one attempted
+  request, one slot refusal, and explicit cancellation for targets not queued.
+- A real TLS peer returning HTTP 503 proves attempted network failure remains
+  distinct from cancellation before scheduling.
+- Service tests prove gate coverage counts attempted variants only and the
+  shared variant discriminator rejects `NotAttempted` before settlement or
+  conflict processing.
+
+## Validation
+
+```text
+go test -count=1 ./internal/remotefetch ./internal/service
+  219 passed on the final rebased head
+go test -race -count=1 ./internal/remotefetch/...
+  11 passed
+go test -count=1 ./internal/remotefetch/... ./internal/service/... -run Remote
+  4 passed
+go test -count=50 ./internal/remotefetch -run 'TestFetchAllReturnsOneOrderedResultPerTargetWhenCancelledMidQueue|TestFetchAllDistinguishesAttemptedNetworkFailureFromCancellation'
+  100 passed
+go test -count=20 ./internal/service -run 'TestFetchGateCoverage|TestAttemptedFetch|TestConflictingIdentities'
+  140 passed, including nil-variant subtests
+go vet ./...
+  passed
+go test -p 4 -count=1 -timeout=20m ./...
+  passed: 57 packages
+```
+
+The first unbounded full-suite run made four `internal/importer` live-helper
+tests hit their existing 30-second request deadline under host contention. All
+four passed together in 14.4 seconds when replayed alone. Bounding package
+concurrency at four made the unchanged full suite pass; no timeout was raised.
+
+## Review
+
+- Spec axis: CLEAN in round 1.
+- Standards round 1 found pointer/value union ambiguity and an incomplete
+  cancellation-window comment. Both were fixed with canonical pointer-only
+  variants, fail-loud invalid-variant handling, tests, and exact contract text.
+- Standards round 2 requested nil-interface and typed-nil regression coverage.
+  Added all three constructible cases. Round 3: CLEAN.
+
+Exact-head CI and merge evidence live on the pull request.

--- a/internal/remotefetch/directory.go
+++ b/internal/remotefetch/directory.go
@@ -172,13 +172,53 @@ type Target struct {
 	Credential string
 }
 
-// Result pairs a target with what came back.
-type Result struct {
+// Result is the closed result union for one input target. Both variants carry
+// target identity, so FetchAll can preserve cardinality and order without
+// turning local scheduling state into a remote Outcome.
+type Result interface {
+	TargetID() string
+	resultKind()
+}
+
+// Attempted is a target for which Directory was called. Err is diagnostic
+// detail; Outcome is the closed operator-visible result even when Err is nil.
+type Attempted struct {
 	ID      string
 	Listing Listing
 	Outcome Outcome
 	Err     error
 }
+
+func (r *Attempted) TargetID() string {
+	if r == nil {
+		panic("remotefetch: nil Attempted result")
+	}
+	return r.ID
+}
+func (*Attempted) resultKind() {}
+
+// NotAttemptedReason says where local scheduling stopped before Directory was
+// called. It must never be persisted as remote health or a fetch-failure audit.
+type NotAttemptedReason string
+
+const (
+	NotAttemptedContextCancelled NotAttemptedReason = "context_cancelled"
+	NotAttemptedSlotNotAcquired  NotAttemptedReason = "slot_not_acquired"
+)
+
+// NotAttempted is local evidence only: the target produced no remote outcome.
+type NotAttempted struct {
+	ID     string
+	Reason NotAttemptedReason
+}
+
+func (r *NotAttempted) TargetID() string {
+	if r == nil {
+		panic("remotefetch: nil NotAttempted result")
+	}
+	return r.ID
+}
+func (*NotAttempted) resultKind() {}
 
 // FetchAll runs one fan-out round under the configured cap.
 //
@@ -187,47 +227,74 @@ type Result struct {
 // 50 and FanOut at 4, a pathological all-unreachable directory is thirteen
 // sequential rounds of the per-remote deadline, which is the arithmetic the
 // bound was chosen for.
-// FetchAll returns a result for every target it ATTEMPTED, and omits every
-// target it did not. The distinction is the whole contract: a target the round
-// never reached has produced no evidence about the remote, and inventing
-// `unreachable` for it would persist a failure snapshot and an audit event for
-// a connection nobody opened. A caller that finds no entry for a target serves
-// its last-known snapshot AS a snapshot, which is the honest answer.
+// FetchAll returns exactly one ordered result per target. A target the round
+// never reached is NotAttempted: it produced no evidence about the remote, and
+// inventing `unreachable` for it would persist a failure snapshot and an audit
+// event for a connection nobody opened.
 //
-// Two places drop a target, both before any byte is written: the queue, if the
-// round ends while it is waiting for a fan-out slot, and the moment after
-// acquiring one, if the round ended in between.
+// Cancellation can prevent an attempt in three scheduling windows: before the
+// scheduler reaches a target, after a slot is granted but before Directory is
+// called, or while the next target waits for a full slot. The first two are
+// context_cancelled; the waiting target is slot_not_acquired. None calls
+// Directory.
 func (c *Client) FetchAll(ctx context.Context, targets []Target) []Result {
 	out := make([]Result, len(targets))
-	attempted := make([]bool, len(targets))
+	if ctx.Err() != nil {
+		fillNotAttempted(out, targets, 0, NotAttemptedContextCancelled)
+		return out
+	}
+
 	sem := make(chan struct{}, c.cfg.FanOut)
 	var wg sync.WaitGroup
+
+schedule:
 	for i, t := range targets {
-		wg.Add(1)
-		go func(i int, t Target) {
-			defer wg.Done()
+		if ctx.Err() != nil {
+			fillNotAttempted(out, targets, i, NotAttemptedContextCancelled)
+			break
+		}
+
+		// Fast path distinguishes a free slot from a target that had to queue.
+		// If cancellation wins after the queue begins, that target names the
+		// slot refusal and targets not yet queued name context cancellation.
+		select {
+		case sem <- struct{}{}:
+		default:
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
-				return
+				out[i] = &NotAttempted{ID: t.ID, Reason: NotAttemptedSlotNotAcquired}
+				fillNotAttempted(out, targets, i+1, NotAttemptedContextCancelled)
+				break schedule
 			}
+			if ctx.Err() != nil {
+				<-sem
+				out[i] = &NotAttempted{ID: t.ID, Reason: NotAttemptedSlotNotAcquired}
+				fillNotAttempted(out, targets, i+1, NotAttemptedContextCancelled)
+				break schedule
+			}
+		}
+
+		wg.Add(1)
+		go func(i int, t Target) {
+			defer wg.Done()
 			defer func() { <-sem }()
 			if ctx.Err() != nil {
+				out[i] = &NotAttempted{ID: t.ID, Reason: NotAttemptedContextCancelled}
 				return
 			}
-			attempted[i] = true
 			l, o, err := c.Directory(ctx, t.Origin, t.Pin, t.Credential)
-			out[i] = Result{ID: t.ID, Listing: l, Outcome: o, Err: err}
+			out[i] = &Attempted{ID: t.ID, Listing: l, Outcome: o, Err: err}
 		}(i, t)
 	}
 	wg.Wait()
-	got := make([]Result, 0, len(targets))
-	for i := range out {
-		if attempted[i] {
-			got = append(got, out[i])
-		}
+	return out
+}
+
+func fillNotAttempted(out []Result, targets []Target, from int, reason NotAttemptedReason) {
+	for i := from; i < len(targets); i++ {
+		out[i] = &NotAttempted{ID: targets[i].ID, Reason: reason}
 	}
-	return got
 }
 
 // RoundBudget is the honest whole-round maximum for n targets: the number of

--- a/internal/remotefetch/remotefetch_test.go
+++ b/internal/remotefetch/remotefetch_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -265,7 +266,7 @@ func TestCanonicalRemoteURLHasNoTrailingSlash(t *testing.T) {
 // a remote that was contacted and did not answer. The caller then persisted a
 // fetch-failure snapshot and an audit event per remote, for connections nobody
 // opened.
-func TestRoundBudgetCoversEveryWaveAndUnattemptedTargetsAreOmitted(t *testing.T) {
+func TestRoundBudgetCoversEveryWave(t *testing.T) {
 	c, err := New(Config{Deadline: 10 * time.Second, ResponseCap: 1 << 20, FanOut: 4})
 	if err != nil {
 		t.Fatal(err)
@@ -279,18 +280,110 @@ func TestRoundBudgetCoversEveryWaveAndUnattemptedTargetsAreOmitted(t *testing.T)
 	if got := c.RoundBudget(1); got < 10*time.Second {
 		t.Errorf("RoundBudget(1) = %v, want at least one per-remote deadline", got)
 	}
+}
 
-	// Three waves' worth of targets against a round context that is already
-	// over: nothing is attempted, so nothing is reported.
-	targets := make([]Target, 12)
-	for i := range targets {
-		targets[i] = Target{ID: "rmt_" + string(rune('a'+i)), Origin: "https://unreachable.invalid", Pin: "x"}
+func TestFetchAllReturnsOneOrderedResultPerTargetWhenCancelledMidQueue(t *testing.T) {
+	started := make(chan struct{}, 1)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		started <- struct{}{}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{Deadline: 5 * time.Second, ResponseCap: 1 << 20, FanOut: 1})
+	if err != nil {
+		t.Fatal(err)
 	}
+	targets := make([]Target, 4)
+	for i := range targets {
+		targets[i] = Target{
+			ID: "rmt_" + strconv.Itoa(i), Origin: srv.URL,
+			Pin: SPKIFingerprint(srv.Certificate()), Credential: "hik_ic_test",
+		}
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	results := make(chan []Result, 1)
+	go func() { results <- c.FetchAll(ctx, targets) }()
+	<-started
+	cancel()
+	got := <-results
+
+	if len(got) != len(targets) {
+		t.Fatalf("FetchAll returned %d results for %d targets", len(got), len(targets))
+	}
+	attempted, slotRefused, cancelled := 0, 0, 0
+	for i, result := range got {
+		if result.TargetID() != targets[i].ID {
+			t.Errorf("result[%d] identifies %q, want %q", i, result.TargetID(), targets[i].ID)
+		}
+		switch result := result.(type) {
+		case *Attempted:
+			attempted++
+			if result.Err == nil {
+				t.Error("cancelled in-flight request reported a successful attempt")
+			}
+		case *NotAttempted:
+			switch result.Reason {
+			case NotAttemptedSlotNotAcquired:
+				slotRefused++
+			case NotAttemptedContextCancelled:
+				cancelled++
+			default:
+				t.Errorf("result[%d] has unknown not-attempted reason %q", i, result.Reason)
+			}
+		default:
+			t.Fatalf("result[%d] has unknown variant %T", i, result)
+		}
+	}
+	if attempted != 1 {
+		t.Errorf("attempted %d targets, want the one request that reached the peer", attempted)
+	}
+	if slotRefused != 1 {
+		t.Errorf("reported %d slot refusals, want the first queued target", slotRefused)
+	}
+	if cancelled != len(targets)-2 {
+		t.Errorf("reported %d context-cancelled targets, want %d never queued targets", cancelled, len(targets)-2)
+	}
+}
+
+func TestFetchAllDistinguishesAttemptedNetworkFailureFromCancellation(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{Deadline: time.Second, ResponseCap: 1 << 20, FanOut: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := Target{
+		ID: "rmt_failure", Origin: srv.URL,
+		Pin: SPKIFingerprint(srv.Certificate()), Credential: "hik_ic_test",
+	}
+	got := c.FetchAll(t.Context(), []Target{target})
+	if len(got) != 1 {
+		t.Fatalf("FetchAll returned %d results, want 1", len(got))
+	}
+	attempt, ok := got[0].(*Attempted)
+	if !ok {
+		t.Fatalf("network request result is %T, want Attempted", got[0])
+	}
+	if attempt.Outcome != OutcomeUnreachable || attempt.Err == nil {
+		t.Errorf("attempt = %+v, want unreachable with error detail", attempt)
+	}
+
 	dead, cancel := context.WithCancel(t.Context())
 	cancel()
-	if got := c.FetchAll(dead, targets); len(got) != 0 {
-		t.Errorf("a cancelled round reported %d results; a target that was never dialled "+
-			"has produced no evidence and must be OMITTED, so the caller serves its "+
-			"last-known snapshot instead of persisting a fabricated failure", len(got))
+	got = c.FetchAll(dead, []Target{target})
+	if len(got) != 1 {
+		t.Fatalf("cancelled FetchAll returned %d results, want 1", len(got))
+	}
+	notAttempted, ok := got[0].(*NotAttempted)
+	if !ok {
+		t.Fatalf("cancelled-before-scheduling result is %T, want NotAttempted", got[0])
+	}
+	if notAttempted.Reason != NotAttemptedContextCancelled {
+		t.Errorf("not-attempted reason = %q, want %q", notAttempted.Reason, NotAttemptedContextCancelled)
 	}
 }

--- a/internal/service/remotefetchgate.go
+++ b/internal/service/remotefetchgate.go
@@ -71,7 +71,7 @@ type fetchGate struct {
 	// rather than one per human.
 	//
 	// A round is reusable ONLY by a request every one of whose remotes the
-	// round actually fetched — its keys ARE its scope. A `remote show A` caches
+	// round actually attempted. A `remote show A` caches
 	// a one-entry round, and handing that to a `remote list` would report every
 	// other entry as unreachable: there is no outcome in the closed enum for
 	// "we did not look", so sharing across scopes can only fabricate one. A
@@ -152,7 +152,11 @@ func covers(round map[string]remotefetch.Result, want []string) bool {
 		return false
 	}
 	for _, id := range want {
-		if _, ok := round[id]; !ok {
+		result, ok := round[id]
+		if !ok {
+			return false
+		}
+		if _, ok := attemptedFetch(result); !ok {
 			return false
 		}
 	}

--- a/internal/service/remotefetchgate_test.go
+++ b/internal/service/remotefetchgate_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
+)
+
+func TestFetchGateCoverageCountsOnlyAttemptedResults(t *testing.T) {
+	round := map[string]remotefetch.Result{
+		"rmt_attempted": &remotefetch.Attempted{ID: "rmt_attempted"},
+		"rmt_queued": &remotefetch.NotAttempted{
+			ID: "rmt_queued", Reason: remotefetch.NotAttemptedSlotNotAcquired,
+		},
+	}
+	if !covers(round, []string{"rmt_attempted"}) {
+		t.Fatal("an attempted target did not count as covered")
+	}
+	if covers(round, []string{"rmt_attempted", "rmt_queued"}) {
+		t.Fatal("a not-attempted target counted as covered and could suppress a later real fetch")
+	}
+}
+
+func TestAttemptedFetchKeepsFailuresAndRejectsNotAttemptedResults(t *testing.T) {
+	wantErr := errors.New("peer refused connection")
+	want := &remotefetch.Attempted{
+		ID: "rmt_attempted", Outcome: remotefetch.OutcomeUnreachable, Err: wantErr,
+	}
+	got, ok := attemptedFetch(want)
+	if !ok || got.Outcome != remotefetch.OutcomeUnreachable || !errors.Is(got.Err, wantErr) {
+		t.Fatalf("attemptedFetch(%+v) = %+v, %v", want, got, ok)
+	}
+
+	notAttempted := &remotefetch.NotAttempted{
+		ID: "rmt_queued", Reason: remotefetch.NotAttemptedSlotNotAcquired,
+	}
+	if got, ok := attemptedFetch(notAttempted); ok {
+		t.Fatalf("attemptedFetch(%+v) = %+v, true; settlement would persist a local refusal", notAttempted, got)
+	}
+}
+
+func TestAttemptedFetchFailsLoudForNilVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		result remotefetch.Result
+	}{
+		{name: "nil interface"},
+		{name: "nil attempted", result: (*remotefetch.Attempted)(nil)},
+		{name: "nil not attempted", result: (*remotefetch.NotAttempted)(nil)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("invalid result variant was silently treated as not attempted")
+				}
+			}()
+			attemptedFetch(test.result)
+		})
+	}
+}
+
+func TestConflictingIdentitiesUsesOnlyAttemptedListings(t *testing.T) {
+	results := map[string]remotefetch.Result{
+		"rmt_a": &remotefetch.Attempted{
+			ID: "rmt_a", Outcome: remotefetch.OutcomeOK,
+			Listing: remotefetch.Listing{Identity: "ins_shared"},
+		},
+		"rmt_b": &remotefetch.NotAttempted{
+			ID: "rmt_b", Reason: remotefetch.NotAttemptedContextCancelled,
+		},
+	}
+	if conflicts := conflictingIdentities(results); len(conflicts) != 0 {
+		t.Fatalf("not-attempted result contributed an identity conflict: %v", conflicts)
+	}
+}

--- a/internal/service/remotes.go
+++ b/internal/service/remotes.go
@@ -480,7 +480,7 @@ func (s *Remotes) runRound(
 	fetchCtx, cancel := context.WithTimeout(ctx, s.Fetch.RoundBudget(len(targets)))
 	defer cancel()
 	for _, res := range s.Fetch.FetchAll(fetchCtx, targets) {
-		out[res.ID] = res
+		out[res.TargetID()] = res
 	}
 	return out
 }
@@ -517,9 +517,15 @@ func (s *Remotes) settle(
 		stale := 0
 		for _, e := range entries {
 			res, got := results[e.ID]
-			if !fetched || !got {
+			var attempted *remotefetch.Attempted
+			wasAttempted := false
+			if fetched && got {
+				attempted, wasAttempted = attemptedFetch(res)
+			}
+			if !fetched || !got || !wasAttempted {
 				// No round covered this entry — the trigger budget was
-				// exhausted, or the shared round's scope did not include it.
+				// exhausted, the shared round's scope did not include it, or
+				// local cancellation/admission prevented an actual request.
 				// The snapshot is served AS a snapshot: nothing is written, and
 				// nothing is claimed to be current. There is deliberately no
 				// outcome invented here; `unreachable` would name a connection
@@ -538,16 +544,16 @@ func (s *Remotes) settle(
 				views = append(views, v)
 				continue
 			}
-			outcome := res.Outcome
+			outcome := attempted.Outcome
 			switch {
-			case outcome == remotefetch.OutcomeOK && res.Listing.Identity == selfIdentity:
+			case outcome == remotefetch.OutcomeOK && attempted.Listing.Identity == selfIdentity:
 				outcome = remotefetch.OutcomeSelfConnected
-			case outcome == remotefetch.OutcomeOK && conflicted[res.Listing.Identity]:
+			case outcome == remotefetch.OutcomeOK && conflicted[attempted.Listing.Identity]:
 				outcome = remotefetch.OutcomeIdentityConflict
 			}
 
 			if outcome == remotefetch.OutcomeOK {
-				snap, err := snapshotOf(e.ID, res.Listing, now)
+				snap, err := snapshotOf(e.ID, attempted.Listing, now)
 				if err != nil {
 					return err
 				}
@@ -728,8 +734,9 @@ func knownIdentities(ctx context.Context, rr store.RemoteReader, p authz.Proof) 
 func conflictingIdentities(results map[string]remotefetch.Result) map[string]bool {
 	seen := map[string]int{}
 	for _, res := range results {
-		if res.Outcome == remotefetch.OutcomeOK {
-			seen[res.Listing.Identity]++
+		attempted, ok := attemptedFetch(res)
+		if ok && attempted.Outcome == remotefetch.OutcomeOK {
+			seen[attempted.Listing.Identity]++
 		}
 	}
 	out := map[string]bool{}
@@ -739,6 +746,26 @@ func conflictingIdentities(results map[string]remotefetch.Result) map[string]boo
 		}
 	}
 	return out
+}
+
+// attemptedFetch is the single variant check shared by settlement, identity
+// conflict detection, and gate coverage. A NotAttempted result is local
+// scheduler state and must never become remote health or audit evidence.
+func attemptedFetch(result remotefetch.Result) (*remotefetch.Attempted, bool) {
+	switch result := result.(type) {
+	case *remotefetch.Attempted:
+		if result == nil {
+			panic("service: nil attempted remote fetch result")
+		}
+		return result, true
+	case *remotefetch.NotAttempted:
+		if result == nil {
+			panic("service: nil not-attempted remote fetch result")
+		}
+		return nil, false
+	default:
+		panic("service: unknown remote fetch result variant")
+	}
 }
 
 func snapshotOf(remoteID string, l remotefetch.Listing, now time.Time) (store.RemoteSnapshot, error) {


### PR DESCRIPTION
Closes #234.

## Contract

- replace partial `[]Result` output with sealed pointer-only `Attempted` / `NotAttempted` variants
- preserve one result per input target, target identity, and input order
- distinguish `context_cancelled` from `slot_not_acquired` without inventing remote health
- settle, audit, identity-conflict, and coalescing coverage only for genuine attempts
- preserve fan-out bounds; result values retain no response bodies

No schema/API migration. No generated outputs.

## Validation

- scoped/current-base tests: 294 passed; remote race: 11 passed
- `go vet ./...`: passed
- full `go test -p 4 -count=1 -timeout=20m ./...`: 57 packages passed
- exact-head CI at `29c97885`: 28 checks passed, 0 failed; strict `ci-required` passed

## Review / delivery

- Spec axis: CLEAN
- Standards: valid findings fixed; round 3 CLEAN
- signed DCO commits
- handoff: `docs/handoff/234-remote-fetch-results.md`
- squash merge: `136f7567b8556e4198e0112c4237464b7e5f9647`
