### PR TITLE
refactor(compose): centralize filesystem publication

### DIFF
--- a/docs/handoff/231-compose-filesystem-publish.md
+++ b/docs/handoff/231-compose-filesystem-publish.md
@@ -1,0 +1,46 @@
+# Issue #231: one Compose filesystem publication owner
+
+## Contract
+
+`RenderLock.Publish(PublishPlan) (PublishResult, error)` is the sole CLI path
+for generation materialization, the atomic stamp switch, and generation GC.
+`PublishPlan` contains only the runtime directory, local stamp keys, and final
+target bytes. Live and offline adapters both call the same operation.
+
+`PublishResult` is meaningful on success and failure. It reports candidate
+stamps, per-target materialization, whether candidate stamps became active,
+whether GC completed, and `Recover` facts: observed active stamps, planned
+candidate stamps, whether the active selection is known, and whether normal
+recovery/GC cleanup remains pending. A failed stamp commit re-reads `.env` so
+an error after rename cannot incorrectly claim the previous stamps are active.
+
+Publication is recoverable, not multi-file atomic. Before a stamp switch, the
+previous selection remains active while complete or torn candidates are safe
+to retry/recover. After the switch, candidate generations remain active even
+if GC fails. GC still derives protected generations from the stamp file.
+
+## Side-effect ordering
+
+- Live: build render plan -> publish filesystem -> save encrypted snapshot ->
+  save cursor.
+- Offline: append and fsync disclosure records -> publish filesystem.
+- Snapshot, cursor, and offline-record persistence are deliberately outside
+  `Publish`; no cross-file atomicity is claimed.
+
+## What changed
+
+- `internal/compose/generation.go` owns publication sequencing and explicit
+  recovery state behind one deep module interface.
+- `internal/cli/compose.go` removes duplicated live/offline generation,
+  stamp-commit, and GC loops.
+- Failure tests cover materialization, stamp switch, post-commit, GC, live
+  post-publish snapshot persistence, and offline pre-publish disclosure order.
+
+## Generated outputs
+
+None.
+
+## Validation
+
+- `go test -count=1 ./internal/compose/... ./internal/cli/...`: passed, 357 tests.
+- Remaining full, race, demo, and review gates: pending.

--- a/docs/handoff/231-compose-filesystem-publish.md
+++ b/docs/handoff/231-compose-filesystem-publish.md
@@ -8,24 +8,28 @@ for generation materialization, the atomic stamp switch, and generation GC.
 target bytes. Live and offline adapters both call the same operation.
 
 `PublishResult` is meaningful on success and failure. It reports candidate
-stamps, per-target materialization, whether candidate stamps became active,
-whether GC completed, and `Recover` facts: observed active stamps, planned
-candidate stamps, whether the active selection is known, and whether normal
-recovery/GC cleanup remains pending. A failed stamp commit re-reads `.env` so
-an error after rename cannot incorrectly claim the previous stamps are active.
+stamps, per-target materialization, the completed `PublishPhase`, and `Recover`
+facts: observed active stamps, planned candidate stamps, whether the active
+selection is known, and whether normal recovery/GC cleanup remains pending. A
+failed stamp commit re-reads `.env` so an error after rename cannot incorrectly
+claim the previous stamps are active.
 
 Publication is recoverable, not multi-file atomic. Before a stamp switch, the
 previous selection remains active while complete or torn candidates are safe
 to retry/recover. After the switch, candidate generations remain active even
-if GC fails. GC still derives protected generations from the stamp file.
+if GC fails. GC derives protected generations from the stamp file and retains
+the configured history independently for each target.
 
 ## Side-effect ordering
 
-- Live: build render plan -> publish filesystem -> save encrypted snapshot ->
-  save cursor.
+- Live: build render plan -> publish filesystem -> persist apply-pending state
+  -> save encrypted snapshot -> save cursor.
 - Offline: append and fsync disclosure records -> publish filesystem.
 - Snapshot, cursor, and offline-record persistence are deliberately outside
   `Publish`; no cross-file atomicity is claimed.
+- Sync compares active stamps with durable last-applied stamps. Docker success
+  records the applied stamps before apply-pending state is cleared, so any
+  crash or bookkeeping failure remains retry-visible.
 
 ## What changed
 
@@ -33,8 +37,9 @@ if GC fails. GC still derives protected generations from the stamp file.
   recovery state behind one deep module interface.
 - `internal/cli/compose.go` removes duplicated live/offline generation,
   stamp-commit, and GC loops.
-- Failure tests cover materialization, stamp switch, post-commit, GC, live
-  post-publish snapshot persistence, and offline pre-publish disclosure order.
+- Failure tests cover materialization, stamp switch, post-commit, partial GC,
+  per-target retention, torn-generation recovery, live snapshot/cursor
+  persistence, offline pre-publish disclosure order, and durable apply retry.
 
 ## Generated outputs
 
@@ -42,5 +47,16 @@ None.
 
 ## Validation
 
-- `go test -count=1 ./internal/compose/... ./internal/cli/...`: passed, 357 tests.
-- Remaining full, race, demo, and review gates: pending.
+- `go test -race -count=1 ./internal/compose/... ./internal/cli/...`: passed,
+  363 tests.
+- `go vet ./internal/compose/... ./internal/cli/...`: passed.
+- `go test -count=1 ./internal/isolation -run '^TestComposeCLI'`: passed,
+  6 tests.
+- `go build ./...`, `go vet ./...`, and `go test -count=1 ./...`: passed;
+  full test suite passed 3,251 tests in 57 packages.
+- `./scripts/compose-demo.sh`: passed; 21 stored values were byte-exact,
+  embedded-newline refusal preserved the generation and stamps, and sync moved
+  the stamp and restarted the app.
+- `gofmt -l internal/compose internal/cli` and `git diff --check`: clean.
+- Three code-review rounds completed; standards and specification reviews are
+  clean.

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -587,36 +588,24 @@ func composeRenderApply(ios IO, lock *compose.RenderLock, cfg *compose.Config, s
 		return false, failf(ExitRefused, "hikyo compose render refused; no generation written, cursor not advanced:\n  %s", strings.Join(refusals, "\n  "))
 	}
 
-	// Write generations (idempotent — a no-op when present+complete, a rewrite
-	// when a reboot lost the tmpfs copy). WriteGeneration computes each target's
-	// stamp with the target bound into the domain (finding 5: two targets with
-	// identical content get distinct stamps and distinct dirs). Then the single
-	// stamp commit, then GC, then snapshot + cursor.
-	finalStamps := map[string]string{}
+	// Publish owns generation materialization, the single stamp commit, and GC.
+	// Snapshot + cursor remain post-publish bookkeeping: they are deliberately
+	// not claimed atomic with the filesystem publication.
 	var allRows []compose.SnapshotRow
