### PR TITLE
refactor(adapter): centralize provider module construction (#232)

### DIFF
--- a/docs/handoff/232-provider-module-factory.md
+++ b/docs/handoff/232-provider-module-factory.md
@@ -1,0 +1,45 @@
+# Handoff: #232 provider-aware adapter module factory
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/232 (parent #204; programme
+#203; audit ID `BE16-B`). Base: `4a4060b0d986111af9822974c7ce264714fc0e04`.
+
+## Contract
+
+- `adapter.Provider` is the closed compiled-in provider set. API defaulting
+  resolves an omitted create provider explicitly to Forgejo; persisted and
+  internal empty or unknown kinds fail before credential opening.
+- One app registry owns the Forgejo and GitHub Actions constructors. One
+  factory instance captures the operator egress policy and is injected into
+  both worker loading and service planning/probing.
+- `adapter.ModuleLease` binds every constructed module to idempotent cleanup.
+  Partial construction errors release immediately; service operations defer
+  release; worker loaders release on later errors or transfer one release-once
+  closure with the loaded plaintext.
+- Provider modules, credential lifetimes, request deadlines, destination
+  validation, and egress exceptions are unchanged. This is compiled-in wiring,
+  not a runtime plugin framework.
+
+## Regression evidence
+
+- Registry totality covers every supported provider exactly once.
+- Unknown-provider tests prove worker and service refusal before credential use.
+- Partial-construction, post-construction error, and repeated-release tests pin
+  release-once behavior.
+- Shared-factory coverage proves worker and service construction resolve the
+  same module type and origin-scoped egress policy.
+
+Generated outputs: none.
+
+## Validation
+
+```text
+go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/...
+                                                          354 passed
+go test -race -count=1 ./internal/adapter/...              110 passed
+go build ./...                                             passed
+go vet ./...                                               passed
+go test -p 4 -count=1 -timeout=20m ./...                   3228 passed / 57 packages
+```
+
+Two-axis Codex review reached `CLEAN` in round 2 after release ownership was
+made singular and production worker/service parity coverage was strengthened.

--- a/docs/handoff/232-provider-module-factory.md
+++ b/docs/handoff/232-provider-module-factory.md
@@ -1,7 +1,7 @@
 # Handoff: #232 provider-aware adapter module factory
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/232 (parent #204; programme
-#203; audit ID `BE16-B`). Base: `6dbb07bc713ec7cb2671274153b563e3683fa2b9`.
+#203; audit ID `BE16-B`). Base: `136f7567b8556e4198e0112c4237464b7e5f9647`.
 
 ## Contract
 
@@ -34,11 +34,11 @@ Generated outputs: none.
 
 ```text
 go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/...
-                                                          355 passed
+                                                          362 passed
 go test -race -count=1 ./internal/adapter/...              110 passed
 go build ./...                                             passed
 go vet ./...                                               passed
-go test -p 4 -count=1 -timeout=20m ./...                   3236 passed / 57 packages
+go test -p 4 -count=1 -timeout=20m ./...                   3245 passed / 57 packages
 ```
 
 Two-axis Codex review reached `CLEAN` in round 2 after release ownership was

--- a/docs/handoff/232-provider-module-factory.md
+++ b/docs/handoff/232-provider-module-factory.md
@@ -1,7 +1,7 @@
 # Handoff: #232 provider-aware adapter module factory
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/232 (parent #204; programme
-#203; audit ID `BE16-B`). Base: `136f7567b8556e4198e0112c4237464b7e5f9647`.
+#203; audit ID `BE16-B`). Base: `e31fc10b9c55afa8c77b002bf6189f4846af03a3`.
 
 ## Contract
 
@@ -38,7 +38,7 @@ go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/..
 go test -race -count=1 ./internal/adapter/...              110 passed
 go build ./...                                             passed
 go vet ./...                                               passed
-go test -p 4 -count=1 -timeout=20m ./...                   3245 passed / 57 packages
+go test -p 4 -count=1 -timeout=20m ./...                   3252 passed / 57 packages
 ```
 
 Two-axis Codex review reached `CLEAN` in round 2 after release ownership was

--- a/docs/handoff/232-provider-module-factory.md
+++ b/docs/handoff/232-provider-module-factory.md
@@ -1,7 +1,7 @@
 # Handoff: #232 provider-aware adapter module factory
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/232 (parent #204; programme
-#203; audit ID `BE16-B`). Base: `709b2b0ca32b906b95a9ae7149664328ca823b97`.
+#203; audit ID `BE16-B`). Base: `6dbb07bc713ec7cb2671274153b563e3683fa2b9`.
 
 ## Contract
 
@@ -34,11 +34,11 @@ Generated outputs: none.
 
 ```text
 go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/...
-                                                          354 passed
+                                                          355 passed
 go test -race -count=1 ./internal/adapter/...              110 passed
 go build ./...                                             passed
 go vet ./...                                               passed
-go test -p 4 -count=1 -timeout=20m ./...                   3235 passed / 57 packages
+go test -p 4 -count=1 -timeout=20m ./...                   3236 passed / 57 packages
 ```
 
 Two-axis Codex review reached `CLEAN` in round 2 after release ownership was

--- a/docs/handoff/232-provider-module-factory.md
+++ b/docs/handoff/232-provider-module-factory.md
@@ -1,7 +1,7 @@
 # Handoff: #232 provider-aware adapter module factory
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/232 (parent #204; programme
-#203; audit ID `BE16-B`). Base: `4a4060b0d986111af9822974c7ce264714fc0e04`.
+#203; audit ID `BE16-B`). Base: `709b2b0ca32b906b95a9ae7149664328ca823b97`.
 
 ## Contract
 
@@ -38,7 +38,7 @@ go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/..
 go test -race -count=1 ./internal/adapter/...              110 passed
 go build ./...                                             passed
 go vet ./...                                               passed
-go test -p 4 -count=1 -timeout=20m ./...                   3228 passed / 57 packages
+go test -p 4 -count=1 -timeout=20m ./...                   3235 passed / 57 packages
 ```
 
 Two-axis Codex review reached `CLEAN` in round 2 after release ownership was

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -277,10 +277,14 @@ func ValidateGitHubActionsManifest(prefix string, entries []ManifestEntry, value
 }
 
 func ValidateProviderManifest(provider, prefix string, entries []ManifestEntry, values bool) error {
-	switch provider {
-	case "github-actions":
+	kind, err := ParseProvider(provider)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case GitHubActionsProvider:
 		return ValidateGitHubActionsManifest(prefix, entries, values)
-	case "forgejo", "":
+	case ForgejoProvider:
 		return ValidateManifest(prefix, entries)
 	default:
 		return fmt.Errorf("adapter: unknown provider %q", provider)

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -82,6 +82,24 @@ func TestGitHubManifestRefusesUnrepresentableNonUTF8ByName(t *testing.T) {
 	}
 }
 
+func TestProviderKindsAreClosedAndRejectUnknownValues(t *testing.T) {
+	want := []Provider{ForgejoProvider, GitHubActionsProvider}
+	if got := SupportedProviders(); !slices.Equal(got, want) {
+		t.Fatalf("SupportedProviders() = %v, want %v", got, want)
+	}
+	for _, provider := range want {
+		got, err := ParseProvider(string(provider))
+		if err != nil || got != provider {
+			t.Fatalf("ParseProvider(%q) = %q, %v", provider, got, err)
+		}
+	}
+	for _, raw := range []string{"", "gitlab", "FORGEJO"} {
+		if _, err := ParseProvider(raw); err == nil {
+			t.Fatalf("ParseProvider(%q) accepted unknown provider", raw)
+		}
+	}
+}
+
 func TestModuleSeamHasExactlyFourOperations(t *testing.T) {
 	typeOf := reflect.TypeOf((*Module)(nil)).Elem()
 	got := make([]string, 0, typeOf.NumMethod())

--- a/internal/adapter/provider.go
+++ b/internal/adapter/provider.go
@@ -1,0 +1,60 @@
+package adapter
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Provider is the closed set of compiled-in deployment providers.
+type Provider string
+
+const (
+	ForgejoProvider       Provider = "forgejo"
+	GitHubActionsProvider Provider = "github-actions"
+)
+
+var supportedProviders = [...]Provider{ForgejoProvider, GitHubActionsProvider}
+
+// SupportedProviders returns the complete compiled-in provider set.
+func SupportedProviders() []Provider {
+	return append([]Provider(nil), supportedProviders[:]...)
+}
+
+// ParseProvider rejects missing and unknown persisted provider identities.
+// API defaults must resolve to an explicit provider before this boundary.
+func ParseProvider(raw string) (Provider, error) {
+	provider := Provider(raw)
+	for _, supported := range supportedProviders {
+		if provider == supported {
+			return provider, nil
+		}
+	}
+	return "", fmt.Errorf("adapter: unknown provider %q", raw)
+}
+
+// ModuleLease binds one constructed module to its idempotent cleanup.
+type ModuleLease struct {
+	Module  Module
+	release func()
+}
+
+// NewModuleLease transfers module cleanup ownership to one release-once value.
+func NewModuleLease(module Module, release func()) (*ModuleLease, error) {
+	if module == nil {
+		return nil, fmt.Errorf("adapter: provider factory returned no module")
+	}
+	if release == nil {
+		release = func() {}
+	}
+	return &ModuleLease{Module: module, release: sync.OnceFunc(release)}, nil
+}
+
+// Release drops provider resources exactly once.
+func (l *ModuleLease) Release() {
+	if l != nil && l.release != nil {
+		l.release()
+	}
+}
+
+// ModuleFactory is the shared worker/service construction seam.
+type ModuleFactory func(Provider, Config, string) (*ModuleLease, error)

--- a/internal/app/adapter_loader.go
+++ b/internal/app/adapter_loader.go
@@ -3,7 +3,7 @@ package app
 import (
 	"context"
 	"errors"
-	"net/netip"
+	"sync"
 
 	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
@@ -13,14 +13,14 @@ import (
 type adapterLoader struct {
 	runtime        *store.AdapterRuntime
 	keyring        *crypto.Keyring
-	egressPolicy   map[string][]netip.Prefix
+	moduleFactory  adapter.ModuleFactory
 	loadExecution  func(context.Context, adapter.Job) (store.AdapterExecution, error)
 	loadActivation func(context.Context, adapter.Job) (store.AdapterActivation, error)
 	openField      func(crypto.ProjectFieldAAD, []byte) ([]byte, error)
 }
 
 func (l *adapterLoader) LoadActivation(ctx context.Context, job adapter.Job, journal adapter.Journal) (adapter.LoadedActivation, error) {
-	if l == nil || (l.runtime == nil && l.loadActivation == nil) || (l.keyring == nil && l.openField == nil) {
+	if l == nil || (l.runtime == nil && l.loadActivation == nil) || (l.keyring == nil && l.openField == nil) || l.moduleFactory == nil {
 		return adapter.LoadedActivation{}, errors.New("adapter activation loader is not configured")
 	}
 	if journal == nil {
@@ -34,6 +34,10 @@ func (l *adapterLoader) LoadActivation(ctx context.Context, job adapter.Job, jou
 		loadActivation = l.runtime.LoadActivation
 	}
 	material, err := loadActivation(ctx, job)
+	if err != nil {
+		return adapter.LoadedActivation{}, err
+	}
+	provider, err := adapter.ParseProvider(material.Provider)
 	if err != nil {
 		return adapter.LoadedActivation{}, err
 	}
@@ -55,13 +59,17 @@ func (l *adapterLoader) LoadActivation(ctx context.Context, job adapter.Job, jou
 	if err != nil {
 		return adapter.LoadedActivation{}, err
 	}
-	module, forget, err := deploymentModule(material.Provider, material.Origin, string(credential), l.allowedCIDRs(material.Origin))
+	lease, err := l.moduleFactory(provider, adapter.Config{Origin: material.Origin}, string(credential))
 	if err != nil {
 		crypto.Zero(credential)
 		return adapter.LoadedActivation{}, err
 	}
+	release := sync.OnceFunc(func() {
+		crypto.Zero(credential)
+		lease.Release()
+	})
 	return adapter.LoadedActivation{
-		Module: module,
+		Module: lease.Module,
 		Request: adapter.ConnectionRequest{
 			Config:      adapter.Config{Origin: material.Origin},
 			Destination: material.Target.Destination, Access: adapter.Access{Credential: string(credential)},
@@ -69,22 +77,12 @@ func (l *adapterLoader) LoadActivation(ctx context.Context, job adapter.Job, jou
 				return journal.Gate(gateCtx, adapter.Effect{Surface: adapter.Secret, EffectiveName: "route", Disposition: adapter.Update})
 			},
 		},
-		Release: func() {
-			crypto.Zero(credential)
-			forget()
-		},
+		Release: release,
 	}, nil
 }
 
-func (l *adapterLoader) allowedCIDRs(origin string) []netip.Prefix {
-	if l == nil {
-		return nil
-	}
-	return append([]netip.Prefix(nil), l.egressPolicy[origin]...)
-}
-
 func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapter.Journal) (adapter.LoadedSync, error) {
-	if l == nil || (l.runtime == nil && l.loadExecution == nil) || (l.keyring == nil && l.openField == nil) {
+	if l == nil || (l.runtime == nil && l.loadExecution == nil) || (l.keyring == nil && l.openField == nil) || l.moduleFactory == nil {
 		return adapter.LoadedSync{}, errors.New("adapter loader is not configured")
 	}
 	if journal == nil {
@@ -98,6 +96,10 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 		loadExecution = l.runtime.LoadExecution
 	}
 	material, err := loadExecution(ctx, job)
+	if err != nil {
+		return adapter.LoadedSync{}, err
+	}
+	provider, err := adapter.ParseProvider(material.Provider)
 	if err != nil {
 		return adapter.LoadedSync{}, err
 	}
@@ -122,7 +124,7 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 	if err != nil {
 		return adapter.LoadedSync{}, err
 	}
-	module, forget, err := deploymentModule(material.Provider, material.Origin, string(credential), l.allowedCIDRs(material.Origin))
+	lease, err := l.moduleFactory(provider, adapter.Config{Origin: material.Origin}, string(credential))
 	if err != nil {
 		crypto.Zero(credential)
 		return adapter.LoadedSync{}, err
@@ -139,7 +141,7 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 				crypto.Zero(value)
 			}
 			crypto.Zero(credential)
-			forget()
+			lease.Release()
 			return adapter.LoadedSync{}, err
 		}
 		plain, err := openField(crypto.ProjectFieldAAD{
@@ -152,7 +154,7 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 				crypto.Zero(value)
 			}
 			crypto.Zero(credential)
-			forget()
+			lease.Release()
 			return adapter.LoadedSync{}, err
 		}
 		opened = append(opened, plain)
@@ -165,17 +167,18 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 		Config: adapter.Config{Origin: material.Origin}, Target: material.Target,
 		Manifest: manifest, Ledger: material.Ledger,
 	}
+	release := sync.OnceFunc(func() {
+		for i := range manifest {
+			manifest[i].Value = ""
+		}
+		for _, value := range opened {
+			crypto.Zero(value)
+		}
+		crypto.Zero(credential)
+		lease.Release()
+	})
 	return adapter.LoadedSync{
-		Module: module, Request: request, Revision: material.Revision,
-		Release: func() {
-			for i := range manifest {
-				manifest[i].Value = ""
-			}
-			for _, value := range opened {
-				crypto.Zero(value)
-			}
-			crypto.Zero(credential)
-			forget()
-		},
+		Module: lease.Module, Request: request, Revision: material.Revision,
+		Release: release,
 	}, nil
 }

--- a/internal/app/adapter_loader_test.go
+++ b/internal/app/adapter_loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/internal/adapter"
@@ -11,14 +12,25 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestAdapterLoaderSelectsPrivateEgressByExactOrigin(t *testing.T) {
+func TestAdapterModuleFactorySelectsPrivateEgressByExactOrigin(t *testing.T) {
 	want := netip.MustParsePrefix("10.42.0.0/16")
-	loader := &adapterLoader{egressPolicy: map[string][]netip.Prefix{"https://git.internal.example": {want}}}
-	if got := loader.allowedCIDRs("https://git.internal.example"); len(got) != 1 || got[0] != want {
-		t.Fatalf("exact origin policy = %v", got)
+	seen := []netip.Prefix(nil)
+	factory := &adapterModuleFactory{
+		egressPolicy: map[string][]netip.Prefix{"https://git.internal.example": {want}},
+		providers: map[adapter.Provider]providerConstructor{
+			adapter.ForgejoProvider: func(_ adapter.Config, _ string, allowed []netip.Prefix) (adapter.Module, func(), error) {
+				seen = append([]netip.Prefix(nil), allowed...)
+				return stubProviderModule{}, nil, nil
+			},
+		},
 	}
-	if got := loader.allowedCIDRs("https://other.internal.example"); len(got) != 0 {
-		t.Fatalf("other origin inherited policy: %v", got)
+	lease, err := factory.Build(adapter.ForgejoProvider, adapter.Config{Origin: "https://git.internal.example"}, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+	if len(seen) != 1 || seen[0] != want {
+		t.Fatalf("exact origin policy = %v", seen)
 	}
 }
 
@@ -27,8 +39,12 @@ func TestAdapterLoaderGatesBeforeLoadAndEveryPlaintextOpen(t *testing.T) {
 	firstValue := []byte("first-value")
 	secondOpened := false
 	loadCalled := false
+	releases := 0
 	journal := &orderedLoaderJournal{failAt: 4}
 	loader := &adapterLoader{
+		moduleFactory: func(adapter.Provider, adapter.Config, string) (*adapter.ModuleLease, error) {
+			return adapter.NewModuleLease(stubProviderModule{}, func() { releases++ })
+		},
 		loadExecution: func(context.Context, adapter.Job) (store.AdapterExecution, error) {
 			loadCalled = true
 			if journal.calls != 1 {
@@ -67,8 +83,8 @@ func TestAdapterLoaderGatesBeforeLoadAndEveryPlaintextOpen(t *testing.T) {
 	if !errors.Is(err, adapter.ErrUnauthorized) {
 		t.Fatalf("Load() = %v, want gate refusal", err)
 	}
-	if !loadCalled || journal.calls != 4 || secondOpened {
-		t.Fatalf("load=%v gates=%d second_opened=%v", loadCalled, journal.calls, secondOpened)
+	if !loadCalled || journal.calls != 4 || secondOpened || releases != 1 {
+		t.Fatalf("load=%v gates=%d second_opened=%v releases=%d", loadCalled, journal.calls, secondOpened, releases)
 	}
 	for _, buffer := range [][]byte{credential, firstValue} {
 		for _, value := range buffer {
@@ -84,6 +100,7 @@ func TestAdapterActivationLoaderRefusesBeforePendingCredentialOpen(t *testing.T)
 	openCalled := false
 	journal := &orderedLoaderJournal{failAt: 2}
 	loader := &adapterLoader{
+		moduleFactory: newAdapterModuleFactory(nil).Build,
 		loadActivation: func(context.Context, adapter.Job) (store.AdapterActivation, error) {
 			loadCalled = true
 			if journal.calls != 1 {
@@ -105,6 +122,31 @@ func TestAdapterActivationLoaderRefusesBeforePendingCredentialOpen(t *testing.T)
 	}
 	if !loadCalled || openCalled || journal.calls != 2 {
 		t.Fatalf("load=%v open=%v gates=%d", loadCalled, openCalled, journal.calls)
+	}
+}
+
+func TestAdapterLoaderRejectsUnknownProviderBeforeCredentialOpen(t *testing.T) {
+	openCalled := false
+	factoryCalled := false
+	loader := &adapterLoader{
+		loadExecution: func(context.Context, adapter.Job) (store.AdapterExecution, error) {
+			return store.AdapterExecution{Provider: "gitlab", CredentialCiphertext: []byte("sealed")}, nil
+		},
+		openField: func(crypto.ProjectFieldAAD, []byte) ([]byte, error) {
+			openCalled = true
+			return []byte("credential"), nil
+		},
+		moduleFactory: func(adapter.Provider, adapter.Config, string) (*adapter.ModuleLease, error) {
+			factoryCalled = true
+			return adapter.NewModuleLease(stubProviderModule{}, nil)
+		},
+	}
+	_, err := loader.Load(t.Context(), adapter.Job{}, &orderedLoaderJournal{})
+	if err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Fatalf("Load() = %v, want unknown provider refusal", err)
+	}
+	if openCalled || factoryCalled {
+		t.Fatalf("unknown provider opened credential=%v called factory=%v", openCalled, factoryCalled)
 	}
 }
 

--- a/internal/app/adapter_provider.go
+++ b/internal/app/adapter_provider.go
@@ -10,21 +10,68 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/adapter/githubactions"
 )
 
-func deploymentModule(provider, origin, credential string, allowed []netip.Prefix) (adapter.Module, func(), error) {
-	switch provider {
-	case "forgejo":
-		client, err := forgejo.NewClient(forgejo.ClientConfig{Origin: origin, Credential: credential, AllowedCIDRs: append([]netip.Prefix(nil), allowed...), Deadline: 15 * time.Second})
-		if err != nil {
-			return nil, nil, err
-		}
-		return &forgejo.Module{API: client}, client.Forget, nil
-	case "github-actions":
-		client, err := githubactions.NewClient(githubactions.ClientConfig{Origin: origin, Credential: credential, AllowedCIDRs: append([]netip.Prefix(nil), allowed...), Deadline: 15 * time.Second})
-		if err != nil {
-			return nil, nil, err
-		}
-		return &githubactions.Module{API: client}, client.Forget, nil
-	default:
-		return nil, nil, errors.New("app: unsupported deployment adapter provider")
+type providerConstructor func(adapter.Config, string, []netip.Prefix) (adapter.Module, func(), error)
+
+type adapterModuleFactory struct {
+	egressPolicy map[string][]netip.Prefix
+	providers    map[adapter.Provider]providerConstructor
+}
+
+type adapterModuleWiring struct {
+	worker  adapter.ModuleFactory
+	service adapter.ModuleFactory
+}
+
+func deploymentProviderRegistry() map[adapter.Provider]providerConstructor {
+	return map[adapter.Provider]providerConstructor{
+		adapter.ForgejoProvider: func(config adapter.Config, credential string, allowed []netip.Prefix) (adapter.Module, func(), error) {
+			client, err := forgejo.NewClient(forgejo.ClientConfig{Origin: config.Origin, Credential: credential, AllowedCIDRs: allowed, Deadline: 15 * time.Second})
+			if err != nil {
+				return nil, nil, err
+			}
+			return &forgejo.Module{API: client}, client.Forget, nil
+		},
+		adapter.GitHubActionsProvider: func(config adapter.Config, credential string, allowed []netip.Prefix) (adapter.Module, func(), error) {
+			client, err := githubactions.NewClient(githubactions.ClientConfig{Origin: config.Origin, Credential: credential, AllowedCIDRs: allowed, Deadline: 15 * time.Second})
+			if err != nil {
+				return nil, nil, err
+			}
+			return &githubactions.Module{API: client}, client.Forget, nil
+		},
 	}
+}
+
+func newAdapterModuleFactory(egressPolicy map[string][]netip.Prefix) *adapterModuleFactory {
+	return &adapterModuleFactory{egressPolicy: egressPolicy, providers: deploymentProviderRegistry()}
+}
+
+func newAdapterModuleWiring(egressPolicy map[string][]netip.Prefix) adapterModuleWiring {
+	factory := newAdapterModuleFactory(egressPolicy)
+	return adapterModuleWiring{worker: factory.Build, service: factory.Build}
+}
+
+func (f *adapterModuleFactory) Build(provider adapter.Provider, config adapter.Config, credential string) (*adapter.ModuleLease, error) {
+	if f == nil {
+		return nil, errors.New("app: adapter module factory is not configured")
+	}
+	constructor := f.providers[provider]
+	if constructor == nil {
+		return nil, errors.New("app: unsupported deployment adapter provider")
+	}
+	allowed := append([]netip.Prefix(nil), f.egressPolicy[config.Origin]...)
+	module, release, err := constructor(config, credential, allowed)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		return nil, err
+	}
+	lease, err := adapter.NewModuleLease(module, release)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		return nil, err
+	}
+	return lease, nil
 }

--- a/internal/app/adapter_provider_test.go
+++ b/internal/app/adapter_provider_test.go
@@ -1,43 +1,140 @@
 package app
 
 import (
+	"context"
+	"errors"
+	"net/netip"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/adapter/forgejo"
 	"github.com/Hikyo-Org/hikyo/internal/adapter/githubactions"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestDeploymentModuleDispatchesCompiledInProviders(t *testing.T) {
-	forgejoModule, forgetForgejo, err := deploymentModule("forgejo", "https://forgejo.example", "scoped-token", nil)
+func TestAdapterModuleFactoryRegistryIsTotal(t *testing.T) {
+	registry := deploymentProviderRegistry()
+	if len(registry) != len(adapter.SupportedProviders()) {
+		t.Fatalf("registry entries = %d, supported providers = %d", len(registry), len(adapter.SupportedProviders()))
+	}
+	for _, provider := range adapter.SupportedProviders() {
+		if registry[provider] == nil {
+			t.Fatalf("provider %q has no construction entry", provider)
+		}
+	}
+}
+
+func TestAdapterModuleFactoryDispatchesCompiledInProviders(t *testing.T) {
+	factory := newAdapterModuleFactory(nil)
+	forgejoLease, err := factory.Build(adapter.ForgejoProvider, adapter.Config{Origin: "https://forgejo.example"}, "scoped-token")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer forgetForgejo()
-	if _, ok := forgejoModule.(*forgejo.Module); !ok {
-		t.Fatalf("forgejo module = %T", forgejoModule)
+	defer forgejoLease.Release()
+	if _, ok := forgejoLease.Module.(*forgejo.Module); !ok {
+		t.Fatalf("forgejo module = %T", forgejoLease.Module)
 	}
 
-	githubModule, forgetGitHub, err := deploymentModule("github-actions", "https://api.github.com", "github_pat_fine", nil)
+	githubLease, err := factory.Build(adapter.GitHubActionsProvider, adapter.Config{Origin: "https://api.github.com"}, "github_pat_fine")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer forgetGitHub()
-	if _, ok := githubModule.(*githubactions.Module); !ok {
-		t.Fatalf("github module = %T", githubModule)
+	defer githubLease.Release()
+	if _, ok := githubLease.Module.(*githubactions.Module); !ok {
+		t.Fatalf("github module = %T", githubLease.Module)
+	}
+}
+
+func TestAdapterModuleFactoryReleasesPartialConstructionOnce(t *testing.T) {
+	wantErr := errors.New("partial construction")
+	releases := 0
+	factory := &adapterModuleFactory{
+		providers: map[adapter.Provider]providerConstructor{
+			adapter.ForgejoProvider: func(adapter.Config, string, []netip.Prefix) (adapter.Module, func(), error) {
+				return nil, func() { releases++ }, wantErr
+			},
+		},
+	}
+	if _, err := factory.Build(adapter.ForgejoProvider, adapter.Config{Origin: "https://forgejo.example"}, "scoped-token"); !errors.Is(err, wantErr) {
+		t.Fatalf("Build() = %v, want %v", err, wantErr)
+	}
+	if releases != 1 {
+		t.Fatalf("partial construction releases = %d, want 1", releases)
+	}
+}
+
+func TestAdapterModuleLeaseReleasesSuccessOnce(t *testing.T) {
+	releases := 0
+	factory := &adapterModuleFactory{
+		providers: map[adapter.Provider]providerConstructor{
+			adapter.ForgejoProvider: func(adapter.Config, string, []netip.Prefix) (adapter.Module, func(), error) {
+				return stubProviderModule{}, func() { releases++ }, nil
+			},
+		},
+	}
+	lease, err := factory.Build(adapter.ForgejoProvider, adapter.Config{Origin: "https://forgejo.example"}, "scoped-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+	lease.Release()
+	if releases != 1 {
+		t.Fatalf("successful construction releases = %d, want 1", releases)
 	}
 }
 
 func TestDeploymentModuleRefusesClassicGitHubPAT(t *testing.T) {
-	_, _, err := deploymentModule("github-actions", "https://api.github.com", "ghp_classic", nil)
+	_, err := newAdapterModuleFactory(nil).Build(adapter.GitHubActionsProvider, adapter.Config{Origin: "https://api.github.com"}, "ghp_classic")
 	if err == nil || !strings.Contains(err.Error(), "classic") {
 		t.Fatalf("deploymentModule() = %v, want named classic PAT refusal", err)
 	}
 }
 
 func TestDeploymentModuleNeverInfersProviderFromCredential(t *testing.T) {
-	_, _, err := deploymentModule("", "https://api.github.com", "github_pat_fine", nil)
+	_, err := newAdapterModuleFactory(nil).Build(adapter.Provider(""), adapter.Config{Origin: "https://api.github.com"}, "github_pat_fine")
 	if err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("deploymentModule() = %v, want missing persisted provider refusal", err)
 	}
+}
+
+func TestWorkerAndServiceWiringUseEquivalentModulesFromOneFactory(t *testing.T) {
+	wiring := newAdapterModuleWiring(map[string][]netip.Prefix{"https://forgejo.example": {netip.MustParsePrefix("10.42.0.0/16")}})
+	loader := &adapterLoader{
+		moduleFactory: wiring.worker,
+		loadActivation: func(context.Context, adapter.Job) (store.AdapterActivation, error) {
+			return store.AdapterActivation{Provider: string(adapter.ForgejoProvider), Origin: "https://forgejo.example", CredentialCiphertext: []byte("sealed")}, nil
+		},
+		openField: func(crypto.ProjectFieldAAD, []byte) ([]byte, error) {
+			return []byte("scoped-token"), nil
+		},
+	}
+	loaded, err := loader.LoadActivation(t.Context(), adapter.Job{}, &orderedLoaderJournal{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loaded.Release()
+	serviceLease, err := wiring.service(adapter.ForgejoProvider, adapter.Config{Origin: "https://forgejo.example"}, "scoped-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serviceLease.Release()
+	if reflect.TypeOf(loaded.Module) != reflect.TypeOf(serviceLease.Module) {
+		t.Fatalf("worker module = %T, service module = %T", loaded.Module, serviceLease.Module)
+	}
+}
+
+type stubProviderModule struct{}
+
+func (stubProviderModule) ValidateConfig(adapter.Config) error { return nil }
+func (stubProviderModule) TestConnection(context.Context, adapter.ConnectionRequest) (adapter.Connection, error) {
+	return adapter.Connection{}, nil
+}
+func (stubProviderModule) Plan(context.Context, adapter.PlanRequest) (adapter.Plan, error) {
+	return adapter.Plan{}, nil
+}
+func (stubProviderModule) Sync(context.Context, adapter.SyncRequest, adapter.Journal) (adapter.SyncResult, error) {
+	return adapter.SyncResult{}, nil
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -396,13 +396,12 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 			return err
 		})
 	})
+	moduleWiring := newAdapterModuleWiring(cfg.AdapterEgressPolicy)
 	adapterWorker := &adapter.Worker{
-		Store: adapterRuntime, Loader: &adapterLoader{runtime: adapterRuntime, keyring: kr, egressPolicy: cfg.AdapterEgressPolicy},
+		Store: adapterRuntime, Loader: &adapterLoader{runtime: adapterRuntime, keyring: kr, moduleFactory: moduleWiring.worker},
 		ID: "adapter-worker-" + uuid.Must(uuid.NewV7()).String(), Poll: time.Second, Log: log,
 	}
-	adapterService := &service.Adapters{DB: db, Auth: authSvc, Keyring: kr, Budget: budget, ProviderModule: func(provider, origin, credential string) (adapter.Module, func(), error) {
-		return deploymentModule(provider, origin, credential, cfg.AdapterEgressPolicy[origin])
-	}}
+	adapterService := &service.Adapters{DB: db, Auth: authSvc, Keyring: kr, Budget: budget, ModuleFactory: moduleWiring.service}
 	definitionsService := &service.Definitions{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset}
 
 	api := &server.API{

--- a/internal/isolation/adapter_audit_e2e_test.go
+++ b/internal/isolation/adapter_audit_e2e_test.go
@@ -91,8 +91,8 @@ func runAdapterAuditLifecycle(t *testing.T, db *store.DB) {
 
 	svc := &service.Adapters{
 		DB: db, Keyring: probeKeyring(t, db), Now: func() time.Time { return now },
-		PlanModule: func(string, string) (adapter.Module, func(), error) {
-			return auditAdapterModule{}, func() {}, nil
+		ModuleFactory: func(adapter.Provider, adapter.Config, string) (*adapter.ModuleLease, error) {
+			return adapter.NewModuleLease(auditAdapterModule{}, func() {})
 		},
 	}
 	created, err := svc.Create(ctx, service.LocalPrincipal(alice), scope, service.CreateAdapterRequest{

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -25,10 +25,9 @@ type Adapters struct {
 	// Budget applies the § 179 adapter sync/trigger concurrency bound (4 per
 	// org). Nil disables it. The per-principal 10/min rate is deferred (see
 	// budget.go).
-	Budget         *Budget
-	Now            func() time.Time
-	PlanModule     func(origin, credential string) (adapter.Module, func(), error)
-	ProviderModule func(provider, origin, credential string) (adapter.Module, func(), error)
+	Budget        *Budget
+	Now           func() time.Time
+	ModuleFactory adapter.ModuleFactory
 }
 
 func (s *Adapters) now() time.Time {
@@ -257,7 +256,11 @@ func (s *Adapters) consumeAdapterCeremony(ctx context.Context, actor Actor, scop
 
 func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, request CreateAdapterRequest) (AdapterView, error) {
 	if request.Provider == "" {
-		request.Provider = "forgejo"
+		request.Provider = string(adapter.ForgejoProvider)
+	}
+	provider, err := adapter.ParseProvider(request.Provider)
+	if err != nil {
+		return AdapterView{}, err
 	}
 	if scope.Project == "" || scope.Env != "" || request.Origin == "" || len(request.Credential) == 0 || request.Target.EnvironmentID == "" || len(request.Target.KeyIDs) == 0 {
 		return AdapterView{}, fmt.Errorf("%w: adapter create requires project scope, credential, and first target", domain.ErrInvalid)
@@ -284,14 +287,12 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	if err != nil {
 		return AdapterView{}, err
 	}
-	module, release, err := s.planModule(request.Provider, request.Origin, string(plain))
+	lease, err := s.buildModule(provider, request.Origin, string(plain))
 	if err != nil {
 		return AdapterView{}, err
 	}
-	if release != nil {
-		defer release()
-	}
-	if err := module.ValidateConfig(adapter.Config{Origin: request.Origin}); err != nil {
+	defer lease.Release()
+	if err := lease.Module.ValidateConfig(adapter.Config{Origin: request.Origin}); err != nil {
 		return AdapterView{}, err
 	}
 	configureEventID, err := audit.NewEventID()
@@ -300,7 +301,7 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	beforeCreate, afterCreate := s.environmentCreateAudit(actor, scope, targetID, request.Target, configureEventID)
 	destination := adapterDestination(request.Target)
-	connection, err := module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: request.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, request.Target.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
+	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: request.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, request.Target.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
 	if err != nil {
 		return AdapterView{}, err
 	}
@@ -462,6 +463,10 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	if err != nil {
 		return store.AdapterTarget{}, err
 	}
+	provider, err := adapter.ParseProvider(record.Provider)
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
 	if len(ciphertext) == 0 {
 		return store.AdapterTarget{}, adapter.ErrProviderAuth
 	}
@@ -470,13 +475,11 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 		return store.AdapterTarget{}, err
 	}
 	defer crypto.Zero(plain)
-	module, release, err := s.planModule(record.Provider, record.Origin, string(plain))
+	lease, err := s.buildModule(provider, record.Origin, string(plain))
 	if err != nil {
 		return store.AdapterTarget{}, err
 	}
-	if release != nil {
-		defer release()
-	}
+	defer lease.Release()
 	targetID, err := newID("tgt")
 	if err != nil {
 		return store.AdapterTarget{}, err
@@ -487,7 +490,7 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	}
 	beforeCreate, afterCreate := s.environmentCreateAudit(actor, scope, targetID, input, configureEventID)
 	destination := adapterDestination(input)
-	connection, err := module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: record.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, input.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
+	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: record.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, input.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
 	if err != nil {
 		return store.AdapterTarget{}, err
 	}
@@ -673,6 +676,10 @@ func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scop
 	if err != nil || record.ID == "" {
 		return err
 	}
+	provider, err := adapter.ParseProvider(record.Provider)
+	if err != nil {
+		return err
+	}
 	if len(ciphertext) == 0 {
 		return adapter.ErrProviderAuth
 	}
@@ -685,17 +692,15 @@ func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scop
 		return err
 	}
 	defer crypto.Zero(plain)
-	module, release, err := s.planModule(record.Provider, record.Origin, string(plain))
+	lease, err := s.buildModule(provider, record.Origin, string(plain))
 	if err != nil {
 		return err
 	}
-	if release != nil {
-		defer release()
-	}
+	defer lease.Release()
 	destination := adapterDestination(request.Target)
 	destination.NumericID = current.DestinationID
 	destination.RepositoryID = current.RepositoryID
-	_, err = module.TestConnection(ctx, adapter.ConnectionRequest{
+	_, err = lease.Module.TestConnection(ctx, adapter.ConnectionRequest{
 		Config: adapter.Config{Origin: record.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)},
 		Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, current.EnvironmentID),
 	})
@@ -797,20 +802,22 @@ func (s *Adapters) MoveOrigin(ctx context.Context, actor Actor, scope domain.Sco
 	if scope.Project == "" || scope.Env != "" || adapterID == "" || origin == "" || len(credential) == 0 {
 		return store.AdapterRouteMoveBatch{}, fmt.Errorf("%w: origin move requires adapter, new origin, and new credential", domain.ErrInvalid)
 	}
+	providerName, err := s.providerForAdapter(ctx, actor, scope, adapterID)
+	if err != nil {
+		return store.AdapterRouteMoveBatch{}, err
+	}
+	provider, err := adapter.ParseProvider(providerName)
+	if err != nil {
+		return store.AdapterRouteMoveBatch{}, err
+	}
 	plain := append([]byte(nil), credential...)
 	defer crypto.Zero(plain)
-	provider, err := s.providerForAdapter(ctx, actor, scope, adapterID)
+	lease, err := s.buildModule(provider, origin, string(plain))
 	if err != nil {
 		return store.AdapterRouteMoveBatch{}, err
 	}
-	module, release, err := s.planModule(provider, origin, string(plain))
-	if err != nil {
-		return store.AdapterRouteMoveBatch{}, err
-	}
-	if release != nil {
-		defer release()
-	}
-	if err := module.ValidateConfig(adapter.Config{Origin: origin}); err != nil {
+	defer lease.Release()
+	if err := lease.Module.ValidateConfig(adapter.Config{Origin: origin}); err != nil {
 		return store.AdapterRouteMoveBatch{}, err
 	}
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpAdapterConfigure, scope)
@@ -1021,20 +1028,22 @@ func (s *Adapters) ResumeOriginMove(ctx context.Context, actor Actor, scope doma
 	if scope.Project == "" || scope.Env != "" || moveID == "" || origin == "" || len(credential) == 0 {
 		return store.AdapterMove{}, fmt.Errorf("%w: pending origin replacement requires project, move, origin, and credential", domain.ErrInvalid)
 	}
+	providerName, err := s.providerForMove(ctx, actor, scope, moveID)
+	if err != nil {
+		return store.AdapterMove{}, err
+	}
+	provider, err := adapter.ParseProvider(providerName)
+	if err != nil {
+		return store.AdapterMove{}, err
+	}
 	plain := append([]byte(nil), credential...)
 	defer crypto.Zero(plain)
-	provider, err := s.providerForMove(ctx, actor, scope, moveID)
+	lease, err := s.buildModule(provider, origin, string(plain))
 	if err != nil {
 		return store.AdapterMove{}, err
 	}
-	module, release, err := s.planModule(provider, origin, string(plain))
-	if err != nil {
-		return store.AdapterMove{}, err
-	}
-	if release != nil {
-		defer release()
-	}
-	if err := module.ValidateConfig(adapter.Config{Origin: origin}); err != nil {
+	defer lease.Release()
+	if err := lease.Module.ValidateConfig(adapter.Config{Origin: origin}); err != nil {
 		return store.AdapterMove{}, err
 	}
 	now := store.CanonTime(s.now())
@@ -1200,6 +1209,10 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 	if err != nil {
 		return adapter.Connection{}, err
 	}
+	provider, err := adapter.ParseProvider(material.Target.Provider)
+	if err != nil {
+		return adapter.Connection{}, err
+	}
 	if len(material.CredentialCiphertext) == 0 {
 		return adapter.Connection{}, adapter.ErrProviderAuth
 	}
@@ -1210,13 +1223,11 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 		return adapter.Connection{}, err
 	}
 	defer crypto.Zero(credential)
-	module, release, err := s.planModule(material.Target.Provider, material.Target.Origin, string(credential))
+	lease, err := s.buildModule(provider, material.Target.Origin, string(credential))
 	if err != nil {
 		return adapter.Connection{}, err
 	}
-	if release != nil {
-		defer release()
-	}
+	defer lease.Release()
 	providerGate := func(gateCtx context.Context) error {
 		return tx.Read(gateCtx, s.DB, func(gateCtx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(gateCtx, az, s.now())
@@ -1227,7 +1238,7 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 			return err
 		})
 	}
-	connection, err := module.TestConnection(ctx, adapter.ConnectionRequest{
+	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{
 		Config: adapter.Config{Origin: material.Target.Origin}, Destination: adapterTarget(material.Target).Destination,
 		Access: adapter.Access{Credential: string(credential)}, Gate: providerGate,
 	})
@@ -1390,14 +1401,11 @@ func (s *Adapters) RevokeCredential(ctx context.Context, actor Actor, scope doma
 	})
 }
 
-func (s *Adapters) planModule(provider, origin, credential string) (adapter.Module, func(), error) {
-	if s.ProviderModule != nil {
-		return s.ProviderModule(provider, origin, credential)
+func (s *Adapters) buildModule(provider adapter.Provider, origin, credential string) (*adapter.ModuleLease, error) {
+	if s.ModuleFactory == nil {
+		return nil, errors.New("service: adapter module factory is not configured")
 	}
-	if s.PlanModule == nil {
-		return nil, nil, errors.New("service: adapter plan module is not configured")
-	}
-	return s.PlanModule(origin, credential)
+	return s.ModuleFactory(provider, adapter.Config{Origin: origin}, credential)
 }
 
 func (s *Adapters) providerForAdapter(ctx context.Context, actor Actor, scope domain.Scope, adapterID string) (string, error) {
@@ -1477,6 +1485,10 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}
+	provider, err := adapter.ParseProvider(material.Target.Provider)
+	if err != nil {
+		return AdapterPlanResult{}, err
+	}
 	if len(material.CredentialCiphertext) == 0 {
 		return AdapterPlanResult{}, adapter.ErrProviderAuth
 	}
@@ -1485,13 +1497,11 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 		return AdapterPlanResult{}, err
 	}
 	defer crypto.Zero(credential)
-	module, release, err := s.planModule(material.Target.Provider, material.Target.Origin, string(credential))
+	lease, err := s.buildModule(provider, material.Target.Origin, string(credential))
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}
-	if release != nil {
-		defer release()
-	}
+	defer lease.Release()
 	providerGate := func(gateCtx context.Context) error {
 		return tx.Read(gateCtx, s.DB, func(gateCtx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
 			caller, err := actor.resolve(gateCtx, az, s.now())
@@ -1502,7 +1512,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 			return err
 		})
 	}
-	plan, err := module.Plan(ctx, adapter.PlanRequest{Config: adapter.Config{Origin: material.Target.Origin}, Target: adapterTarget(material.Target), Manifest: material.Manifest, Ledger: material.Ledger, Gate: providerGate})
+	plan, err := lease.Module.Plan(ctx, adapter.PlanRequest{Config: adapter.Config{Origin: material.Target.Origin}, Target: adapterTarget(material.Target), Manifest: material.Manifest, Ledger: material.Ledger, Gate: providerGate})
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,6 +74,25 @@ func adapterServiceDB(t *testing.T) *store.DB {
 }
 
 type fakeAdapterPlanModule struct{ plan adapter.Plan }
+
+func testModuleFactory(factory func(adapter.Provider, string, string) (adapter.Module, func(), error)) adapter.ModuleFactory {
+	return func(provider adapter.Provider, config adapter.Config, credential string) (*adapter.ModuleLease, error) {
+		module, release, err := factory(provider, config.Origin, credential)
+		if err != nil {
+			if release != nil {
+				release()
+			}
+			return nil, err
+		}
+		return adapter.NewModuleLease(module, release)
+	}
+}
+
+func providerBlindTestModuleFactory(factory func(string, string) (adapter.Module, func(), error)) adapter.ModuleFactory {
+	return testModuleFactory(func(_ adapter.Provider, origin, credential string) (adapter.Module, func(), error) {
+		return factory(origin, credential)
+	})
+}
 
 func (m fakeAdapterPlanModule) ValidateConfig(adapter.Config) error { return nil }
 func (m fakeAdapterPlanModule) TestConnection(context.Context, adapter.ConnectionRequest) (adapter.Connection, error) {
@@ -154,10 +174,10 @@ func TestAdapterCreateAndAddTargetRefuseBeforeCredentialOrProviderWithoutCeremon
 		db := adapterServiceDB(t)
 		bearer := adapterCLISession(t, db)
 		providerCalls := 0
-		svc := &Adapters{DB: db, Auth: &Auth{DB: db}, PlanModule: func(string, string) (adapter.Module, func(), error) {
+		svc := &Adapters{DB: db, Auth: &Auth{DB: db}, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 			providerCalls++
 			return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
-		}}
+		})}
 		_, err := svc.Create(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
 			Origin: "https://new.example", Credential: []byte("provider-token"),
 			Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", KeyIDs: []string{"key_create"}},
@@ -174,10 +194,10 @@ func TestAdapterCreateAndAddTargetRefuseBeforeCredentialOrProviderWithoutCeremon
 		}
 		bearer := adapterCLISession(t, db)
 		providerCalls := 0
-		svc := &Adapters{DB: db, Auth: &Auth{DB: db}, PlanModule: func(string, string) (adapter.Module, func(), error) {
+		svc := &Adapters{DB: db, Auth: &Auth{DB: db}, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 			providerCalls++
 			return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
-		}}
+		})}
 		_, err := svc.AddTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{
 			EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", KeyIDs: []string{"key_create"},
 		})
@@ -185,6 +205,24 @@ func TestAdapterCreateAndAddTargetRefuseBeforeCredentialOrProviderWithoutCeremon
 			t.Fatalf("AddTarget() error=%v provider calls=%d", err, providerCalls)
 		}
 	})
+}
+
+func TestAdapterCreateRejectsUnknownProviderBeforeCredentialUse(t *testing.T) {
+	factoryCalled := false
+	svc := &Adapters{ModuleFactory: func(adapter.Provider, adapter.Config, string) (*adapter.ModuleLease, error) {
+		factoryCalled = true
+		return adapter.NewModuleLease(fakeAdapterPlanModule{}, nil)
+	}}
+	_, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
+		Provider: "gitlab", Origin: "https://gitlab.example", Credential: []byte("provider-token"),
+		Target: AdapterTargetInput{EnvironmentID: "env_one", KeyIDs: []string{"key_one"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Fatalf("Create() = %v, want unknown provider refusal", err)
+	}
+	if factoryCalled {
+		t.Fatal("unknown provider reached module factory")
+	}
 }
 
 func (fakeAdapterConfigureModule) ValidateConfig(adapter.Config) error { return nil }
@@ -228,12 +266,12 @@ func TestAdapterCreateAtomicallyBootstrapsCredentialAndFirstTarget(t *testing.T)
 	}
 	gates := 0
 	expires := time.Date(2026, 9, 30, 12, 34, 56, 0, time.UTC)
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(origin, credential string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(origin, credential string) (adapter.Module, func(), error) {
 		if origin != "https://new.example" || credential != "provider-token" {
 			t.Fatalf("factory=%q/%q", origin, credential)
 		}
 		return fakeAdapterConfigureModule{gates: &gates, credentialExpiry: expires}, nil, nil
-	}}
+	})}
 	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{Origin: "https://new.example", Credential: []byte("provider-token"), Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", NamePrefix: "PROD_", KeyIDs: []string{"key_create"}}})
 	if err != nil {
 		t.Fatal(err)
@@ -281,12 +319,12 @@ func TestEnvironmentCreatePersistsGenerationFenceAndCorrelatedAudit(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc := &Adapters{DB: db, Keyring: kr, ProviderModule: func(provider, _, _ string) (adapter.Module, func(), error) {
-		if provider != "github-actions" {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: testModuleFactory(func(provider adapter.Provider, _, _ string) (adapter.Module, func(), error) {
+		if provider != adapter.GitHubActionsProvider {
 			t.Fatalf("provider = %q, want persisted github-actions", provider)
 		}
 		return fakeEnvironmentConfigureModule{}, nil, nil
-	}}
+	})}
 	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
 		Provider: "github-actions", Origin: "https://api.github.com", Credential: []byte("github_pat_fine"),
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "environment", DestinationOwner: "acme", DestinationName: "app", DestinationEnvironment: "production", KeyIDs: []string{"key_env_create"}},
@@ -351,12 +389,12 @@ func TestOrganizationSelectedRepositoryIDsAreVerifiedBeforeRoutingCommit(t *test
 		t.Fatal(err)
 	}
 	seen := []int64{}
-	svc := &Adapters{DB: db, Keyring: kr, ProviderModule: func(provider, _, _ string) (adapter.Module, func(), error) {
-		if provider != "github-actions" {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: testModuleFactory(func(provider adapter.Provider, _, _ string) (adapter.Module, func(), error) {
+		if provider != adapter.GitHubActionsProvider {
 			t.Fatalf("provider = %q", provider)
 		}
 		return fakeRoutingPreflightModule{seen: &seen}, nil, nil
-	}}
+	})}
 	updated, err := svc.UpdateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "acme", Visibility: "selected", SelectedRepositoryIDs: []int64{11, 22}, NamePrefix: "ONE_", KeyIDs: []string{"key_org_route"}},
@@ -423,9 +461,9 @@ func TestAdapterTargetAddAuditsTransactionAuthorityTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 	expires := time.Date(2026, 10, 1, 2, 3, 4, 0, time.UTC)
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(string, string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: new(int), destinationID: 303, credentialExpiry: expires}, nil, nil
-	}}
+	})}
 	target, err := svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{
 		EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "THREE_", KeyIDs: []string{"key_add_authority"},
 	})
@@ -480,9 +518,9 @@ func TestAdapterTargetAddRefusesDestinationEffectiveNameCollisionAtomically(t *t
 		t.Fatal(err)
 	}
 	gates := 0
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(string, string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: &gates, destinationID: 42}, nil, nil
-	}}
+	})}
 	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_collision"}})
 	if !errors.Is(err, domain.ErrConflict) {
 		t.Fatalf("AddTarget() error = %v, want conflict", err)
@@ -584,9 +622,9 @@ func TestAdapterTargetAddRequiresRevealAcrossEveryAdapterEnvironmentBeforeCreden
 		t.Fatal(err)
 	}
 	gates := 0
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(string, string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: &gates, destinationID: 42}, nil, nil
-	}}
+	})}
 	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "THREE_", KeyIDs: []string{"key_new_target"}})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("AddTarget() error = %v, want tenant-safe refusal without env_two reveal", err)
@@ -1034,12 +1072,12 @@ func TestAdapterOriginMoveKeepsOldRouteAndCredentialThroughScrubBarrier(t *testi
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, oldCredential); err != nil {
 		t.Fatal(err)
 	}
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(origin, credential string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(origin, credential string) (adapter.Module, func(), error) {
 		if origin != "https://git.next.example" || credential != "new-token" {
 			t.Fatalf("pending factory=%q/%q", origin, credential)
 		}
 		return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
-	}}
+	})}
 	move, err := svc.MoveOrigin(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", "https://git.next.example", []byte("new-token"), false)
 	if err != nil {
 		t.Fatal(err)
@@ -1189,12 +1227,12 @@ func TestAdapterPendingOriginReplacementAuditsTransactionAuthorityTransition(t *
 	if _, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter"); err != nil {
 		t.Fatal(err)
 	}
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(origin, credential string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(origin, credential string) (adapter.Module, func(), error) {
 		if origin != "https://git.fixed.example" || credential != "fixed-token" {
 			t.Fatalf("pending origin factory=%q/%q", origin, credential)
 		}
 		return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
-	}}
+	})}
 	resumed, err := svc.ResumeOriginMove(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "move_origin_resume", "https://git.fixed.example", []byte("fixed-token"))
 	if err != nil {
 		t.Fatal(err)
@@ -1688,12 +1726,12 @@ func TestAdapterTargetConnectionReauthorizesEveryProviderRequest(t *testing.T) {
 	}
 	gates := 0
 	expires := time.Date(2026, 11, 2, 3, 4, 5, 0, time.UTC)
-	svc := &Adapters{DB: db, Keyring: kr, PlanModule: func(origin, credential string) (adapter.Module, func(), error) {
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(origin, credential string) (adapter.Module, func(), error) {
 		if origin != "https://git.example" || credential != "provider-token" {
 			t.Fatalf("factory origin=%q credential=%q", origin, credential)
 		}
 		return fakeAdapterTestModule{gates: &gates, credentialExpiry: expires}, nil, nil
-	}}
+	})}
 	if _, err := svc.ReplaceCredential(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", []byte("provider-token")); err != nil {
 		t.Fatal(err)
 	}
