### PR TITLE
refactor: let service classify adapter target mutations #233

### DIFF
--- a/docs/handoff/233-target-mutation-classification.md
+++ b/docs/handoff/233-target-mutation-classification.md
@@ -1,0 +1,59 @@
+# Handoff: #233 service-owned target mutation classification
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/233 (parent #204; programme
+#203; audit ID `BE16-A`). Base: `32018f096e6eae5695fcb43046c7f1b52eec051d`.
+
+## Contract
+
+- `Adapters.ApplyTargetMutation` accepts requested target state plus
+  `keepRemote` and returns the closed `TargetMutationUpdated |
+  TargetMutationMoveStarted` result.
+- Destination kind, owner, name, or destination-environment changes select the
+  scrub-before-switch move path. Visibility, selected repositories, prefix,
+  and key changes remain metadata updates. Target environment stays immutable.
+- Classification checks the caller-authorized current generation first, then
+  rechecks generation and destination identity inside the selected write
+  transaction. A concurrent change is refused; it cannot cross from update to
+  move without scrub ceremony.
+- HTTP and CLI send one update-target intent. HTTP maps the service result to
+  the existing `200 AdapterTarget` or `202 AdapterMove` contract; CLI renders
+  the returned variant instead of choosing a response workflow itself.
+- CLI browser reauthentication remains a transport pre-step because it owns
+  the interactive handoff. Service ceremony checks stay authoritative and run
+  in the mutation transaction. Remote scrub ordering, protected-environment
+  authorization, audit identities, and `keep_remote` semantics are unchanged.
+
+OpenAPI and generated outputs: unchanged.
+
+## Regression evidence
+
+- Service tables cover metadata update versus destination move and reject
+  update-only `keep_remote` plus environment changes without mutation.
+- A concurrent update/move test proves one expected generation wins and the
+  stale request is refused.
+- CLI result tables cover both existing HTTP response variants, independent of
+  the CLI's pre-request snapshot.
+- HTTP service-boundary and CLI transport tables prove both variants submit one
+  intent without a transport-supplied move decision.
+- Public-operation ceremony tables cover protected update and move refusals;
+  existing scrub, keep-remote, and audit tests now route through the public
+  classifier.
+
+Two-axis Codex review reached `CLEAN` in round 2 after classification moved
+into the mutation write transaction and transport/concurrency/ceremony coverage
+became deterministic.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service/... ./internal/server/... ./internal/cli/... -run Adapter
+                                                        passed
+go test -count=1 ./internal/service/... ./internal/server/... ./internal/cli/...
+                                                        passed
+go test -race -count=1 ./internal/service -run TestApplyTargetMutation
+                                                        passed
+go test -count=1 ./internal/isolation/                  passed (76.828s)
+go build ./...                                          passed
+go vet ./...                                            passed
+go test -p 4 -count=1 -timeout=20m ./...                passed
+```

--- a/internal/cli/adapters.go
+++ b/internal/cli/adapters.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -21,6 +22,27 @@ import (
 type adapterCredentialSource struct {
 	stdin bool
 	file  string
+}
+
+func renderAdapterTargetMutation(out io.Writer, format Format, payload []byte) error {
+	var discriminator struct {
+		Kind *apigen.AdapterMoveKind `json:"kind"`
+	}
+	if err := json.Unmarshal(payload, &discriminator); err != nil {
+		return failf(ExitInternal, "the server's response did not match the contract: %v", err)
+	}
+	if discriminator.Kind != nil {
+		var move apigen.AdapterMove
+		if err := json.Unmarshal(payload, &move); err != nil {
+			return failf(ExitInternal, "the server's move response did not match the contract: %v", err)
+		}
+		return Render(out, format, adapterMoveTable(move))
+	}
+	var target apigen.AdapterTarget
+	if err := json.Unmarshal(payload, &target); err != nil {
+		return failf(ExitInternal, "the server's target response did not match the contract: %v", err)
+	}
+	return Render(out, format, targetTable(apigen.AdapterTargetList{Items: []apigen.AdapterTarget{target}}))
 }
 
 func (s adapterCredentialSource) read(ios IO) ([]byte, error) {
@@ -399,13 +421,11 @@ func runAdapter(ctx context.Context, ios IO, args []string) error {
 			}
 			path = base + "/adapter-targets/" + url.PathEscape(target)
 			body = apigen.UpdateAdapterTargetRequest{EnvironmentId: input.EnvironmentId, DestinationKind: input.DestinationKind, DestinationOwner: input.DestinationOwner, DestinationName: input.DestinationName, DestinationEnvironment: input.DestinationEnvironment, Visibility: apigen.UpdateAdapterTargetRequestVisibility(input.Visibility), SelectedRepositoryIds: input.SelectedRepositoryIds, NamePrefix: input.NamePrefix, KeyIds: input.KeyIds, ExpectedGeneration: current.Target.Generation, KeepRemote: &keepRemote}
-			if !destinationChanged {
-				var updated apigen.AdapterTarget
-				if err := client.Do(ctx, http.MethodPatch, path, body, &updated); err != nil {
-					return err
-				}
-				return Render(ios.Stdout, f, targetTable(apigen.AdapterTargetList{Items: []apigen.AdapterTarget{updated}}))
+			var response []byte
+			if err := client.Do(ctx, http.MethodPatch, path, body, &response); err != nil {
+				return err
 			}
+			return renderAdapterTargetMutation(ios.Stdout, f, response)
 		}
 		if err := client.Do(ctx, http.MethodPatch, path, body, &out); err != nil {
 			return err

--- a/internal/cli/adapters_internal_test.go
+++ b/internal/cli/adapters_internal_test.go
@@ -104,6 +104,36 @@ func TestAdapterMoveOutputEnumeratesPendingRouteJobsAndOrphansWithoutCredential(
 	}
 }
 
+func TestAdapterTargetMutationOutputFollowsServiceResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     string
+	}{
+		{
+			name:     "updated",
+			response: `{"id":"tgt_one","adapter_id":"adp_one","environment_id":"env_one","destination_kind":"repository","destination_owner":"team","destination_name":"app","destination_id":42,"name_prefix":"PROD_","generation":2,"state":"active","sync_status":"converging","failure_names":[]}`,
+			want:     "converging",
+		},
+		{
+			name:     "move started",
+			response: `{"id":"mov_one","adapter_id":"adp_one","kind":"target","state":"scrubbing","keep_remote":false,"pending_origin":"","targets":[{"target_id":"tgt_one","environment_id":"env_one","destination_kind":"repository","destination_owner":"team","destination_name":"next","visibility":"","selected_repository_ids":[],"name_prefix":"PROD_","key_ids":["key_one"],"jobs":[],"orphaned_names":[]}],"created_at":"2026-08-17T00:00:00Z"}`,
+			want:     "mov_one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := renderAdapterTargetMutation(&out, FormatTable, []byte(tt.response)); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), tt.want) {
+				t.Fatalf("output = %q, want %q", out.String(), tt.want)
+			}
+		})
+	}
+}
+
 func TestAdapterShowIncludesTargetStatusRevisionAndFailures(t *testing.T) {
 	revision := int64(42)
 	adapter := apigen.Adapter{Id: "adp_one", Origin: "https://forgejo.example", Targets: []apigen.AdapterTarget{{

--- a/internal/cli/cli_reauth_internal_test.go
+++ b/internal/cli/cli_reauth_internal_test.go
@@ -175,6 +175,79 @@ func TestAdapterTargetNarrowingSkipsCeremonyAndUsesSynchronousTargetResponse(t *
 	}
 }
 
+func TestAdapterTargetMutationCLIAPIParity(t *testing.T) {
+	tests := []struct {
+		name        string
+		destination string
+		status      int
+		response    string
+		wantOutput  string
+	}{
+		{
+			name: "metadata update", destination: "app", status: http.StatusOK,
+			response:   `{"id":"tgt_one","adapter_id":"adp_one","environment_id":"env_one","destination_kind":"repository","destination_owner":"team","destination_name":"app","destination_id":42,"name_prefix":"NEXT_","generation":2,"state":"active","sync_status":"converging","failure_names":[]}`,
+			wantOutput: "converging",
+		},
+		{
+			name: "move started", destination: "next", status: http.StatusAccepted,
+			response:   `{"id":"mov_one","adapter_id":"adp_one","kind":"target","state":"scrubbing","keep_remote":false,"pending_origin":"","targets":[{"target_id":"tgt_one","environment_id":"env_one","destination_kind":"repository","destination_owner":"team","destination_name":"next","visibility":"","selected_repository_ids":[],"name_prefix":"NEXT_","key_ids":["key_one"],"jobs":[],"orphaned_names":[]}],"created_at":"2026-08-17T00:00:00Z"}`,
+			wantOutput: "mov_one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var patchCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/orgs/org_one/projects/prj_one/adapter-targets/tgt_one":
+					_, _ = io.WriteString(w, `{"target":{"id":"tgt_one","adapter_id":"adp_one","environment_id":"env_one","destination_kind":"repository","destination_owner":"team","destination_name":"app","destination_id":42,"name_prefix":"PROD_","generation":1,"state":"active","sync_status":"converged","failure_names":[]},"mapping":[{"key_id":"key_one","canonical_name":"ONE","surface":"secret","effective_name":"PROD_ONE"}],"conflicts":[]}`)
+				case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/orgs/org_one/projects/prj_one/adapter-targets/tgt_one":
+					patchCount++
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Error(err)
+						return
+					}
+					if body["destination_name"] != tt.destination || body["expected_generation"] != float64(1) {
+						t.Errorf("patch body=%v", body)
+					}
+					if _, ok := body["move"]; ok {
+						t.Errorf("transport supplied move decision: %v", body)
+					}
+					w.WriteHeader(tt.status)
+					_, _ = io.WriteString(w, tt.response)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			stateDir := t.TempDir()
+			st := &State{dir: stateDir}
+			if err := st.Trust().Put(TrustEntry{Name: "local", Origin: server.URL}); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.PutSession(SessionArtifact{Instance: "local", Origin: server.URL, Token: "session-secret", SessionID: "ses_one", Principal: "usr_one", ExpiresAt: "2030-01-01T00:00:00Z"}); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run(t.Context(), IO{
+				Stdin: strings.NewReader(""), Stdout: &stdout, Stderr: &stderr,
+				Env: Env{Getenv: func(name string) string {
+					if name == "HIKYO_STATE_DIR" {
+						return stateDir
+					}
+					return ""
+				}},
+			}, []string{"adapter", "update", "adp_one", "--instance", "local", "--org", "org_one", "--project", "prj_one", "--env", "env_one", "--target", "tgt_one", "--kind", "repository", "--owner", "team", "--repo", tt.destination, "--prefix", "NEXT_", "--keys", "key_one"})
+			if code != ExitOK || patchCount != 1 || !strings.Contains(stdout.String(), tt.wantOutput) {
+				t.Fatalf("exit=%d patches=%d stdout=%q stderr=%q", code, patchCount, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunCLIAdapterReauthBindsExactLoopbackStateAndSilentlyRotatesBearer(t *testing.T) {
 	const (
 		oldBearer = "old-session-secret"

--- a/internal/server/adapters.go
+++ b/internal/server/adapters.go
@@ -290,44 +290,41 @@ func (a *API) ShowAdapterTarget(ctx context.Context, req apigen.ShowAdapterTarge
 	return apigen.ShowAdapterTarget200JSONResponse(out), nil
 }
 
-func (a *API) UpdateAdapterTarget(ctx context.Context, req apigen.UpdateAdapterTargetRequestObject) (apigen.UpdateAdapterTargetResponseObject, error) {
+type targetMutationService interface {
+	ApplyTargetMutation(context.Context, service.Actor, domain.Scope, service.UpdateAdapterTargetRequest, bool) (service.TargetMutationResult, error)
+	Move(context.Context, service.Actor, domain.Scope, string) (service.AdapterMove, error)
+}
+
+func updateAdapterTarget(ctx context.Context, adapters targetMutationService, req apigen.UpdateAdapterTargetRequestObject) (apigen.UpdateAdapterTargetResponseObject, error) {
 	input := service.AdapterTargetInput{EnvironmentID: string(req.Body.EnvironmentId), DestinationKind: string(req.Body.DestinationKind), DestinationOwner: req.Body.DestinationOwner, DestinationName: req.Body.DestinationName, DestinationEnvironment: req.Body.DestinationEnvironment, Visibility: string(req.Body.Visibility), SelectedRepositoryIDs: append([]int64(nil), req.Body.SelectedRepositoryIds...), NamePrefix: req.Body.NamePrefix}
 	for _, id := range req.Body.KeyIds {
 		input.KeyIDs = append(input.KeyIDs, string(id))
 	}
 	request := service.UpdateAdapterTargetRequest{TargetID: string(req.Target), ExpectedGeneration: req.Body.ExpectedGeneration, Target: input}
-	current, err := a.Adapters.InspectTarget(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), string(req.Target))
+	result, err := adapters.ApplyTargetMutation(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), request, req.Body.KeepRemote != nil && *req.Body.KeepRemote)
 	if err != nil {
 		return nil, err
 	}
-	if input.EnvironmentID != current.Target.EnvironmentID {
-		return nil, fmt.Errorf("%w: target environment is immutable; remove and add the target", domain.ErrConflict)
-	}
-	sameDestination := input.DestinationKind == current.Target.DestinationKind &&
-		input.DestinationOwner == current.Target.DestinationOwner && input.DestinationName == current.Target.DestinationName && input.DestinationEnvironment == current.Target.DestinationEnvironment
-	if sameDestination {
-		if req.Body.KeepRemote != nil && *req.Body.KeepRemote {
-			return nil, fmt.Errorf("%w: keep_remote applies only to a destination move", domain.ErrInvalid)
-		}
-		updated, err := a.Adapters.UpdateTarget(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), request)
+	switch result := result.(type) {
+	case service.TargetMutationUpdated:
+		return apigen.UpdateAdapterTarget200JSONResponse(adapterTargetResponse(result.Target)), nil
+	case service.TargetMutationMoveStarted:
+		move, err := adapters.Move(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), result.Move.MoveID)
 		if err != nil {
 			return nil, err
 		}
-		return apigen.UpdateAdapterTarget200JSONResponse(adapterTargetResponse(updated)), nil
+		out, err := adapterMoveResponse(move)
+		if err != nil {
+			return nil, err
+		}
+		return apigen.UpdateAdapterTarget202JSONResponse(out), nil
+	default:
+		return nil, fmt.Errorf("unknown target mutation result %T", result)
 	}
-	started, err := a.Adapters.MoveTarget(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), request, req.Body.KeepRemote != nil && *req.Body.KeepRemote)
-	if err != nil {
-		return nil, err
-	}
-	move, err := a.Adapters.Move(ctx, service.Bearer(bearer(ctx)), adapterScope(req.Org, req.Project), started.MoveID)
-	if err != nil {
-		return nil, err
-	}
-	out, err := adapterMoveResponse(move)
-	if err != nil {
-		return nil, err
-	}
-	return apigen.UpdateAdapterTarget202JSONResponse(out), nil
+}
+
+func (a *API) UpdateAdapterTarget(ctx context.Context, req apigen.UpdateAdapterTargetRequestObject) (apigen.UpdateAdapterTargetResponseObject, error) {
+	return updateAdapterTarget(ctx, a.Adapters, req)
 }
 
 func (a *API) RemoveAdapterTarget(ctx context.Context, req apigen.RemoveAdapterTargetRequestObject) (apigen.RemoveAdapterTargetResponseObject, error) {

--- a/internal/server/adapters_internal_test.go
+++ b/internal/server/adapters_internal_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,8 +9,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 )
+
+type recordingTargetMutationService struct {
+	result     service.TargetMutationResult
+	request    service.UpdateAdapterTargetRequest
+	keepRemote bool
+}
+
+func (s *recordingTargetMutationService) ApplyTargetMutation(_ context.Context, _ service.Actor, _ domain.Scope, request service.UpdateAdapterTargetRequest, keepRemote bool) (service.TargetMutationResult, error) {
+	s.request = request
+	s.keepRemote = keepRemote
+	return s.result, nil
+}
+
+func (*recordingTargetMutationService) Move(context.Context, service.Actor, domain.Scope, string) (service.AdapterMove, error) {
+	return service.AdapterMove{ID: "mov_one", AdapterID: "adp_one", Kind: "target", State: "scrubbing", CreatedAt: "2026-08-17T00:00:00Z"}, nil
+}
 
 func TestAdapterResponseRejectsMalformedStoredTimestamps(t *testing.T) {
 	tests := []struct {
@@ -97,5 +116,41 @@ func TestAdapterTargetResponseIncludesConvergedRevisionAndPendingConflicts(t *te
 	}
 	if len(out.Conflicts) != 1 || string(out.Conflicts[0].Id) != artifact.ID || len(out.Conflicts[0].Entries) != 1 || out.Conflicts[0].Entries[0].EffectiveName != "PROD_MODE" {
 		t.Fatalf("conflicts = %+v", out.Conflicts)
+	}
+}
+
+func TestUpdateAdapterTargetMapsOneIntentToServiceResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     service.TargetMutationResult
+		keepRemote bool
+		status     int
+	}{
+		{name: "updated", result: service.TargetMutationUpdated{Target: service.AdapterTarget{ID: "tgt_one", Generation: 8}}, status: http.StatusOK},
+		{name: "move started", result: service.TargetMutationMoveStarted{}, keepRemote: true, status: http.StatusAccepted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keepRemote := tt.keepRemote
+			body := apigen.UpdateAdapterTargetRequest{
+				EnvironmentId: "env_one", DestinationKind: "repository", DestinationOwner: "team",
+				DestinationName: "app", Visibility: "", NamePrefix: "PROD_",
+				KeyIds: []apigen.ID{"key_one"}, ExpectedGeneration: 7, KeepRemote: &keepRemote,
+			}
+			stub := &recordingTargetMutationService{result: tt.result}
+			response, err := updateAdapterTarget(withBearer(t.Context(), "bearer"), stub, apigen.UpdateAdapterTargetRequestObject{
+				Org: "org_one", Project: "prj_one", Target: "tgt_one", Body: &body,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			recorder := httptest.NewRecorder()
+			if err := response.VisitUpdateAdapterTargetResponse(recorder); err != nil {
+				t.Fatal(err)
+			}
+			if recorder.Code != tt.status || stub.request.TargetID != "tgt_one" || stub.request.ExpectedGeneration != 7 || stub.request.Target.DestinationName != "app" || stub.keepRemote != tt.keepRemote {
+				t.Fatalf("status=%d request=%+v keep_remote=%v", recorder.Code, stub.request, stub.keepRemote)
+			}
+		})
 	}
 }

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -168,6 +168,24 @@ type UpdateAdapterTargetRequest struct {
 	Target             AdapterTargetInput
 }
 
+// TargetMutationResult is the closed result of applying target intent. Its
+// unexported marker keeps callers from inventing a third transport workflow.
+type TargetMutationResult interface {
+	targetMutationResult()
+}
+
+type TargetMutationUpdated struct {
+	Target store.AdapterTarget
+}
+
+func (TargetMutationUpdated) targetMutationResult() {}
+
+type TargetMutationMoveStarted struct {
+	Move store.AdapterRouteMoveResult
+}
+
+func (TargetMutationMoveStarted) targetMutationResult() {}
+
 type AdoptAdapterRequest struct {
 	TargetID              string
 	ArtifactID            string
@@ -528,24 +546,73 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	return out, err
 }
 
-func (s *Adapters) UpdateTarget(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest) (store.AdapterTarget, error) {
+func targetDestinationChanged(current store.AdapterTarget, requested AdapterTargetInput) bool {
+	return requested.DestinationKind != current.DestinationKind ||
+		requested.DestinationOwner != current.DestinationOwner ||
+		requested.DestinationName != current.DestinationName ||
+		requested.DestinationEnvironment != current.DestinationEnvironment
+}
+
+// prepareTargetMutation performs only the provider-preflight classification.
+// ApplyTargetMutation repeats the authoritative decision in its write
+// transaction before selecting either result branch.
+func (s *Adapters) prepareTargetMutation(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest) (bool, error) {
 	if scope.Project == "" || scope.Env != "" || request.TargetID == "" || request.ExpectedGeneration <= 0 || len(request.Target.KeyIDs) == 0 {
-		return store.AdapterTarget{}, fmt.Errorf("%w: target update requires target, generation, and full keys replacement", domain.ErrInvalid)
+		return false, fmt.Errorf("%w: target mutation requires target, generation, and full keys replacement", domain.ErrInvalid)
 	}
-	if err := s.preflightTargetRouting(ctx, actor, scope, request); err != nil {
-		return store.AdapterTarget{}, err
-	}
-	// § 179 adapter sync/trigger concurrency: 4 per org, held for the reconfigure
-	// exactly as SyncTarget holds it — a reconfigure that re-syncs is an adapter
-	// trigger, so it takes the same concurrency slot, not just the rate. Acquired
-	// at entry (before the provider fence retries), released on return.
-	release, err := s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
+	var move bool
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		caller, err := actor.resolve(ctx, az, s.now())
+		if err != nil {
+			return err
+		}
+		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		if err != nil {
+			return err
+		}
+		current, err := r.Adapters().Target(ctx, proof, request.TargetID)
+		if err != nil {
+			return err
+		}
+		if current.Generation != request.ExpectedGeneration {
+			return adapter.ErrSuperseded
+		}
+		if request.Target.EnvironmentID != current.EnvironmentID {
+			return fmt.Errorf("%w: target environment is immutable; remove and add the target", domain.ErrConflict)
+		}
+		move = targetDestinationChanged(current, request.Target)
+		return nil
+	})
+	return move, err
+}
+
+// ApplyTargetMutation accepts requested target state and owns the update-versus-
+// move decision. The decision and selected mutation share one write transaction,
+// so a concurrent target mutation cannot bypass scrub-before-switch.
+func (s *Adapters) ApplyTargetMutation(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest, keepRemote bool) (TargetMutationResult, error) {
+	preparedMove, err := s.prepareTargetMutation(ctx, actor, scope, request)
 	if err != nil {
-		return store.AdapterTarget{}, err
+		return nil, err
+	}
+	release := func() {}
+	if !preparedMove {
+		if keepRemote {
+			return nil, fmt.Errorf("%w: keep_remote applies only to a destination move", domain.ErrInvalid)
+		}
+		if err := s.preflightTargetRouting(ctx, actor, scope, request); err != nil {
+			return nil, err
+		}
+		release, err = s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer release()
+	// § 179 adapter sync/trigger concurrency: 4 per org, held for the reconfigure
+	// exactly as SyncTarget holds it. Preparation acquires it only for an update;
+	// generation fencing refuses any classification drift before mutation.
 	now := store.CanonTime(s.now())
-	var out store.AdapterTarget
+	var result TargetMutationResult
 	var rateCharged bool
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
@@ -564,87 +631,107 @@ func (s *Adapters) UpdateTarget(ctx context.Context, actor Actor, scope domain.S
 			if current.Generation != request.ExpectedGeneration {
 				return adapter.ErrSuperseded
 			}
-			if current.Provider == "github-actions" && request.Target.DestinationKind == string(adapter.Organization) && request.Target.Visibility == "" {
-				return fmt.Errorf("%w: GitHub organization target requires all, private, or selected visibility", domain.ErrInvalid)
+			if request.Target.EnvironmentID != current.EnvironmentID {
+				return fmt.Errorf("%w: target environment is immutable; remove and add the target", domain.ErrConflict)
 			}
-			oldIDs, err := r.Adapters().TargetKeyIDs(ctx, p, request.TargetID)
-			if err != nil {
-				return err
+			move := targetDestinationChanged(current, request.Target)
+			if move != preparedMove {
+				return adapter.ErrSuperseded
 			}
-			slices.Sort(oldIDs)
-			newIDs := append([]string(nil), request.Target.KeyIDs...)
-			slices.Sort(newIDs)
-			widened := false
-			for _, id := range newIDs {
-				if !slices.Contains(oldIDs, id) {
-					widened = true
-					break
+			if !move && keepRemote {
+				return fmt.Errorf("%w: keep_remote applies only to a destination move", domain.ErrInvalid)
+			}
+			if move {
+				started, err := s.applyTargetMove(ctx, r, az, caller, p, scope, request, current, keepRemote, now)
+				if err == nil {
+					result = TargetMutationMoveStarted{Move: started}
 				}
-			}
-			full := widened || request.Target.NamePrefix != current.NamePrefix ||
-				adapter.RecipientSetNeedsCeremony(current.Visibility, current.SelectedRepositoryIDs, request.Target.Visibility, request.Target.SelectedRepositoryIDs)
-			authority := current.AuthorityPrincipalID
-			if full {
-				environmentIDs, err := r.Adapters().Environments(ctx, p, current.AdapterID)
-				if err != nil {
-					return err
-				}
-				if err := s.requireAdapterCeremony(ctx, az, caller, scope, adapterEnvironmentSet(environmentIDs), authz.OpAdapterConfigure, now); err != nil {
-					return err
-				}
-				authority = string(caller.Principal)
-			}
-			updated, err := r.Adapters().UpdateTarget(ctx, p, store.AdapterTargetUpdate{ExpectedGeneration: request.ExpectedGeneration, AuthorityPrincipalID: authority, At: now, Target: store.AdapterTargetMutation{ID: request.TargetID, AdapterID: current.AdapterID, EnvironmentID: request.Target.EnvironmentID, DestinationKind: request.Target.DestinationKind, DestinationOwner: request.Target.DestinationOwner, DestinationName: request.Target.DestinationName, DestinationEnvironment: request.Target.DestinationEnvironment, DestinationID: current.DestinationID, RepositoryID: current.RepositoryID, Visibility: request.Target.Visibility, SelectedRepositoryIDs: append([]int64(nil), request.Target.SelectedRepositoryIDs...), NamePrefix: request.Target.NamePrefix, KeyIDs: newIDs}})
-			if err != nil {
 				return err
 			}
-			out = updated.Target
-			// § 179 adapter sync/trigger rate: a reconfigure that re-syncs enqueues
-			// a "trigger":"manual" job just like SyncTarget, so it charges the same
-			// 10/min per-principal budget — otherwise a script re-toggles a target's
-			// keys to trigger syncs past the bound. Charged only when a job was
-			// actually enqueued (a pure config edit that re-syncs nothing does not),
-			// once across the fence/tx retry loops; a refusal rolls the enqueue back.
-			if updated.Enqueue.JobID != "" {
-				if err := s.Budget.chargeOnce(&rateCharged, budgetAdapterRate, budgetKeys{Principal: caller.Principal}); err != nil {
-					return err
-				}
+			updated, err := s.applyTargetUpdate(ctx, r, az, caller, p, scope, request, current, now, &rateCharged)
+			if err == nil {
+				result = TargetMutationUpdated{Target: updated}
 			}
-			payload := audit.Payload{"mutation": "target-update", "authority": updated.AuthorityPrincipalID}
-			if full {
-				payload["previous_authority"] = updated.PreviousAuthorityPrincipalID
-			}
-			ev, err := domainEvent(ctx, audit.EventAdapterConfigure, caller.Principal, audit.Object{Type: "adapter-target", ID: request.TargetID}, payload)
-			if err != nil {
-				return err
-			}
-			if err := r.Audit().InsertTenant(ctx, p, ev); err != nil {
-				return err
-			}
-			requested, err := newAuditEvent(ctx, audit.EventAdapterSyncRequested, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.OutcomeSuccess,
-				updated.Enqueue.JobID, audit.Payload{"trigger": "manual"})
-			if err != nil {
-				return err
-			}
-			requested.AuthorityID = updated.Enqueue.AuthorityPrincipalID
-			if err := r.Audit().InsertTenant(ctx, p, requested); err != nil {
-				return err
-			}
-			if updated.Enqueue.SupersededJobID == "" {
-				return nil
-			}
-			superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-					"previous_job_id": updated.Enqueue.SupersededJobID, "job_id": updated.Enqueue.JobID,
-				})
-			if err != nil {
-				return err
-			}
-			return r.Audit().InsertTenant(ctx, p, superseded)
+			return err
 		})
 	})
-	return out, err
+	return result, err
+}
+
+func (s *Adapters) applyTargetUpdate(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity, proof authz.Proof, scope domain.Scope, request UpdateAdapterTargetRequest, current store.AdapterTarget, now time.Time, rateCharged *bool) (store.AdapterTarget, error) {
+	if current.Provider == "github-actions" && request.Target.DestinationKind == string(adapter.Organization) && request.Target.Visibility == "" {
+		return store.AdapterTarget{}, fmt.Errorf("%w: GitHub organization target requires all, private, or selected visibility", domain.ErrInvalid)
+	}
+	oldIDs, err := r.Adapters().TargetKeyIDs(ctx, proof, request.TargetID)
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	slices.Sort(oldIDs)
+	newIDs := append([]string(nil), request.Target.KeyIDs...)
+	slices.Sort(newIDs)
+	widened := false
+	for _, id := range newIDs {
+		if !slices.Contains(oldIDs, id) {
+			widened = true
+			break
+		}
+	}
+	full := widened || request.Target.NamePrefix != current.NamePrefix ||
+		adapter.RecipientSetNeedsCeremony(current.Visibility, current.SelectedRepositoryIDs, request.Target.Visibility, request.Target.SelectedRepositoryIDs)
+	authority := current.AuthorityPrincipalID
+	if full {
+		environmentIDs, err := r.Adapters().Environments(ctx, proof, current.AdapterID)
+		if err != nil {
+			return store.AdapterTarget{}, err
+		}
+		if err := s.requireAdapterCeremony(ctx, az, caller, scope, adapterEnvironmentSet(environmentIDs), authz.OpAdapterConfigure, now); err != nil {
+			return store.AdapterTarget{}, err
+		}
+		authority = string(caller.Principal)
+	}
+	updated, err := r.Adapters().UpdateTarget(ctx, proof, store.AdapterTargetUpdate{ExpectedGeneration: request.ExpectedGeneration, AuthorityPrincipalID: authority, At: now, Target: store.AdapterTargetMutation{ID: request.TargetID, AdapterID: current.AdapterID, EnvironmentID: request.Target.EnvironmentID, DestinationKind: request.Target.DestinationKind, DestinationOwner: request.Target.DestinationOwner, DestinationName: request.Target.DestinationName, DestinationEnvironment: request.Target.DestinationEnvironment, DestinationID: current.DestinationID, RepositoryID: current.RepositoryID, Visibility: request.Target.Visibility, SelectedRepositoryIDs: append([]int64(nil), request.Target.SelectedRepositoryIDs...), NamePrefix: request.Target.NamePrefix, KeyIDs: newIDs}})
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	if updated.Enqueue.JobID != "" {
+		if err := s.Budget.chargeOnce(rateCharged, budgetAdapterRate, budgetKeys{Principal: caller.Principal}); err != nil {
+			return store.AdapterTarget{}, err
+		}
+	}
+	payload := audit.Payload{"mutation": "target-update", "authority": updated.AuthorityPrincipalID}
+	if full {
+		payload["previous_authority"] = updated.PreviousAuthorityPrincipalID
+	}
+	ev, err := domainEvent(ctx, audit.EventAdapterConfigure, caller.Principal, audit.Object{Type: "adapter-target", ID: request.TargetID}, payload)
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	if err := r.Audit().InsertTenant(ctx, proof, ev); err != nil {
+		return store.AdapterTarget{}, err
+	}
+	requested, err := newAuditEvent(ctx, audit.EventAdapterSyncRequested, caller.Principal,
+		audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.OutcomeSuccess,
+		updated.Enqueue.JobID, audit.Payload{"trigger": "manual"})
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	requested.AuthorityID = updated.Enqueue.AuthorityPrincipalID
+	if err := r.Audit().InsertTenant(ctx, proof, requested); err != nil {
+		return store.AdapterTarget{}, err
+	}
+	if updated.Enqueue.SupersededJobID != "" {
+		superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
+			audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
+				"previous_job_id": updated.Enqueue.SupersededJobID, "job_id": updated.Enqueue.JobID,
+			})
+		if err != nil {
+			return store.AdapterTarget{}, err
+		}
+		if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
+			return store.AdapterTarget{}, err
+		}
+	}
+	return updated.Target, nil
 }
 
 func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest) error {
@@ -707,92 +794,66 @@ func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scop
 	return err
 }
 
-// MoveTarget begins the scrub-before-switch transition for a destination or
+// applyTargetMove begins the scrub-before-switch transition for a destination or
 // environment move. The current route stays stored for the scrub job; the new
 // route is pending and cannot receive a push until activation tests it.
-func (s *Adapters) MoveTarget(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest, keepRemote bool) (store.AdapterRouteMoveResult, error) {
-	if scope.Project == "" || scope.Env != "" || request.TargetID == "" || request.ExpectedGeneration <= 0 || len(request.Target.KeyIDs) == 0 {
-		return store.AdapterRouteMoveResult{}, fmt.Errorf("%w: target move requires target, generation, and full keys replacement", domain.ErrInvalid)
+func (s *Adapters) applyTargetMove(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, caller authz.Identity, proof authz.Proof, scope domain.Scope, request UpdateAdapterTargetRequest, current store.AdapterTarget, keepRemote bool, now time.Time) (store.AdapterRouteMoveResult, error) {
+	environments, err := r.Adapters().Environments(ctx, proof, current.AdapterID)
+	if err != nil {
+		return store.AdapterRouteMoveResult{}, err
 	}
-	now := store.CanonTime(s.now())
-	var out store.AdapterRouteMoveResult
-	err := retryAdapterProviderFence(ctx, func() error {
-		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
-			if err != nil {
-				return err
-			}
-			current, err := r.Adapters().Target(ctx, proof, request.TargetID)
-			if err != nil {
-				return err
-			}
-			if current.Generation != request.ExpectedGeneration {
-				return adapter.ErrSuperseded
-			}
-			if request.Target.EnvironmentID != current.EnvironmentID {
-				return fmt.Errorf("%w: target environment is immutable; remove and add the target", domain.ErrConflict)
-			}
-			environments, err := r.Adapters().Environments(ctx, proof, current.AdapterID)
-			if err != nil {
-				return err
-			}
-			environments = adapterEnvironmentSet(environments, request.Target.EnvironmentID)
-			if err := s.requireAdapterCeremony(ctx, az, caller, scope, environments, authz.OpAdapterConfigure, now); err != nil {
-				return err
-			}
-			out, err = r.Adapters().MoveTarget(ctx, proof, store.AdapterRouteMoveMutation{
-				Target: store.AdapterTargetMutation{
-					ID: request.TargetID, AdapterID: current.AdapterID, EnvironmentID: request.Target.EnvironmentID,
-					DestinationKind: request.Target.DestinationKind, DestinationOwner: request.Target.DestinationOwner,
-					DestinationName: request.Target.DestinationName, DestinationEnvironment: request.Target.DestinationEnvironment,
-					Visibility: request.Target.Visibility, SelectedRepositoryIDs: append([]int64(nil), request.Target.SelectedRepositoryIDs...), NamePrefix: request.Target.NamePrefix,
-					KeyIDs: append([]string(nil), request.Target.KeyIDs...),
-				},
-				ExpectedGeneration: request.ExpectedGeneration, AuthorityPrincipalID: string(caller.Principal),
-				KeepRemote: keepRemote, At: now,
-			})
-			if err != nil {
-				return err
-			}
-			configured, err := domainEvent(ctx, audit.EventAdapterConfigure, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-					"mutation": "target-move", "previous_authority": current.AuthorityPrincipalID,
-					"authority": string(caller.Principal),
-				})
-			if err != nil {
-				return err
-			}
-			if err := r.Audit().InsertTenant(ctx, proof, configured); err != nil {
-				return err
-			}
-			if out.SupersededJobID != "" {
-				superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-					audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-						"previous_job_id": out.SupersededJobID, "job_id": out.JobID,
-					})
-				if err != nil {
-					return err
-				}
-				if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
-					return err
-				}
-			}
-			if !keepRemote {
-				return nil
-			}
-			scrubbed, err := domainEvent(ctx, audit.EventAdapterScrub, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{"orphaned": append([]string(nil), out.Orphaned...)})
-			if err != nil {
-				return err
-			}
-			return r.Audit().InsertTenant(ctx, proof, scrubbed)
-		})
+	environments = adapterEnvironmentSet(environments, request.Target.EnvironmentID)
+	if err := s.requireAdapterCeremony(ctx, az, caller, scope, environments, authz.OpAdapterConfigure, now); err != nil {
+		return store.AdapterRouteMoveResult{}, err
+	}
+	out, err := r.Adapters().MoveTarget(ctx, proof, store.AdapterRouteMoveMutation{
+		Target: store.AdapterTargetMutation{
+			ID: request.TargetID, AdapterID: current.AdapterID, EnvironmentID: request.Target.EnvironmentID,
+			DestinationKind: request.Target.DestinationKind, DestinationOwner: request.Target.DestinationOwner,
+			DestinationName: request.Target.DestinationName, DestinationEnvironment: request.Target.DestinationEnvironment,
+			Visibility: request.Target.Visibility, SelectedRepositoryIDs: append([]int64(nil), request.Target.SelectedRepositoryIDs...), NamePrefix: request.Target.NamePrefix,
+			KeyIDs: append([]string(nil), request.Target.KeyIDs...),
+		},
+		ExpectedGeneration: request.ExpectedGeneration, AuthorityPrincipalID: string(caller.Principal),
+		KeepRemote: keepRemote, At: now,
 	})
-	return out, err
+	if err != nil {
+		return store.AdapterRouteMoveResult{}, err
+	}
+	configured, err := domainEvent(ctx, audit.EventAdapterConfigure, caller.Principal,
+		audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
+			"mutation": "target-move", "previous_authority": current.AuthorityPrincipalID,
+			"authority": string(caller.Principal),
+		})
+	if err != nil {
+		return store.AdapterRouteMoveResult{}, err
+	}
+	if err := r.Audit().InsertTenant(ctx, proof, configured); err != nil {
+		return store.AdapterRouteMoveResult{}, err
+	}
+	if out.SupersededJobID != "" {
+		superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
+			audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
+				"previous_job_id": out.SupersededJobID, "job_id": out.JobID,
+			})
+		if err != nil {
+			return store.AdapterRouteMoveResult{}, err
+		}
+		if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
+			return store.AdapterRouteMoveResult{}, err
+		}
+	}
+	if keepRemote {
+		scrubbed, err := domainEvent(ctx, audit.EventAdapterScrub, caller.Principal,
+			audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{"orphaned": append([]string(nil), out.Orphaned...)})
+		if err != nil {
+			return store.AdapterRouteMoveResult{}, err
+		}
+		if err := r.Audit().InsertTenant(ctx, proof, scrubbed); err != nil {
+			return store.AdapterRouteMoveResult{}, err
+		}
+	}
+	return out, nil
 }
 
 // MoveOrigin keeps the old credential and origin authoritative through every

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -73,6 +73,32 @@ func adapterServiceDB(t *testing.T) *store.DB {
 	return db
 }
 
+// updateTarget and moveTarget preserve the focused assertions of older tests
+// while routing every mutation through the public classifier under test.
+func (s *Adapters) updateTarget(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest) (store.AdapterTarget, error) {
+	result, err := s.ApplyTargetMutation(ctx, actor, scope, request, false)
+	if err != nil {
+		return store.AdapterTarget{}, err
+	}
+	updated, ok := result.(TargetMutationUpdated)
+	if !ok {
+		return store.AdapterTarget{}, fmt.Errorf("target update returned %T", result)
+	}
+	return updated.Target, nil
+}
+
+func (s *Adapters) moveTarget(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest, keepRemote bool) (store.AdapterRouteMoveResult, error) {
+	result, err := s.ApplyTargetMutation(ctx, actor, scope, request, keepRemote)
+	if err != nil {
+		return store.AdapterRouteMoveResult{}, err
+	}
+	started, ok := result.(TargetMutationMoveStarted)
+	if !ok {
+		return store.AdapterRouteMoveResult{}, fmt.Errorf("target move returned %T", result)
+	}
+	return started.Move, nil
+}
+
 type fakeAdapterPlanModule struct{ plan adapter.Plan }
 
 func testModuleFactory(factory func(adapter.Provider, string, string) (adapter.Module, func(), error)) adapter.ModuleFactory {
@@ -152,6 +178,24 @@ func (fakeEnvironmentConfigureModule) Sync(context.Context, adapter.SyncRequest,
 type fakeRoutingPreflightModule struct {
 	seen *[]int64
 	err  error
+}
+
+type blockingRoutingPreflightModule struct {
+	started chan<- struct{}
+	proceed <-chan struct{}
+}
+
+func (blockingRoutingPreflightModule) ValidateConfig(adapter.Config) error { return nil }
+func (m blockingRoutingPreflightModule) TestConnection(context.Context, adapter.ConnectionRequest) (adapter.Connection, error) {
+	m.started <- struct{}{}
+	<-m.proceed
+	return adapter.Connection{Version: "github-actions", DestinationID: 42}, nil
+}
+func (blockingRoutingPreflightModule) Plan(context.Context, adapter.PlanRequest) (adapter.Plan, error) {
+	return adapter.Plan{}, nil
+}
+func (blockingRoutingPreflightModule) Sync(context.Context, adapter.SyncRequest, adapter.Journal) (adapter.SyncResult, error) {
+	return adapter.SyncResult{}, nil
 }
 
 func (fakeRoutingPreflightModule) ValidateConfig(adapter.Config) error { return nil }
@@ -395,7 +439,7 @@ func TestOrganizationSelectedRepositoryIDsAreVerifiedBeforeRoutingCommit(t *test
 		}
 		return fakeRoutingPreflightModule{seen: &seen}, nil, nil
 	})}
-	updated, err := svc.UpdateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	updated, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "acme", Visibility: "selected", SelectedRepositoryIDs: []int64{11, 22}, NamePrefix: "ONE_", KeyIDs: []string{"key_org_route"}},
 	})
@@ -424,6 +468,232 @@ func TestAdapterRoutingStateRoundTripsFromStore(t *testing.T) {
 	target := view.Targets[0]
 	if target.Provider != "github-actions" || target.DestinationEnvironment != "prod/blue" || target.DestinationID != 73 || target.RepositoryID != 42 {
 		t.Fatalf("round-trip target = %+v", target)
+	}
+}
+
+func TestApplyTargetMutationClassifiesUpdateAndMove(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      AdapterTargetInput
+		keepRemote  bool
+		wantUpdated bool
+	}{
+		{
+			name: "metadata update",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "app", NamePrefix: "NARROW_", KeyIDs: []string{"key_mutation"},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "destination identity move",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_mutation"},
+			},
+			keepRemote: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := adapterServiceDB(t)
+			for _, statement := range []string{
+				`INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_mutation_reveal_two','usr_adapter','reveal','org_adapter','prj_adapter','env_two','2026-08-17T00:00:00Z')`,
+				`INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_mutation','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`,
+				`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) VALUES ('org_adapter','prj_adapter','env_one','tgt_one','adp_1','key_mutation')`,
+			} {
+				if _, err := db.SQLiteWrite().ExecContext(t.Context(), statement); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
+			}, tt.keepRemote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch result := result.(type) {
+			case TargetMutationUpdated:
+				if !tt.wantUpdated || result.Target.NamePrefix != "NARROW_" || result.Target.Generation != 2 {
+					t.Fatalf("updated result = %+v", result)
+				}
+			case TargetMutationMoveStarted:
+				if tt.wantUpdated || result.Move.MoveID == "" || result.Move.Generation != 2 {
+					t.Fatalf("move result = %+v", result)
+				}
+			default:
+				t.Fatalf("result type = %T", result)
+			}
+		})
+	}
+}
+
+func TestApplyTargetMutationKeepsMovePolicyInsideService(t *testing.T) {
+	tests := []struct {
+		name       string
+		target     AdapterTargetInput
+		keepRemote bool
+		want       error
+	}{
+		{
+			name: "keep remote without move",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_policy"},
+			},
+			keepRemote: true,
+			want:       domain.ErrInvalid,
+		},
+		{
+			name: "environment remains immutable",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_two", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_policy"},
+			},
+			want: domain.ErrConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := adapterServiceDB(t)
+			if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_policy','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`); err != nil {
+				t.Fatal(err)
+			}
+			_, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
+			}, tt.keepRemote)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("ApplyTargetMutation() error = %v, want %v", err, tt.want)
+			}
+			var generation int64
+			if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT generation FROM adapter_targets WHERE id='tgt_one'`).Scan(&generation); err != nil {
+				t.Fatal(err)
+			}
+			if generation != 1 {
+				t.Fatalf("refused mutation changed generation to %d", generation)
+			}
+		})
+	}
+}
+
+func TestApplyTargetMutationRequiresCeremonyForUpdateAndMove(t *testing.T) {
+	tests := []struct {
+		name   string
+		target AdapterTargetInput
+	}{
+		{
+			name: "metadata widening",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "app", NamePrefix: "WIDER_", KeyIDs: []string{"key_ceremony"},
+			},
+		},
+		{
+			name: "destination move",
+			target: AdapterTargetInput{
+				EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme",
+				DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_ceremony"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := adapterServiceDB(t)
+			for _, statement := range []string{
+				`INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_ceremony_reveal_two','usr_adapter','reveal','org_adapter','prj_adapter','env_two','2026-08-17T00:00:00Z')`,
+				`INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_ceremony','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`,
+				`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) VALUES ('org_adapter','prj_adapter','env_one','tgt_one','adp_1','key_ceremony')`,
+			} {
+				if _, err := db.SQLiteWrite().ExecContext(t.Context(), statement); err != nil {
+					t.Fatal(err)
+				}
+			}
+			bearer := adapterCLISession(t, db)
+			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).ApplyTargetMutation(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
+			}, false)
+			if !errors.Is(err, ErrReauthRequired) {
+				t.Fatalf("ApplyTargetMutation() error = %v, want reauth required", err)
+			}
+			var generation, audits int
+			if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT generation FROM adapter_targets WHERE id='tgt_one'`).Scan(&generation); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM audit_tenant_events WHERE object_id='tgt_one' AND type='adapter.configure'`).Scan(&audits); err != nil {
+				t.Fatal(err)
+			}
+			if generation != 1 || audits != 0 {
+				t.Fatalf("refused ceremony generation=%d audits=%d", generation, audits)
+			}
+		})
+	}
+}
+
+func TestApplyTargetMutationConcurrentChangesUseLockedGeneration(t *testing.T) {
+	db := adapterServiceDB(t)
+	for _, statement := range []string{
+		`INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_concurrent_mutation_reveal_two','usr_adapter','reveal','org_adapter','prj_adapter','env_two','2026-08-17T00:00:00Z')`,
+		`INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_concurrent_mutation','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) VALUES ('org_adapter','prj_adapter','env_one','tgt_one','adp_1','key_concurrent_mutation')`,
+		`UPDATE adapters SET provider='github-actions' WHERE id='adp_1'`,
+		`UPDATE adapter_targets SET destination_kind='organization',destination_name='',visibility='all' WHERE id='tgt_one'`,
+	} {
+		if _, err := db.SQLiteWrite().ExecContext(t.Context(), statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root, err := crypto.GenerateRootKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("github_pat_fine"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
+		t.Fatal(err)
+	}
+	preflightStarted := make(chan struct{}, 1)
+	preflightProceed := make(chan struct{})
+	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: testModuleFactory(func(adapter.Provider, string, string) (adapter.Module, func(), error) {
+		return blockingRoutingPreflightModule{started: preflightStarted, proceed: preflightProceed}, nil, nil
+	})}
+	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	update := UpdateAdapterTargetRequest{
+		TargetID: "tgt_one", ExpectedGeneration: 1,
+		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "acme", Visibility: "selected", SelectedRepositoryIDs: []int64{11}, NamePrefix: "ONE_", KeyIDs: []string{"key_concurrent_mutation"}},
+	}
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := svc.ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), scope, update, false)
+		updateDone <- err
+	}()
+	<-preflightStarted
+
+	move, err := svc.ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), scope, UpdateAdapterTargetRequest{
+		TargetID: "tgt_one", ExpectedGeneration: 1,
+		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "next", Visibility: "all", NamePrefix: "ONE_", KeyIDs: []string{"key_concurrent_mutation"}},
+	}, false)
+	if err != nil {
+		close(preflightProceed)
+		t.Fatal(err)
+	}
+	if _, ok := move.(TargetMutationMoveStarted); !ok {
+		close(preflightProceed)
+		t.Fatalf("move result = %T", move)
+	}
+	close(preflightProceed)
+	if err := <-updateDone; !errors.Is(err, adapter.ErrSuperseded) {
+		t.Fatalf("stale update error = %v, want superseded", err)
 	}
 }
 
