### PR TITLE
Own root auth and session cache lifecycle #241

### DIFF
--- a/docs/handoff/issue-241-root-auth-cache.md
+++ b/docs/handoff/issue-241-root-auth-cache.md
@@ -1,0 +1,37 @@
+# Handoff: #241 root auth and session-owned browser cache
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/241 (parent #205; programme
+#203; audit ID `FE01-B`). Base: `4522f5f5fc7f30bcd79460f3ff11cb6352ec6e07`.
+
+## Contract
+
+- `AuthProvider` owns the exhaustive root states: checking, anonymous,
+  authenticated, and transitioning. An authenticated state's `sessionEpoch` is
+  the server-issued session id; principal and non-secret session metadata stay
+  in memory only.
+- Root `whoami` checks are deliberately outside TanStack. There is no public
+  cache: every root QueryClient entry belongs to one anonymous or authenticated
+  session epoch. New ids, logout, and expiry cancel old work, clear mutations,
+  and destroy every query before the new epoch renders. A same-id assurance
+  refresh preserves entries and invalidates their answers.
+- Login, passkey login, step-up, logout, account-security changes, membership
+  changes, and hierarchy/policy changes report session transitions to the root
+  owner. Operation-specific 401 responses do not cause global logout; only a
+  `whoami` 401 does. Mutation completions carry a root revision guard; a stale
+  completion suspends and reconciles the cookie-authoritative identity.
+- Tabs publish only the constant `session-changed` event over a
+  `BroadcastChannel`. Focus and the earliest server-reported idle/absolute
+  expiry recheck `whoami`. No token, principal, or session id enters the
+  channel, localStorage, or sessionStorage.
+
+## Coverage
+
+- `AuthProvider.test.tsx` pins replacement isolation against a deferred old
+  result, same-epoch cache preservation, expiry-to-anonymous reset, blocking
+  focus replacement, and stale-mutation reconciliation.
+- `shell.spec.ts` drives two tabs through one real browser-cookie login and
+  logout, proving both tabs leave the obsolete route/cache epoch.
+- Post-merge validation: 253 Vitest tests, TypeScript, production build, full
+  desktop browser run (135 unaffected passes plus repaired settings 20/20),
+  mobile shell 16/16, and mobile settings 20/20.
+- Generated outputs: none.

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -245,4 +245,24 @@ test.describe('sign out', () => {
     expect(names).not.toContain('__Host-hikyo');
     expect(names).not.toContain('__Host-hikyo-csrf');
   });
+
+  test('moves two tabs through one login and logout state machine', async ({ context, page }) => {
+    const other = await context.newPage();
+    await page.goto('/login');
+    await other.goto('/login');
+    await expect(other.getByRole('heading', { name: 'Sign in to Hikyo' })).toBeVisible();
+
+    await page.getByLabel('Username').fill(ADMIN.username);
+    await page.getByLabel('Password').fill(ADMIN.password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(page.getByRole('navigation', { name: 'Organisations' })).toBeVisible();
+    await expect(other.getByRole('navigation', { name: 'Organisations' })).toBeVisible();
+
+    await page.getByRole('button', { name: /^Account:/ }).click();
+    await page.getByRole('menuitem', { name: 'Sign out' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Sign in to Hikyo' })).toBeVisible();
+    await expect(other.getByRole('heading', { name: 'Sign in to Hikyo' })).toBeVisible();
+  });
 });

--- a/web/src/api/access.ts
+++ b/web/src/api/access.ts
@@ -19,6 +19,7 @@ import { zGrantList } from '@hikyo/zod';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import type { z } from 'zod';
 
+import { useAuth } from '../app/AuthProvider.tsx';
 import { ApiError, ok, parsed } from './client.ts';
 import type { Grant } from './identities.ts';
 
@@ -667,7 +668,7 @@ export function grantOutcomeSummary(results: readonly GrantOutcomeView[]): strin
  * shape #55 gave `access member remove`.
  */
 export function useCreateGrants() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: async (input: {
       scope: ScopeRef;
@@ -678,12 +679,12 @@ export function useCreateGrants() {
         createOne(input.scope, { principal: input.principal, capability }),
       );
     },
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useApplyTemplate() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { scope: ScopeRef; principal: string; template: string }) => {
       const body = { principal: input.principal, template: templateOf(input.template) };
@@ -708,7 +709,7 @@ export function useApplyTemplate() {
           return parsed(applyOrgTemplateOp, { path: { org: input.scope.org }, body });
       }
     },
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
@@ -729,7 +730,7 @@ function templateOf(
 }
 
 export function useRevokeGrant() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { grant: Grant }) => {
       const query = {
@@ -751,7 +752,7 @@ export function useRevokeGrant() {
           return ok(revokeInstanceGrantOp, { query });
       }
     },
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 

--- a/web/src/api/account.ts
+++ b/web/src/api/account.ts
@@ -23,6 +23,7 @@ import {
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import type { z } from 'zod';
 
+import { useAuth } from '../app/AuthProvider.tsx';
 import { ApiError, parsed } from './client.ts';
 import { fromBase64URL, toBase64URL } from './values.ts';
 
@@ -107,9 +108,9 @@ export function useAuthMethods(): UseQueryResult<AuthMethods> {
 
 /** invalidate everything: a reissued session invalidates every cached answer. */
 function useAfterAccountMutation(): () => void {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return () => {
-    void queries.invalidateQueries();
+    void auth.refreshSession();
   };
 }
 

--- a/web/src/api/session.ts
+++ b/web/src/api/session.ts
@@ -2,14 +2,14 @@ import {
   listMyOrgsOp,
   localLoginOp,
   logoutOp,
-  whoamiOp,
 } from '@hikyo/operations';
-import { zLoginResult, zMyOrgList, zWhoAmI } from '@hikyo/zod';
-import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { zLoginResult, zMyOrgList } from '@hikyo/zod';
+import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { z } from 'zod';
 
 import { ApiError, ok, parsed } from './client.ts';
 import { useTransport } from './transport.tsx';
+import { useAuth } from '../app/AuthProvider.tsx';
 
 /**
  * loginFailureText turns a login failure into something true.
@@ -36,35 +36,11 @@ export function loginFailureText(error: unknown): string {
   return 'Sign-in could not be completed: the server could not be reached, or it answered something this client does not understand.';
 }
 
-export type WhoAmI = z.infer<typeof zWhoAmI>;
+export type { WhoAmI } from '../app/AuthProvider.tsx';
 export type LoginResult = z.infer<typeof zLoginResult>;
 export type MyOrgList = z.infer<typeof zMyOrgList>;
 
-export const sessionKey = ['session'] as const;
 export const orgsKey = ['orgs'] as const;
-
-/**
- * useSession is the SPA's boot question: is there a live session behind the
- * cookie? A 401 is an ANSWER (no), not a failure, so it resolves to null
- * rather than throwing into an error boundary — the login page is the
- * rendering of that answer.
- */
-export function useSession(): UseQueryResult<WhoAmI | null> {
-  return useQuery({
-    queryKey: sessionKey,
-    queryFn: async () => {
-      try {
-        return await parsed(whoamiOp, {});
-      } catch (err) {
-        if (err instanceof ApiError && err.status === 401) {
-          return null;
-        }
-        throw err;
-      }
-    },
-    retry: false,
-  });
-}
 
 /**
  * useOrgs is the rail's data source: the organisations the caller's OWN grants
@@ -93,13 +69,14 @@ export function useOrgs(enabled: boolean): UseQueryResult<MyOrgList> {
 /**
  * useLogin asks for a BROWSER artifact explicitly. The server then delivers
  * the session token only on the HttpOnly cookie and its synchronizer token on
- * the readable companion — nothing lands in JavaScript's hands, which is why
- * the response body is discarded here and the session is re-read through
- * whoami.
+ * the readable companion — nothing replayable lands in JavaScript's hands.
+ * The parsed response lets the root auth owner bind its cache epoch to the
+ * returned session id without another request.
  */
 export function useLogin() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
+    onMutate: auth.captureTransition,
     mutationFn: async (input: { username: string; password: string }) => {
       // Parsed, not discarded. The session itself arrives on cookies, but the
       // response body is still contract-bearing — a server that answered a
@@ -117,19 +94,15 @@ export function useLogin() {
       }
       return result;
     },
-    onSuccess: () => queries.invalidateQueries(),
+    onSuccess: (identity, _input, guard) => auth.acceptSession(identity, guard),
   });
 }
 
 export function useLogout() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
+    onMutate: auth.captureTransition,
     mutationFn: () => ok(logoutOp, {}),
-    // The server clears both cookies; the client discards every cached
-    // answer, because every one of them was scoped to the session that just
-    // ended. `resetQueries`, not `clear`: clearing empties the cache but
-    // leaves mounted observers holding their last result, so the chrome would
-    // keep rendering a signed-out principal until something else refetched.
-    onSuccess: () => queries.resetQueries(),
+    onSuccess: (_result, _input, guard) => auth.endSession(guard),
   });
 }

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -39,6 +39,7 @@ import {
 import type { Client } from '@hikyo/runtime-core';
 import type { z } from 'zod';
 
+import { useAuth } from '../app/AuthProvider.tsx';
 import { ApiError, ok, parsed } from './client.ts';
 import type { EnvironmentNode, ProjectNode } from './access.ts';
 import { useTransport } from './transport.tsx';
@@ -390,7 +391,7 @@ export function useInstanceOrgs(): UseQueryResult<OrgList> {
 }
 
 export function useCreateOrg(onCreated?: (org: Org) => void) {
-  const queries = useQueryClient();
+  const auth = useAuth();
 	return useMutation({
 		mutationFn: (input: { name: string }) =>
 			parsed(createOrgOp, { body: { name: input.name } }),
@@ -398,43 +399,43 @@ export function useCreateOrg(onCreated?: (org: Org) => void) {
 		// success runs before query invalidation unmounts the caller; a per-call
 		// mutate callback is not guaranteed to run after that unmount.
 		onSuccess: onCreated,
-		onSettled: () => queries.invalidateQueries(),
+		onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useDeleteOrg(onDeleted?: () => void) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { org: string }) => ok(deleteOrgOp, { path: { org: input.org } }),
     onSuccess: onDeleted,
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useRenameOrg() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { org: string; name: string }) =>
       parsed(renameOrgOp, { path: { org: input.org }, body: { name: input.name } }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useRenameProject(org: string) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { project: string; name: string }) =>
       parsed(renameProjectOp, { path: { org, project: input.project }, body: { name: input.name } }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useDeleteProject(org: string) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: { project: string }) =>
       ok(deleteProjectOp, { path: { org, project: input.project } }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
@@ -541,7 +542,7 @@ export function useRotateTokenKey() {
 // --- environment policy -----------------------------------------------------
 
 export function useSetEnvironmentSettings(org: string, project: string) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: {
       environment: string;
@@ -555,23 +556,23 @@ export function useSetEnvironmentSettings(org: string, project: string) {
             reauth_window_seconds: input.reauthWindowSeconds,
           },
         }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 // --- retention --------------------------------------------------------------
 
 export function useSetOrgRetention(org: string) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (policy: RetentionPolicy) =>
       parsed(setOrgRetentionOp, { path: { org }, body: policy }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 
 export function useSetProjectRetention(org: string, project: string) {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
     mutationFn: (input: {
       inherited: boolean;
@@ -586,7 +587,7 @@ export function useSetProjectRetention(org: string, project: string) {
             last_revisions: input.lastRevisions,
           },
         }),
-    onSettled: () => queries.invalidateQueries(),
+    onSettled: () => auth.refreshSession(),
   });
 }
 

--- a/web/src/api/stepup.ts
+++ b/web/src/api/stepup.ts
@@ -5,8 +5,9 @@ import {
   stepUpPasskeyStartOp,
   stepUpTotpOp,
 } from '@hikyo/operations';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
+import { useAuth } from '../app/AuthProvider.tsx';
 import { ApiError, parsed } from './client.ts';
 import type { WhoAmI } from './session.ts';
 import { requestOptions, toBase64URL } from './values.ts';
@@ -59,8 +60,9 @@ export function stepUpFailureText(error: unknown): string {
  * each of them was computed under the assurance that just changed.
  */
 export function useStepUpTotp() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
+    onMutate: auth.captureTransition,
     mutationFn: async (code: string) => {
       const result = await parsed(stepUpTotpOp, { body: { code } });
       if (result.session.artifact === 'browser' && result.session_token !== undefined) {
@@ -68,14 +70,15 @@ export function useStepUpTotp() {
       }
       return result;
     },
-    onSuccess: () => queries.invalidateQueries(),
+    onSuccess: (identity, _code, guard) => auth.acceptSession(identity, guard),
   });
 }
 
 /** useStepUpPasskey elevates the acting session with a passkey assertion. */
 export function useStepUpPasskey() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
+    onMutate: auth.captureTransition,
     mutationFn: async () => {
       const options = await parsed(stepUpPasskeyStartOp, {});
       const body = await assert(options);
@@ -85,7 +88,7 @@ export function useStepUpPasskey() {
       }
       return result;
     },
-    onSuccess: () => queries.invalidateQueries(),
+    onSuccess: (identity, _input, guard) => auth.acceptSession(identity, guard),
   });
 }
 
