### PR TITLE
fix(cli): reject sparse tenant scopes

### DIFF
--- a/docs/handoff/issue-237-contiguous-cli-scope.md
+++ b/docs/handoff/issue-237-contiguous-cli-scope.md
@@ -26,6 +26,7 @@ server authorization, API, database, migration, or generated output changed.
 - `go test -count=1 ./internal/isolation/`: 1,092 passed
 - `go vet ./internal/cli/...`: passed
 - `go build ./...`: passed
-- `go test -count=1 ./...`: 3,267 passed in 57 packages
+- `go test -count=1 ./...`: 3,276 passed in 57 packages after merging current
+  `origin/main`
 - Two-axis review round 2: standards CLEAN; spec CLEAN after fixing pre-auth
   access validation and config-fold validation findings from round 1.

--- a/docs/handoff/issue-237-contiguous-cli-scope.md
+++ b/docs/handoff/issue-237-contiguous-cli-scope.md
@@ -21,9 +21,11 @@ server authorization, API, database, migration, or generated output changed.
 
 ## Validation
 
-- `go test -count=1 ./internal/cli/... -run 'Scope|Access|Resolve'`: 26 passed
-- `go test -count=1 ./internal/cli/...`: 259 passed
+- `go test -count=1 ./internal/cli/... -run 'Scope|Access|Resolve'`: 34 passed
+- `go test -count=1 ./internal/cli/...`: 267 passed
 - `go test -count=1 ./internal/isolation/`: 1,092 passed
 - `go vet ./internal/cli/...`: passed
 - `go build ./...`: passed
-- `go test -count=1 ./...`: 3,259 passed in 57 packages
+- `go test -count=1 ./...`: 3,267 passed in 57 packages
+- Two-axis review round 1: standards CLEAN; both spec findings fixed before
+  round 2 (pre-auth access validation and config-fold validation).

--- a/docs/handoff/issue-237-contiguous-cli-scope.md
+++ b/docs/handoff/issue-237-contiguous-cli-scope.md
@@ -27,5 +27,5 @@ server authorization, API, database, migration, or generated output changed.
 - `go vet ./internal/cli/...`: passed
 - `go build ./...`: passed
 - `go test -count=1 ./...`: 3,267 passed in 57 packages
-- Two-axis review round 1: standards CLEAN; both spec findings fixed before
-  round 2 (pre-auth access validation and config-fold validation).
+- Two-axis review round 2: standards CLEAN; spec CLEAN after fixing pre-auth
+  access validation and config-fold validation findings from round 1.

--- a/docs/handoff/issue-237-contiguous-cli-scope.md
+++ b/docs/handoff/issue-237-contiguous-cli-scope.md
@@ -1,0 +1,29 @@
+# Issue #237: contiguous CLI tenant scope
+
+## Contract
+
+CLI tenant targeting now closes resolved org/project/environment dimensions into
+one validated `TenantScope`: instance, org, project, or environment. Project
+without org and environment without project return `ExitUsage`; access routing
+cannot inspect or silently discard a sparse child dimension.
+
+Resolution precedence remains flag, environment variable, project pin, then
+selected context, independently per dimension. A higher-precedence child may
+inherit missing parents from authoritative lower-precedence selections, but the
+assembled result must be contiguous before access builds a route. Explicit
+`--instance-scope` continues to override implicit tenant selections and still
+conflicts with explicit `--org`, `--project`, or `--env` flags.
+
+## Compatibility
+
+Instance, org, project, and environment access route bytes are unchanged. No
+server authorization, API, database, migration, or generated output changed.
+
+## Validation
+
+- `go test -count=1 ./internal/cli/... -run 'Scope|Access|Resolve'`: 26 passed
+- `go test -count=1 ./internal/cli/...`: 259 passed
+- `go test -count=1 ./internal/isolation/`: 1,092 passed
+- `go vet ./internal/cli/...`: passed
+- `go build ./...`: passed
+- `go test -count=1 ./...`: 3,259 passed in 57 packages

