### PR TITLE
refactor(cli): model auth artifacts explicitly

### DIFF
--- a/docs/handoff/236-cli-auth-artifacts.md
+++ b/docs/handoff/236-cli-auth-artifacts.md
@@ -1,0 +1,74 @@
+# Handoff: #236 explicit CLI authentication artifacts
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/236 (subissue of #205;
+programme #203; audit `CL01-A`). Implemented and validated on current
+`origin/main` at `136f7567b8556e4198e0112c4237464b7e5f9647`.
+
+## Contract
+
+- `AuthArtifact` is a sealed union: `HumanSession{SessionArtifact}` or
+  `MachineCredential{Origin, CredentialRef}`. Machine credential plaintext
+  remains only on the request client; the aggregate records `HIKYO_TOKEN` or
+  `--token-file`, never the value or file path.
+- The leaf-command authentication table is exhaustive and default-deny.
+  Machine eligibility is limited to the locked automation commands;
+  management, account, adapter, and other human-only commands reject machine
+  artifacts before network work.
+- `--auth=human|machine` selects explicitly. When both eligible artifact kinds
+  exist and neither is selected, resolution refuses rather than letting an
+  ambient machine credential replace the stored human session. An ineligible
+  ambient artifact does not displace the one eligible artifact.
+- Legacy unversioned `sessions.json` maps still decode unchanged. A future
+  numeric version envelope fails with an actionable CLI-upgrade message.
+  Machine credentials remain invocation-scoped and are never persisted as
+  sessions.
+
+## Tests and fixtures
+
+- The auth table test proves every shipped top-level command has leaf rules and
+  asserts the locked human/machine boundaries for mixed families.
+- Resolution tests cover explicit machine artifacts, plaintext exclusion,
+  dual-eligible collision refusal, explicit human selection without reading a
+  token file, ineligible ambient-token handling, and pre-network human-only
+  refusal.
+- `sessions-legacy.json` and `sessions-future.json` exercise safe legacy reads
+  and actionable future-version failure.
+- The scanning isolation canary now stores its administrator token as the human
+  CLI session it actually is instead of feeding that token through the machine
+  `--token-file` channel.
+
+Generated code: none. The frozen help golden changed only for the new `--auth`
+selection guidance.
+
+## Validation
+
+```text
+gofmt -l internal/cli
+  clean
+go build ./...
+  passed
+go vet ./...
+  passed
+go test -count=1 ./internal/cli/...
+  251 passed
+go test -count=1 ./internal/isolation/ -run 'CLI|Machine'
+  36 passed
+go test -count=1 ./internal/isolation/ -run TestScanningCanarySweepSQLite
+  1 passed
+go test -p 4 -count=1 -timeout=20m ./...
+  3260 passed in 57 packages
+```
+
+The first full-suite run exposed the scanning canary's misclassified human
+token. After the fixture stored a real `SessionArtifact`, the focused canary
+and complete suite passed without changing production eligibility.
+
+## Review
+
+- Round 1 Standards and Spec both found the same two blockers: top-level policy
+  was too coarse, and ambient machine auth still silently won collisions.
+- The implementation moved policy to exact leaf operations supplied by
+  `parseCommon`, added explicit selection, and added collision regression tests.
+- Round 2 Standards: CLEAN. Round 2 Spec: CLEAN.
+
+Exact-head CI and merge evidence live on the pull request.

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -153,6 +153,11 @@ func runAccessGrant(ctx context.Context, ios IO, args []string) error {
 	case "add":
 		var res apigen.GrantResult
 		body := apigen.CreateGrantRequest{Principal: principal, Capability: capability}
+		if capability == "reveal" {
+			if _, err := requireHumanSession("hikyo access grant add --capability reveal", artifact); err != nil {
+				return err
+			}
+		}
 		// A grant that makes machine plaintext reachable (reveal on a machine
 		// principal) consumes the grantor's reauthentication window over the
 		// environments it reaches. For an environment-scoped grant that is
@@ -459,9 +464,14 @@ func runMachineReveal(ctx context.Context, ios IO, args []string) error {
 			return failf(ExitUsage, "usage: hikyo project-settings machine-reveal set --enabled true|false")
 		}
 	}
-	client, _, resolved, err := authenticatedTarget(st, ios, flags)
+	client, artifact, resolved, err := authenticatedTarget(st, ios, flags)
 	if err != nil {
 		return err
+	}
+	if sub == "set" {
+		if _, err := requireHumanSession("hikyo project-settings machine-reveal set", artifact); err != nil {
+			return err
+		}
 	}
 	base, err := projectBase(resolved)
 	if err != nil {

--- a/internal/cli/adapters.go
+++ b/internal/cli/adapters.go
@@ -122,15 +122,16 @@ func splitAdapterKeys(raw string) []string {
 	return out
 }
 
-func runAdapterCeremony(ctx context.Context, ios IO, client *Client, st *State, artifact SessionArtifact, base, adapterID, operation string, additional ...string) error {
+func runAdapterCeremony(ctx context.Context, ios IO, client *Client, st *State, artifact AuthArtifact, base, adapterID, operation string, additional ...string) error {
+	session, err := requireHumanSession("adapter reauthentication", artifact)
+	if err != nil {
+		return err
+	}
 	// Command tests and embedded callers may deliberately omit the browser
 	// adapter. The shipped binary always supplies it; omission keeps this
 	// transport seam injectable without launching a real browser in tests.
 	if ios.OpenURL == nil {
 		return nil
-	}
-	if artifact.Instance == "" {
-		return failf(ExitRefused, "adapter reauthentication requires a stored human CLI session")
 	}
 	environments := append([]string(nil), additional...)
 	if adapterID != "" {
@@ -147,7 +148,7 @@ func runAdapterCeremony(ctx context.Context, ios IO, client *Client, st *State, 
 	if len(environments) == 0 {
 		return failf(ExitRefused, "adapter reauthentication requires at least one target environment")
 	}
-	return runCLIAdapterReauth(ctx, client, st, artifact, operation, environments, ios.OpenURL)
+	return runCLIAdapterReauth(ctx, client, st, session, operation, environments, ios.OpenURL)
 }
 
 func runAdapter(ctx context.Context, ios IO, args []string) error {

--- a/internal/cli/auth_artifact.go
+++ b/internal/cli/auth_artifact.go
@@ -1,0 +1,247 @@
+package cli
+
+import "strings"
+
+// AuthKind is the closed set of authentication artifacts a CLI command may
+// carry. Unauthenticated is included only in policy: it is never an
+// AuthArtifact value.
+type AuthKind string
+
+const (
+	AuthKindUnauthenticated   AuthKind = "unauthenticated"
+	AuthKindHumanSession      AuthKind = "human-session"
+	AuthKindMachineCredential AuthKind = "machine-credential"
+)
+
+type AuthKinds uint8
+
+const (
+	authAllowsUnauthenticated AuthKinds = 1 << iota
+	authAllowsHumanSession
+	authAllowsMachineCredential
+)
+
+func (kinds AuthKinds) Allows(kind AuthKind) bool {
+	switch kind {
+	case AuthKindUnauthenticated:
+		return kinds&authAllowsUnauthenticated != 0
+	case AuthKindHumanSession:
+		return kinds&authAllowsHumanSession != 0
+	case AuthKindMachineCredential:
+		return kinds&authAllowsMachineCredential != 0
+	default:
+		return false
+	}
+}
+
+const (
+	humanOnly      = authAllowsHumanSession
+	machineOnly    = authAllowsMachineCredential
+	humanOrMachine = authAllowsHumanSession | authAllowsMachineCredential
+)
+
+// AuthOperation is the canonical leaf command name already owned by each
+// handler's parseCommon call (for example, "values export").
+type AuthOperation string
+
+type authRuleRow struct {
+	Kinds      AuthKinds
+	Operations []AuthOperation
+}
+
+// authRuleRows is the closed verb x artifact table. Every leaf command is
+// listed, including local/pre-auth commands, so a new command defaults denied
+// until its eligibility is chosen here.
+var authRuleRows = []authRuleRow{
+	{Kinds: authAllowsUnauthenticated, Operations: authOperations(
+		"login",
+		"context create", "context list", "context show", "context delete",
+		"account establish-credential", "account recovery begin",
+		"account passkey enrol", "account passkey list", "account passkey remove",
+		"definitions scaffold",
+	)},
+	{Kinds: humanOnly, Operations: authOperations(
+		"logout", "whoami",
+		"account reset-credential", "account factor enrol-totp", "account factor confirm-totp",
+		"account factor step-up", "account recovery-codes regenerate",
+		"org list", "org show", "org create", "org rename", "org delete",
+		"org retention get", "org retention set",
+		"project list", "project show", "project create", "project rename", "project delete",
+		"project retention get", "project retention set",
+		"env list", "env show", "env create", "env rename", "env reorder", "env delete",
+		"folder list", "folder show", "folder create", "folder rename", "folder delete",
+		"key list", "key show", "key group list", "key group show",
+		"values list", "values get", "values set", "values declare", "values diff",
+		"values copy", "values import", "values publish", "values pending",
+		"revision list", "revision show", "revision rollback",
+		"pin create", "pin list", "pin release",
+		"rotate-token-key", "rotate-scanning-key", "rotate-dek", "rotate-master-key",
+		"rotate-root-key", "reencrypt", "doctor",
+		"access grant list", "access grant add", "access grant remove", "access grant template",
+		"access member list", "access member remove",
+		"project-settings get", "project-settings set",
+		"project-settings machine-reveal get", "project-settings machine-reveal set",
+		"sa list", "sa create", "sa delete", "sa credential list", "sa credential mint",
+		"sa credential rotate", "sa credential revoke", "sa binding create",
+		"instance-config credential-policy get", "instance-config credential-policy set",
+		"instance-config federation-issuer list", "instance-config federation-issuer add",
+		"instance-config federation-issuer update", "instance-config federation-issuer remove",
+		"instance-config saml-sp-key list", "instance-config saml-sp-key rotate",
+		"instance-config saml-sp-key retire", "instance-config saml-sp-key compromise-retire",
+		"instance-config provider create", "instance-config provider list", "instance-config provider show",
+		"instance-config provider update", "instance-config provider disable", "instance-config provider remove",
+		"instance-config provider refresh-metadata",
+		"scim binding create", "scim binding list", "scim binding show", "scim binding delete",
+		"scim mapping add", "scim mapping update", "scim mapping remove", "scim mapping list",
+		"scim credential mint", "scim credential list", "scim credential show", "scim credential revoke",
+		"scim user list", "scim group list",
+		"remote add", "remote list", "remote show", "remote remove",
+		"remote-credential create", "remote-credential list", "remote-credential show", "remote-credential revoke",
+		"import",
+		"adapter create", "adapter list", "adapter show", "adapter update", "adapter delete",
+		"adapter credential set", "adapter credential revoke",
+		"adapter target add", "adapter target list", "adapter target show", "adapter target remove",
+		"adapter adopt", "adapter plan", "adapter sync", "adapter test",
+		"definitions export",
+	)},
+	{Kinds: humanOrMachine, Operations: authOperations(
+		"definitions check", "definitions plan", "definitions apply",
+		"key create", "key rename", "key declare", "key reclassify", "key update", "key set-group", "key delete",
+		"key group create", "key group rename", "key group delete",
+		"values export", "run",
+	)},
+	{Kinds: machineOnly, Operations: authOperations(
+		"compose render", "compose sync", "compose doctor",
+	)},
+}
+
+var operationAuthKinds = buildOperationAuthKinds(authRuleRows)
+
+func authOperations(names ...string) []AuthOperation {
+	out := make([]AuthOperation, len(names))
+	for i, name := range names {
+		out[i] = AuthOperation(name)
+	}
+	return out
+}
+
+func buildOperationAuthKinds(rows []authRuleRow) map[AuthOperation]AuthKinds {
+	out := make(map[AuthOperation]AuthKinds)
+	for _, row := range rows {
+		for _, operation := range row.Operations {
+			if _, exists := out[operation]; exists {
+				panic("duplicate authentication operation " + operation)
+			}
+			out[operation] = row.Kinds
+		}
+	}
+	return out
+}
+
+func authKindsFor(operation AuthOperation) (AuthKinds, error) {
+	kinds, ok := operationAuthKinds[operation]
+	if !ok {
+		return 0, failf(ExitInternal, "hikyo %s has no authentication-kind rule", operation)
+	}
+	return kinds, nil
+}
+
+func topLevelOperation(operation AuthOperation) string {
+	return strings.SplitN(string(operation), " ", 2)[0]
+}
+
+func selectAuthKind(operation AuthOperation, kinds AuthKinds, choice string, humanPresent, machinePresent bool) (AuthKind, error) {
+	switch choice {
+	case "human":
+		if !kinds.Allows(AuthKindHumanSession) {
+			return "", failf(ExitRefused, "hikyo %s does not accept human-session authentication", operation)
+		}
+		if !humanPresent {
+			return "", failf(ExitAuth, "hikyo %s selected --auth=human, but no stored human session is available", operation)
+		}
+		return AuthKindHumanSession, nil
+	case "machine":
+		if !kinds.Allows(AuthKindMachineCredential) {
+			return "", failf(ExitRefused, "hikyo %s requires a human session; machine credentials are not eligible", operation)
+		}
+		if !machinePresent {
+			return "", failf(ExitAuth, "hikyo %s selected --auth=machine, but no --token-file or HIKYO_TOKEN is available", operation)
+		}
+		return AuthKindMachineCredential, nil
+	}
+
+	humanEligible := humanPresent && kinds.Allows(AuthKindHumanSession)
+	machineEligible := machinePresent && kinds.Allows(AuthKindMachineCredential)
+	switch {
+	case humanEligible && machineEligible:
+		return "", failf(ExitRefused,
+			"hikyo %s found both a stored human session and a machine credential; pass --auth=human or --auth=machine",
+			operation)
+	case humanEligible:
+		return AuthKindHumanSession, nil
+	case machineEligible:
+		return AuthKindMachineCredential, nil
+	case machinePresent && !kinds.Allows(AuthKindMachineCredential):
+		return "", failf(ExitRefused, "hikyo %s requires a human session; machine credentials are not eligible", operation)
+	case humanPresent && !kinds.Allows(AuthKindHumanSession):
+		return "", failf(ExitRefused, "hikyo %s requires a machine credential; stored human sessions are not eligible", operation)
+	case kinds.Allows(AuthKindHumanSession):
+		return "", failf(ExitAuth, "no human session is available for hikyo %s: run `hikyo login <url> --local --as <user>`", operation)
+	default:
+		return "", failf(ExitAuth, "hikyo %s requires --token-file or HIKYO_TOKEN", operation)
+	}
+}
+
+// AuthArtifact is a sealed human-session | machine-credential sum. Credential
+// plaintext deliberately lives only on Client, never in this aggregate.
+type AuthArtifact interface {
+	authArtifact()
+	Kind() AuthKind
+	ArtifactOrigin() string
+}
+
+type HumanSession struct{ SessionArtifact }
+
+func (HumanSession) authArtifact()            {}
+func (HumanSession) Kind() AuthKind           { return AuthKindHumanSession }
+func (h HumanSession) ArtifactOrigin() string { return h.Origin }
+
+// CredentialRef identifies the invocation channel without retaining its
+// plaintext or a token-file path.
+type CredentialRef string
+
+const (
+	CredentialRefEnvironment CredentialRef = "HIKYO_TOKEN"
+	CredentialRefTokenFile   CredentialRef = "--token-file"
+)
+
+func (r CredentialRef) String() string { return string(r) }
+
+type MachineCredential struct {
+	Origin        string
+	CredentialRef CredentialRef
+}
+
+func (MachineCredential) authArtifact()            {}
+func (MachineCredential) Kind() AuthKind           { return AuthKindMachineCredential }
+func (m MachineCredential) ArtifactOrigin() string { return m.Origin }
+
+func requireHumanSession(action string, artifact AuthArtifact) (SessionArtifact, error) {
+	switch value := artifact.(type) {
+	case HumanSession:
+		return value.SessionArtifact, nil
+	case MachineCredential:
+		return SessionArtifact{}, failf(ExitRefused,
+			"%s requires a stored human CLI session; machine credential %s is not eligible",
+			action, value.CredentialRef)
+	default:
+		return SessionArtifact{}, failf(ExitInternal, "%s received unknown authentication artifact %T", action, artifact)
+	}
+}
+
+func credentialRef(tokenFile string) CredentialRef {
+	if tokenFile != "" {
+		return CredentialRefTokenFile
+	}
+	return CredentialRefEnvironment
+}

--- a/internal/cli/auth_artifact_internal_test.go
+++ b/internal/cli/auth_artifact_internal_test.go
@@ -1,0 +1,247 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestVerbAuthKindsCoverEveryVerb(t *testing.T) {
+	topLevels := map[string]bool{}
+	for operation, kinds := range operationAuthKinds {
+		topLevels[topLevelOperation(operation)] = true
+		if kinds == 0 {
+			t.Errorf("%s has no allowed authentication kind", operation)
+		}
+	}
+	declared := slices.Sorted(maps.Keys(topLevels))
+	if !slices.Equal(declared, Verbs) {
+		t.Fatalf("auth-kind top-level verbs = %v, want %v", declared, Verbs)
+	}
+
+	for _, test := range []struct {
+		operation AuthOperation
+		kind      AuthKind
+		want      bool
+	}{
+		{operation: "logout", kind: AuthKindHumanSession, want: true},
+		{operation: "logout", kind: AuthKindMachineCredential, want: false},
+		{operation: "adapter sync", kind: AuthKindMachineCredential, want: false},
+		{operation: "definitions export", kind: AuthKindMachineCredential, want: false},
+		{operation: "definitions apply", kind: AuthKindMachineCredential, want: true},
+		{operation: "key list", kind: AuthKindMachineCredential, want: false},
+		{operation: "key update", kind: AuthKindMachineCredential, want: true},
+		{operation: "values get", kind: AuthKindMachineCredential, want: false},
+		{operation: "values export", kind: AuthKindMachineCredential, want: true},
+		{operation: "compose render", kind: AuthKindMachineCredential, want: true},
+		{operation: "compose render", kind: AuthKindHumanSession, want: false},
+		{operation: "run", kind: AuthKindHumanSession, want: true},
+		{operation: "run", kind: AuthKindMachineCredential, want: true},
+	} {
+		t.Run(string(test.operation)+"/"+string(test.kind), func(t *testing.T) {
+			if got := operationAuthKinds[test.operation].Allows(test.kind); got != test.want {
+				t.Fatalf("Allows(%s) = %t, want %t", test.kind, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAuthenticatedTargetReturnsExplicitMachineCredential(t *testing.T) {
+	stateDir := t.TempDir()
+	st := &State{dir: stateDir}
+	if err := st.Trust().Put(TrustEntry{Name: "local", Origin: "http://127.0.0.1:1234"}); err != nil {
+		t.Fatal(err)
+	}
+	ios := IO{Env: Env{
+		StateD: stateDir,
+		Getenv: func(key string) string {
+			if key == "HIKYO_TOKEN" {
+				return "hik_1_machine-secret"
+			}
+			return ""
+		},
+	}, Stderr: &bytes.Buffer{}}
+
+	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
+		Flags: Flags{Instance: "local"}, operation: "definitions apply",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	machine, ok := artifact.(MachineCredential)
+	if !ok {
+		t.Fatalf("artifact type = %T, want MachineCredential", artifact)
+	}
+	if machine.Origin != "http://127.0.0.1:1234" || machine.CredentialRef != CredentialRefEnvironment {
+		t.Fatalf("machine artifact = %+v", machine)
+	}
+	if strings.Contains(machine.CredentialRef.String(), "machine-secret") {
+		t.Fatal("machine artifact contains credential plaintext")
+	}
+}
+
+func TestDualEligibleOperationRequiresExplicitAuthChoice(t *testing.T) {
+	st, ios := authTargetFixture(t)
+	_, _, _, err := authenticatedTarget(st, ios, commonFlags{
+		Flags: Flags{Instance: "local"}, operation: "values export",
+	})
+	if err == nil || !strings.Contains(err.Error(), "both a stored human session and a machine credential") || !strings.Contains(err.Error(), "--auth=human") {
+		t.Fatalf("error = %v, want explicit artifact-choice refusal", err)
+	}
+}
+
+func TestExplicitHumanChoiceDoesNotReadMachineCredential(t *testing.T) {
+	st, ios := authTargetFixture(t)
+	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
+		Flags: Flags{Instance: "local"}, operation: "values export", Auth: "human",
+		TokenFile: filepath.Join(t.TempDir(), "missing-token"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := artifact.(HumanSession); !ok {
+		t.Fatalf("artifact type = %T, want HumanSession", artifact)
+	}
+}
+
+func TestHumanOnlyOperationIgnoresIneligibleAmbientMachineCredential(t *testing.T) {
+	st, ios := authTargetFixture(t)
+	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
+		Flags: Flags{Instance: "local"}, operation: "whoami",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := artifact.(HumanSession); !ok {
+		t.Fatalf("artifact type = %T, want HumanSession", artifact)
+	}
+}
+
+func authTargetFixture(t *testing.T) (*State, IO) {
+	t.Helper()
+	stateDir := t.TempDir()
+	st := &State{dir: stateDir}
+	const origin = "http://127.0.0.1:1234"
+	if err := st.Trust().Put(TrustEntry{Name: "local", Origin: origin}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSession(SessionArtifact{
+		Instance: "local", Origin: origin, Token: "hik_1_human-secret", SessionID: "ses_1",
+		Principal: "usr_1", ExpiresAt: "2030-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ios := IO{Env: Env{
+		StateD: stateDir,
+		Getenv: func(key string) string {
+			if key == "HIKYO_TOKEN" {
+				return "hik_1_machine-secret"
+			}
+			return ""
+		},
+	}, Stderr: &bytes.Buffer{}}
+	return st, ios
+}
+
+func TestHumanOnlyVerbRefusesMachineCredentialBeforeNetwork(t *testing.T) {
+	stateDir := t.TempDir()
+	st := &State{dir: stateDir}
+	if err := st.Trust().Put(TrustEntry{Name: "local", Origin: "http://127.0.0.1:1"}); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	ios := IO{
+		Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &stderr, Workdir: t.TempDir(),
+		Env: Env{StateD: stateDir, Getenv: func(key string) string {
+			if key == "HIKYO_STATE_DIR" {
+				return stateDir
+			}
+			if key == "HIKYO_TOKEN" {
+				return "hik_1_machine-secret"
+			}
+			return ""
+		}},
+	}
+	if code := Run(context.Background(), ios, []string{"logout", "--instance", "local"}); code != ExitRefused {
+		t.Fatalf("exit = %d, want %d; stderr=%s", code, ExitRefused, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "logout requires a human session") {
+		t.Fatalf("refusal = %q", stderr.String())
+	}
+}
+
+func TestAdapterReauthRefusesMachineCredentialBeforeNetwork(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	t.Cleanup(server.Close)
+	stateDir := t.TempDir()
+	st := &State{dir: stateDir}
+	if err := st.Trust().Put(TrustEntry{Name: "local", Origin: server.URL}); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	ios := IO{
+		Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &stderr, Workdir: t.TempDir(),
+		Env: Env{StateD: stateDir, Getenv: func(key string) string {
+			if key == "HIKYO_STATE_DIR" {
+				return stateDir
+			}
+			if key == "HIKYO_TOKEN" {
+				return "hik_1_machine-secret"
+			}
+			return ""
+		}},
+	}
+	args := []string{"adapter", "sync", "--target", "target_1", "--instance", "local", "--org", "org_1", "--project", "project_1"}
+	if code := Run(context.Background(), ios, args); code != ExitRefused {
+		t.Fatalf("exit = %d, want %d; stderr=%s", code, ExitRefused, stderr.String())
+	}
+	if requests != 0 {
+		t.Fatalf("network requests = %d, want 0", requests)
+	}
+	if !strings.Contains(stderr.String(), "hikyo adapter sync requires a human session") {
+		t.Fatalf("refusal = %q", stderr.String())
+	}
+}
+
+func TestSessionsReadLegacyFixture(t *testing.T) {
+	stateDir := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join("testdata", "sessions-legacy.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "sessions.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := (&State{dir: stateDir}).Sessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sessions["local"]; got.Instance != "local" || got.Token != "hik_1_legacy" || got.Principal != "usr_legacy" {
+		t.Fatalf("legacy session = %+v", got)
+	}
+}
+
+func TestSessionsRefuseFutureVersionActionably(t *testing.T) {
+	stateDir := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join("testdata", "sessions-future.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "sessions.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = (&State{dir: stateDir}).Sessions()
+	if err == nil || !strings.Contains(err.Error(), "state version 2") || !strings.Contains(err.Error(), "upgrade") {
+		t.Fatalf("error = %v, want actionable version refusal", err)
+	}
+}

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -123,6 +123,10 @@ func runRun(ctx context.Context, ios IO, args []string) error {
 	// reauth ceremony hold. `render` and `sync` have no human path, so this branch
 	// lives here rather than in resolveMachineTarget.
 	if useHumanSession {
+		if flags.Auth == "machine" {
+			return failf(ExitRefused, "hikyo run --use-human-session conflicts with --auth=machine")
+		}
+		flags.Auth = "human"
 		return runHumanSession(ctx, ios, st, flags, cfg, childArgs, configOnly, allowOverride)
 	}
 	client, entry, resolved, token, err := resolveMachineTarget(st, ios, flags, cfg, cfgDir, "run")
@@ -272,7 +276,11 @@ func runHumanSession(ctx context.Context, ios IO, st *State, flags commonFlags, 
 			"hikyo run --use-human-session requires stderr to be a terminal; a captured stderr means a non-interactive process, which the human-session exception refuses")
 	}
 
-	client, session, resolved, err := authenticatedTarget(st, ios, flags)
+	client, artifact, resolved, err := authenticatedTarget(st, ios, flags)
+	if err != nil {
+		return err
+	}
+	session, err := requireHumanSession("hikyo run --use-human-session", artifact)
 	if err != nil {
 		return err
 	}
@@ -1069,6 +1077,20 @@ func doctorServerStamps(ctx context.Context, client *Client, cfg *compose.Config
 // error), and REQUIRES a machine credential. It never falls back to the stored
 // human session — that path is a refusal in this build.
 func resolveMachineTarget(st *State, ios IO, flags commonFlags, cfg *compose.Config, cfgPath, verb string) (*Client, TrustEntry, Resolved, string, error) {
+	kinds, err := authKindsFor(flags.operation)
+	if err != nil {
+		return nil, TrustEntry{}, Resolved{}, "", err
+	}
+	if !kinds.Allows(AuthKindMachineCredential) {
+		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s does not accept machine credentials", flags.operation)
+	}
+	if flags.Auth == "human" {
+		hint := "this operation requires a machine credential"
+		if flags.operation == "run" {
+			hint = "pass --use-human-session for run's gated human-session exception"
+		}
+		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s cannot use --auth=human: %s", flags.operation, hint)
+	}
 	resolved, err := Resolve(st, ios.Env, flags.Flags, ios.Workdir)
 	if err != nil {
 		return nil, TrustEntry{}, Resolved{}, "", err

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -1077,20 +1077,6 @@ func doctorServerStamps(ctx context.Context, client *Client, cfg *compose.Config
 // error), and REQUIRES a machine credential. It never falls back to the stored
 // human session — that path is a refusal in this build.
 func resolveMachineTarget(st *State, ios IO, flags commonFlags, cfg *compose.Config, cfgPath, verb string) (*Client, TrustEntry, Resolved, string, error) {
-	kinds, err := authKindsFor(flags.operation)
-	if err != nil {
-		return nil, TrustEntry{}, Resolved{}, "", err
-	}
-	if !kinds.Allows(AuthKindMachineCredential) {
-		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s does not accept machine credentials", flags.operation)
-	}
-	if flags.Auth == "human" {
-		hint := "this operation requires a machine credential"
-		if flags.operation == "run" {
-			hint = "pass --use-human-session for run's gated human-session exception"
-		}
-		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s cannot use --auth=human: %s", flags.operation, hint)
-	}
 	resolved, err := Resolve(st, ios.Env, flags.Flags, ios.Workdir)
 	if err != nil {
 		return nil, TrustEntry{}, Resolved{}, "", err
@@ -1107,6 +1093,20 @@ func resolveMachineTarget(st *State, ios IO, flags commonFlags, cfg *compose.Con
 	}
 	if _, err := NewTenantScope(resolved); err != nil {
 		return nil, TrustEntry{}, Resolved{}, "", err
+	}
+	kinds, err := authKindsFor(flags.operation)
+	if err != nil {
+		return nil, TrustEntry{}, Resolved{}, "", err
+	}
+	if !kinds.Allows(AuthKindMachineCredential) {
+		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s does not accept machine credentials", flags.operation)
+	}
+	if flags.Auth == "human" {
+		hint := "this operation requires a machine credential"
+		if flags.operation == "run" {
+			hint = "pass --use-human-session for run's gated human-session exception"
+		}
+		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s cannot use --auth=human: %s", flags.operation, hint)
 	}
 
 	entry, err := machineEntry(st, resolved, cfg)

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -65,10 +65,12 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	fs := flag.NewFlagSet("import", flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
 	var c commonFlags
+	c.operation = "import"
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")
 	fs.StringVar(&c.Project, "project", "", "project")
+	fs.StringVar(&c.Auth, "auth", "", "select human authentication")
 	// NOT --env: see the file comment. --env is the SOURCE slice.
 	environment := fs.String("environment", "", "the target environment (exactly one per invocation)")
 	from := fs.String("from", "", "the source connector: "+importSourceList)
@@ -89,6 +91,9 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	}
 	if len(positional) > 0 {
 		return failf(ExitUsage, "hikyo import takes no positional arguments, got: %s", strings.Join(positional, " "))
+	}
+	if c.Auth != "" && c.Auth != "human" && c.Auth != "machine" {
+		return failf(ExitUsage, "--auth must be human or machine, got %q", c.Auth)
 	}
 	c.Env = *environment
 	explicitLive := *live

--- a/internal/cli/reveal_window.go
+++ b/internal/cli/reveal_window.go
@@ -73,14 +73,18 @@ type disclosure struct {
 // browser's purpose-bound passkey ceremony (handoff) where it does not. The
 // attempt comes first so a live window costs no extra round trip and a
 // config-only copy never prompts.
-func withRevealCeremony(ctx context.Context, client *Client, st *State, ios IO, artifact SessionArtifact,
+func withRevealCeremony(ctx context.Context, client *Client, st *State, ios IO, artifact AuthArtifact,
 	projectBase string, envs []string, d disclosure, attempt func() error) error {
 	err := attempt()
 	if err == nil || !forbidden(err) {
 		return err
 	}
+	session, sessionErr := requireHumanSession("CLI reauthentication", artifact)
+	if sessionErr != nil {
+		return sessionErr
+	}
 	for _, env := range envs {
-		if cerr := ensureRevealWindow(ctx, client, st, ios, &artifact, projectBase, env, d, err); cerr != nil {
+		if cerr := ensureRevealWindow(ctx, client, st, ios, &session, projectBase, env, d, err); cerr != nil {
 			return cerr
 		}
 	}

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -138,6 +138,20 @@ func (s *State) Sessions() (map[string]SessionArtifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	// sessions.json was historically an unversioned map of instance reference
+	// to human session. Keep reading that shape byte-for-byte. A future
+	// versioned envelope must fail as a version mismatch instead of decoding
+	// its metadata keys into zero-value SessionArtifacts.
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("session file at %s is unreadable: %w", s.sessionsPath(), err)
+	}
+	if encodedVersion, ok := root["version"]; ok {
+		var version int
+		if err := json.Unmarshal(encodedVersion, &version); err == nil {
+			return nil, fmt.Errorf("session file at %s uses state version %d; upgrade the Hikyo CLI before using this state", s.sessionsPath(), version)
+		}
+	}
 	var out map[string]SessionArtifact
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("session file at %s is unreadable: %w", s.sessionsPath(), err)

--- a/internal/cli/testdata/help.txt
+++ b/internal/cli/testdata/help.txt
@@ -190,6 +190,8 @@ machine identities:
   a minted credential is shown ONCE. It reaches a workload through
   --token-file <path> or HIKYO_TOKEN, never a --token flag: a secret in argv
   is visible in ps, in /proc, and in shell history.
+  When both eligible artifact kinds are available, pass --auth=human or
+  --auth=machine; Hikyo refuses to guess.
 
 oidc federation:
   hikyo instance-config federation-issuer list [-o table|json]

--- a/internal/cli/testdata/sessions-future.json
+++ b/internal/cli/testdata/sessions-future.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "artifacts": {}
+}

--- a/internal/cli/testdata/sessions-legacy.json
+++ b/internal/cli/testdata/sessions-legacy.json
@@ -1,0 +1,10 @@
+{
+  "local": {
+    "instance": "local",
+    "origin": "https://hikyo.example",
+    "token": "hik_1_legacy",
+    "session_id": "ses_legacy",
+    "principal": "usr_legacy",
+    "expires_at": "2030-01-01T00:00:00Z"
+  }
+}

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -1516,7 +1516,7 @@ func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, AuthArt
 // authenticatedResolvedTarget authenticates against a target whose dimensions
 // the caller already resolved and validated. It lets safety-sensitive verbs
 // reject malformed scope before trust or session state can change the answer.
-func authenticatedResolvedTarget(st *State, ios IO, flags commonFlags, resolved Resolved) (*Client, SessionArtifact, Resolved, error) {
+func authenticatedResolvedTarget(st *State, ios IO, flags commonFlags, resolved Resolved) (*Client, AuthArtifact, Resolved, error) {
 	instance, err := resolved.Require(DimInstance)
 	if err != nil {
 		// Exactly one established instance is not an ambiguity, so falling

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -352,6 +352,8 @@ machine identities:
   a minted credential is shown ONCE. It reaches a workload through
   --token-file <path> or HIKYO_TOKEN, never a --token flag: a secret in argv
   is visible in ps, in /proc, and in shell history.
+  When both eligible artifact kinds are available, pass --auth=human or
+  --auth=machine; Hikyo refuses to guess.
 
 oidc federation:
   hikyo instance-config federation-issuer list [-o table|json]
@@ -657,20 +659,24 @@ func runLogout(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
+	session, err := requireHumanSession("hikyo logout", artifact)
+	if err != nil {
+		return err
+	}
 	if err := client.Do(ctx, http.MethodPost, api.PathPrefix+"/auth/logout", nil, nil); err != nil {
 		// A session the server has already forgotten is still worth clearing
 		// locally: leaving a dead artifact on disk is how "logged out" becomes
 		// a lie the next command tells.
 		var ce *Error
 		if asCLIError(err, &ce) && ce.Code == ExitAuth {
-			_ = st.DeleteSession(artifact.Instance)
+			_ = st.DeleteSession(session.Instance)
 		}
 		return err
 	}
-	if err := st.DeleteSession(artifact.Instance); err != nil {
+	if err := st.DeleteSession(session.Instance); err != nil {
 		return err
 	}
-	fmt.Fprintf(ios.Stderr, "logged out of %s\n", artifact.Origin)
+	fmt.Fprintf(ios.Stderr, "logged out of %s\n", session.Origin)
 	return nil
 }
 
@@ -950,6 +956,10 @@ func runFactorConfirmTOTP(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
+	session, err := requireHumanSession("hikyo account factor confirm-totp", artifact)
+	if err != nil {
+		return err
+	}
 	code, err := ios.readPassword("Enter the code from your authenticator to confirm: ")
 	if err != nil {
 		return err
@@ -959,7 +969,7 @@ func runFactorConfirmTOTP(ctx context.Context, ios IO, args []string) error {
 		apigen.TotpCodeRequest{Code: code}, &result); err != nil {
 		return err
 	}
-	if err := persistRotatedSession(st, artifact, result); err != nil {
+	if err := persistRotatedSession(st, session, result); err != nil {
 		return err
 	}
 	fmt.Fprintf(ios.Stderr, "TOTP enrolled. Step up to present it with\n    hikyo account factor step-up\n")
@@ -976,6 +986,10 @@ func runFactorStepUp(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
+	session, err := requireHumanSession("hikyo account factor step-up", artifact)
+	if err != nil {
+		return err
+	}
 	code, err := ios.readPassword("Enter the code from your authenticator: ")
 	if err != nil {
 		return err
@@ -985,7 +999,7 @@ func runFactorStepUp(ctx context.Context, ios IO, args []string) error {
 		apigen.TotpCodeRequest{Code: code}, &result); err != nil {
 		return err
 	}
-	if err := persistRotatedSession(st, artifact, result); err != nil {
+	if err := persistRotatedSession(st, session, result); err != nil {
 		return err
 	}
 	fmt.Fprintf(ios.Stderr, "session elevated: factors now %s\n",
@@ -1016,6 +1030,10 @@ func runRecoveryCodes(ctx context.Context, ios IO, args []string) (returnErr err
 	if err != nil {
 		return err
 	}
+	session, err := requireHumanSession("hikyo account recovery-codes regenerate", artifact)
+	if err != nil {
+		return err
+	}
 	proof, err := ios.readPassword("Account-security proof (your TOTP code, or password if no factor): ")
 	if err != nil {
 		return err
@@ -1028,7 +1046,7 @@ func runRecoveryCodes(ctx context.Context, ios IO, args []string) (returnErr err
 	if _, err := sink.WriteOnce("recovery codes (single-use)", strings.Join(result.RecoveryCodes, "\n")); err != nil {
 		return failf(ExitRefused, "disclosing the recovery codes: %v", err)
 	}
-	if err := persistRotatedSession(st, artifact, result.Login); err != nil {
+	if err := persistRotatedSession(st, session, result.Login); err != nil {
 		return err
 	}
 	fmt.Fprintf(ios.Stderr, "recovery codes regenerated; the previous batch is now void\n")
@@ -1385,6 +1403,8 @@ func runOrg(ctx context.Context, ios IO, args []string) error {
 
 type commonFlags struct {
 	Flags
+	operation AuthOperation
+	Auth      string
 	// TokenFile is the machine-credential channel (#61). There is
 	// deliberately no `--token` flag beside it: a secret in argv is visible
 	// in `ps`, in /proc/<pid>/cmdline and in shell history, and the property
@@ -1445,12 +1465,14 @@ func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) 
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
 	var c commonFlags
+	c.operation = AuthOperation(name)
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")
 	fs.StringVar(&c.Project, "project", "", "project")
 	fs.StringVar(&c.Env, "env", "", "environment")
 	fs.StringVar(&c.TokenFile, "token-file", "", "read a machine credential from this file (never --token: argv is public)")
+	fs.StringVar(&c.Auth, "auth", "", "select human or machine authentication when both are available")
 	if extra != nil {
 		extra(fs)
 	}
@@ -1459,6 +1481,9 @@ func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) 
 		return nil, commonFlags{}, err
 	}
 	c.positionals = positional
+	if c.Auth != "" && c.Auth != "human" && c.Auth != "machine" {
+		return nil, commonFlags{}, failf(ExitUsage, "--auth must be human or machine, got %q", c.Auth)
+	}
 	st, err := NewState(ios.Env)
 	if err != nil {
 		return nil, commonFlags{}, err
@@ -1471,7 +1496,7 @@ func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) 
 // The artifact is presented only to the origin it was established against —
 // the record carries that origin, and a mismatch is a hard refusal rather
 // than a best-effort send.
-func authenticatedClient(st *State, ios IO, flags commonFlags) (*Client, SessionArtifact, error) {
+func authenticatedClient(st *State, ios IO, flags commonFlags) (*Client, AuthArtifact, error) {
 	client, artifact, _, err := authenticatedTarget(st, ios, flags)
 	return client, artifact, err
 }
@@ -1480,10 +1505,10 @@ func authenticatedClient(st *State, ios IO, flags commonFlags) (*Client, Session
 // verbs that address a scope rather than the instance. The resolution is the
 // same one either way — the hierarchy verbs must not invent a second
 // precedence chain.
-func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, SessionArtifact, Resolved, error) {
+func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, AuthArtifact, Resolved, error) {
 	resolved, err := Resolve(st, ios.Env, flags.Flags, ios.Workdir)
 	if err != nil {
-		return nil, SessionArtifact{}, Resolved{}, err
+		return nil, nil, Resolved{}, err
 	}
 	instance, err := resolved.Require(DimInstance)
 	if err != nil {
@@ -1498,10 +1523,10 @@ func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, Session
 		// script deciding whether to re-authenticate.
 		entries, serr := st.Trust().Load()
 		if serr != nil {
-			return nil, SessionArtifact{}, Resolved{}, serr
+			return nil, nil, Resolved{}, serr
 		}
 		if len(entries) != 1 {
-			return nil, SessionArtifact{}, Resolved{}, err
+			return nil, nil, Resolved{}, err
 		}
 		for k := range entries {
 			instance = k
@@ -1509,51 +1534,55 @@ func authenticatedTarget(st *State, ios IO, flags commonFlags) (*Client, Session
 	}
 	entry, err := st.Trust().Lookup(instance)
 	if err != nil {
-		return nil, SessionArtifact{}, Resolved{}, err
+		return nil, nil, Resolved{}, err
 	}
 	sessions, err := st.Sessions()
 	if err != nil {
-		return nil, SessionArtifact{}, Resolved{}, err
+		return nil, nil, Resolved{}, err
 	}
-	// A MACHINE credential, when one is presented, is used INSTEAD of the
-	// stored human session — it is a distinct artifact type with its own
-	// lifetime and revocation surface, and a workload host has no session
-	// file at all. It reaches this process through exactly two channels
-	// (`--token-file` and HIKYO_TOKEN) and never through a flag that would put
-	// it in argv.
-	if token, err := machineToken(ios, flags.TokenFile); err != nil {
-		return nil, SessionArtifact{}, Resolved{}, err
-	} else if token != "" {
+	kinds, err := authKindsFor(flags.operation)
+	if err != nil {
+		return nil, nil, Resolved{}, err
+	}
+	humanSession, humanPresent := sessions[instance]
+	machinePresent := flags.TokenFile != "" || ios.Env.Getenv("HIKYO_TOKEN") != ""
+	selected, err := selectAuthKind(flags.operation, kinds, flags.Auth, humanPresent, machinePresent)
+	if err != nil {
+		return nil, nil, Resolved{}, err
+	}
+
+	if selected == AuthKindMachineCredential {
+		token, err := machineToken(ios, flags.TokenFile)
+		if err != nil {
+			return nil, nil, Resolved{}, err
+		}
+		artifact := MachineCredential{Origin: entry.Origin, CredentialRef: credentialRef(flags.TokenFile)}
 		client, err := NewClient(entry, token)
 		if err != nil {
-			return nil, SessionArtifact{}, Resolved{}, err
+			return nil, nil, Resolved{}, err
 		}
 		if echo := resolved.Echo(); echo != "" {
 			fmt.Fprintf(ios.Stderr, "target: %s [origin %s, artifact machine-credential]\n", echo, entry.Origin)
 		}
-		return client, SessionArtifact{Origin: entry.Origin}, resolved, nil
+		return client, artifact, resolved, nil
 	}
-	artifact, ok := sessions[instance]
-	if !ok {
-		return nil, SessionArtifact{}, Resolved{}, failf(ExitAuth,
-			"no session for instance %q: run `hikyo login <url> --local --as <user>`", instance)
-	}
-	if artifact.Origin != entry.Origin {
-		return nil, SessionArtifact{}, Resolved{}, failf(ExitRefused,
+	if humanSession.Origin != entry.Origin {
+		return nil, nil, Resolved{}, failf(ExitRefused,
 			"the stored session for %q was established against %s, but the trust store now records %s; log in again",
-			instance, artifact.Origin, entry.Origin)
+			instance, humanSession.Origin, entry.Origin)
 	}
-	client, err := NewClient(entry, artifact.Token)
+	human := HumanSession{SessionArtifact: humanSession}
+	client, err := NewClient(entry, humanSession.Token)
 	if err != nil {
-		return nil, SessionArtifact{}, Resolved{}, err
+		return nil, nil, Resolved{}, err
 	}
 	// The disclosure echo: the fully resolved target, to stderr, before
 	// acting — including which precedence level supplied each dimension.
 	if echo := resolved.Echo(); echo != "" {
 		fmt.Fprintf(ios.Stderr, "target: %s [origin %s, artifact human-session %s]\n",
-			echo, entry.Origin, artifact.Principal)
+			echo, entry.Origin, humanSession.Principal)
 	}
-	return client, artifact, resolved, nil
+	return client, human, resolved, nil
 }
 
 func (ios IO) readPassword(prompt string) (string, error) {

--- a/internal/isolation/scanning_sweep_e2e_test.go
+++ b/internal/isolation/scanning_sweep_e2e_test.go
@@ -446,10 +446,6 @@ func (e sweepEnv) call(t *testing.T, method, path string, body any) (int, []byte
 func (e sweepEnv) runCLI(t *testing.T, args ...string) (string, string) {
 	t.Helper()
 	var stdout, stderr strings.Builder
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	if err := os.WriteFile(tokenFile, []byte(e.token+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	ios := cli.IO{
 		Stdout:  &stdout,
 		Stderr:  &stderr,
@@ -461,6 +457,15 @@ func (e sweepEnv) runCLI(t *testing.T, args ...string) (string, string) {
 			return ""
 		}},
 	}
-	cli.Run(t.Context(), ios, append(args, "--token-file", tokenFile))
+	state, err := cli.NewState(ios.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.PutSession(cli.SessionArtifact{
+		Instance: "local", Origin: e.srv.URL, Token: e.token, Principal: string(e.admin),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cli.Run(t.Context(), ios, args)
 	return stdout.String(), stderr.String()
 }


### PR DESCRIPTION
## Summary

- model CLI auth as a sealed `HumanSession | MachineCredential` artifact
- enforce exact leaf-command auth eligibility and explicit `--auth` collision selection
- preserve legacy session state while refusing future versions with an upgrade action

## Contract and migration

Human sessions retain the existing `sessions.json` storage shape. Machine credentials remain invocation-scoped through `HIKYO_TOKEN` or `--token-file`; `AuthArtifact` stores only the credential channel reference, never plaintext or a file path. Existing unversioned state reads unchanged. A numeric future version envelope fails with an actionable upgrade message.

Human-only session and reauthentication actions reject machine artifacts before network work. Dual-eligible operations refuse when both artifacts are present unless `--auth=human|machine` selects one.

## Generated outputs

None. The frozen CLI help golden changed only for the new `--auth` guidance.

## Validation

```text
gofmt -l internal/cli
  clean
go build ./...
  passed
go vet ./...
  passed
go test -count=1 ./internal/cli/...
  251 passed
go test -count=1 ./internal/isolation/ -run CLI|Machine
  36 passed
go test -count=1 ./internal/isolation/ -run TestScanningCanarySweepSQLite
  1 passed
go test -p 4 -count=1 -timeout=20m ./...
  3260 passed in 57 packages
```

## Review

- Standards: CLEAN (round 3)
- Spec: SOUND (round 3)

Closes #236