-	var lines []string
-	moved := false
 	for _, target := range plan.Targets {
 		allRows = append(allRows, target.SnapshotRows...)
-		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, target.Name, target.Content)
-		if err != nil {
-			return false, failf(ExitInternal, "compose render: write generation %s: %v", target.Name, err)
-		}
-		finalStamps[target.Name] = stamp
-		// moved when the stamp changed OR the generation had to be re-materialised
-		// (the tmpfs copy was lost): either way sync must re-apply (R1-10).
-		if currentStamps[target.Name] != stamp || materialized {
-			moved = true
-			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", target.Name, stamp, filepath.Join(runtimeDir, stamp, target.Name+".env")))
-		} else {
-			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", target.Name, stamp))
-		}
 	}
-	if err := lock.CommitStamps(finalStamps); err != nil {
-		return false, failf(ExitInternal, "compose render: commit stamps: %v", err)
+	published, err := publishRenderPlan(lock, runtimeDir, keys, plan)
+	if err != nil {
+		if pendingErr := persistCommittedPublish(stateDir, runtimeDir, plan, currentStamps, published); pendingErr != nil {
+			return false, failf(ExitInternal, "compose render: publish: %v", errors.Join(err, fmt.Errorf("persist apply-pending: %w", pendingErr)))
+		}
+		return false, failf(ExitInternal, "compose render: publish: %v", err)
 	}
-	if err := lock.GC(runtimeDir, compose.DefaultGenerationsKept); err != nil {
-		return false, failf(ExitInternal, "compose render: gc: %v", err)
+	finalStamps := published.Stamps
+	moved, lines := publishOutcome(runtimeDir, plan, currentStamps, published)
+	if err := persistCommittedPublish(stateDir, runtimeDir, plan, currentStamps, published); err != nil {
+		return false, failf(ExitInternal, "compose render: persist apply-pending: %v", err)
 	}
 
 	// Snapshot BEFORE cursor: a snapshot is a harmless cache, but a cursor saved
@@ -664,8 +653,8 @@ func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock,
 		return false, failf(ExitRefused, "hikyo compose render (offline) refused; no generation written:\n  %s", strings.Join(refusals, "\n  "))
 	}
 
-	// One offline record per served key, fsynced BEFORE any generation is
-	// written, then the generations, then the stamp commit and GC.
+	// One offline record per served key, fsynced BEFORE Publish can materialize
+	// any generation. This audit ordering remains outside filesystem publication.
 	var records []compose.OfflineRecord
 	stamps := make(map[string]string, len(plan.Targets))
 	for _, target := range plan.Targets {
@@ -693,38 +682,69 @@ func composeRenderOffline(ctx context.Context, ios IO, lock *compose.RenderLock,
 	if err != nil {
 		return false, failf(ExitRefused, "compose render: %v", err)
 	}
-	finalStamps := map[string]string{}
+	published, err := publishRenderPlan(lock, runtimeDir, keys, plan)
+	if err != nil {
+		if pendingErr := persistCommittedPublish(stateDir, runtimeDir, plan, currentStamps, published); pendingErr != nil {
+			return false, failf(ExitInternal, "compose render: publish: %v", errors.Join(err, fmt.Errorf("persist apply-pending: %w", pendingErr)))
+		}
+		return false, failf(ExitInternal, "compose render: publish: %v", err)
+	}
+	for _, target := range plan.Targets {
+		stamp := published.Stamps[target.Name]
+		if stamp != stamps[target.Name] {
+			return false, failf(ExitInternal, "compose render: target %s stamp changed between offline record and publish", target.Name)
+		}
+		fmt.Fprintf(ios.Stderr, "serving stale from %s, generation %s\n", aad.IssuedAt, stamp)
+	}
+	moved, lines := publishOutcome(runtimeDir, plan, currentStamps, published)
+	if err := persistCommittedPublish(stateDir, runtimeDir, plan, currentStamps, published); err != nil {
+		return false, failf(ExitInternal, "compose render: persist apply-pending: %v", err)
+	}
+	for _, l := range lines {
+		fmt.Fprintln(ios.Stderr, l)
+	}
+	return moved, nil
+}
+
+// publishRenderPlan adapts the pure render plan to the one filesystem-owner
+// operation shared by live and offline flows.
+func publishRenderPlan(lock *compose.RenderLock, runtimeDir string, keys *crypto.LocalKeys, plan compose.RenderPlan) (compose.PublishResult, error) {
+	targets := make(map[string][]byte, len(plan.Targets))
+	for _, target := range plan.Targets {
+		targets[target.Name] = target.Content
+	}
+	return lock.Publish(compose.PublishPlan{RuntimeDir: runtimeDir, Keys: keys, Targets: targets})
+}
+
+func publishOutcome(runtimeDir string, plan compose.RenderPlan, currentStamps map[string]string, published compose.PublishResult) (bool, []string) {
 	var lines []string
 	moved := false
 	for _, target := range plan.Targets {
-		stamp, materialized, err := lock.WriteGeneration(runtimeDir, keys, target.Name, target.Content)
-		if err != nil {
-			return false, failf(ExitInternal, "compose render: write generation %s: %v", target.Name, err)
-		}
-		if stamp != stamps[target.Name] {
-			return false, failf(ExitInternal, "compose render: target %s stamp changed between planning and write", target.Name)
-		}
-		finalStamps[target.Name] = stamp
-		fmt.Fprintf(ios.Stderr, "serving stale from %s, generation %s\n", aad.IssuedAt, stamp)
-		// moved when the stamp changed OR the generation had to be re-materialised
-		// (the tmpfs copy was lost): either way sync must re-apply (R1-10).
-		if currentStamps[target.Name] != stamp || materialized {
+		stamp := published.Stamps[target.Name]
+		// A changed stamp or re-materialized tmpfs generation both require sync to
+		// re-apply the target (R1-10).
+		if currentStamps[target.Name] != stamp || published.Materialized[target.Name] {
 			moved = true
 			lines = append(lines, fmt.Sprintf("rendered %s generation %s → %s", target.Name, stamp, filepath.Join(runtimeDir, stamp, target.Name+".env")))
 		} else {
 			lines = append(lines, fmt.Sprintf("unchanged %s generation %s", target.Name, stamp))
 		}
 	}
-	if err := lock.CommitStamps(finalStamps); err != nil {
-		return false, failf(ExitInternal, "compose render: commit stamps: %v", err)
+	return moved, lines
+}
+
+// persistCommittedPublish closes the crash/error window between a stamp switch
+// and sync's Docker apply. Render writes the marker too: a successful render is
+// filesystem-visible but remains unapplied until a later sync clears it.
+func persistCommittedPublish(stateDir, runtimeDir string, plan compose.RenderPlan, currentStamps map[string]string, published compose.PublishResult) error {
+	if !published.CandidateActive() {
+		return nil
 	}
-	if err := lock.GC(runtimeDir, compose.DefaultGenerationsKept); err != nil {
-		return false, failf(ExitInternal, "compose render: gc: %v", err)
+	moved, _ := publishOutcome(runtimeDir, plan, currentStamps, published)
+	if !moved {
+		return nil
 	}
-	for _, l := range lines {
-		fmt.Fprintln(ios.Stderr, l)
-	}
-	return moved, nil
+	return writeApplyPending(stateDir, published.Stamps)
 }
 
 // ---------------------------------------------------------------------------
@@ -771,25 +791,31 @@ func runComposeSync(ctx context.Context, ios IO, args []string) error {
 		return err
 	}
 
-	// (3) Apply through `docker compose up -d` when a stamp moved, OR when a prior
-	// sync left an apply-pending marker (its docker call failed, or a reboot lost
-	// the tmpfs generation and it was re-materialized): the marker forces a retry
-	// even when nothing moved this time (finding 10). The marker is written BEFORE
-	// docker and removed only after docker succeeds, so a failed apply is retried
-	// on the next sync rather than left permanently stale.
+	// (3) Apply through `docker compose up -d` when a stamp moved, a prior sync
+	// left an apply-pending marker, OR active stamps differ from the durable
+	// last-applied record. The last comparison closes the crash window after the
+	// stamp rename but before a marker write: no active generation can become
+	// permanently unapplied merely because the process died at that boundary.
 	pending := applyPendingExists(rp.stateDir)
-	if !moved && !pending {
-		return nil
-	}
 	stamps, err := compose.CurrentStamps(rp.cfgDir)
 	if err != nil {
 		return failf(ExitRefused, "hikyo compose sync: %v", err)
+	}
+	applied, err := loadAppliedStamps(rp.stateDir)
+	if err != nil {
+		return failf(ExitRefused, "hikyo compose sync: %v", err)
+	}
+	if !moved && !pending && !stampsNeedApply(stamps, applied) {
+		return nil
 	}
 	if err := writeApplyPending(rp.stateDir, stamps); err != nil {
 		return failf(ExitInternal, "hikyo compose sync: writing apply-pending marker: %v", err)
 	}
 	if err := dockerComposeUp(ctx, ios, rp.cfgDir); err != nil {
 		return err // marker stays: the next sync retries the apply
+	}
+	if err := writeAppliedStamps(rp.stateDir, stamps); err != nil {
+		return failf(ExitInternal, "hikyo compose sync: recording applied stamps: %v", err)
 	}
 	if err := removeApplyPending(rp.stateDir); err != nil {
 		return failf(ExitInternal, "hikyo compose sync: clearing apply-pending marker: %v", err)
@@ -822,7 +848,10 @@ func dockerComposeUp(ctx context.Context, ios IO, projectDir string) error {
 	return nil
 }
 
-const applyPendingFile = "apply-pending"
+const (
+	applyPendingFile  = "apply-pending"
+	appliedStampsFile = "applied-stamps.json"
+)
 
 // applyPendingExists reports whether a prior sync left an unfinished apply.
 func applyPendingExists(stateDir string) bool {
@@ -837,6 +866,56 @@ func writeApplyPending(stateDir string, stamps map[string]string) error {
 		return err
 	}
 	return writeFileAtomic0600(filepath.Join(stateDir, applyPendingFile), data)
+}
+
+// loadAppliedStamps returns the last stamp selection successfully handed to
+// Docker. A missing file is an unapplied state, including upgrades from clients
+// predating this record. Malformed state fails loudly rather than skipping an
+// apply on guessed data.
+func loadAppliedStamps(stateDir string) (map[string]string, error) {
+	b, err := os.ReadFile(filepath.Join(stateDir, appliedStampsFile))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading applied stamps: %w", err)
+	}
+	var stamps map[string]string
+	if err := json.Unmarshal(b, &stamps); err != nil {
+		return nil, fmt.Errorf("parsing applied stamps: %w", err)
+	}
+	if stamps == nil {
+		return nil, errors.New("parsing applied stamps: expected a target-to-stamp object")
+	}
+	for target, stamp := range stamps {
+		if strings.TrimSpace(target) == "" {
+			return nil, errors.New("parsing applied stamps: target name is empty")
+		}
+		if err := crypto.ParseStamp(stamp); err != nil {
+			return nil, fmt.Errorf("parsing applied stamps for %q: %w", target, err)
+		}
+	}
+	return stamps, nil
+}
+
+func writeAppliedStamps(stateDir string, stamps map[string]string) error {
+	for target, stamp := range stamps {
+		if strings.TrimSpace(target) == "" {
+			return errors.New("writing applied stamps: target name is empty")
+		}
+		if err := crypto.ParseStamp(stamp); err != nil {
+			return fmt.Errorf("writing applied stamps for %q: %w", target, err)
+		}
+	}
+	data, err := json.Marshal(stamps)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic0600(filepath.Join(stateDir, appliedStampsFile), data)
+}
+
+func stampsNeedApply(current, applied map[string]string) bool {
+	return !maps.Equal(current, applied)
 }
 
 // removeApplyPending clears the marker after a successful docker apply.

--- a/internal/cli/compose_internal_test.go
+++ b/internal/cli/compose_internal_test.go
@@ -798,6 +798,224 @@ func TestComposeRenderIdenticalContentDistinctStamps(t *testing.T) {
 	}
 }
 
+func TestComposeRenderSnapshotFailureLeavesPublishedGenerationUsable(t *testing.T) {
+	projectDir := t.TempDir()
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := crypto.LoadOrCreateLocalKey(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := compose.NewWriter(stateDir, nil).BeginRender(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+
+	blockedParent := t.TempDir()
+	if err := os.Chmod(blockedParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	blockedStorage := filepath.Join(blockedParent, "not-a-directory")
+	if err := os.WriteFile(blockedStorage, []byte("block snapshot persistence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	binding, err := newSnapshotBinding(blockedStorage, TrustEntry{Origin: "https://hikyo.example"}, "org_1", "prj_1", "env_1", "wl_token", false, []string{"api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := deliveryResp([]apigen.DeliveredKey{{
+		KeyId: "key_1", Name: "DATABASE_URL", Classification: apigen.KeyClassificationConfig,
+		Presence: apigen.DeliveredKeyPresenceSet, Value: strPtr("postgres://x"),
+	}})
+	binding, err = bindSnapshotDelivery(binding, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &compose.Config{Targets: map[string]compose.Target{"api": {Keys: []string{"key_1"}}}}
+	ios, _, _ := composeIO(stateDir, projectDir, "wl_token", nil)
+
+	moved, err := composeRenderApply(ios, lock, cfg, stateDir, runtimeDir, keys, binding, "wl_token", "env_1", false, resp, map[string]string{})
+	if err == nil || moved {
+		t.Fatalf("composeRenderApply moved=%v err=%v, want post-publish snapshot failure", moved, err)
+	}
+	if !strings.Contains(err.Error(), "save snapshot") {
+		t.Fatalf("composeRenderApply error = %v, want snapshot boundary", err)
+	}
+	stamps, err := compose.CurrentStamps(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp := stamps["api"]
+	if present, complete := compose.GenerationState(runtimeDir, stamp); !present || !complete {
+		t.Fatalf("published generation present=%v complete=%v after snapshot failure", present, complete)
+	}
+	if !applyPendingExists(stateDir) {
+		t.Fatal("committed publication must persist apply-pending before snapshot bookkeeping")
+	}
+}
+
+func TestComposeRenderCursorFailureLeavesPublishedGenerationPendingApply(t *testing.T) {
+	projectDir := t.TempDir()
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := crypto.LoadOrCreateLocalKey(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := compose.NewWriter(stateDir, nil).BeginRender(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if err := os.Mkdir(filepath.Join(stateDir, "cursor.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	binding, err := newSnapshotBinding(stateDir, TrustEntry{Origin: "https://hikyo.example"}, "org_1", "prj_1", "env_1", "wl_token", false, []string{"api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := deliveryResp([]apigen.DeliveredKey{{
+		KeyId: "key_1", Name: "DATABASE_URL", Classification: apigen.KeyClassificationConfig,
+		Presence: apigen.DeliveredKeyPresenceSet, Value: strPtr("postgres://x"),
+	}})
+	binding, err = bindSnapshotDelivery(binding, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &compose.Config{Targets: map[string]compose.Target{"api": {Keys: []string{"key_1"}}}}
+	ios, _, _ := composeIO(stateDir, projectDir, "wl_token", nil)
+
+	_, err = composeRenderApply(ios, lock, cfg, stateDir, runtimeDir, keys, binding, "wl_token", "env_1", false, resp, map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "save cursor") {
+		t.Fatalf("composeRenderApply err=%v, want cursor persistence failure", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "snapshot.bin")); err != nil {
+		t.Fatalf("snapshot must be durable before cursor failure: %v", err)
+	}
+	if !applyPendingExists(stateDir) {
+		t.Fatal("committed publication must remain pending apply after cursor failure")
+	}
+	stamps, err := compose.CurrentStamps(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present, complete := compose.GenerationState(runtimeDir, stamps["api"]); !present || !complete {
+		t.Fatalf("published generation present=%v complete=%v after cursor failure", present, complete)
+	}
+}
+
+func TestComposeRenderOfflineRecordsDisclosureBeforePublishFailure(t *testing.T) {
+	origin := "https://hikyo.example"
+	projectDir := t.TempDir()
+	stateDir := filepath.Join(t.TempDir(), "compose-state")
+	rows := []compose.SnapshotRow{{Name: "DATABASE_URL", KeyID: "key_1", Classification: "config", Value: "postgres://x"}}
+	seedRenderSnapshot(t, stateDir, origin, "wl_token", "api", rows)
+	keys, err := crypto.LoadOrCreateLocalKey(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := compose.NewWriter(stateDir, nil).BeginRender(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	binding, err := newSnapshotBinding(stateDir, TrustEntry{Origin: origin}, "org_1", "prj_1", "env_1", "wl_token", false, []string{"api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := compose.ParseConfig([]byte("version: 1\ninstance: " + origin + "\norg: org_1\nproject: prj_1\nenvironment: env_1\nsnapshot:\n  offline_serve: true\ntargets:\n  api:\n    keys: [key_1]\n    services: [api]\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedRuntime := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedRuntime, []byte("block generation materialization"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ios, _, _ := composeIO(stateDir, projectDir, "wl_token", nil)
+
+	moved, err := composeRenderOffline(t.Context(), ios, lock, cfg, projectDir, stateDir, filepath.Join(blockedRuntime, "runtime"), keys, binding, false, failf(ExitUnavailable, "offline"))
+	if err == nil || moved {
+		t.Fatalf("composeRenderOffline moved=%v err=%v, want publish failure", moved, err)
+	}
+	records, _, pendingErr := compose.Pending(stateDir)
+	if pendingErr != nil {
+		t.Fatal(pendingErr)
+	}
+	if len(records) != 1 || records[0].KeyID != "key_1" {
+		t.Fatalf("pending offline records = %+v after err=%v, want disclosure durable before publish", records, err)
+	}
+	if stamps, stampErr := compose.CurrentStamps(projectDir); stampErr != nil || len(stamps) != 0 {
+		t.Fatalf("CurrentStamps = %v err=%v, want no stamp switch after publish failure", stamps, stampErr)
+	}
+}
+
+func TestComposeApplyStateDetectsCommittedGenerationWithoutPendingMarker(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	current := map[string]string{"api": "v1-11111111111111111111111111111111"}
+	applied, err := loadAppliedStamps(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stampsNeedApply(current, applied) {
+		t.Fatal("missing last-applied record must force apply after a post-commit crash")
+	}
+	if err := writeAppliedStamps(stateDir, current); err != nil {
+		t.Fatal(err)
+	}
+	applied, err = loadAppliedStamps(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stampsNeedApply(current, applied) {
+		t.Fatal("matching last-applied record should not force a redundant apply")
+	}
+	current["api"] = "v1-22222222222222222222222222222222"
+	if !stampsNeedApply(current, applied) {
+		t.Fatal("changed active stamps must force apply without relying on apply-pending")
+	}
+}
+
+func TestComposeApplyPendingWriteFailureRemainsRetryVisible(t *testing.T) {
+	parent := t.TempDir()
+	blockedState := filepath.Join(parent, "state-is-a-file")
+	if err := os.WriteFile(blockedState, []byte("block marker write"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := map[string]string{"api": "v1-11111111111111111111111111111111"}
+	published := compose.PublishResult{
+		Phase:        compose.PublishPhaseComplete,
+		Stamps:       map[string]string{"api": "v1-22222222222222222222222222222222"},
+		Materialized: map[string]bool{"api": true},
+	}
+	plan := compose.RenderPlan{Targets: []compose.RenderTargetPlan{{Name: "api"}}}
+	if err := persistCommittedPublish(blockedState, t.TempDir(), plan, current, published); err == nil {
+		t.Fatal("persistCommittedPublish should surface the blocked marker write")
+	}
+	if err := os.Remove(blockedState); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(blockedState, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	applied, err := loadAppliedStamps(blockedState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stampsNeedApply(published.Stamps, applied) {
+		t.Fatal("missing last-applied record must force retry after marker-write recovery")
+	}
+}
+
 // TestComposeRenderOfflineRefusesUnacknowledged: a snapshot saved with a
 // loader-control key acknowledged, then a config with the ack removed, must be
 // refused by name on offline render BEFORE any offline record is written

--- a/internal/compose/generation.go
+++ b/internal/compose/generation.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -64,8 +65,8 @@ const (
 	// two distinct (target, content) pairs cannot collide into the same bytes.
 	targetSep = "\x00"
 
-	// DefaultGenerationsKept is the retention beyond the current stamp
-	// (ops-spec § 6: current + previous 3).
+	// DefaultGenerationsKept is the retention per target beyond the current
+	// stamp (ops-spec § 6: current + previous 3).
 	DefaultGenerationsKept = 3
 )
 
@@ -103,6 +104,10 @@ type Probe interface {
 	AfterGenerationDirCreated(stamp string) error
 	BeforeGenerationComplete(stamp string) error
 	BeforeStampRename() error
+	AfterGenerationMaterialized(target, stamp string) error
+	AfterStampCommit() error
+	BeforeGarbageCollection() error
+	BeforeGenerationRemoval(stamp string) error
 }
 
 // Writer owns a per-project state directory and mints RenderLocks.
@@ -123,6 +128,58 @@ type RenderLock struct {
 	projectDir string
 	fl         *flock.Flock
 	closed     bool
+}
+
+// PublishPlan is the complete filesystem input for one Compose publication.
+// Targets contains final rendered bytes only; snapshot rows, cursors, offline
+// records, and other persistent bookkeeping deliberately remain outside this
+// filesystem publication because they do not share its commit point.
+type PublishPlan struct {
+	RuntimeDir string
+	Keys       *crypto.LocalKeys
+	Targets    map[string][]byte
+}
+
+// PublishRecovery names the durable facts a caller can use after Publish
+// returns, including on error. ActiveStamps are the generations selected by the
+// stamp file. CandidateStamps are the deterministic generations the plan was
+// attempting to publish. NeedsCleanup means the next lock holder must run the
+// normal Recover/GC path before relying on unreferenced candidates being gone.
+type PublishRecovery struct {
+	ActiveStamps    map[string]string
+	CandidateStamps map[string]string
+	ActiveKnown     bool
+	NeedsCleanup    bool
+}
+
+// PublishPhase is the latest durable stage reached by a publication.
+type PublishPhase string
+
+const (
+	PublishPhaseMaterializing PublishPhase = "materializing"
+	PublishPhaseSwitching     PublishPhase = "switching"
+	PublishPhaseCollecting    PublishPhase = "collecting"
+	PublishPhaseComplete      PublishPhase = "complete"
+)
+
+// PublishResult records how far one recoverable filesystem publication got.
+// Stamps are the plan's candidate stamps and Materialized reports whether each
+// immutable generation was newly written.
+type PublishResult struct {
+	Stamps       map[string]string
+	Materialized map[string]bool
+	Phase        PublishPhase
+	Recover      PublishRecovery
+}
+
+// CandidateActive reports whether the candidate stamp selection is active.
+func (r PublishResult) CandidateActive() bool {
+	return r.Phase == PublishPhaseCollecting || r.Phase == PublishPhaseComplete
+}
+
+// GCComplete reports whether bounded retention completed.
+func (r PublishResult) GCComplete() bool {
+	return r.Phase == PublishPhaseComplete
 }
 
 // errLockReleased is returned by every RenderLock verb — including a second
@@ -161,6 +218,109 @@ func (rl *RenderLock) Close() error {
 	}
 	rl.closed = true
 	return rl.fl.Unlock()
+}
+
+// Publish owns the complete recoverable filesystem sequence for one render:
+// materialize every immutable target generation, atomically switch the stamp
+// file once, then collect superseded generations. It does not claim atomicity
+// with snapshot, cursor, or offline-record persistence performed by callers.
+//
+// On error, result.Recover states which stamps remain active and which
+// deterministic candidates a retry will reuse. Before Committed, the previous
+// stamp selection remains active. After Committed, the candidate selection is
+// active even if GC fails.
+func (rl *RenderLock) Publish(plan PublishPlan) (PublishResult, error) {
+	var result PublishResult
+	if rl.closed {
+		return result, errLockReleased
+	}
+	if plan.RuntimeDir == "" {
+		return result, errors.New("compose: publish runtime dir is required")
+	}
+	if plan.Keys == nil {
+		return result, errors.New("compose: publish local keys are required")
+	}
+	if len(plan.Targets) == 0 {
+		return result, errors.New("compose: publish target set is required")
+	}
+
+	targets := make([]string, 0, len(plan.Targets))
+	stamps := make(map[string]string, len(plan.Targets))
+	for target, content := range plan.Targets {
+		if !targetNameGrammar.MatchString(target) {
+			return result, fmt.Errorf("compose: refusing to publish generation: invalid target name %q", target)
+		}
+		targets = append(targets, target)
+		stamps[target] = TargetStamp(plan.Keys, target, content)
+	}
+	sort.Strings(targets)
+
+	active, err := CurrentStamps(rl.projectDir)
+	if err != nil {
+		return result, err
+	}
+	result = PublishResult{
+		Stamps:       maps.Clone(stamps),
+		Materialized: make(map[string]bool, len(stamps)),
+		Phase:        PublishPhaseMaterializing,
+		Recover: PublishRecovery{
+			ActiveStamps:    maps.Clone(active),
+			CandidateStamps: maps.Clone(stamps),
+			ActiveKnown:     true,
+		},
+	}
+
+	for _, target := range targets {
+		stamp, materialized, err := rl.WriteGeneration(plan.RuntimeDir, plan.Keys, target, plan.Targets[target])
+		if err != nil {
+			result.Recover.NeedsCleanup = true
+			return result, fmt.Errorf("compose: publish materialize %s: %w", target, err)
+		}
+		if stamp != stamps[target] {
+			result.Recover.NeedsCleanup = true
+			return result, fmt.Errorf("compose: publish target %s stamp changed between plan and materialization", target)
+		}
+		result.Materialized[target] = materialized
+		if rl.w.probe != nil {
+			if err := rl.w.probe.AfterGenerationMaterialized(target, stamp); err != nil {
+				result.Recover.NeedsCleanup = true
+				return result, fmt.Errorf("compose: publish after materialize %s: %w", target, err)
+			}
+		}
+	}
+	result.Phase = PublishPhaseSwitching
+	result.Recover.NeedsCleanup = true
+	if err := rl.CommitStamps(stamps); err != nil {
+		active, inspectErr := CurrentStamps(rl.projectDir)
+		if inspectErr != nil {
+			result.Recover.ActiveStamps = nil
+			result.Recover.ActiveKnown = false
+			return result, errors.Join(fmt.Errorf("compose: publish commit stamps: %w", err), fmt.Errorf("compose: inspect active stamps after commit failure: %w", inspectErr))
+		}
+		result.Recover.ActiveStamps = maps.Clone(active)
+		if maps.Equal(active, stamps) {
+			result.Phase = PublishPhaseCollecting
+		}
+		return result, fmt.Errorf("compose: publish commit stamps: %w", err)
+	}
+	result.Phase = PublishPhaseCollecting
+	result.Recover.ActiveStamps = maps.Clone(stamps)
+	if rl.w.probe != nil {
+		if err := rl.w.probe.AfterStampCommit(); err != nil {
+			return result, fmt.Errorf("compose: publish after stamp commit: %w", err)
+		}
+	}
+	if rl.w.probe != nil {
+		if err := rl.w.probe.BeforeGarbageCollection(); err != nil {
+			return result, fmt.Errorf("compose: publish before gc: %w", err)
+		}
+	}
+	if err := rl.GC(plan.RuntimeDir, DefaultGenerationsKept); err != nil {
+		return result, fmt.Errorf("compose: publish gc: %w", err)
+	}
+	result.Phase = PublishPhaseComplete
+	result.Recover.NeedsCleanup = false
+	return result, nil
 }
 
 // WriteGeneration writes an immutable generation directory
@@ -562,6 +722,11 @@ func (rl *RenderLock) Recover(runtimeDir string) error {
 			return fmt.Errorf("compose: refusing to recover: stamp-named entry %q under runtime dir %s is not a directory", name, runtimeDir)
 		}
 		if _, complete := generationStateRoot(root, name); !complete {
+			if rl.w.probe != nil {
+				if err := rl.w.probe.BeforeGenerationRemoval(name); err != nil {
+					return fmt.Errorf("compose: gc before removing incomplete %s: %w", name, err)
+				}
+			}
 			if err := root.RemoveAll(name); err != nil {
 				return fmt.Errorf("compose: recover remove %s: %w", name, err)
 			}
@@ -571,7 +736,7 @@ func (rl *RenderLock) Recover(runtimeDir string) error {
 }
 
 // GC removes generation directories not named by any current stamp beyond the
-// `keep` most recent (by mtime). Current stamps are derived by reading the
+// `keep` most recent PER TARGET (by mtime). Current stamps are derived by reading the
 // managed block itself, not trusted from a caller. It NEVER removes a current
 // generation, removes INCOMPLETE directories regardless of age, and errors on a
 // foreign entry. It is a method on the held lock.
@@ -598,7 +763,7 @@ func (rl *RenderLock) GC(runtimeDir string, keep int) error {
 		name  string
 		mtime int64
 	}
-	var superseded []gen
+	superseded := map[string][]gen{}
 	for _, e := range entries {
 		name := e.Name()
 		if err := crypto.ParseStamp(name); err != nil {
@@ -620,18 +785,72 @@ func (rl *RenderLock) GC(runtimeDir string, keep int) error {
 		if err != nil {
 			return fmt.Errorf("compose: gc stat %s: %w", name, err)
 		}
-		superseded = append(superseded, gen{name: name, mtime: info.ModTime().UnixNano()})
-	}
-	sort.Slice(superseded, func(i, j int) bool { return superseded[i].mtime > superseded[j].mtime })
-	for i, g := range superseded {
-		if i < keep {
-			continue
+		target, err := generationTargetRoot(root, name)
+		if err != nil {
+			return fmt.Errorf("compose: gc inspect %s: %w", name, err)
 		}
-		if err := root.RemoveAll(g.name); err != nil {
-			return fmt.Errorf("compose: gc remove %s: %w", g.name, err)
+		superseded[target] = append(superseded[target], gen{name: name, mtime: info.ModTime().UnixNano()})
+	}
+	for _, generations := range superseded {
+		sort.Slice(generations, func(i, j int) bool { return generations[i].mtime > generations[j].mtime })
+		for i, g := range generations {
+			if i < keep {
+				continue
+			}
+			if rl.w.probe != nil {
+				if err := rl.w.probe.BeforeGenerationRemoval(g.name); err != nil {
+					return fmt.Errorf("compose: gc before removing %s: %w", g.name, err)
+				}
+			}
+			if err := root.RemoveAll(g.name); err != nil {
+				return fmt.Errorf("compose: gc remove %s: %w", g.name, err)
+			}
 		}
 	}
 	return nil
+}
+
+// generationTargetRoot returns the sole target represented by one complete
+// immutable generation. A malformed directory is refused rather than grouped
+// under guessed retention state.
+func generationTargetRoot(root *os.Root, stamp string) (string, error) {
+	d, err := root.Open(stamp)
+	if err != nil {
+		return "", err
+	}
+	entries, err := d.ReadDir(-1)
+	d.Close()
+	if err != nil {
+		return "", err
+	}
+	var target string
+	for _, entry := range entries {
+		if entry.Name() == completeMarker {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".env") {
+			return "", fmt.Errorf("unexpected entry %q", entry.Name())
+		}
+		candidate := strings.TrimSuffix(entry.Name(), ".env")
+		if !targetNameGrammar.MatchString(candidate) {
+			return "", fmt.Errorf("invalid target file %q", entry.Name())
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return "", err
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("target file %q is not regular", entry.Name())
+		}
+		if target != "" {
+			return "", fmt.Errorf("multiple target files %q and %q", target+".env", entry.Name())
+		}
+		target = candidate
+	}
+	if target == "" {
+		return "", errors.New("target file is missing")
+	}
+	return target, nil
 }
 
 // openRuntimeEntries opens runtimeDir as an os.Root and lists its top-level

--- a/internal/compose/generation_test.go
+++ b/internal/compose/generation_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -92,6 +93,51 @@ func TestWriteGenerationAndState(t *testing.T) {
 	}
 }
 
+func TestPublishMaterializesCommitsAndCollects(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	rl := begin(t, projectDir, nil)
+	content := map[string][]byte{
+		"api":    []byte("API=1\n"),
+		"worker": []byte("WORKER=1\n"),
+	}
+
+	result, err := rl.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantStamps := map[string]string{
+		"api":    TargetStamp(keys, "api", content["api"]),
+		"worker": TargetStamp(keys, "worker", content["worker"]),
+	}
+	if !reflect.DeepEqual(result.Stamps, wantStamps) {
+		t.Fatalf("Publish stamps = %v, want %v", result.Stamps, wantStamps)
+	}
+	if !reflect.DeepEqual(result.Materialized, map[string]bool{"api": true, "worker": true}) {
+		t.Fatalf("Publish materialized = %v, want both targets", result.Materialized)
+	}
+	if !result.CandidateActive() || !result.GCComplete() {
+		t.Fatalf("Publish phase=%s, want complete", result.Phase)
+	}
+	if !result.Recover.ActiveKnown || result.Recover.NeedsCleanup || !reflect.DeepEqual(result.Recover.ActiveStamps, wantStamps) || !reflect.DeepEqual(result.Recover.CandidateStamps, wantStamps) {
+		t.Fatalf("Publish recovery = %+v, want active candidates and no cleanup", result.Recover)
+	}
+	gotStamps, err := CurrentStamps(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotStamps, wantStamps) {
+		t.Fatalf("CurrentStamps = %v, want %v", gotStamps, wantStamps)
+	}
+	for target, stamp := range wantStamps {
+		got, err := os.ReadFile(filepath.Join(rt, stamp, target+".env"))
+		if err != nil || string(got) != string(content[target]) {
+			t.Fatalf("%s generation = %q err=%v", target, got, err)
+		}
+	}
+}
+
 func TestWriteGenerationRejectsBadTarget(t *testing.T) {
 	_, rt := dirs(t)
 	keys := testKeys(t)
@@ -124,9 +170,13 @@ func TestWriteGenerationExistingMismatch(t *testing.T) {
 
 // errProbe fails at a chosen seam.
 type errProbe struct {
-	failAfterCreate bool
-	failComplete    bool
-	failRename      bool
+	failAfterCreate      bool
+	failComplete         bool
+	failAfterMaterialize bool
+	failRename           bool
+	failAfterCommit      bool
+	failGC               bool
+	failGCRemoval        string
 }
 
 func (p errProbe) AfterGenerationDirCreated(string) error {
@@ -146,6 +196,145 @@ func (p errProbe) BeforeStampRename() error {
 		return errors.New("injected crash before rename")
 	}
 	return nil
+}
+func (p errProbe) AfterGenerationMaterialized(string, string) error {
+	if p.failAfterMaterialize {
+		return errors.New("injected crash after generation materialized")
+	}
+	return nil
+}
+func (p errProbe) AfterStampCommit() error {
+	if p.failAfterCommit {
+		return errors.New("injected crash after stamp commit")
+	}
+	return nil
+}
+func (p errProbe) BeforeGarbageCollection() error {
+	if p.failGC {
+		return errors.New("injected crash before gc")
+	}
+	return nil
+}
+func (p errProbe) BeforeGenerationRemoval(stamp string) error {
+	if p.failGCRemoval == stamp {
+		return errors.New("injected crash during gc removal")
+	}
+	return nil
+}
+
+func TestPublishMaterializeFailureKeepsPreviousActive(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	oldContent := []byte("API=old\n")
+	oldStamp := TargetStamp(keys, "api", oldContent)
+	seed := begin(t, projectDir, nil)
+	if _, _, err := seed.WriteGeneration(rt, keys, "api", oldContent); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.CommitStamps(map[string]string{"api": oldStamp}); err != nil {
+		t.Fatal(err)
+	}
+
+	lock := begin(t, projectDir, errProbe{failAfterMaterialize: true})
+	newContent := []byte("API=new\n")
+	newStamp := TargetStamp(keys, "api", newContent)
+	result, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": newContent}})
+	if err == nil {
+		t.Fatal("Publish should surface the injected materialization failure")
+	}
+	if result.CandidateActive() || result.GCComplete() {
+		t.Fatalf("Publish phase=%s after materialization failure", result.Phase)
+	}
+	if !result.Materialized["api"] || !result.Recover.NeedsCleanup {
+		t.Fatalf("Publish result = %+v, want materialized candidate needing cleanup", result)
+	}
+	if result.Recover.ActiveStamps["api"] != oldStamp || result.Recover.CandidateStamps["api"] != newStamp {
+		t.Fatalf("Publish recovery = %+v, want old active and new candidate", result.Recover)
+	}
+	if present, complete := GenerationState(rt, newStamp); !present || !complete {
+		t.Fatalf("candidate present=%v complete=%v, want recoverable complete candidate", present, complete)
+	}
+}
+
+func TestPublishPostCommitFailureReportsCandidateActive(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	lock := begin(t, projectDir, errProbe{failAfterCommit: true})
+	content := []byte("API=new\n")
+	stamp := TargetStamp(keys, "api", content)
+
+	result, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": content}})
+	if err == nil {
+		t.Fatal("Publish should surface the injected post-commit failure")
+	}
+	if !result.CandidateActive() || result.GCComplete() {
+		t.Fatalf("Publish phase=%s after post-commit failure", result.Phase)
+	}
+	if !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != stamp {
+		t.Fatalf("Publish recovery = %+v, want committed candidate active and cleanup pending", result.Recover)
+	}
+	got, err := CurrentStamps(projectDir)
+	if err != nil || got["api"] != stamp {
+		t.Fatalf("CurrentStamps = %v err=%v, want committed %s", got, err, stamp)
+	}
+}
+
+func TestPublishStampSwitchFailureKeepsPreviousActive(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	oldContent := []byte("API=old\n")
+	oldStamp := TargetStamp(keys, "api", oldContent)
+	seed := begin(t, projectDir, nil)
+	if _, _, err := seed.WriteGeneration(rt, keys, "api", oldContent); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.CommitStamps(map[string]string{"api": oldStamp}); err != nil {
+		t.Fatal(err)
+	}
+
+	lock := begin(t, projectDir, errProbe{failRename: true})
+	newContent := []byte("API=new\n")
+	newStamp := TargetStamp(keys, "api", newContent)
+	result, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": newContent}})
+	if err == nil {
+		t.Fatal("Publish should surface the injected stamp-switch failure")
+	}
+	if result.CandidateActive() || result.GCComplete() {
+		t.Fatalf("Publish phase=%s after stamp-switch failure", result.Phase)
+	}
+	if !result.Recover.ActiveKnown || !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != oldStamp || result.Recover.CandidateStamps["api"] != newStamp {
+		t.Fatalf("Publish recovery = %+v, want old active and new recoverable candidate", result.Recover)
+	}
+	got, err := CurrentStamps(projectDir)
+	if err != nil || got["api"] != oldStamp {
+		t.Fatalf("CurrentStamps = %v err=%v, want previous %s", got, err, oldStamp)
+	}
+}
+
+func TestPublishGCFailureNeverRemovesActiveGeneration(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	lock := begin(t, projectDir, errProbe{failGC: true})
+	content := []byte("API=new\n")
+	stamp := TargetStamp(keys, "api", content)
+
+	result, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": content}})
+	if err == nil {
+		t.Fatal("Publish should surface the injected GC failure")
+	}
+	if !result.CandidateActive() || result.GCComplete() {
+		t.Fatalf("Publish phase=%s after GC failure", result.Phase)
+	}
+	if !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != stamp {
+		t.Fatalf("Publish recovery = %+v, want active generation retained", result.Recover)
+	}
+	if present, complete := GenerationState(rt, stamp); !present || !complete {
+		t.Fatalf("active generation present=%v complete=%v after GC failure", present, complete)
+	}
 }
 
 func TestCrashAfterDirCreatedLeavesUnreferenced(t *testing.T) {
@@ -474,6 +663,131 @@ func TestGCKeepsCurrentPlusThree(t *testing.T) {
 	}
 }
 
+func TestGCKeepsPreviousGenerationsPerTarget(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	rl := begin(t, projectDir, nil)
+
+	apiOld, _, err := rl.WriteGeneration(rt, keys, "api", []byte("api-old"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiCurrent, _, err := rl.WriteGeneration(rt, keys, "api", []byte("api-current"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(rt, apiOld), time.Unix(1, 0), time.Unix(1, 0)); err != nil {
+		t.Fatal(err)
+	}
+
+	worker := make([]string, 5)
+	for i := range worker {
+		worker[i], _, err = rl.WriteGeneration(rt, keys, "worker", []byte{byte('a' + i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Unix(100+int64(i), 0)
+		if err := os.Chtimes(filepath.Join(rt, worker[i]), mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := rl.CommitStamps(map[string]string{"api": apiCurrent, "worker": worker[4]}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rl.GC(rt, DefaultGenerationsKept); err != nil {
+		t.Fatal(err)
+	}
+
+	if present, complete := GenerationState(rt, apiOld); !present || !complete {
+		t.Fatalf("api previous generation present=%v complete=%v, want retained independently of worker history", present, complete)
+	}
+	workerPrevious := 0
+	for _, stamp := range worker[:4] {
+		if present, _ := GenerationState(rt, stamp); present {
+			workerPrevious++
+		}
+	}
+	if workerPrevious != DefaultGenerationsKept {
+		t.Fatalf("worker previous generations = %d, want %d", workerPrevious, DefaultGenerationsKept)
+	}
+}
+
+func TestPublishGCPartialFailureKeepsActiveAndReportsCleanup(t *testing.T) {
+	_, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	seed := begin(t, projectDir, nil)
+	stamps := make([]string, 6)
+	for i := range stamps {
+		stamp, _, err := seed.WriteGeneration(rt, keys, "api", []byte{byte('a' + i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		stamps[i] = stamp
+		mt := time.Unix(100+int64(i), 0)
+		if err := os.Chtimes(filepath.Join(rt, stamp), mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := seed.CommitStamps(map[string]string{"api": stamps[4]}); err != nil {
+		t.Fatal(err)
+	}
+
+	lock := begin(t, projectDir, errProbe{failGCRemoval: stamps[0]})
+	result, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": []byte("f")}})
+	if err == nil {
+		t.Fatal("Publish should surface the injected partial GC failure")
+	}
+	if !result.CandidateActive() || result.GCComplete() || !result.Recover.NeedsCleanup {
+		t.Fatalf("Publish result = %+v, want committed active state with cleanup pending", result)
+	}
+	if present, complete := GenerationState(rt, stamps[5]); !present || !complete {
+		t.Fatalf("active generation present=%v complete=%v after partial GC failure", present, complete)
+	}
+	if present, _ := GenerationState(rt, stamps[1]); present {
+		t.Fatal("first over-retention generation should be removed before injected failure")
+	}
+	if present, complete := GenerationState(rt, stamps[0]); !present || !complete {
+		t.Fatalf("failed-removal generation present=%v complete=%v, want recoverable", present, complete)
+	}
+}
+
+func TestPublishRecoversTornGenerationAfterLockRestart(t *testing.T) {
+	state, rt := dirs(t)
+	projectDir := t.TempDir()
+	keys := testKeys(t)
+	content := []byte("API=restart\n")
+	stamp := TargetStamp(keys, "api", content)
+	first, err := NewWriter(state, errProbe{failComplete: true}).BeginRender(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := first.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": content}})
+	if err == nil || result.CandidateActive() {
+		t.Fatalf("first Publish result=%+v err=%v, want torn pre-switch failure", result, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if present, complete := GenerationState(rt, stamp); !present || complete {
+		t.Fatalf("torn candidate present=%v complete=%v before restart recovery", present, complete)
+	}
+
+	restarted, err := NewWriter(state, nil).BeginRender(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restarted.Close()
+	if err := restarted.Recover(rt); err != nil {
+		t.Fatal(err)
+	}
+	result, err = restarted.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": content}})
+	if err != nil || result.Phase != PublishPhaseComplete || !result.Materialized["api"] {
+		t.Fatalf("restart Publish result=%+v err=%v, want complete re-materialization", result, err)
+	}
+}
+
 func TestGCRemovesIncompleteRegardlessOfAge(t *testing.T) {
 	_, rt := dirs(t)
 	keys := testKeys(t)
@@ -612,6 +926,9 @@ func TestRenderLockRefusedAfterClose(t *testing.T) {
 	}
 	if err := lock.GC(rt, DefaultGenerationsKept); !errors.Is(err, errLockReleased) {
 		t.Errorf("GC after Close err = %v, want errLockReleased", err)
+	}
+	if _, err := lock.Publish(PublishPlan{RuntimeDir: rt, Keys: keys, Targets: map[string][]byte{"api": []byte("x")}}); !errors.Is(err, errLockReleased) {
+		t.Errorf("Publish after Close err = %v, want errLockReleased", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make RenderLock.Publish the single owner of Compose generation materialization, stamp commit, and per-target garbage collection
- route live and offline publication through the same recoverable operation while preserving their required persistence order
- make post-publication Docker application retry-safe with durable active-vs-applied stamp tracking
- add failure-injection coverage for every publication phase, partial GC, restart recovery, snapshot/cursor failures, and apply bookkeeping failures

## Contract and migration

- publication is explicitly recoverable rather than multi-file atomic
- no database migration and no generated outputs
- handoff: docs/handoff/231-compose-filesystem-publish.md

## Validation

- go build ./...
- go vet ./...
- go test -count=1 ./... (3,258 tests in 57 packages)
- go test -race -count=1 ./internal/compose/... ./internal/cli/... (363 tests)
- go test -count=1 ./internal/isolation -run ^TestComposeCLI$ (6 tests)
- ./scripts/compose-demo.sh
- three review rounds; standards and specification clean

Closes #231