--- a/docs/handoff/issue-237-contiguous-cli-scope.md
+++ b/docs/handoff/issue-237-contiguous-cli-scope.md
@@ -26,7 +26,7 @@ server authorization, API, database, migration, or generated output changed.
 - `go test -count=1 ./internal/isolation/`: 1,092 passed
 - `go vet ./internal/cli/...`: passed
 - `go build ./...`: passed
-- `go test -count=1 ./...`: 3,276 passed in 57 packages after merging current
+- `go test -count=1 ./...`: 3,283 passed in 57 packages after merging current
   `origin/main`
 - Two-axis review round 2: standards CLEAN; spec CLEAN after fixing pre-auth
   access validation and config-fold validation findings from round 1.

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -146,11 +146,15 @@ func runAccessGrant(ctx context.Context, ios IO, args []string) error {
 		return failf(ExitUsage, "usage: hikyo access grant template --principal <id> --template <name>")
 	}
 
-	client, artifact, resolved, err := authenticatedTarget(st, ios, flags)
+	resolved, err := Resolve(st, ios.Env, flags.Flags, ios.Workdir)
 	if err != nil {
 		return err
 	}
 	scope, err := resolveAccessScope(resolved, flags, instanceScope, "access grant "+sub)
+	if err != nil {
+		return err
+	}
+	client, artifact, _, err := authenticatedResolvedTarget(st, ios, flags, resolved)
 	if err != nil {
 		return err
 	}
@@ -264,11 +268,15 @@ func runAccessMember(ctx context.Context, ios IO, args []string) error {
 		return failf(ExitUsage, "usage: hikyo access member remove --principal <id>")
 	}
 
-	client, _, resolved, err := authenticatedTarget(st, ios, flags)
+	resolved, err := Resolve(st, ios.Env, flags.Flags, ios.Workdir)
 	if err != nil {
 		return err
 	}
 	scope, err := resolveAccessScope(resolved, flags, instanceScope, "access member "+sub)