@@ -95,8 +98,9 @@ export function useStepUpPasskey() {
  * assurance — no step-up follows.
  */
 export function usePasskeyLogin() {
-  const queries = useQueryClient();
+  const auth = useAuth();
   return useMutation({
+    onMutate: auth.captureTransition,
     mutationFn: async () => {
       const options = await parsed(passkeyLoginStartOp, {});
       const body = await assert(options);
@@ -106,7 +110,7 @@ export function usePasskeyLogin() {
       }
       return result;
     },
-    onSuccess: () => queries.invalidateQueries(),
+    onSuccess: (identity, _input, guard) => auth.acceptSession(identity, guard),
   });
 }
 

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 
-import { useSession } from '../api/session.ts';
 import { AccountSecurity } from '../routes/AccountSecurity.tsx';
 import { CLIReauth } from '../routes/CLIReauth.tsx';
 import { InstanceAdmin } from '../routes/InstanceAdmin.tsx';
@@ -21,6 +20,7 @@ import { WorkspaceCallback } from '../routes/WorkspaceCallback.tsx';
 import { WorkspaceScope } from '../routes/WorkspaceScope.tsx';
 import { CHROMELESS, SURFACES, surfaceById, type Surface, type SurfaceId } from './navigation.ts';
 import { ToastViewport } from './notifications.tsx';
+import { useAuth } from './AuthProvider.tsx';
 
 /**
  * ELEMENTS is what each locked surface renders.
@@ -95,21 +95,14 @@ const publicSurfaces: readonly Surface[] = CHROMELESS;
 /**
  * The application root.
  *
- * Two states, decided by one question asked once per load: `whoami` either
- * resolves a live session or answers 401. There is no third "maybe" state and
- * no optimistic render of the chrome — showing an org rail to someone who is
- * about to be bounced to the login page is a flash of somebody else's data.
+ * AuthProvider resolves and revalidates the one root identity. Checking and
+ * transitions render no chrome, so an old session cannot keep painting while
+ * its replacement is being bound to a fresh cache.
  */
 export function App() {
-  const session = useSession();
+  const auth = useAuth();
 
-  if (session.isPending) {
-    // Deliberately quiet: this resolves in one round trip against a local
-    // server, and a spinner that appears for 20ms is noise, not feedback.
-    return <><p className="login" role="status">Loading…</p><ToastViewport /></>;
-  }
-
-  if (session.isError) {
+  if (auth.failure !== null) {
     return <>
       <main className="login">
         <p className="alert" role="alert">
@@ -123,7 +116,21 @@ export function App() {
     </>;
   }
 
-  const live = session.data;
+  let live: typeof auth.identity = null;
+  switch (auth.state.status) {
+    case 'checking':
+    case 'transitioning':
+      // Deliberately quiet: this resolves in one round trip against a local
+      // server, and a spinner that appears for 20ms is noise, not feedback.
+      return <><p className="login" role="status">Loading…</p><ToastViewport /></>;
+    case 'anonymous':
+      break;
+    case 'authenticated':
+      live = auth.identity;
+      if (live === null) {
+        throw new Error('authenticated root state has no identity');
+      }
+  }
 
   return <>
     <BrowserRouter>

--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -1,0 +1,275 @@
+// @vitest-environment happy-dom
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { act, useState, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { AuthProvider, useAuth, type WhoAmI } from './AuthProvider.tsx';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = (_value) => {
+    throw new Error('deferred promise was resolved before construction');
+  };
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const id = (prefix: string, suffix: string) =>
+  `${prefix}_123e4567-e89b-12d3-a456-4266141740${suffix}`;
+
+function identity(
+  sessionSuffix: string,
+  principalSuffix: string,
+  factors = ['password'],
+): WhoAmI {
+  return {
+    session: {
+      id: id('ses', sessionSuffix),
+      artifact: 'browser',
+      created_at: '2026-08-22T10:00:00Z',
+      idle_expires_at: '2099-08-22T10:30:00Z',
+      absolute_expires_at: '2099-08-22T18:00:00Z',
+      assurance: {
+        method: 'local-password',
+        factors,
+        authenticated_at: '2026-08-22T10:00:00Z',
+      },
+    },
+    principal: {
+      id: id('prn', principalSuffix),
+      kind: 'human',
+      display_name: `Person ${principalSuffix}`,
+    },
+  };
+}
+
+function json(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function Probe({
+  oldResult,
+  mutationResult,
+}: {
+  oldResult?: Deferred<string>;
+  mutationResult?: Deferred<WhoAmI>;
+}) {
+  const auth = useAuth();
+  const queries = useQueryClient();
+  const [, renderMarker] = useState(0);
+  const epoch = auth.state.status === 'authenticated' ? auth.state.sessionEpoch : '';
+  const privateQuery = useQuery({
+    queryKey: ['private'],
+    queryFn: () =>
+      epoch.endsWith('00') && oldResult !== undefined
+        ? oldResult.promise
+        : Promise.resolve(`fresh:${epoch}`),
+    enabled: epoch !== '',
+    retry: false,
+  });
+
+  return (
+    <>
+      <output data-testid="state">
+        {auth.state.status}
+        {epoch === '' ? '' : `:${epoch}`}
+      </output>
+      <output data-testid="private">
+        {auth.state.status === 'authenticated' ? (privateQuery.data ?? '') : ''}
+      </output>
+      <output data-testid="marker">{String(queries.getQueryData(['marker']) ?? '')}</output>
+      <button type="button" onClick={() => void auth.revalidate()}>
+        Revalidate
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          queries.setQueryData(['marker'], 'owned');
+          renderMarker((value) => value + 1);
+        }}
+      >
+        Mark cache
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const guard = auth.captureTransition();
+          void mutationResult?.promise.then((result) => auth.acceptSession(result, guard));
+        }}
+      >
+        Start mutation
+      </button>
+    </>
+  );
+}
+
+function text(container: HTMLElement, testId: string): string {
+  return container.querySelector(`[data-testid="${testId}"]`)?.textContent ?? '';
+}
+
+const unmounts: Array<() => Promise<void>> = [];
+
+async function renderAuth(node: ReactNode) {
+  const rendered = await renderForm(node);
+  unmounts.push(rendered.unmount);
+  return rendered;
+}
+
+afterEach(async () => {
+  await Promise.all(unmounts.splice(0).map((unmount) => unmount()));
+  vi.unstubAllGlobals();
+});
+
+describe('AuthProvider', () => {
+  it('drops deferred results from the previous session before rendering a replacement', async () => {
+    const oldResult = deferred<string>();
+    const replacement = deferred<Response>();
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(identity('00', '10')))
+      .mockReturnValueOnce(replacement.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe oldResult={oldResult} />
+      </AuthProvider>,
+    );
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[1]?.click());
+    expect(text(container, 'marker')).toBe('owned');
+    await act(async () => buttons[0]?.click());
+    expect(text(container, 'state')).toBe('transitioning');
+    expect(text(container, 'private')).toBe('');
+
+    await act(async () => replacement.resolve(json(identity('01', '11'))));
+    await settle(30);
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
+    expect(text(container, 'marker')).toBe('');
+
+    oldResult.resolve('old-session-secret');
+    await settle();
+    expect(container.textContent).not.toContain('old-session-secret');
+  });
+
+  it('preserves the session cache for a same-epoch assurance refresh', async () => {
+    const current = identity('00', '10');
+    const elevated = identity('00', '10', ['password', 'totp']);
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(current))
+      .mockResolvedValueOnce(json(elevated));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle();
+
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[1]?.click());
+    expect(text(container, 'marker')).toBe('owned');
+    await act(async () => buttons[0]?.click());
+    await settle();
+
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+    expect(text(container, 'marker')).toBe('owned');
+  });
+
+  it('moves an expired session to anonymous and discards its cache', async () => {
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(identity('00', '10')))
+      .mockResolvedValueOnce(json({ error: { code: 'unauthenticated', message: 'no session' } }, 401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle();
+
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[1]?.click());
+    await act(async () => buttons[0]?.click());
+    await settle();
+
+    expect(text(container, 'state')).toBe('anonymous');
+    expect(text(container, 'marker')).toBe('');
+  });
+
+  it('suspends authenticated routes while focus discovers a replacement session', async () => {
+    const replacement = deferred<Response>();
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(identity('00', '10')))
+      .mockReturnValueOnce(replacement.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle(30);
+    expect(text(container, 'private')).toContain(id('ses', '00'));
+
+    await act(async () => globalThis.dispatchEvent(new Event('focus')));
+    expect(text(container, 'state')).toBe('transitioning');
+    expect(text(container, 'private')).toBe('');
+
+    await act(async () => replacement.resolve(json(identity('01', '11'))));
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
+  });
+
+  it('ignores a mutation result captured before a newer session replacement', async () => {
+    const mutationResult = deferred<WhoAmI>();
+    const authoritativeIdentity = deferred<Response>();
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(identity('00', '10')))
+      .mockResolvedValueOnce(json(identity('01', '11')))
+      .mockReturnValueOnce(authoritativeIdentity.promise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe mutationResult={mutationResult} />
+      </AuthProvider>,
+    );
+    await settle();
+
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[2]?.click());
+    await act(async () => buttons[0]?.click());
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
+
+    await act(async () => mutationResult.resolve(identity('02', '12')));
+    expect(text(container, 'state')).toBe('transitioning');
+    expect(container.textContent).not.toContain(id('ses', '02'));
+
+    await act(async () => authoritativeIdentity.resolve(json(identity('01', '11'))));
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
+    expect(container.textContent).not.toContain(id('ses', '02'));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/src/app/AuthProvider.tsx
+++ b/web/src/app/AuthProvider.tsx
@@ -1,0 +1,336 @@
+import { whoamiOp } from '@hikyo/operations';
+import { zWhoAmI } from '@hikyo/zod';
+import { QueryClientProvider } from '@tanstack/react-query';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { z } from 'zod';
+
+import { ApiError, parsed } from '../api/client.ts';
+import { makeQueryClient } from './queryClient.ts';
+
+export type WhoAmI = z.infer<typeof zWhoAmI>;
+
+export type AuthState =
+  | { readonly status: 'checking' }
+  | { readonly status: 'anonymous' }
+  | {
+      readonly status: 'authenticated';
+      readonly sessionEpoch: string;
+      readonly principal: WhoAmI['principal'];
+    }
+  | { readonly status: 'transitioning' };
+
+type AuthContextValue = {
+  readonly state: AuthState;
+  readonly identity: WhoAmI | null;
+  readonly failure: Error | null;
+  readonly captureTransition: () => SessionTransitionGuard;
+  readonly acceptSession: (identity: WhoAmI, guard: SessionTransitionGuard) => void;
+  readonly endSession: (guard: SessionTransitionGuard) => void;
+  readonly refreshSession: () => Promise<void>;
+  readonly revalidate: () => Promise<void>;
+};
+
+type SessionTransitionGuard = {
+  readonly revision: number;
+};
+
+type SessionCheckMode = 'blocking' | 'blocking-and-publish' | 'refresh-and-publish';
+
+type Snapshot = {
+  readonly state: AuthState;
+  readonly identity: WhoAmI | null;
+  readonly failure: Error | null;
+  readonly queries: ReturnType<typeof makeQueryClient>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+const CHANNEL_NAME = 'hikyo-root-auth';
+const CHANNEL_MESSAGE = 'session-changed';
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+/** Read root identity without putting it in a session-owned query cache. */
+async function readIdentity(): Promise<WhoAmI | null> {
+  try {
+    return await parsed(whoamiOp, {});
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function stateFor(identity: WhoAmI | null): AuthState {
+  return identity === null
+    ? { status: 'anonymous' }
+    : {
+        status: 'authenticated',
+        sessionEpoch: identity.session.id,
+        principal: identity.principal,
+      };
+}
+
+function identityVersion(identity: WhoAmI | null): string | null {
+  if (identity === null) {
+    return null;
+  }
+  return [
+    identity.session.id,
+    identity.principal.id,
+    identity.session.assurance.method,
+    identity.session.assurance.authenticated_at,
+    ...identity.session.assurance.factors,
+  ].join('\u001f');
+}
+
+/**
+ * AuthProvider is the one owner of root identity and local-instance cache
+ * lifetime.
+ *
+ * There is deliberately no public QueryClient. Root `whoami` checks are
+ * uncached, and every TanStack entry below this provider belongs to exactly one
+ * browser session epoch (or to the anonymous pre-session epoch). A new session
+ * id, logout, or expiry cancels old work and destroys every cached query and
+ * mutation before the new epoch renders. A same-id assurance refresh preserves
+ * entries and invalidates their answers for re-evaluation.
+ */
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [snapshot, setSnapshot] = useState<Snapshot>(() => ({
+    state: { status: 'checking' },
+    identity: null,
+    failure: null,
+    queries: makeQueryClient(),
+  }));
+  const snapshotRef = useRef(snapshot);
+  const requestRef = useRef(0);
+  const transitionRevisionRef = useRef(0);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  const commit = useCallback((next: Snapshot) => {
+    snapshotRef.current = next;
+    setSnapshot(next);
+  }, []);
+
+  const destroySessionCache = useCallback((current: Snapshot): Snapshot => {
+    void current.queries.cancelQueries();
+    current.queries.clear();
+    return current;
+  }, []);
+
+  const publishChange = useCallback(() => {
+    channelRef.current?.postMessage(CHANNEL_MESSAGE);
+  }, []);
+
+  const settleIdentity = useCallback(
+    (identity: WhoAmI | null, publish: boolean) => {
+      const current = snapshotRef.current;
+      const sameSession =
+        identity !== null &&
+        current.identity !== null &&
+        identity.session.id === current.identity.session.id;
+      if (identityVersion(identity) !== identityVersion(current.identity)) {
+        transitionRevisionRef.current += 1;
+      }
+
+      if (sameSession) {
+        commit({
+          ...current,
+          state: stateFor(identity),
+          identity,
+          failure: null,
+        });
+        void current.queries.invalidateQueries();
+      } else {
+        const fresh = destroySessionCache(current);
+        commit({
+          ...fresh,
+          state: stateFor(identity),
+          identity,
+          failure: null,
+        });
+      }
+      if (publish) {
+        publishChange();
+      }
+    },
+    [commit, destroySessionCache, publishChange],
+  );
+
+  const checkSession = useCallback(
+    async (mode: SessionCheckMode) => {
+      const blocking = mode !== 'refresh-and-publish';
+      const request = requestRef.current + 1;
+      requestRef.current = request;
+      const current = snapshotRef.current;
+      if (blocking) {
+        commit({
+          ...current,
+          state:
+            current.identity === null ? { status: 'checking' } : { status: 'transitioning' },
+          failure: null,
+        });
+      }
+      try {
+        const identity = await readIdentity();
+        if (requestRef.current === request) {
+          settleIdentity(identity, mode !== 'blocking');
+        }
+      } catch (error) {
+        if (requestRef.current === request) {
+          const latest = snapshotRef.current;
+          commit({
+            ...latest,
+            state: blocking ? stateFor(latest.identity) : latest.state,
+            failure: error instanceof Error ? error : new Error('root authentication check failed'),
+          });
+        }
+      }
+    },
+    [commit, settleIdentity],
+  );
+
+  const revalidate = useCallback(() => checkSession('blocking'), [checkSession]);
+  const refreshSession = useCallback(
+    () => {
+      // Operation completion must stale the affected session answers now, not
+      // one identity round-trip later. The root still owns that broad
+      // invalidation and the subsequent whoami check remains the only place an
+      // operation-adjacent 401 can end the browser session.
+      void snapshotRef.current.queries.invalidateQueries();
+      return checkSession('refresh-and-publish');
+    },
+    [checkSession],
+  );
+  const reconcileTransition = useCallback(
+    () => checkSession('blocking-and-publish'),
+    [checkSession],
+  );
+
+  const captureTransition = useCallback(
+    (): SessionTransitionGuard => ({ revision: transitionRevisionRef.current }),
+    [],
+  );
+
+  const acceptSession = useCallback(
+    (identity: WhoAmI, guard: SessionTransitionGuard) => {
+      if (guard.revision !== transitionRevisionRef.current) {
+        void reconcileTransition();
+        return;
+      }
+      transitionRevisionRef.current += 1;
+      const request = requestRef.current + 1;
+      requestRef.current = request;
+      const current = snapshotRef.current;
+      commit({ ...current, state: { status: 'transitioning' }, failure: null });
+      queueMicrotask(() => {
+        if (requestRef.current === request) {
+          settleIdentity(identity, true);
+        }
+      });
+    },
+    [commit, reconcileTransition, settleIdentity],
+  );
+
+  const endSession = useCallback(
+    (guard: SessionTransitionGuard) => {
+      if (guard.revision !== transitionRevisionRef.current) {
+        void reconcileTransition();
+        return;
+      }
+      transitionRevisionRef.current += 1;
+      const request = requestRef.current + 1;
+      requestRef.current = request;
+      const current = snapshotRef.current;
+      commit({ ...current, state: { status: 'transitioning' }, failure: null });
+      queueMicrotask(() => {
+        if (requestRef.current === request) {
+          settleIdentity(null, true);
+        }
+      });
+    },
+    [commit, reconcileTransition, settleIdentity],
+  );
+
+  useEffect(() => {
+    void revalidate();
+  }, [revalidate]);
+
+  useEffect(
+    () => () => {
+      const current = snapshotRef.current;
+      void current.queries.cancelQueries();
+      current.queries.clear();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (typeof BroadcastChannel !== 'function') {
+      return;
+    }
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+    channel.addEventListener('message', (event) => {
+      if (event.data === CHANNEL_MESSAGE) {
+        void revalidate();
+      }
+    });
+    return () => {
+      channelRef.current = null;
+      channel.close();
+    };
+  }, [revalidate]);
+
+  useEffect(() => {
+    const onFocus = () => void revalidate();
+    globalThis.addEventListener?.('focus', onFocus);
+    return () => globalThis.removeEventListener?.('focus', onFocus);
+  }, [revalidate]);
+
+  useEffect(() => {
+    if (snapshot.state.status !== 'authenticated' || snapshot.identity === null) {
+      return;
+    }
+    const idle = Date.parse(snapshot.identity.session.idle_expires_at);
+    const absolute = Date.parse(snapshot.identity.session.absolute_expires_at);
+    const expiresAt = Math.min(idle, absolute);
+    const delay = Number.isFinite(expiresAt)
+      ? Math.min(MAX_TIMEOUT_MS, Math.max(1_000, expiresAt - Date.now()))
+      : 1_000;
+    const timer = setTimeout(() => void revalidate(), delay);
+    return () => clearTimeout(timer);
+  }, [revalidate, snapshot.identity, snapshot.state.status]);
+
+  const value = {
+    state: snapshot.state,
+    identity: snapshot.identity,
+    failure: snapshot.failure,
+    captureTransition,
+    acceptSession,
+    endSession,
+    refreshSession,
+    revalidate,
+  };
+
+  return (
+    <QueryClientProvider client={snapshot.queries}>
+      <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const value = useContext(AuthContext);
+  if (value === null) {
+    throw new Error('useAuth must be rendered under AuthProvider');
+  }
+  return value;
+}

--- a/web/src/app/queryClient.ts
+++ b/web/src/app/queryClient.ts
@@ -3,12 +3,12 @@ import { QueryClient } from '@tanstack/react-query';
 /**
  * makeQueryClient builds the app's TanStack client with ONE set of defaults.
  *
- * There is more than one client in this app: the root client the SPA uses for
- * its own instance, and a fresh client per open workspace (#71) so a remote's
- * cache is structurally isolated and dies with the subtree — same-named
- * org/project on two instances can never collide because the caches are
- * different objects, not merely different keys. Both must behave identically,
- * so the defaults live here rather than being written twice.
+ * There is more than one client in this app: AuthProvider owns and resets the
+ * local root client, destroying all of its entries at each browser-session
+ * epoch, and each open workspace gets another (#71). Both boundaries are
+ * structural: cache contents die with their owning session, so same-named data
+ * from different sessions or instances cannot collide merely because a query
+ * key was reused. Their defaults live here once.
  *
  * The choices are the architecture's, not taste:
  *

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,12 +4,11 @@ import '@fontsource/ibm-plex-mono/500.css';
 import './styles/tokens.css';
 import './styles/app.css';
 
-import { QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './app/App.tsx';
-import { makeQueryClient } from './app/queryClient.ts';
+import { AuthProvider } from './app/AuthProvider.tsx';
 import { initTheme } from './app/theme.ts';
 
 // Paint the stored theme choice before first render, so a reload lands on it
@@ -21,8 +20,6 @@ initTheme();
 // relaxation and unsolicited egress the threat model's telemetry stance
 // forbids by default.
 
-const queries = makeQueryClient();
-
 const host = document.getElementById('root');
 if (host === null) {
   // Fail loud: a missing mount point means the document the server served is
@@ -32,8 +29,8 @@ if (host === null) {
 
 createRoot(host).render(
   <StrictMode>
-    <QueryClientProvider client={queries}>
+    <AuthProvider>
       <App />
-    </QueryClientProvider>
+    </AuthProvider>
   </StrictMode>,
 );

--- a/web/src/routes/AccountSecurity.tsx
+++ b/web/src/routes/AccountSecurity.tsx
@@ -17,7 +17,7 @@ import {
   useUnlinkIdentity,
 } from '../api/account.ts';
 import { useRevokeSession, useSessions, type ActiveSession } from '../api/remotes.ts';
-import { useSession } from '../api/session.ts';
+import { useAuth } from '../app/AuthProvider.tsx';
 import { themeLabel, useThemeChoice, type ThemeChoice } from '../app/theme.ts';
 import { clearNotification, notifyFailure } from '../app/notifications.tsx';
 import { Alert, Done, JumpIndex, Panel } from './Sections.tsx';
@@ -51,7 +51,7 @@ import { useFeedback, useModalDialog } from './useModalDialog.ts';
  *    that security alerts are not disableable — so there is nothing to offer.
  */
 export function AccountSecurity() {
-  const session = useSession();
+  const auth = useAuth();
   const passkeys = usePasskeys();
   const totpStatus = useTotpStatus();
   const identities = useIdentities();
@@ -168,8 +168,8 @@ export function AccountSecurity() {
     }
   };
 
-  const principal = session.data?.principal;
-  const assurance = session.data?.session.assurance;
+  const principal = auth.identity?.principal;
+  const assurance = auth.identity?.session.assurance;
 
   return (
     <div className="page">

--- a/web/src/routes/CLIReauth.tsx
+++ b/web/src/routes/CLIReauth.tsx
@@ -7,7 +7,7 @@ import {
   loadCLIReauthTransaction,
 } from '../api/cliReauth.ts';
 import { useTotpStatus } from '../api/account.ts';
-import { useSession } from '../api/session.ts';
+import { useAuth } from '../app/AuthProvider.tsx';
 import {
   runAdapterPasskeyCeremony,
   runAdapterTOTPCeremony,
@@ -18,7 +18,7 @@ import { Login } from './Login.tsx';
 
 /** Browser half of the CLI's state + PKCE reauthentication handoff. */
 export function CLIReauth() {
-  const session = useSession();
+  const auth = useAuth();
   const [state] = useState(
     () => new URLSearchParams(globalThis.location.search).get('transaction') ?? '',
   );
@@ -27,7 +27,7 @@ export function CLIReauth() {
   const transaction = useQuery({
     queryKey: ['cli-reauth', state] as const,
     queryFn: () => loadCLIReauthTransaction(state),
-    enabled: state !== '' && session.data !== null,
+    enabled: state !== '' && auth.state.status === 'authenticated',
     retry: false,
   });
   const approve = useMutation({
@@ -79,10 +79,10 @@ export function CLIReauth() {
   if (state === '') {
     return <CLIReauthMessage title="Nothing to authorize" text="This page has no CLI transaction. Return to the terminal and start again." />;
   }
-  if (session.isPending) {
+  if (auth.state.status === 'checking' || auth.state.status === 'transitioning') {
     return <p className="login" role="status">Loading…</p>;
   }
-  if (session.isSuccess && session.data === null) {
+  if (auth.state.status === 'anonymous') {
     return <Login />;
   }
 

--- a/web/src/routes/Members.tsx
+++ b/web/src/routes/Members.tsx
@@ -27,8 +27,8 @@ import {
   type ScopeOption,
 } from '../api/access.ts';
 import type { Grant } from '../api/identities.ts';
-import { useSession } from '../api/session.ts';
 import { useOrg, useOrgTopology } from '../api/settings.ts';
+import { useAuth } from '../app/AuthProvider.tsx';
 import { Alert, Done, Explain, JumpIndex, Panel } from './Sections.tsx';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
 
@@ -55,7 +55,7 @@ export function Members() {
   const orgQuery = useOrg(org);
   const grants = useOrgGrants(org);
   const topology = useOrgTopology(org);
-  const session = useSession();
+  const auth = useAuth();
   const revoke = useRevokeGrant();
   const feedback = useFeedback(grantFailureText);
   const [modal, setModal] = useState<'none' | 'grant' | 'blast'>('none');
@@ -71,7 +71,7 @@ export function Members() {
       topology.projects.flatMap((p) => p.environments).find((e) => e.id === id)?.name ?? id,
   };
   const rows = membershipRows(lines, names);
-  const me = session.data === undefined || session.data === null ? '' : session.data.principal.id;
+  const me = auth.identity?.principal.id ?? '';
 
   const [draft, setDraft] = useState<GrantDraft>({
     principal: '',

--- a/web/src/routes/OrgSettings.tsx
+++ b/web/src/routes/OrgSettings.tsx
@@ -124,7 +124,12 @@ export function OrgSettings() {
         </dl>
         <div className="field">
           <label htmlFor={nameId}>Name</label>
-          <input id={nameId} value={name} onChange={(event) => setName(event.target.value)} />
+          <input
+            id={nameId}
+            value={name}
+            disabled={current === undefined}
+            onChange={(event) => setName(event.target.value)}
+          />
           <p className="field__hint">
             Renaming an organisation is instance-operator work: the permission model has no
             org-lifecycle capability, so an organisation administrator is refused here with the same

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -126,7 +126,12 @@ export function ProjectSettings() {
         </dl>
         <div className="field">
           <label htmlFor={nameId}>Name</label>
-          <input id={nameId} value={name} onChange={(event) => setName(event.target.value)} />
+          <input
+            id={nameId}
+            value={name}
+            disabled={current === undefined}
+            onChange={(event) => setName(event.target.value)}
+          />
         </div>
         <div className="panel__actions">
           <button

--- a/web/src/routes/Sections.tsx
+++ b/web/src/routes/Sections.tsx
@@ -123,6 +123,7 @@ export function TypedNameConfirm({
         <input
           id={id}
           value={typed}
+          disabled={expect === null}
           autoComplete="off"
           spellCheck={false}
           placeholder={expect === null ? undefined : expect}

--- a/web/src/routes/WorkspaceApprove.tsx
+++ b/web/src/routes/WorkspaceApprove.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState, type FormEvent } from 'react';
 
 import { parsed } from '../api/client.ts';
-import { useSession } from '../api/session.ts';
+import { useAuth } from '../app/AuthProvider.tsx';
 import { ceremonyRefusalText, runPasskeyCeremony, runTOTPCeremony } from '../api/values.ts';
 import { Login } from './Login.tsx';
 
@@ -46,7 +46,7 @@ import { Login } from './Login.tsx';
  *     open redirector with a fresh authorization code attached.
  */
 export function WorkspaceApprove() {
-  const session = useSession();
+  const auth = useAuth();
   const [query] = useState(() => new URLSearchParams(globalThis.location.search));
   const state = query.get('state') ?? '';
   const isStepUp = query.get('purpose') === 'step-up';
@@ -60,7 +60,7 @@ export function WorkspaceApprove() {
   const transaction = useQuery({
     queryKey: ['workspace-handoff', state],
     queryFn: () => parsed(showWorkspaceHandoffOp, { path: { state } }),
-    enabled: isStepUp && state !== '' && session.data != null,
+    enabled: isStepUp && state !== '' && auth.state.status === 'authenticated',
     retry: false,
   });
 
@@ -95,7 +95,7 @@ export function WorkspaceApprove() {
     );
   }
 
-  if (session.isPending) {
+  if (auth.state.status === 'checking' || auth.state.status === 'transitioning') {
     return (
       <p className="login" role="status">
         Loading…
@@ -105,11 +105,11 @@ export function WorkspaceApprove() {
 
   // No session on THIS instance: authenticate here, on this origin, with this
   // instance's own ceremonies. The URL — and with it the state — survives.
-  if (session.isSuccess && session.data === null) {
+  if (auth.state.status === 'anonymous') {
     return <Login />;
   }
 
-  const name = session.data?.principal.display_name ?? session.data?.principal.id ?? '';
+  const name = auth.identity?.principal.display_name ?? auth.identity?.principal.id ?? '';
 
   return (
     <main className="login">

--- a/web/src/testkit/renderForm.tsx
+++ b/web/src/testkit/renderForm.tsx
@@ -12,7 +12,11 @@ import { createRoot } from 'react-dom/client';
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 /** Mount a node under a fresh, retry-free QueryClient in the happy-dom document. */
-export async function renderForm(node: ReactNode): Promise<{ container: HTMLElement; client: QueryClient }> {
+export async function renderForm(node: ReactNode): Promise<{
+  container: HTMLElement;
+  client: QueryClient;
+  unmount: () => Promise<void>;
+}> {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const client = new QueryClient({
@@ -22,7 +26,14 @@ export async function renderForm(node: ReactNode): Promise<{ container: HTMLElem
   await act(async () => {
     root.render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
   });
-  return { container, client };
+  return {
+    container,
+    client,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
 }
 
 /** Write a controlled input's value the way React's synthetic onChange observes. */


### PR DESCRIPTION
Closes #241

## Summary
- make AuthProvider the exhaustive owner of root auth state and session-owned query lifetime
- destroy old-session cache entries, fence stale auth mutations, and reconcile cookie-authoritative transitions
- synchronize login, logout, expiry, replacement, focus, and cross-tab transitions without durable client secrets
- harden pending route identity and destructive confirmation races

## Validation
- 260 Vitest tests
- TypeScript typecheck
- production Vite build
- shell browser flows: 34/34 desktop + mobile
- settings browser flows: 20/20 desktop and 20/20 mobile
- two-axis code review clean after fixes