@@ -647,7 +917,7 @@ func TestAdapterTargetDestinationMoveScrubsOldRouteBeforePendingRouteActivation(
 		}
 	}
 	svc := &Adapters{DB: db}
-	result, err := svc.MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	result, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_move"}},
 	}, false)
@@ -708,7 +978,7 @@ func TestAdapterTargetDestinationMoveKeepRemoteReleasesBeforeActivation(t *testi
 			t.Fatal(err)
 		}
 	}
-	result, err := (&Adapters{DB: db}).MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	result, err := (&Adapters{DB: db}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_keep_move"}},
 	}, true)
@@ -754,7 +1024,7 @@ func TestAdapterTargetMoveScrubCompletionQueuesPendingRouteActivation(t *testing
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_scrub_move"}},
 	}, false)
@@ -802,7 +1072,7 @@ func TestAdapterTargetMoveDeadCredentialReleasesOldCustodyThenActivates(t *testi
 		}
 	}
 	now := time.Now().UTC()
-	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_dead_move"}},
 	}, false)
@@ -856,7 +1126,7 @@ func TestAdapterMoveCredentialFailureRequiresAttentionAndCancelReconvergesOldRou
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_attention"}},
 	}, true)
@@ -922,7 +1192,7 @@ func TestAdapterAttentionTargetReplacementResumesActivation(t *testing.T) {
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "bad", NamePrefix: "BAD_", KeyIDs: []string{"key_resume"}},
 	}, true)