@@ -1762,12 +1800,15 @@ func TestAdapterPlanPersistsProviderConflictArtifactAndInspectReturnsIt(t *testi
 	wantChange := adapter.Change{Surface: adapter.Secret, EffectiveName: "ONE_API_TOKEN", Disposition: adapter.Conflict}
 	svc := &Adapters{
 		DB: db, Keyring: kr,
-		PlanModule: func(origin, credential string) (adapter.Module, func(), error) {
+		ModuleFactory: testModuleFactory(func(provider adapter.Provider, origin, credential string) (adapter.Module, func(), error) {
+			if provider != adapter.ForgejoProvider {
+				t.Fatalf("factory got provider=%q, want forgejo", provider)
+			}
 			if origin != "https://git.example" || credential != "provider-token" {
 				t.Fatalf("factory got origin=%q credential=%q", origin, credential)
 			}
 			return fakeAdapterPlanModule{plan: adapter.Plan{Changes: []adapter.Change{wantChange}}}, func() {}, nil
-		},
+		}),
 	}
 	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
 	result, err := svc.Plan(t.Context(), LocalPrincipal("usr_adapter"), scope, "tgt_one")


### PR DESCRIPTION
Closes #232.

## Summary

- close deployment provider identity over the compiled-in Forgejo and GitHub Actions set
- construct provider modules through one origin-aware app registry shared by worker loading and service planning/probing
- bind every module to an idempotent `ModuleLease`, including partial-construction and later-error cleanup
- reject unknown providers before credential opening and preserve explicit operator egress policy

## Contract and migration

- omitted create-provider input still resolves explicitly to Forgejo at the API boundary
- no API, database, migration, or generated output changed
- credential, HTTP-client, request-deadline, and egress-exception lifetimes are unchanged
- registry remains compiled-in wiring, not a runtime plugin framework

## Review

Two-axis Codex review reached CLEAN in round 2. No Opus used.

## Validation

```text
go test -count=1 ./internal/app/... ./internal/adapter/... ./internal/service/...  354 passed
go test -race -count=1 ./internal/adapter/...                              110 passed
go build ./...                                                               passed
go vet ./...                                                                 passed
go test -p 4 -count=1 -timeout=20m ./...                                  3235 passed / 57 packages
./scripts/ci/verify-docs.sh                                                   passed
```