### PR TITLE
Centralize SPA route access and chrome policy #240

### DIFF
--- a/docs/handoff/240-route-policy-registry.md
+++ b/docs/handoff/240-route-policy-registry.md
@@ -1,0 +1,51 @@
+# Handoff: #240 explicit SPA route policy
+
+Parent #205, programme #203, frontend slice FE01-A.
+
+## Contract
+
+`web/src/app/navigation.ts` is now the single authoritative route registry.
+Every entry declares both its access mode and chrome mode through a closed
+discriminated union:
+
+| Access mode | Chrome | Anonymous behavior |
+|---|---|---|
+| `public` | `none` | Render the route |
+| `ceremony` + `establish-or-reuse` | `none` | Render login in place, preserving ceremony state |
+| `ceremony` + `required` | `none` | Follow the authenticated fallback to `/login` |
+| `authenticated` | `shell` | Follow the authenticated fallback to `/login` |
+
+The registry constructor rejects duplicate ids and paths, invalid access/chrome
+combinations, ceremony routes without an explicit session policy, and
+chromeless routes placed in sidebar navigation. `SurfaceId`, anonymous routes,
+shell routes, and signed-in chromeless routes are derived from this registry.
+The old manually maintained `SurfaceId`, `CHROMELESS_IDS`, and `CHROMELESS`
+lists are gone.
+
+## Migration
+
+- `/login` and `/workspace/callback` are public and chromeless.
+- `/reauth/cli` and `/workspace/approve` are chromeless establishment
+  ceremonies. They retain their state-bearing URL while login renders.
+- Every other current route is authenticated and renders in the shell.
+- Route URLs and component ownership are unchanged.
+
+The browser parity checks pin anonymous authenticated-route redirects, live
+session login redirects, and anonymous CLI/workspace ceremony behavior. During
+the mobile run, the existing shell scroll container failed the accessibility
+rule for keyboard-focusable scroll regions. Making `main#content` focusable
+also gives the skip link a valid target; the isolated dark/light reproductions
+and both exact CI-shaped browser projects pass with that campsite fix.
+
+## Generated outputs
+
+None. This slice changes handwritten TypeScript, tests, and this handoff only.
+
+## Validation
+
+- `pnpm --dir web exec vitest run src/app/navigation.test.ts e2e/registry.test.ts`: 22 passed.
+- `pnpm --dir web run typecheck`: passed.
+- `./scripts/ci/build-spa.sh --verify`: 24 files, 255 tests, typecheck, and production build passed.
+- Playwright desktop with a fresh fixture: 142 passed, 1 intentional skip.
+- Playwright mobile with a fresh fixture: 143 passed.
+

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -77,6 +77,14 @@ test.describe('login', () => {
     expect(await page.context().cookies()).toEqual([]);
   });
 