@@ -989,7 +1259,7 @@ func TestAdapterTargetMoveActivationTestsPendingRouteThenEnqueuesConverge(t *tes
 		}
 	}
 	now := time.Now().UTC()
-	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).MoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "NEXT_", KeyIDs: []string{"key_activate_move"}},
 	}, true)
@@ -1261,7 +1531,7 @@ func TestAdapterTargetWidenRequiresRevealAcrossEveryAdapterEnvironment(t *testin
 		}
 	}
 	svc := &Adapters{DB: db}
-	_, err := svc.UpdateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{TargetID: "tgt_one", ExpectedGeneration: 1, Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_existing", "key_widened"}}})
+	_, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{TargetID: "tgt_one", ExpectedGeneration: 1, Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_existing", "key_widened"}}})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("UpdateTarget() error = %v, want tenant-safe refusal without env_two reveal", err)
 	}
@@ -1302,7 +1572,7 @@ func TestAdapterTargetInPlaceClassificationAndReplacementConverge(t *testing.T) 
 			t.Fatal(err)
 		}
 		bearer := adapterCLISession(t, db)
-		out, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).UpdateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+		out, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 			TargetID: "tgt_one", ExpectedGeneration: 1,
 			Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_update_a"}},
 		})
@@ -1349,7 +1619,7 @@ func TestAdapterTargetInPlaceClassificationAndReplacementConverge(t *testing.T) 
 				t.Fatal(err)
 			}
 			bearer := adapterCLISession(t, db)