+	if err != nil {
+		return err
+	}
+	client, _, _, err := authenticatedResolvedTarget(st, ios, flags, resolved)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -67,23 +67,36 @@ type accessScope struct {
 // silently widening it to the org would be the surface handing out more than
 // the operator asked for.
 func resolveAccessScope(resolved Resolved, flags commonFlags, instanceScope bool, verb string) (accessScope, error) {
+	var tenant TenantScope
+	var err error
 	if instanceScope {
 		if flags.Org != "" || flags.Project != "" || flags.Env != "" {
 			return accessScope{}, failf(ExitUsage,
 				"hikyo %s: --instance-scope and --org/--project/--env name two different scopes; choose one", verb)
 		}
-		return accessScope{path: api.PathPrefix + "/instance/grants", label: "instance"}, nil
+		// --instance-scope explicitly overrides lower-precedence tenant selections.
+		// Still construct the Instance variant through the one scope validator.
+		tenant, err = NewTenantScope(Resolved{})
+	} else {
+		tenant, err = NewTenantScope(resolved)
 	}
-	org, err := resolved.Require(DimOrg)
 	if err != nil {
 		return accessScope{}, err
 	}
+	if tenant.Kind() == TenantScopeInstance {
+		if instanceScope {
+			return accessScope{path: api.PathPrefix + "/instance/grants", label: "instance"}, nil
+		}
+		_, err := resolved.Require(DimOrg)
+		return accessScope{}, err
+	}
+	org := tenant.Get(DimOrg)
 	path := api.PathPrefix + "/orgs/" + url.PathEscape(org)
 	label := org
-	if project := resolved.Get(DimProject); project != "" {
+	if project := tenant.Get(DimProject); project != "" {
 		path += "/projects/" + url.PathEscape(project)
 		label += "/" + project
-		if env := resolved.Get(DimEnv); env != "" {
+		if env := tenant.Get(DimEnv); env != "" {
 			path += "/environments/" + url.PathEscape(env)
 			label += "/" + env
 		}

--- a/internal/cli/access_internal_test.go
+++ b/internal/cli/access_internal_test.go
@@ -1,12 +1,103 @@
 package cli
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 )
+
+func TestResolveAccessScopePreservesCanonicalRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		resolved      Resolved
+		instanceScope bool
+		wantPath      string
+		wantLabel     string
+	}{
+		{
+			name:          "instance",
+			resolved:      Resolved{},
+			instanceScope: true,
+			wantPath:      api.PathPrefix + "/instance/grants",
+			wantLabel:     "instance",
+		},
+		{
+			name:      "org",
+			resolved:  resolvedTenantDimensions("org/one", "", ""),
+			wantPath:  api.PathPrefix + "/orgs/org%2Fone/grants",
+			wantLabel: "org/one",
+		},
+		{
+			name:      "project",
+			resolved:  resolvedTenantDimensions("org_one", "project/one", ""),
+			wantPath:  api.PathPrefix + "/orgs/org_one/projects/project%2Fone/grants",
+			wantLabel: "org_one/project/one",
+		},
+		{
+			name:      "environment",
+			resolved:  resolvedTenantDimensions("org_one", "project_one", "env/one"),
+			wantPath:  api.PathPrefix + "/orgs/org_one/projects/project_one/environments/env%2Fone/grants",
+			wantLabel: "org_one/project_one/env/one",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scope, err := resolveAccessScope(tc.resolved, commonFlags{}, tc.instanceScope, "access grant list")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scope.path != tc.wantPath || scope.label != tc.wantLabel {
+				t.Fatalf("scope = {%q, %q}, want {%q, %q}", scope.path, scope.label, tc.wantPath, tc.wantLabel)
+			}
+		})
+	}
+}
+
+func TestResolveAccessScopeRefusesSparseHierarchy(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		resolved Resolved
+		want     string
+	}{
+		{
+			name:     "project without org",
+			resolved: resolvedTenantDimensions("", "project_one", ""),
+			want:     "project",
+		},
+		{
+			name:     "environment without project",
+			resolved: resolvedTenantDimensions("org_one", "", "env_one"),
+			want:     "environment",
+		},
+		{
+			name:     "environment and project without org",
+			resolved: resolvedTenantDimensions("", "project_one", "env_one"),
+			want:     "project",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveAccessScope(tc.resolved, commonFlags{}, false, "access grant list")
+			if err == nil {
+				t.Fatal("sparse scope was accepted")
+			}
+			var cliErr *Error
+			if !errors.As(err, &cliErr) || cliErr.Code != ExitUsage {
+				t.Fatalf("error = %v, want ExitUsage", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func resolvedTenantDimensions(org, project, environment string) Resolved {
+	return Resolved{Values: map[Dimension]string{
+		DimOrg: org, DimProject: project, DimEnv: environment,
+	}}
+}
 
 func TestGrantResultRowRendersEveryOutcome(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/cli/access_internal_test.go
+++ b/internal/cli/access_internal_test.go
@@ -93,6 +93,45 @@ func TestResolveAccessScopeRefusesSparseHierarchy(t *testing.T) {
 	}
 }
 
+func TestAccessRejectsSparseHierarchyBeforeAuthentication(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "grant project without org",
+			args: []string{"access", "grant", "list", "--instance", "local", "--project", "project_one"},
+			want: "project",
+		},
+		{
+			name: "grant environment without project",
+			args: []string{"access", "grant", "list", "--instance", "local", "--org", "org_one", "--env", "env_one"},
+			want: "environment",
+		},
+		{
+			name: "member project without org",
+			args: []string{"access", "member", "list", "--instance", "local", "--project", "project_one"},
+			want: "project",
+		},
+		{
+			name: "member environment without project",
+			args: []string{"access", "member", "list", "--instance", "local", "--org", "org_one", "--env", "env_one"},
+			want: "environment",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ios, _, stderr := composeIO(t.TempDir(), t.TempDir(), "", nil)
+			if code := Run(t.Context(), ios, tc.args); code != ExitUsage {
+				t.Fatalf("exit = %d, want ExitUsage; stderr=%s", code, stderr)
+			}
+			if !strings.Contains(stderr.String(), tc.want) || strings.Contains(stderr.String(), "trust") {
+				t.Fatalf("scope was not rejected before authentication: %s", stderr)
+			}
+		})
+	}
+}
+
 func resolvedTenantDimensions(org, project, environment string) Resolved {
 	return Resolved{Values: map[Dimension]string{
 		DimOrg: org, DimProject: project, DimEnv: environment,

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -1083,6 +1083,9 @@ func resolveMachineTarget(st *State, ios IO, flags commonFlags, cfg *compose.Con
 			}
 		}
 	}
+	if _, err := NewTenantScope(resolved); err != nil {
+		return nil, TrustEntry{}, Resolved{}, "", err
+	}
 
 	entry, err := machineEntry(st, resolved, cfg)
 	if err != nil {

--- a/internal/cli/compose_internal_test.go
+++ b/internal/cli/compose_internal_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -201,6 +202,42 @@ func TestRunConfigResolveDisagreement(t *testing.T) {
 		t.Fatalf("message must name both sources: %s", stderr)
 	}
 	_ = st
+}
+
+func TestResolveMachineTargetRejectsSparseConfigBeforeTrustLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  compose.Config
+		want string
+	}{
+		{
+			name: "project without org",
+			cfg:  compose.Config{Instance: "https://untrusted.example", Project: "project_one", Environment: "env_one"},
+			want: "project",
+		},
+		{
+			name: "environment without project",
+			cfg:  compose.Config{Instance: "https://untrusted.example", Org: "org_one", Environment: "env_one"},
+			want: "environment",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			ios, _, _ := composeIO(stateDir, t.TempDir(), "", nil)
+			st := &State{dir: stateDir}
+			_, _, _, _, err := resolveMachineTarget(st, ios, commonFlags{}, &tc.cfg, "hikyo-compose.yaml", "compose")
+			if err == nil {
+				t.Fatal("sparse config was accepted")
+			}
+			var cliErr *Error
+			if !errors.As(err, &cliErr) || cliErr.Code != ExitUsage {
+				t.Fatalf("error = %v, want ExitUsage", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) || strings.Contains(err.Error(), "trust store") {
+				t.Fatalf("config was not rejected before trust lookup: %v", err)
+			}
+		})
+	}
 }
 
 func TestRunArgMaxRefusal(t *testing.T) {

--- a/internal/cli/golden_test.go
+++ b/internal/cli/golden_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -332,38 +333,213 @@ func TestCanonicalOriginRefusesWhatIsNotAnOrigin(t *testing.T) {
 }
 
 func TestTargetResolutionPrecedence(t *testing.T) {
-	// Per dimension, first hit wins: flags, then environment, then the pin
-	// file, then the named context. Overriding ONE dimension is legitimate
-	// exactly because the others re-resolve within the same chain.
-	ios, _, _ := testIO(t, map[string]string{"HIKYO_PROJECT": "from-env"})
-	if err := os.WriteFile(filepath.Join(ios.Workdir, cli.PinFileName),
-		[]byte(`{"instance":"pinned","org":"pinned-org","project":"pinned-project","env":"pinned-env"}`), 0o644); err != nil {
-		t.Fatal(err)
+	// First hit wins independently for each dimension. The table documents the
+	// full order and proves an explicit child may inherit its missing parents
+	// from lower-precedence authoritative selections.
+	for _, tc := range []struct {
+		name    string
+		flags   cli.Flags
+		env     map[string]string
+		pin     string
+		context cli.Context
+		want    map[cli.Dimension]struct {
+			value  string
+			source cli.Source
+		}
+	}{
+		{
+			name:  "flag beats environment pin and context",
+			flags: cli.Flags{Context: "selected", Instance: "flag-instance", Org: "flag-org", Project: "flag-project", Env: "flag-env"},
+			env: map[string]string{
+				"HIKYO_INSTANCE": "env-instance", "HIKYO_ORG": "env-org",
+				"HIKYO_PROJECT": "env-project", "HIKYO_ENV": "env-env",
+			},
+			pin:     `{"instance":"pin-instance","org":"pin-org","project":"pin-project","env":"pin-env"}`,
+			context: cli.Context{Name: "selected", Instance: "context-instance", Org: "context-org", Project: "context-project", Env: "context-env"},
+			want:    resolvedWant("flag-instance", "flag-org", "flag-project", "flag-env", cli.SourceFlag),
+		},
+		{
+			name:  "environment beats pin and context",
+			flags: cli.Flags{Context: "selected"},
+			env: map[string]string{
+				"HIKYO_INSTANCE": "env-instance", "HIKYO_ORG": "env-org",
+				"HIKYO_PROJECT": "env-project", "HIKYO_ENV": "env-env",
+			},
+			pin:     `{"instance":"pin-instance","org":"pin-org","project":"pin-project","env":"pin-env"}`,
+			context: cli.Context{Name: "selected", Instance: "context-instance", Org: "context-org", Project: "context-project", Env: "context-env"},
+			want:    resolvedWant("env-instance", "env-org", "env-project", "env-env", cli.SourceEnv),
+		},
+		{
+			name:    "pin beats context",
+			flags:   cli.Flags{Context: "selected"},
+			pin:     `{"instance":"pin-instance","org":"pin-org","project":"pin-project","env":"pin-env"}`,
+			context: cli.Context{Name: "selected", Instance: "context-instance", Org: "context-org", Project: "context-project", Env: "context-env"},
+			want:    resolvedWant("pin-instance", "pin-org", "pin-project", "pin-env", cli.SourcePinFile),
+		},
+		{
+			name:    "context fills unresolved dimensions",
+			flags:   cli.Flags{Context: "selected"},
+			context: cli.Context{Name: "selected", Instance: "context-instance", Org: "context-org", Project: "context-project", Env: "context-env"},
+			want:    resolvedWant("context-instance", "context-org", "context-project", "context-env", cli.SourceContext),
+		},
+		{
+			name:  "mixed override retains complete parents",
+			flags: cli.Flags{Context: "selected", Env: "flag-env"},
+			env:   map[string]string{"HIKYO_PROJECT": "env-project"},
+			pin:   `{"org":"pin-org"}`,
+			context: cli.Context{
+				Name: "selected", Instance: "context-instance",
+			},
+			want: map[cli.Dimension]struct {
+				value  string
+				source cli.Source
+			}{
+				cli.DimInstance: {"context-instance", cli.SourceContext},
+				cli.DimOrg:      {"pin-org", cli.SourcePinFile},
+				cli.DimProject:  {"env-project", cli.SourceEnv},
+				cli.DimEnv:      {"flag-env", cli.SourceFlag},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ios, _, _ := testIO(t, tc.env)
+			if tc.pin != "" {
+				if err := os.WriteFile(filepath.Join(ios.Workdir, cli.PinFileName), []byte(tc.pin), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			st, err := cli.NewState(ios.Env)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.context.Name != "" {
+				if err := st.PutContext(tc.context); err != nil {
+					t.Fatal(err)
+				}
+			}
+			resolved, err := cli.Resolve(st, ios.Env, tc.flags, ios.Workdir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for dim, want := range tc.want {
+				if got := resolved.Get(dim); got != want.value {
+					t.Errorf("%s = %q, want %q", dim, got, want.value)
+				}
+				if got := resolved.Sources[dim]; got != want.source {
+					t.Errorf("%s came from %q, want %q", dim, got, want.source)
+				}
+			}
+		})
 	}
-	st, err := cli.NewState(ios.Env)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resolved, err := cli.Resolve(st, ios.Env, cli.Flags{Env: "from-flag"}, ios.Workdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := map[cli.Dimension]struct {
+}
+
+func resolvedWant(instance, org, project, environment string, source cli.Source) map[cli.Dimension]struct {
+	value  string
+	source cli.Source
+} {
+	return map[cli.Dimension]struct {
 		value  string
 		source cli.Source
 	}{
-		cli.DimEnv:      {"from-flag", cli.SourceFlag},
-		cli.DimProject:  {"from-env", cli.SourceEnv},
-		cli.DimOrg:      {"pinned-org", cli.SourcePinFile},
-		cli.DimInstance: {"pinned", cli.SourcePinFile},
+		cli.DimInstance: {instance, source},
+		cli.DimOrg:      {org, source},
+		cli.DimProject:  {project, source},
+		cli.DimEnv:      {environment, source},
 	}
-	for dim, w := range want {
-		if got := resolved.Get(dim); got != w.value {
-			t.Errorf("%s = %q, want %q", dim, got, w.value)
-		}
-		if got := resolved.Sources[dim]; got != w.source {
-			t.Errorf("%s came from %q, want %q", dim, got, w.source)
-		}
+}
+
+func TestTenantScopeConstructsOnlyContiguousHierarchy(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		values  map[cli.Dimension]string
+		want    cli.TenantScopeKind
+		wantErr string
+	}{
+		{name: "instance", values: map[cli.Dimension]string{}, want: cli.TenantScopeInstance},
+		{name: "org", values: map[cli.Dimension]string{cli.DimOrg: "org_one"}, want: cli.TenantScopeOrg},
+		{name: "project", values: map[cli.Dimension]string{cli.DimOrg: "org_one", cli.DimProject: "project_one"}, want: cli.TenantScopeProject},
+		{name: "environment", values: map[cli.Dimension]string{cli.DimOrg: "org_one", cli.DimProject: "project_one", cli.DimEnv: "env_one"}, want: cli.TenantScopeEnvironment},
+		{name: "project gap", values: map[cli.Dimension]string{cli.DimProject: "project_one"}, wantErr: "project"},
+		{name: "environment gap", values: map[cli.Dimension]string{cli.DimOrg: "org_one", cli.DimEnv: "env_one"}, wantErr: "environment"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scope, err := cli.NewTenantScope(cli.Resolved{Values: tc.values})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want error naming %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scope.Kind() != tc.want {
+				t.Fatalf("kind = %v, want %v", scope.Kind(), tc.want)
+			}
+		})
+	}
+}
+
+func TestTenantScopeRejectsSparseHierarchyFromEveryResolutionSource(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		flags   cli.Flags
+		env     map[string]string
+		pin     string
+		context cli.Context
+		want    string
+	}{
+		{name: "flag project gap", flags: cli.Flags{Project: "project_one"}, want: "project"},
+		{name: "flag environment gap", flags: cli.Flags{Org: "org_one", Env: "env_one"}, want: "environment"},
+		{name: "environment project gap", env: map[string]string{"HIKYO_PROJECT": "project_one"}, want: "project"},
+		{name: "environment environment gap", env: map[string]string{"HIKYO_ORG": "org_one", "HIKYO_ENV": "env_one"}, want: "environment"},
+		{name: "pin project gap", pin: `{"project":"project_one"}`, want: "project"},
+		{name: "pin environment gap", pin: `{"org":"org_one","env":"env_one"}`, want: "environment"},
+		{
+			name:    "context project gap",
+			flags:   cli.Flags{Context: "selected"},
+			context: cli.Context{Name: "selected", Project: "project_one"},
+			want:    "project",
+		},
+		{
+			name:    "context environment gap",
+			flags:   cli.Flags{Context: "selected"},
+			context: cli.Context{Name: "selected", Org: "org_one", Env: "env_one"},
+			want:    "environment",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ios, _, _ := testIO(t, tc.env)
+			if tc.pin != "" {
+				if err := os.WriteFile(filepath.Join(ios.Workdir, cli.PinFileName), []byte(tc.pin), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			st, err := cli.NewState(ios.Env)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.context.Name != "" {
+				if err := st.PutContext(tc.context); err != nil {
+					t.Fatal(err)
+				}
+			}
+			resolved, err := cli.Resolve(st, ios.Env, tc.flags, ios.Workdir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = cli.NewTenantScope(resolved)
+			if err == nil {
+				t.Fatal("sparse scope was accepted")
+			}
+			var cliErr *cli.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != cli.ExitUsage {
+				t.Fatalf("error = %v, want ExitUsage", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -52,6 +52,75 @@ type Resolved struct {
 	ContextName string
 }
 
+// TenantScopeKind is the closed set of contiguous tenant hierarchy depths.
+type TenantScopeKind uint8
+
+const (
+	TenantScopeInstance TenantScopeKind = iota
+	TenantScopeOrg
+	TenantScopeProject
+	TenantScopeEnvironment
+)
+
+// TenantScope is a validated contiguous tenant hierarchy. Its fields stay
+// private so callers can obtain one only through NewTenantScope, which makes
+// sparse shapes such as org+env impossible to route accidentally.
+type TenantScope struct {
+	kind        TenantScopeKind
+	org         string
+	project     string
+	environment string
+}
+
+// NewTenantScope closes independently resolved dimensions into exactly one
+// hierarchy variant. Resolution may combine flag, environment, pin-file and
+// context values; the resulting tuple must still contain every parent.
+func NewTenantScope(resolved Resolved) (TenantScope, error) {
+	org := resolved.Get(DimOrg)
+	project := resolved.Get(DimProject)
+	environment := resolved.Get(DimEnv)
+
+	if project != "" && org == "" {
+		return TenantScope{}, failf(ExitUsage,
+			"project %q resolved without an org; refusing sparse tenant scope", project)
+	}
+	if environment != "" && project == "" {
+		return TenantScope{}, failf(ExitUsage,
+			"environment %q resolved without a project; refusing sparse tenant scope", environment)
+	}
+
+	scope := TenantScope{org: org, project: project, environment: environment}
+	switch {
+	case environment != "":
+		scope.kind = TenantScopeEnvironment
+	case project != "":
+		scope.kind = TenantScopeProject
+	case org != "":
+		scope.kind = TenantScopeOrg
+	default:
+		scope.kind = TenantScopeInstance
+	}
+	return scope, nil
+}
+
+// Kind returns the validated hierarchy depth.
+func (s TenantScope) Kind() TenantScopeKind { return s.kind }
+
+// Get returns the value at one tenant dimension. A successful constructor
+// guarantees every parent of a returned value is present.
+func (s TenantScope) Get(d Dimension) string {
+	switch d {
+	case DimOrg:
+		return s.org
+	case DimProject:
+		return s.project
+	case DimEnv:
+		return s.environment
+	default:
+		return ""
+	}
+}
+
 // Get returns a dimension's value.
 func (r Resolved) Get(d Dimension) string { return r.Values[d] }
 

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -1485,6 +1485,13 @@ func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, Session
 	if err != nil {
 		return nil, SessionArtifact{}, Resolved{}, err
 	}
+	return authenticatedResolvedTarget(st, ios, flags, resolved)
+}
+
+// authenticatedResolvedTarget authenticates against a target whose dimensions
+// the caller already resolved and validated. It lets safety-sensitive verbs
+// reject malformed scope before trust or session state can change the answer.
+func authenticatedResolvedTarget(st *State, ios IO, flags commonFlags, resolved Resolved) (*Client, SessionArtifact, Resolved, error) {
 	instance, err := resolved.Require(DimInstance)
 	if err != nil {
 		// Exactly one established instance is not an ambiguity, so falling


### PR DESCRIPTION
Closes #237

## Contract and migration

- closes resolved org/project/environment inputs into one validated `TenantScope`
- rejects project-without-org and environment-without-project as usage errors before trust/session lookup
- routes access grants and members only from validated contiguous scopes
- preserves flag > environment > pin > selected-context precedence and validates folded `hikyo-compose.yaml` dimensions through the same constructor
- preserves valid instance/org/project/environment route bytes
- changes no server authorization behavior and requires no migration

## Generated outputs

None.

## Validation

- `go test -count=1 ./internal/cli/... -run 'Scope|Access|Resolve'` — 34 passed
- `go test -count=1 ./internal/cli/...` — 267 passed
- `go test -count=1 ./internal/isolation/` — 1,092 passed
- `go vet ./internal/cli/...` — passed
- `go build ./...` — passed
- `go test -count=1 ./...` after merging current main — 3,276 passed in 57 packages
- two-axis review round 2 — Standards CLEAN; Spec CLEAN