+  test('redirects an anonymous authenticated-route deep link to login', async ({ page }) => {
+    await page.goto('/projects');
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('heading', { name: 'Sign in to Hikyo' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Organisations' })).toHaveCount(0);
+  });
+
   test('signs in and establishes a browser session on cookies alone', async ({ page }) => {
     await page.goto('/login');
     await page.getByLabel('Username').fill(ADMIN.username);

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -63,6 +63,14 @@ test.describe('app chrome', () => {
     await expect(page.getByRole('heading', { name: 'Projects', level: 1 })).toBeVisible();
   });
 
+  test('redirects the public login route to overview with a live session', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole('navigation', { name: 'Organisations' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
+  });
+
   test('the binary toggle flips theme and keeps the choice explicit', async ({ page }) => {
     // The header control is a two-state sun/moon; `system` lives in the account
     // Preferences panel. Each click writes an explicit theme opposite the one

--- a/web/e2e/flows/workspace.spec.ts
+++ b/web/e2e/flows/workspace.spec.ts
@@ -69,6 +69,24 @@ function card(page: Page) {
 test.describe('multi-instance', () => {
   test.use({ storageState: STORAGE_STATE });
 
+  test('keeps anonymous ceremony URLs intact and outside shell chrome', async ({ page, context }) => {
+    await context.clearCookies();
+
+    for (const path of [
+      '/reauth/cli?transaction=hik_1_test',
+      '/workspace/approve?state=hik_1_test',
+    ]) {
+      await page.goto(path);
+      await expect(page).toHaveURL(new RegExp(`${path.replace('?', '\\?')}$`));
+      await expect(page.getByRole('heading', { name: 'Sign in to Hikyo' })).toBeVisible();
+      await expect(page.getByRole('navigation', { name: 'Organisations' })).toHaveCount(0);
+    }
+
+    await page.goto('/workspace/callback');
+    await expect(page.getByRole('heading', { name: 'Returning to your workspace' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Organisations' })).toHaveCount(0);
+  });
+
   test('the directory card carries state, identity and the last-known listing', async ({ page }) => {
     await page.goto('/remotes');
     const entry = card(page);

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -19,7 +19,12 @@ import { Values } from '../routes/Values.tsx';
 import { WorkspaceApprove } from '../routes/WorkspaceApprove.tsx';
 import { WorkspaceCallback } from '../routes/WorkspaceCallback.tsx';
 import { WorkspaceScope } from '../routes/WorkspaceScope.tsx';
-import { CHROMELESS, SURFACES, surfaceById, type Surface, type SurfaceId } from './navigation.ts';
+import {
+  allowsAnonymousSession,
+  SURFACES,
+  surfaceById,
+  type SurfaceId,
+} from './navigation.ts';
 import { ToastViewport } from './notifications.tsx';
 
 /**
@@ -70,15 +75,16 @@ const ELEMENTS: Record<SurfaceId, ReactElement> = {
 };
 
 /**
- * The surfaces that render inside the chrome and behind a session: everything
- * that is not chromeless. Complement of CHROMELESS rather than
- * `section !== null`, because `values` has no section and is still a chromed,
- * signed-in surface — see the note on CHROMELESS.
+ * Chrome and session access both come from the route registry. `section`
+ * remains navigation placement only: `values` has no sidebar section but is
+ * still an authenticated shell route.
  */
-const shellSurfaces: readonly Surface[] = SURFACES.filter((s) => !CHROMELESS.includes(s));
+const shellSurfaces = SURFACES.filter((surface) => surface.chrome === 'shell');
 
 /**
- * The chromeless surfaces reachable WITHOUT a session.
+ * Routes reachable WITHOUT a session. Public routes need no session;
+ * establishing ceremonies render Login in place so their state-bearing URL
+ * survives authentication.
  *
  * The approve page is here deliberately and it is the non-obvious one: a first
  * establishment lands in a popup carrying no cookies for this instance at all,
@@ -90,7 +96,12 @@ const shellSurfaces: readonly Surface[] = SURFACES.filter((s) => !CHROMELESS.inc
  * parameters and shouts them down a channel, and making that depend on a
  * session would break the one arc where the human has no session yet.
  */
-const publicSurfaces: readonly Surface[] = CHROMELESS;
+const anonymousSurfaces = SURFACES.filter(allowsAnonymousSession);
+
+/** Every non-login route that renders without shell chrome after sign-in. */
+const sessionChromelessSurfaces = SURFACES.filter(
+  (surface) => surface.chrome === 'none' && surface.id !== 'login',
+);
 
 /**
  * The application root.
@@ -129,7 +140,7 @@ export function App() {
     <BrowserRouter>
       {live === null ? (
         <Routes>
-          {publicSurfaces.map((surface) => (
+          {anonymousSurfaces.map((surface) => (
             <Route key={surface.id} path={surface.path} element={ELEMENTS[surface.id]} />
           ))}
           <Route path="*" element={<Navigate to={surfaceById('login').path} replace />} />
@@ -140,11 +151,9 @@ export function App() {
             path={surfaceById('login').path}
             element={<Navigate to={surfaceById('overview').path} replace />}
           />
-          {publicSurfaces
-            .filter((surface) => surface.id !== 'login')
-            .map((surface) => (
-              <Route key={surface.id} path={surface.path} element={ELEMENTS[surface.id]} />
-            ))}
+          {sessionChromelessSurfaces.map((surface) => (
+            <Route key={surface.id} path={surface.path} element={ELEMENTS[surface.id]} />
+          ))}
           <Route element={<Shell session={live} />}>
             {shellSurfaces.map((surface) => (
               <Route key={surface.id} path={surface.path} element={ELEMENTS[surface.id]} />

--- a/web/src/app/navigation.test.ts
+++ b/web/src/app/navigation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { allowsAnonymousSession, routeRegistryViolations, SURFACES } from './navigation.ts';
+
+describe('the route policy registry', () => {
+  it('gives every current route one explicit access and chrome policy', () => {
+    expect(SURFACES.map((surface) => `${surface.id}:${surface.mode}:${surface.chrome}`)).toEqual([
+      'login:public:none',
+      'overview:authenticated:shell',
+      'projects:authenticated:shell',
+      'remotes:authenticated:shell',
+      'members:authenticated:shell',
+      'org-settings:authenticated:shell',
+      'project-settings:authenticated:shell',
+      'instance-admin:authenticated:shell',
+      'settings:authenticated:shell',
+      'matrix:authenticated:shell',
+      'history:authenticated:shell',
+      'values:authenticated:shell',
+      'machine-access:authenticated:shell',
+      'cli-reauth:ceremony:none',
+      'workspace-approve:ceremony:none',
+      'workspace-callback:public:none',
+    ]);
+    expect(routeRegistryViolations(SURFACES)).toEqual([]);
+  });
+
+  it('makes only public and session-establishing ceremony routes anonymous-reachable', () => {
+    expect(SURFACES.filter(allowsAnonymousSession).map((surface) => surface.id)).toEqual([
+      'login',
+      'cli-reauth',
+      'workspace-approve',
+      'workspace-callback',
+    ]);
+    expect(
+      allowsAnonymousSession({
+        id: 'required-ceremony',
+        path: '/required-ceremony',
+        label: 'Required ceremony',
+        section: null,
+        mode: 'ceremony',
+        chrome: 'none',
+        session: 'required',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects public routes with shell chrome', () => {
+    expect(
+      routeRegistryViolations([
+        {
+          id: 'bad-public',
+          path: '/bad-public',
+          label: 'Bad public route',
+          section: null,
+          mode: 'public',
+          chrome: 'shell',
+        },
+      ]),
+    ).toContain('route "bad-public" is public but uses shell chrome');
+  });
+
+  it('rejects authenticated routes without shell chrome', () => {
+    expect(
+      routeRegistryViolations([
+        {
+          id: 'bad-authenticated',
+          path: '/bad-authenticated',
+          label: 'Bad authenticated route',
+          section: null,
+          mode: 'authenticated',
+          chrome: 'none',
+        },
+      ]),
+    ).toContain('route "bad-authenticated" is authenticated but has no shell chrome');
+  });
+
+  it('rejects ceremonies whose session behavior is absent or inconsistent', () => {
+    expect(
+      routeRegistryViolations([
+        {
+          id: 'missing-session-policy',
+          path: '/missing-session-policy',
+          label: 'Missing session policy',
+          section: null,
+          mode: 'ceremony',
+          chrome: 'none',
+        },
+        {
+          id: 'chromed-ceremony',
+          path: '/chromed-ceremony',
+          label: 'Chromed ceremony',
+          section: null,
+          mode: 'ceremony',
+          chrome: 'shell',
+          session: 'required',
+        },
+        {
+          id: 'public-session-policy',
+          path: '/public-session-policy',
+          label: 'Public session policy',
+          section: null,
+          mode: 'public',
+          chrome: 'none',
+          session: 'required',
+        },
+      ]),
+    ).toEqual([
+      'route "missing-session-policy" is a ceremony without an explicit session policy',
+      'route "chromed-ceremony" is a ceremony but uses shell chrome',
+      'route "public-session-policy" declares a ceremony session policy outside ceremony mode',
+    ]);
+  });
+
+  it('rejects duplicate route ids and paths', () => {
+    expect(
+      routeRegistryViolations([
+        {
+          id: 'duplicate',
+          path: '/duplicate',
+          label: 'First',
+          section: null,
+          mode: 'public',
+          chrome: 'none',
+        },
+        {
+          id: 'duplicate',
+          path: '/duplicate',
+          label: 'Second',
+          section: null,
+          mode: 'public',
+          chrome: 'none',
+        },
+      ]),
+    ).toEqual([
+      'route id "duplicate" is declared more than once',
+      'route path "/duplicate" is declared more than once',
+    ]);
+  });
+
+  it('rejects a chromeless route placed in shell navigation', () => {
+    expect(
+      routeRegistryViolations([
+        {
+          id: 'chromeless-navigation',
+          path: '/chromeless-navigation',
+          label: 'Chromeless navigation',
+          section: 'Account',
+          mode: 'public',
+          chrome: 'none',
+        },
+      ]),
+    ).toContain('route "chromeless-navigation" has no chrome but appears in section "Account"');
+  });
+});

--- a/web/src/app/navigation.ts
+++ b/web/src/app/navigation.ts
@@ -12,36 +12,138 @@
  * login page is reached by not being signed in, never by choosing it).
  */
 
-export type SurfaceId =
-  | 'login'
-  | 'overview'
-  | 'projects'
-  | 'members'
-  | 'org-settings'
-  | 'project-settings'
-  | 'instance-admin'
-  | 'settings'
-  | 'matrix'
-  | 'history'
-  | 'values'
-  | 'machine-access'
-  | 'remotes'
-  | 'cli-reauth'
-  | 'workspace-approve'
-  | 'workspace-callback';
+export type RouteMode = 'public' | 'ceremony' | 'authenticated';
+export type ChromeMode = 'none' | 'shell';
+export type CeremonySessionPolicy = 'establish-or-reuse' | 'required';
 
-export type Surface = {
-  readonly id: SurfaceId;
+type SurfaceBase = {
+  readonly id: string;
   readonly path: string;
   readonly label: string;
   readonly section: string | null;
 };
 
-export const SURFACES: readonly Surface[] = [
-  { id: 'login', path: '/login', label: 'Sign in', section: null },
-  { id: 'overview', path: '/', label: 'Overview', section: 'Organisation' },
-  { id: 'projects', path: '/projects', label: 'Projects', section: 'Organisation' },
-  { id: 'remotes', path: '/remotes', label: 'Remotes', section: 'Organisation' },
+export type RouteDefinition = SurfaceBase &
+  (
+    | { readonly mode: 'public'; readonly chrome: 'none' }
+    | {
+        readonly mode: 'ceremony';
+        readonly chrome: 'none';
+        readonly session: CeremonySessionPolicy;
+      }
+    | { readonly mode: 'authenticated'; readonly chrome: 'shell' }
+  );
+
+export type RouteCandidate = SurfaceBase & {
+  readonly mode: string;
+  readonly chrome: string;
+  readonly session?: string;
+};
+
+/** Returns every invalid or ambiguous route-policy declaration. */
+export function routeRegistryViolations(routes: readonly RouteCandidate[]): string[] {
+  const problems: string[] = [];
+  const ids = new Set<string>();
+  const paths = new Set<string>();
+
+  for (const route of routes) {
+    if (ids.has(route.id)) {
+      problems.push(`route id "${route.id}" is declared more than once`);
+    }
+    ids.add(route.id);
+    if (paths.has(route.path)) {
+      problems.push(`route path "${route.path}" is declared more than once`);
+    }
+    paths.add(route.path);
+
+    if (route.chrome === 'none' && route.section !== null) {
+      problems.push(
+        `route "${route.id}" has no chrome but appears in section "${route.section}"`,
+      );
+    }
+
+    switch (route.mode) {
+      case 'public':
+        if (route.chrome !== 'none') {
+          problems.push(`route "${route.id}" is public but uses shell chrome`);
+        }
+        if (route.session !== undefined) {
+          problems.push(
+            `route "${route.id}" declares a ceremony session policy outside ceremony mode`,
+          );
+        }
+        break;
+      case 'ceremony':
+        if (route.chrome !== 'none') {
+          problems.push(`route "${route.id}" is a ceremony but uses shell chrome`);
+        }
+        if (route.session !== 'establish-or-reuse' && route.session !== 'required') {
+          problems.push(
+            `route "${route.id}" is a ceremony without an explicit session policy`,
+          );
+        }
+        break;
+      case 'authenticated':
+        if (route.chrome !== 'shell') {
+          problems.push(`route "${route.id}" is authenticated but has no shell chrome`);
+        }
+        if (route.session !== undefined) {
+          problems.push(
+            `route "${route.id}" declares a ceremony session policy outside ceremony mode`,
+          );
+        }
+        break;
+      default:
+        problems.push(`route "${route.id}" has unknown access mode "${route.mode}"`);
+    }
+  }
+
+  return problems;
+}
+
+function defineSurfaceRegistry<const Routes extends readonly RouteDefinition[]>(
+  routes: Routes,
+): Routes {
+  const problems = routeRegistryViolations(routes);
+  if (problems.length !== 0) {
+    throw new Error(`invalid route registry:\n${problems.join('\n')}`);
+  }
+  return routes;
+}
+
+export const SURFACES = defineSurfaceRegistry([
+  {
+    id: 'login',
+    path: '/login',
+    label: 'Sign in',
+    section: null,
+    mode: 'public',
+    chrome: 'none',
+  },
+  {
+    id: 'overview',
+    path: '/',
+    label: 'Overview',
+    section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
+  {
+    id: 'projects',
+    path: '/projects',
+    label: 'Projects',
+    section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
+  {
+    id: 'remotes',
+    path: '/remotes',
+    label: 'Remotes',
+    section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
   // The two org-scoped chrome surfaces (#60). Their org is ROUTE DATA, not
   // chrome state: a members page and a settings page each administer ONE
   // organisation, and a path that did not name it would make a deep link, a
@@ -50,12 +152,21 @@ export const SURFACES: readonly Surface[] = [
   // is what fills the parameter, and the entry is absent while there is no
   // organisation to fill it with, which is the honest rendering of the
   // zero-organisation state rather than a link that resolves to nothing.
-  { id: 'members', path: '/orgs/:org/members', label: 'Members', section: 'Organisation' },
+  {
+    id: 'members',
+    path: '/orgs/:org/members',
+    label: 'Members',
+    section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
   {
     id: 'org-settings',
     path: '/orgs/:org/settings',
     label: 'Organisation settings',
     section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   // Project settings addresses ONE project, exactly like the matrix, so no
   // static sidebar entry could know which one to mean. It is reached from the
@@ -65,14 +176,25 @@ export const SURFACES: readonly Surface[] = [
     path: '/orgs/:org/projects/:project/settings',
     label: 'Project settings',
     section: null,
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   {
     id: 'instance-admin',
     path: '/instance',
     label: 'Instance administration',
     section: 'Instance',
+    mode: 'authenticated',
+    chrome: 'shell',
   },
-  { id: 'settings', path: '/settings', label: 'Account & security', section: 'Account' },
+  {
+    id: 'settings',
+    path: '/settings',
+    label: 'Account & security',
+    section: 'Account',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
   // The environment matrix addresses one whole project. Like the
   // environment-scoped value surface, its org and project are route data, so
   // no static sidebar destination can point at it honestly.
@@ -81,6 +203,8 @@ export const SURFACES: readonly Surface[] = [
     path: '/orgs/:org/projects/:project/matrix',
     label: 'Environment matrix',
     section: null,
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   // The revision-history drawer (#59). It is the matrix WITH its history drawer
   // open — the locked prototype's list+detail panes render over the matrix, not
@@ -93,6 +217,8 @@ export const SURFACES: readonly Surface[] = [
     path: '/orgs/:org/projects/:project/matrix/history',
     label: 'Revision history',
     section: null,
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   // The reveal / copy / write-only-edit surface (#58). `section: null` because
   // it is not a navigation destination: it addresses one environment of one
@@ -103,6 +229,8 @@ export const SURFACES: readonly Surface[] = [
     path: '/orgs/:org/projects/:project/environments/:environment/values',
     label: 'Values',
     section: null,
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   // The machine-access surface (#67). `section: null` for the same reason
   // `values` is: it addresses ONE project, and a static sidebar entry could not
@@ -114,13 +242,23 @@ export const SURFACES: readonly Surface[] = [
     path: '/orgs/:org/projects/:project/machine-access',
     label: 'Machine access',
     section: null,
+    mode: 'authenticated',
+    chrome: 'shell',
   },
   // Browser half of the CLI's purpose-bound reauthentication handoff. The
   // opaque transaction state stays in the query string so login can render on
   // this same route without losing it.
-  { id: 'cli-reauth', path: '/reauth/cli', label: 'Authorize CLI', section: null },
-  // The two ceremony pages. Neither is a navigation destination and neither
-  // wears the chrome: they are the two ends of the workspace handoff's front
+  {
+    id: 'cli-reauth',
+    path: '/reauth/cli',
+    label: 'Authorize CLI',
+    section: null,
+    mode: 'ceremony',
+    chrome: 'none',
+    session: 'establish-or-reuse',
+  },
+  // The two workspace handoff pages. Neither is a navigation destination and
+  // neither wears the chrome: they are the two ends of the handoff's front
   // channel, and both are reached by a redirect, never by choosing them.
   //
   // `workspace-approve` is served by the SERVING instance and is where the
@@ -129,9 +267,27 @@ export const SURFACES: readonly Surface[] = [
   // in one route. `workspace-callback` is served by the VIEWING instance and
   // is the same-origin return path that exists because the popup is opened
   // with `noopener` and therefore has no `window.opener` to talk back through.
-  { id: 'workspace-approve', path: '/workspace/approve', label: 'Authorize workspace', section: null },
-  { id: 'workspace-callback', path: '/workspace/callback', label: 'Returning', section: null },
-];
+  {
+    id: 'workspace-approve',
+    path: '/workspace/approve',
+    label: 'Authorize workspace',
+    section: null,
+    mode: 'ceremony',
+    chrome: 'none',
+    session: 'establish-or-reuse',
+  },
+  {
+    id: 'workspace-callback',
+    path: '/workspace/callback',
+    label: 'Returning',
+    section: null,
+    mode: 'public',
+    chrome: 'none',
+  },
+]);
+
+export type Surface = (typeof SURFACES)[number];
+export type SurfaceId = Surface['id'];
 
 type Section = {
   readonly title: string;
@@ -141,43 +297,26 @@ type Section = {
 /** SECTIONS is the sidebar, derived so it cannot drift from the surface list. */
 export const SECTIONS: readonly Section[] = Object.entries(
   SURFACES.filter((s) => s.section !== null).reduce<Record<string, Surface[]>>((acc, surface) => {
-    if (surface.section === null) {
-      throw new Error(`navigation surface ${surface.id} lost its section`);
-    }
     const key = surface.section;
     (acc[key] ??= []).push(surface);
     return acc;
   }, {}),
 ).map(([title, items]) => ({ title, items }));
 
-/**
- * CHROMELESS is every surface that renders WITHOUT the application chrome AND
- * without a session — the login page and the two workspace ceremony pages.
- *
- * DECLARED, not derived from `section === null`, and the counterexample is
- * `values`: it is not a navigation destination either (it addresses one
- * environment of one project, so it is reached from the matrix, never from a
- * static sidebar entry), yet it is a signed-in surface that wears the chrome
- * like any other. Deriving this set from `section` would have made the reveal
- * surface publicly routable the moment both tickets met — the two properties
- * look alike and are not the same property.
- *
- * A popup 520px wide showing an org rail would be chrome around a consent
- * decision, which is why the ceremony pages are here; and the approve page in
- * particular must render for a caller with NO session at all, or a first
- * establishment would be bounced to `/login` and lose the `state` the whole
- * transaction is addressed by.
- */
-const CHROMELESS_IDS: readonly SurfaceId[] = [
-  'login',
-  'cli-reauth',
-  'workspace-approve',
-  'workspace-callback',
-];
-
-export const CHROMELESS: readonly Surface[] = SURFACES.filter((s) =>
-  CHROMELESS_IDS.includes(s.id),
-);
+/** Whether a route may render before the SPA has a live session. */
+export function allowsAnonymousSession(surface: RouteDefinition): boolean {
+  switch (surface.mode) {
+    case 'public':
+      return true;
+    case 'ceremony':
+      // Establishing ceremonies render Login in place. This preserves their
+      // state-bearing URL; required-session ceremonies instead follow the
+      // ordinary anonymous fallback to /login.
+      return surface.session === 'establish-or-reuse';
+    case 'authenticated':
+      return false;
+  }
+}
 
 /**
  * needsOrg reports whether a surface's path carries the active organisation.

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -226,7 +226,10 @@ export function Shell({ session }: { session: WhoAmI }) {
             </span>
           </p>
         ) : null}
-        <main className="content" id="content" tabIndex={-1}>
+        {/* This is the app's scroll container. `tabIndex=0` both gives the skip
+            link a focus target and lets keyboard users operate the region when
+            its content overflows on a phone. */}
+        <main className="content" id="content" tabIndex={0}>
           <StepUpBanner session={session} />
           <Outlet context={{ activeOrgId }} />
         </main>


### PR DESCRIPTION
Closes #240

## Contract and migration

- Every SPA surface now declares one closed access mode and one compatible chrome mode in the authoritative registry.
- Ceremony routes explicitly declare whether they establish or require a session.
- App routing derives anonymous, signed-in chromeless, and shell partitions from that registry.
- Route URLs and component ownership are unchanged; the previous manual chromeless and SurfaceId lists are removed.

## Generated outputs

None.

## Validation

- Focused registry suites: 22 passed.
- Full SPA verifier: 24 files and 255 tests passed, plus typecheck and production build.
- Playwright desktop with fresh fixture: 142 passed, 1 intentional skip.
- Playwright mobile with fresh fixture: 143 passed.
- Standards review: no actionable findings.
- Spec review: no actionable findings.