-			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).UpdateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 				TargetID: "tgt_one", ExpectedGeneration: 1,
 				Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: tc.prefix, KeyIDs: tc.keys},
 			})
@@ -1382,7 +1652,7 @@ func TestAdapterFullTargetUpdateAuditsTransactionAuthorityTransition(t *testing.
 			t.Fatal(err)
 		}
 	}
-	out, err := (&Adapters{DB: db}).UpdateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	out, err := (&Adapters{DB: db}).updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_update_a", "key_update_b"}},
 	})


### PR DESCRIPTION
Closes #233

## Contract

- Adds one service-owned ApplyTargetMutation operation with closed Updated or MoveStarted results.
- Classifies destination identity changes inside the mutation write transaction; metadata-only changes stay updates.
- Keeps CLI browser reauthentication as the interactive transport pre-step while service authorization and ceremony checks remain authoritative.
- Preserves existing HTTP 200 update and 202 move responses. No OpenAPI or generated output changes.

## Coverage

- Deterministic concurrent-change test requires the stale request to return ErrSuperseded.
- CLI and API parity tables prove both variants submit one intent without a transport move boolean.
- Public-operation ceremony coverage verifies protected update and move refusal; existing scrub and audit suites route through the classifier.
- Two-axis Codex review: CLEAN in round 2.

## Validation

- go test -count=1 ./internal/service/... ./internal/server/... ./internal/cli/...
- go test -race -count=1 ./internal/service -run TestApplyTargetMutation
- go vet ./...
- go build ./...
- go test -p 4 -count=1 -timeout=20m ./...

All passed again after merging current main.