### PR TITLE
Return environment-keyed matrix rows #243

### DIFF
--- a/docs/handoff/243-environment-keyed-matrix-rows.md
+++ b/docs/handoff/243-environment-keyed-matrix-rows.md
@@ -1,0 +1,39 @@
+# Issue #243: environment-keyed matrix rows
+
+## Contract
+
+`useMatrixProject` returns one ordered `environmentRows` collection. Each row
+embeds its `environmentId`, environment metadata, and the values, signals,
+settings, and pending-draft query states for that same ID. Server environment
+order remains the explicit display order; independently updating query families
+are joined by ID and duplicate or missing identities fail loudly.
+
+The route and row editor consume keyed rows. They no longer correlate a
+separate environment list with positional query arrays. The existing project
+owner still issues three project queries plus four query families per
+environment; no per-row hook or mutation owner was added.
+
+## What changed
+
+- Added the keyed row DTO and ID-based query-family assembler at the matrix API
+  boundary.
+- Migrated matrix rendering, pending/revision/protection derivation, history
+  props, and row-editor props to explicit environment IDs.
+- Added reorder, removal, partial-loading, duplicate-ID, and missing-ID unit
+  coverage.
+- Added a real browser reorder flow that verifies row interaction identity and
+  the unchanged 11-resource read shape for two environments.
+
+## Generated outputs
+
+None.
+
+## Validation
+
+- `./scripts/ci/build-spa.sh --verify`: typecheck, 254 Vitest tests, and Vite
+  production build passed.
+- Isolated desktop matrix flow: 7 passed.
+- Isolated mobile matrix flow: 7 passed.
+- `git diff --check`: passed.
+- Standards and issue-spec review axes: CLEAN in round 3 after cache-contract
+  and observer-count findings were fixed.

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { zEnvironmentList } from '@hikyo/zod';
 
 import {
   expectPinnedAssertionSet,
   expectStatusIsTextAndAria,
 } from '../fixtures/assertions.ts';
+import { fixtureBrowserCall } from '../fixtures/api.ts';
 import {
   installPasskeyAuthenticator,
   readSeed,
@@ -110,6 +112,66 @@ test.describe('environment matrix', () => {
     } finally {
       await persistPasskey();
       await refreshSharedSession();
+    }
+  });
+
+  test('keeps values on their environment IDs after display reorder without adding queries', async ({ page }) => {
+    const environmentsPath =
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/environments`;
+    const orderPath = `${environmentsPath}/order`;
+    await fixtureBrowserCall(page, 'PUT', orderPath, zEnvironmentList, {
+      environment_ids: [seed.prod, seed.dev],
+    });
+
+    const readResources = new Set<string>();
+    const recordMatrixRead = (request: { method: () => string; url: () => string }) => {
+      if (request.method() !== 'GET') return;
+      const path = new URL(request.url()).pathname;
+      if (
+        path === environmentsPath ||
+        path === `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys` ||
+        path === `/api/v1/orgs/${seed.org}/projects/${seed.project}/key-groups` ||
+        path.startsWith(`${environmentsPath}/`)
+      ) {
+        readResources.add(path);
+      }
+    };
+    page.on('request', recordMatrixRead);
+
+    try {
+      await page.reload();
+      await expect(page.getByRole('columnheader').nth(1)).toContainText('production');
+      await expect(page.getByRole('columnheader').nth(2)).toContainText('development');
+      await expect(
+        page.getByRole('button', { name: new RegExp(`${seed.matrixRequired} in production:`) }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: new RegExp(`${seed.matrixRequired} in development:`) }),
+      ).toBeVisible();
+
+      await page
+        .getByRole('button', { name: new RegExp(`${seed.matrixRequired} in production:`) })
+        .click();
+      const editor = page.getByRole('dialog');
+      await editor.getByLabel('production value').fill('identity-check-not-saved');
+      await expect(editor.getByLabel('production value')).toHaveValue('identity-check-not-saved');
+      await expect(editor.getByLabel('development value')).not.toHaveValue(
+        'identity-check-not-saved',
+      );
+      await expect(editor.getByRole('link', { name: 'Open Values' })).toHaveAttribute(
+        'href',
+        `/orgs/${seed.org}/projects/${seed.project}/environments/${seed.prod}/values`,
+      );
+      await editor.getByRole('button', { name: 'Close row editor' }).click();
+
+      // Three project reads plus four existing query families per environment.
+      // Re-keying changes representation, not observer/query count.
+      await expect.poll(() => readResources.size).toBe(3 + 4 * 2);
+    } finally {
+      page.off('request', recordMatrixRead);
+      await fixtureBrowserCall(page, 'PUT', orderPath, zEnvironmentList, {
+        environment_ids: [seed.dev, seed.prod],
+      });
     }
   });
 

--- a/web/src/api/matrix-hook.test.tsx
+++ b/web/src/api/matrix-hook.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useMatrixProject } from './matrix.ts';
+import { pendingDraftsKey, signalsKey, valuesKey } from './keys.ts';
+
+const ref = { org: 'org_a', project: 'project_a' };
+const devId = 'env_01989abc-def0-7123-8123-123456789abc';
+const prodId = 'env_01989abc-def0-7123-8123-123456789abd';
+const keyId = 'key_01989abc-def0-7123-8123-123456789abc';
+const environmentBase = {
+  org_id: 'org_01989abc-def0-7123-8123-123456789abc',
+  project_id: 'prj_01989abc-def0-7123-8123-123456789abc',
+  created_at: '2026-08-22T08:00:00Z',
+};
+const development = {
+  ...environmentBase,
+  id: devId,
+  name: 'development',
+  display_order: 0,
+};
+const production = {
+  ...environmentBase,
+  id: prodId,
+  name: 'production',
+  display_order: 1,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe('useMatrixProject query ownership', () => {
+  it('renders keyed reorder/removal with one observer per unchanged query', async () => {
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const path = new URL(url, 'http://localhost').pathname;
+      const body = matrixResponse(path);
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    }));
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={client}>
+            <MatrixRows />
+          </QueryClientProvider>,
+        );
+      });
+      await settleTasks();
+
+      expect(renderedRows(container)).toEqual(['development:debug', 'production:warn']);
+      expect(activeQueries(client)).toHaveLength(3 + 4 * 2);
+      expect(activeQueries(client).every((query) => query.getObserversCount() === 1)).toBe(true);
+      expect(client.getQueryData(valuesKey({ ...ref, environment: devId }))).toEqual({
+        items: [
+          {
+            key_id: keyId,
+            name: 'LOG_LEVEL',
+            classification: 'config',
+            set: true,
+            revealed: true,
+            value: 'debug',
+          },
+        ],
+        count: 1,
+      });
+      expect(client.getQueryData(signalsKey(ref, devId))).toEqual({
+        environment_id: devId,
+        revision: 2n,
+        cells: [],
+      });
+      expect(client.getQueryData(pendingDraftsKey(ref, devId))).toEqual({ items: [], count: 0 });
+
+      await act(async () => {
+        client.setQueryData(['environments', ref.org, ref.project], {
+          items: [production, development],
+          count: 2,
+        });
+      });
+      await settleTasks();
+
+      expect(renderedRows(container)).toEqual(['production:warn', 'development:debug']);
+      expect(activeQueries(client)).toHaveLength(3 + 4 * 2);
+      expect(activeQueries(client).every((query) => query.getObserversCount() === 1)).toBe(true);
+
+      await act(async () => {
+        client.setQueryData(['environments', ref.org, ref.project], {
+          items: [production],
+          count: 1,
+        });
+      });
+      await settleTasks();
+
+      expect(renderedRows(container)).toEqual(['production:warn']);
+      expect(activeQueries(client)).toHaveLength(3 + 4);
+      expect(activeQueries(client).every((query) => query.getObserversCount() === 1)).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      client.clear();
+    }
+  });
+});
+
+function MatrixRows() {
+  const matrix = useMatrixProject(ref);
+  return (
+    <ol>
+      {matrix.environmentRows.map((row) => (
+        <li key={row.environmentId}>
+          {`${row.environment.name}:${row.values.data?.items[0]?.value ?? 'pending'}`}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function renderedRows(container: HTMLElement): readonly string[] {
+  return [...container.querySelectorAll('li')].map((row) => row.textContent ?? '');
+}
+
+function activeQueries(client: QueryClient) {
+  return client.getQueryCache().getAll().filter((query) => query.getObserversCount() > 0);
+}
+
+async function settleTasks(rounds = 20): Promise<void> {
+  for (let round = 0; round < rounds; round += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+function matrixResponse(path: string): unknown {
+  const projectPath = `/api/v1/orgs/${ref.org}/projects/${ref.project}`;
+  if (path === `${projectPath}/environments`) {
+    return { items: [development, production], count: 2 };
+  }
+  if (path === `${projectPath}/keys`) {
+    return { items: [], count: 0, schema_revision: 1 };
+  }
+  if (path === `${projectPath}/key-groups`) {
+    return { items: [], count: 0 };
+  }
+  for (const [environmentId, value, revision, protectedEnvironment] of [
+    [devId, 'debug', 2, false],
+    [prodId, 'warn', 7, true],
+  ] satisfies readonly (readonly [string, string, number, boolean])[]) {
+    const environmentPath = `${projectPath}/environments/${environmentId}`;
+    if (path === `${environmentPath}/values`) {
+      return {
+        items: [
+          {
+            key_id: keyId,
+            name: 'LOG_LEVEL',
+            classification: 'config',
+            set: true,
+            revealed: true,
+            value,
+          },
+        ],
+        count: 1,
+      };
+    }
+    if (path === `${environmentPath}/signals`) {
+      return { environment_id: environmentId, revision, cells: [] };
+    }
+    if (path === `${environmentPath}/settings`) {
+      return { protected: protectedEnvironment, reauth_window_seconds: null };
+    }
+    if (path === `${environmentPath}/pending`) {
+      return { items: [], count: 0 };
+    }
+  }
+  throw new Error(`unexpected matrix request ${path}`);
+}

--- a/web/src/api/matrix.test.ts
+++ b/web/src/api/matrix.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ApiError } from './client.ts';
 import {
+  assembleMatrixEnvironmentRows,
+  bindMatrixEnvironmentQueries,
   matrixPublishValidation,
   matrixMutationError,
   forgetRestorePreviews,
@@ -19,6 +21,30 @@ const keyLog = 'key_01989abc-def0-7123-8123-123456789abc';
 const keyOther = 'key_01989abc-def0-7123-8123-123456789abd';
 const version = 'ver_01989abc-def0-7123-8123-123456789abc';
 const ref = { org: 'org', project: 'project' };
+
+const environmentDev = {
+  id: envDev,
+  org_id: 'org_01989abc-def0-7123-8123-123456789abc',
+  project_id: 'prj_01989abc-def0-7123-8123-123456789abc',
+  name: 'development',
+  display_order: 0,
+  created_at: '2026-08-22T08:00:00Z',
+};
+const envProd = 'env_01989abc-def0-7123-8123-123456789abd';
+const environmentProd = {
+  ...environmentDev,
+  id: envProd,
+  name: 'production',
+  display_order: 1,
+};
+
+function query<T>(data: T | undefined, isPending = false) {
+  return { data, isPending, isError: false };
+}
+
+function environmentQuery<T>(environmentId: string, data: T | undefined, isPending = false) {
+  return { environmentId, query: query(data, isPending) };
+}
 
 beforeEach(() => {
   forgetRestorePreviews(ref, [version, 'ver_second', 'ver_other']);
@@ -114,6 +140,95 @@ describe('matrix cache coherence', () => {
     expect(signalsRequireValuesRefresh(undefined, 2n)).toBe(true);
     expect(signalsRequireValuesRefresh(2n, 2n)).toBe(false);
     expect(signalsRequireValuesRefresh(2n, 3n)).toBe(true);
+  });
+});
+
+describe('environment-keyed matrix rows', () => {
+  const configClassification: 'config' = 'config';
+  const valueCell = {
+    key_id: keyLog,
+    name: 'LOG_LEVEL',
+    classification: configClassification,
+    set: true,
+    revealed: true,
+  };
+  const devValues = {
+    items: [{ ...valueCell, value: 'debug' }],
+    count: 1,
+  };
+  const prodValues = {
+    items: [{ ...valueCell, value: 'warn' }],
+    count: 1,
+  };
+  const devSignals = { environment_id: envDev, revision: 2n, cells: [] };
+  const prodSignals = { environment_id: envProd, revision: 7n, cells: [] };
+  const devSettings = { protected: false, reauth_window_seconds: null };
+  const prodSettings = { protected: true, reauth_window_seconds: 300 };
+  const drafts = { items: [], count: 0 };
+
+  const inputs = {
+    values: [environmentQuery(envDev, devValues), environmentQuery(envProd, prodValues)],
+    signals: [environmentQuery(envProd, prodSignals), environmentQuery(envDev, devSignals)],
+    settings: [environmentQuery(envDev, devSettings), environmentQuery(envProd, prodSettings)],
+    pendingDrafts: [environmentQuery(envProd, drafts), environmentQuery(envDev, drafts)],
+  };
+
+  it('keeps query state attached by environment id while display order changes', () => {
+    const rows = assembleMatrixEnvironmentRows(
+      [environmentProd, environmentDev],
+      inputs,
+    );
+
+    expect(rows.map((row) => row.environmentId)).toEqual([envProd, envDev]);
+    expect(rows.map((row) => row.values.data?.items[0]?.value)).toEqual(['warn', 'debug']);
+    expect(rows.map((row) => row.signals.data?.revision)).toEqual([7n, 2n]);
+    expect(rows.map((row) => row.settings.data?.protected)).toEqual([true, false]);
+  });
+
+  it('removes a row without shifting another environment query into its place', () => {
+    const rows = assembleMatrixEnvironmentRows([environmentProd], inputs);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.environmentId).toBe(envProd);
+    expect(rows[0]?.values.data?.items[0]?.value).toBe('warn');
+  });
+
+  it('keeps one pending query on its own row while other rows render ready data', () => {
+    const rows = assembleMatrixEnvironmentRows([environmentDev, environmentProd], {
+      ...inputs,
+      signals: [environmentQuery(envProd, undefined, true), environmentQuery(envDev, devSignals)],
+    });
+
+    expect(rows[0]?.signals.data?.revision).toBe(2n);
+    expect(rows[0]?.signals.isPending).toBe(false);
+    expect(rows[1]?.environmentId).toBe(envProd);
+    expect(rows[1]?.signals.data).toBeUndefined();
+    expect(rows[1]?.signals.isPending).toBe(true);
+  });
+
+  it('rejects duplicate or missing query identities instead of guessing by position', () => {
+    expect(() =>
+      assembleMatrixEnvironmentRows([environmentDev, environmentProd], {
+        ...inputs,
+        values: [environmentQuery(envDev, devValues), environmentQuery(envDev, prodValues)],
+      }),
+    ).toThrow(`matrix values queries contain duplicate environment ${envDev}`);
+
+    expect(() =>
+      assembleMatrixEnvironmentRows([environmentDev, environmentProd], {
+        ...inputs,
+        values: [environmentQuery(envDev, devValues)],
+      }),
+    ).toThrow(`matrix values query is missing environment ${envProd}`);
+  });
+
+  it('refuses to assign returned data to a different positional environment', () => {
+    expect(() =>
+      bindMatrixEnvironmentQueries('values', [environmentProd, environmentDev], [
+        query({ environmentId: envDev, value: devValues }),
+        query({ environmentId: envProd, value: prodValues }),
+      ]),
+    ).toThrow(`matrix values query for ${envProd} returned data for ${envDev}`);
   });
 });
 

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -11,13 +11,17 @@ import {
   setValueOp,
 } from '@hikyo/operations';
 import {
+  zEnvironmentList,
+  zEnvironmentSettings,
   zEnvironmentSignals,
   zKeyList,
   zPendingDraftList,
   zPublishResult,
   zScanFinding,
+  zValueList,
 } from '@hikyo/zod';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { z } from 'zod';
 
 import { ApiError, parsed } from './client.ts';
@@ -60,6 +64,125 @@ export type MatrixKeyList = z.infer<typeof zKeyList>;
 export type ScanFinding = z.infer<typeof zScanFinding>;
 export type MatrixEnvironmentSignals = z.infer<typeof zEnvironmentSignals>;
 export type MatrixSignalCell = MatrixEnvironmentSignals['cells'][number];
+
+type MatrixEnvironment = z.infer<typeof zEnvironmentList>['items'][number];
+type MatrixEnvironmentSettings = z.infer<typeof zEnvironmentSettings>;
+type MatrixValueList = z.infer<typeof zValueList>;
+type MatrixPendingDraftList = z.infer<typeof zPendingDraftList>;
+
+export type MatrixQueryState<T> = {
+  readonly data: T | undefined;
+  readonly isPending: boolean;
+  readonly isError: boolean;
+};
+
+export type MatrixEnvironmentQuery<T> = {
+  readonly environmentId: string;
+  readonly query: MatrixQueryState<T>;
+};
+
+type EnvironmentQueryData<T> = {
+  readonly environmentId: string;
+  readonly value: T;
+};
+
+/** One ordered display row with every per-environment query attached by identity. */
+export type MatrixEnvironmentRow = {
+  readonly environmentId: string;
+  readonly environment: MatrixEnvironment;
+  readonly values: MatrixQueryState<MatrixValueList>;
+  readonly signals: MatrixQueryState<MatrixEnvironmentSignals>;
+  readonly settings: MatrixQueryState<MatrixEnvironmentSettings>;
+  readonly pendingDrafts: MatrixQueryState<MatrixPendingDraftList>;
+};
+
+type MatrixEnvironmentQueries = {
+  readonly values: readonly MatrixEnvironmentQuery<MatrixValueList>[];
+  readonly signals: readonly MatrixEnvironmentQuery<MatrixEnvironmentSignals>[];
+  readonly settings: readonly MatrixEnvironmentQuery<MatrixEnvironmentSettings>[];
+  readonly pendingDrafts: readonly MatrixEnvironmentQuery<MatrixPendingDraftList>[];
+};
+
+function matrixQueryIndex<T>(
+  label: string,
+  entries: readonly MatrixEnvironmentQuery<T>[],
+): ReadonlyMap<string, MatrixQueryState<T>> {
+  const queries = new Map<string, MatrixQueryState<T>>();
+  for (const entry of entries) {
+    if (queries.has(entry.environmentId)) {
+      throw new Error(
+        `matrix ${label} queries contain duplicate environment ${entry.environmentId}`,
+      );
+    }
+    queries.set(entry.environmentId, entry.query);
+  }
+  return queries;
+}
+
+function requiredMatrixQuery<T>(
+  label: string,
+  environmentId: string,
+  queries: ReadonlyMap<string, MatrixQueryState<T>>,
+): MatrixQueryState<T> {
+  const query = queries.get(environmentId);
+  if (query === undefined) {
+    throw new Error(`matrix ${label} query is missing environment ${environmentId}`);
+  }
+  return query;
+}
+
+/**
+ * Join independently updating query families by environment ID while keeping
+ * the server's environment order as the explicit display order.
+ */
+export function assembleMatrixEnvironmentRows(
+  environments: readonly MatrixEnvironment[],
+  input: MatrixEnvironmentQueries,
+): readonly MatrixEnvironmentRow[] {
+  const values = matrixQueryIndex('values', input.values);
+  const signals = matrixQueryIndex('signals', input.signals);
+  const settings = matrixQueryIndex('settings', input.settings);
+  const pendingDrafts = matrixQueryIndex('pending drafts', input.pendingDrafts);
+  return environments.map((environment) => ({
+    environmentId: environment.id,
+    environment,
+    values: requiredMatrixQuery('values', environment.id, values),
+    signals: requiredMatrixQuery('signals', environment.id, signals),
+    settings: requiredMatrixQuery('settings', environment.id, settings),
+    pendingDrafts: requiredMatrixQuery('pending drafts', environment.id, pendingDrafts),
+  }));
+}
+
+export function bindMatrixEnvironmentQueries<T>(
+  label: string,
+  environments: readonly MatrixEnvironment[],
+  queries: readonly MatrixQueryState<EnvironmentQueryData<T>>[],
+): readonly MatrixEnvironmentQuery<T>[] {
+  if (environments.length !== queries.length) {
+    throw new Error(
+      `matrix ${label} query count ${String(queries.length)} does not match environment count ${String(environments.length)}`,
+    );
+  }
+  return environments.map((environment, index) => {
+    const query = queries[index];
+    if (query === undefined) {
+      throw new Error(`matrix ${label} query is missing position ${String(index)}`);
+    }
+    if (query.data !== undefined && query.data.environmentId !== environment.id) {
+      throw new Error(
+        `matrix ${label} query for ${environment.id} returned data for ${query.data.environmentId}`,
+      );
+    }
+    return {
+      environmentId: environment.id,
+      query: {
+        data: query.data?.value,
+        isPending: query.isPending,
+        isError: query.isError,
+      },
+    };
+  });
+}
 
 type RestorePreview = { readonly versionIds: readonly string[]; readonly token: string };
 
@@ -267,14 +390,30 @@ export function useMatrixProject(ref: MatrixRef) {
     queries: environmentItems.map((environment) => ({
       queryKey: valuesKey({ ...ref, environment: environment.id }),
       queryFn: () =>
-        parsed(listValuesOp, { path: { ...ref, environment: environment.id }, ...transport }),
+        parsed(listValuesOp, {
+          path: { ...ref, environment: environment.id },
+          ...transport,
+        }),
+      select: (value: MatrixValueList) => ({ environmentId: environment.id, value }),
       retry: false,
     })),
   });
   const settings = useQueries({
-    queries: environmentItems.map((environment) =>
-      environmentSettingsQueryOptions(ref.org, ref.project, environment.id, transport.client),
-    ),
+    queries: environmentItems.map((environment) => {
+      const options = environmentSettingsQueryOptions(
+        ref.org,
+        ref.project,
+        environment.id,
+        transport.client,
+      );
+      return {
+        ...options,
+        select: (value: MatrixEnvironmentSettings) => ({
+          environmentId: environment.id,
+          value,
+        }),
+      };
+    }),
   });
   const signals = useQueries({
     queries: environmentItems.map((environment) => ({
@@ -293,8 +432,14 @@ export function useMatrixProject(ref: MatrixRef) {
             queryKey: valuesKey({ ...ref, environment: environment.id }),
           });
         }
+        if (next.environment_id !== environment.id) {
+          throw new Error(
+            `matrix signals query for ${environment.id} returned data for ${next.environment_id}`,
+          );
+        }
         return next;
       },
+      select: (value: MatrixEnvironmentSignals) => ({ environmentId: environment.id, value }),
       refetchInterval: 2_000,
       retry: false,
     })),
@@ -309,11 +454,27 @@ export function useMatrixProject(ref: MatrixRef) {
             ...transport,
           }),
         ),
+      select: (value: MatrixPendingDraftList) => ({ environmentId: environment.id, value }),
       retry: false,
     })),
   });
 
-  return { environments, keys, groups, values, signals, settings, pendingDrafts };
+  const environmentRows = useMemo(
+    () =>
+      assembleMatrixEnvironmentRows(environmentItems, {
+        values: bindMatrixEnvironmentQueries('values', environmentItems, values),
+        signals: bindMatrixEnvironmentQueries('signals', environmentItems, signals),
+        settings: bindMatrixEnvironmentQueries('settings', environmentItems, settings),
+        pendingDrafts: bindMatrixEnvironmentQueries(
+          'pending drafts',
+          environmentItems,
+          pendingDrafts,
+        ),
+      }),
+    [environmentItems, pendingDrafts, settings, signals, values],
+  );
+
+  return { environments, keys, groups, environmentRows };
 }
 
 export function useStageMatrixValue(ref: MatrixRef) {

--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -227,8 +227,11 @@ describe('AuthProvider', () => {
         <Probe />
       </AuthProvider>,
     );
-    await settle(30);
-    expect(text(container, 'private')).toContain(id('ses', '00'));
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(text(container, 'private')).toContain(id('ses', '00'));
+      });
+    });
 
     await act(async () => globalThis.dispatchEvent(new Event('focus')));
     expect(text(container, 'state')).toBe('transitioning');

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -17,6 +17,7 @@ import {
   useReclassifyKey,
   useStageMatrixValue,
   type MatrixKeyList,
+  type MatrixEnvironmentRow,
   type MatrixPendingDraft,
   type MatrixRef,
   type MatrixSignalCell,
@@ -87,7 +88,8 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
   const copy = useCopyMatrixConfig(ref);
   const reclassify = useReclassifyKey(ref);
 
-  const environments = matrix.environments.data?.items ?? [];
+  const environmentRows = matrix.environmentRows;
+  const environments = environmentRows.map((row) => row.environment);
   const keys = matrix.keys.data?.items ?? [];
   const keyGroups = matrix.groups.data?.items ?? [];
   const [visibleEnvironmentIds, setVisibleEnvironmentIds] = useState<readonly string[]>([]);
@@ -132,36 +134,36 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
 
   const valuesByCell = useMemo(() => {
     const cells = new Map<string, ValueCell>();
-    environments.forEach((environment, index) => {
-      for (const cell of matrix.values[index]?.data?.items ?? []) {
-        cells.set(cellID(cell.key_id, environment.id), cell);
+    for (const row of environmentRows) {
+      for (const cell of row.values.data?.items ?? []) {
+        cells.set(cellID(cell.key_id, row.environmentId), cell);
       }
-    });
+    }
     return cells;
-  }, [environments, matrix.values]);
+  }, [environmentRows]);
 
   const signalsByCell = useMemo(() => {
     const cells = new Map<string, MatrixSignalCell>();
-    environments.forEach((environment, index) => {
-      for (const signal of matrix.signals[index]?.data?.cells ?? []) {
-        cells.set(cellID(signal.key_id, environment.id), signal);
+    for (const row of environmentRows) {
+      for (const signal of row.signals.data?.cells ?? []) {
+        cells.set(cellID(signal.key_id, row.environmentId), signal);
       }
-    });
+    }
     return cells;
-  }, [environments, matrix.signals]);
+  }, [environmentRows]);
 
   // The caller's own drafts, keyed by immutable version id. Server truth: the
   // publish sheet and the editors preview from this map, never from anything
   // cached client-side, so a reload or a second browser shows the same review.
   const draftsByVersion = useMemo(() => {
     const drafts = new Map<string, MatrixPendingDraft>();
-    for (const query of matrix.pendingDrafts) {
-      for (const draft of query.data?.items ?? []) {
+    for (const row of environmentRows) {
+      for (const draft of row.pendingDrafts.data?.items ?? []) {
         drafts.set(draft.version_id, draft);
       }
     }
     return drafts;
-  }, [matrix.pendingDrafts]);
+  }, [environmentRows]);
 
   const stateKeys = useMemo<readonly MatrixStateKey[]>(
     () =>
@@ -239,9 +241,9 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
   const firstVisibleEnvironment = visibleEnvironments[0];
   const pendingByEnvironment = useMemo(() => {
     const pending = new Map<string, readonly MatrixPendingEntry[]>();
-    environments.forEach((environment, index) => {
+    for (const row of environmentRows) {
       const rows: MatrixPendingEntry[] = [];
-      for (const signal of matrix.signals[index]?.data?.cells ?? []) {
+      for (const signal of row.signals.data?.cells ?? []) {
         if (signal.pending_version_id !== undefined) {
           if (signal.pending_operation === undefined) {
             throw new Error(
@@ -258,26 +260,26 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
           });
         }
       }
-      pending.set(environment.id, rows);
-    });
+      pending.set(row.environmentId, rows);
+    }
     return pending;
-  }, [environments, matrix.signals, draftsByVersion]);
+  }, [draftsByVersion, environmentRows]);
   const pendingCount = [...pendingByEnvironment.values()].reduce(
     (total, entries) => total + entries.length,
     0,
   );
   const revisionsByEnvironment = useMemo<ReadonlyMap<string, bigint>>(() => {
     const revisions = new Map<string, bigint>();
-    environments.forEach((environment, index) => {
-      const revision = matrix.signals[index]?.data?.revision;
+    for (const row of environmentRows) {
+      const revision = row.signals.data?.revision;
       if (revision !== undefined) {
-        revisions.set(environment.id, revision);
+        revisions.set(row.environmentId, revision);
       }
-    });
+    }
     return revisions;
-  }, [environments, matrix.signals]);
-  const protectedEnvironmentIds = environments.flatMap((environment, index) =>
-    matrix.settings[index]?.data?.protected === true ? [environment.id] : [],
+  }, [environmentRows]);
+  const protectedEnvironmentIds = environmentRows.flatMap((row) =>
+    row.settings.data?.protected === true ? [row.environmentId] : [],
   );
   const pendingCountByEnvironment = useMemo<ReadonlyMap<string, number>>(
     () =>
@@ -291,14 +293,14 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
   );
   const pendingByOthersByEnvironment = useMemo<ReadonlyMap<string, number>>(() => {
     const counts = new Map<string, number>();
-    environments.forEach((environment, index) => {
+    for (const row of environmentRows) {
       counts.set(
-        environment.id,
-        (matrix.signals[index]?.data?.cells ?? []).filter((cell) => cell.pending_by_others).length,
+        row.environmentId,
+        (row.signals.data?.cells ?? []).filter((cell) => cell.pending_by_others).length,
       );
-    });
+    }
     return counts;
-  }, [environments, matrix.signals]);
+  }, [environmentRows]);
   // The history drawer needs the CURRENT cell state to enumerate the ceremony
   // unit a restore will need: the comparison opens current secret plaintext only
   // where a set secret is being replaced.
@@ -320,34 +322,43 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
     ReadonlyMap<string, readonly ValueCell[]>
   >(() => {
     const values = new Map<string, readonly ValueCell[]>();
-    environments.forEach((environment, index) => {
-      values.set(environment.id, matrix.values[index]?.data?.items ?? []);
-    });
+    for (const row of environmentRows) {
+      values.set(row.environmentId, row.values.data?.items ?? []);
+    }
     return values;
-  }, [environments, matrix.values]);
+  }, [environmentRows]);
   const loading =
     matrix.environments.isPending ||
     matrix.keys.isPending ||
     matrix.groups.isPending ||
-    matrix.values.some((query) => query.isPending) ||
-    matrix.signals.some((query) => query.isPending) ||
-    matrix.settings.some((query) => query.isPending) ||
-    matrix.pendingDrafts.some((query) => query.isPending);
+    environmentRows.some(
+      (row) =>
+        row.values.isPending ||
+        row.signals.isPending ||
+        row.settings.isPending ||
+        row.pendingDrafts.isPending,
+    );
   const loadError =
     (matrix.environments.isError && matrix.environments.data === undefined) ||
     (matrix.keys.isError && matrix.keys.data === undefined) ||
     (matrix.groups.isError && matrix.groups.data === undefined) ||
-    matrix.values.some((query) => query.isError && query.data === undefined) ||
-    matrix.signals.some((query) => query.isError && query.data === undefined) ||
-    matrix.settings.some((query) => query.isError && query.data === undefined) ||
-    matrix.pendingDrafts.some((query) => query.isError && query.data === undefined);
+    environmentRows.some(
+      (row) =>
+        (row.values.isError && row.values.data === undefined) ||
+        (row.signals.isError && row.signals.data === undefined) ||
+        (row.settings.isError && row.settings.data === undefined) ||
+        (row.pendingDrafts.isError && row.pendingDrafts.data === undefined),
+    );
   const backgroundRefreshError =
     (matrix.environments.isError && matrix.environments.data !== undefined) ||
     (matrix.keys.isError && matrix.keys.data !== undefined) ||
     (matrix.groups.isError && matrix.groups.data !== undefined) ||
-    matrix.values.some((query) => query.isError && query.data !== undefined) ||
-    matrix.signals.some((query) => query.isError && query.data !== undefined) ||
-    matrix.settings.some((query) => query.isError && query.data !== undefined);
+    environmentRows.some(
+      (row) =>
+        (row.values.isError && row.values.data !== undefined) ||
+        (row.signals.isError && row.signals.data !== undefined) ||
+        (row.settings.isError && row.settings.data !== undefined),
+    );
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualPaddingTop = virtualRows[0]?.start ?? 0;
   const virtualPaddingBottom =
@@ -769,19 +780,18 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
         <MatrixRowEditor
           refData={ref}
           keyRecord={selectedKey}
-          environment={selectedEnvironment}
-          environments={environments}
-          protectedEnvironmentIds={protectedEnvironmentIds}
-          rows={environments.map((environment) => {
-            const signal = signalsByCell.get(cellID(selectedKey.id, environment.id));
+          environmentId={selectedEnvironment.id}
+          rows={environmentRows.map((row: MatrixEnvironmentRow) => {
+            const signal = signalsByCell.get(cellID(selectedKey.id, row.environmentId));
             return {
-              environment,
-              protected: protectedEnvironmentIds.includes(environment.id),
-              cell: valuesByCell.get(cellID(selectedKey.id, environment.id)),
+              environmentId: row.environmentId,
+              environment: row.environment,
+              protected: row.settings.data?.protected === true,
+              cell: valuesByCell.get(cellID(selectedKey.id, row.environmentId)),
               signal,
               draftPreview: pendingConfigPreview(signal, draftsByVersion),
               problems:
-                problemsByCell.get(cellID(selectedKey.id, environment.id)) ?? [],
+                problemsByCell.get(cellID(selectedKey.id, row.environmentId)) ?? [],
             };
           })}
           busy={stage.isPending || clear.isPending || copy.isPending}

--- a/web/src/routes/MatrixRowEditor.tsx
+++ b/web/src/routes/MatrixRowEditor.tsx
@@ -28,6 +28,7 @@ type MatrixKey = MatrixKeyList['items'][number];
 type Environment = EnvironmentList['items'][number];
 
 type EditorRow = {
+  readonly environmentId: string;
   readonly environment: Environment;
   readonly protected: boolean;
   readonly cell: ValueCell | undefined;
@@ -42,9 +43,7 @@ export type MatrixEditorChange = MatrixDraftChange;
 export function MatrixRowEditor({
   refData,
   keyRecord,
-  environment,
-  environments,
-  protectedEnvironmentIds,
+  environmentId,
   rows,
   busy,
   mutationError,
@@ -54,9 +53,7 @@ export function MatrixRowEditor({
 }: {
   refData: MatrixRef;
   keyRecord: MatrixKey;
-  environment: Environment;
-  environments: readonly Environment[];
-  protectedEnvironmentIds: readonly string[];
+  environmentId: string;
   rows: readonly EditorRow[];
   busy: boolean;
   mutationError: string | null;
@@ -69,7 +66,7 @@ export function MatrixRowEditor({
     () =>
       new Map(
         rows.map((row) => [
-          row.environment.id,
+          row.environmentId,
           draftValueForMatrixCell(
             keyRecord.classification,
             row.cell?.set === true ? row.cell.value : undefined,
@@ -90,39 +87,47 @@ export function MatrixRowEditor({
   const [destinations, setDestinations] = useState<readonly string[]>([]);
   const [protectedCopyConfirmed, setProtectedCopyConfirmed] = useState(false);
   const protectedGuard = useProtectedPublishCeremony(refData);
+  const sourceRow = rows.find((row) => row.environmentId === environmentId);
+  if (sourceRow === undefined) {
+    throw new Error(`matrix editor environment ${environmentId} is not in its keyed rows`);
+  }
+  const environment = sourceRow.environment;
+  const protectedEnvironmentIds = rows.flatMap((row) =>
+    row.protected ? [row.environmentId] : [],
+  );
 
   const valuesPath = generatePath(surfaceById('values').path, {
     org: refData.org,
     project: refData.project,
-    environment: environment.id,
+    environment: environmentId,
   });
-  const sourceRow = rows.find((row) => row.environment.id === environment.id);
-  const sourceSet = sourceRow?.cell?.set === true;
+  const sourceSet = sourceRow.cell?.set === true;
   const protectedConfirmationRequired = copyRequiresProtectedConfirmation(
     destinations,
     protectedEnvironmentIds,
   );
-  const protectedDestinationNames = environments
+  const protectedDestinationNames = rows
     .filter(
-      (candidate) =>
-        destinations.includes(candidate.id) && protectedEnvironmentIds.includes(candidate.id),
+      (row) =>
+        destinations.includes(row.environmentId) &&
+        protectedEnvironmentIds.includes(row.environmentId),
     )
-    .map((candidate) => candidate.name);
+    .map((row) => row.environment.name);
 
   const validationByEnvironment = new Map<string, ReturnType<typeof validateMatrixDraft>>();
   for (const row of rows) {
-    if (!dirty.has(row.environment.id) || clears.has(row.environment.id)) {
+    if (!dirty.has(row.environmentId) || clears.has(row.environmentId)) {
       continue;
     }
-    const value = drafts.get(row.environment.id) ?? '';
+    const value = drafts.get(row.environmentId) ?? '';
     const error = validateDeclaration(keyRecord, value);
     if (error !== null) {
-      validationByEnvironment.set(row.environment.id, error);
+      validationByEnvironment.set(row.environmentId, error);
     }
   }
 
   const changes = matrixDraftChanges(
-    rows.map((row) => row.environment.id),
+    rows.map((row) => row.environmentId),
     drafts,
     dirty,
     clears,
@@ -132,13 +137,13 @@ export function MatrixRowEditor({
     destinations
       .filter((environmentId) => protectedEnvironmentIds.includes(environmentId))
       .map((environmentId) => {
-        const destination = environments.find((candidate) => candidate.id === environmentId);
+        const destination = rows.find((row) => row.environmentId === environmentId);
         if (destination === undefined) {
           throw new Error(`protected copy destination ${environmentId} is not in the matrix`);
         }
         return {
           environmentId,
-          environmentName: destination.name,
+          environmentName: destination.environment.name,
           keys: [{ id: keyRecord.id, name: keyRecord.name }],
         };
       });
@@ -195,8 +200,8 @@ export function MatrixRowEditor({
                 className="btn"
                 disabled={fillAll === '' || busy || applying}
                 onClick={() => {
-                  setDrafts(new Map(rows.map((row) => [row.environment.id, fillAll])));
-                  setDirty(new Set(rows.map((row) => row.environment.id)));
+                  setDrafts(new Map(rows.map((row) => [row.environmentId, fillAll])));
+                  setDirty(new Set(rows.map((row) => row.environmentId)));
                   setClears(new Set());
                 }}
               >
@@ -207,18 +212,18 @@ export function MatrixRowEditor({
 
           <div className="matrix-row-editor__rows">
             {rows.map((row) => {
-              const environmentId = row.environment.id;
+              const rowEnvironmentId = row.environmentId;
               const publishedSet = row.cell?.set === true;
-              const clearing = clears.has(environmentId);
-              const liveValidation = validationByEnvironment.get(environmentId) ?? null;
+              const clearing = clears.has(rowEnvironmentId);
+              const liveValidation = validationByEnvironment.get(rowEnvironmentId) ?? null;
               return (
                 <section
                   className={`matrix-row-editor__row${row.protected ? ' matrix-row-editor__row--protected' : ''}`}
-                  key={environmentId}
-                  aria-labelledby={`matrix-row-${environmentId}`}
+                  key={rowEnvironmentId}
+                  aria-labelledby={`matrix-row-${rowEnvironmentId}`}
                 >
                   <div className="matrix-row-editor__row-head">
-                    <h3 id={`matrix-row-${environmentId}`}>{row.environment.name}</h3>
+                    <h3 id={`matrix-row-${rowEnvironmentId}`}>{row.environment.name}</h3>
                     {row.protected ? <span>PROTECTED</span> : null}
                     <span>{publishedSet ? 'explicit set' : 'explicit absent'}</span>
                     {row.signal?.pending_operation === undefined ? null : (
@@ -231,15 +236,15 @@ export function MatrixRowEditor({
                       <span>{problem.message}</span>
                     </p>
                   ))}
-                  <label htmlFor={`matrix-edit-${environmentId}`}>
+                  <label htmlFor={`matrix-edit-${rowEnvironmentId}`}>
                     {`${row.environment.name} value`}
                   </label>
                   <textarea
-                    id={`matrix-edit-${environmentId}`}
+                    id={`matrix-edit-${rowEnvironmentId}`}
                     className="mono matrix-editor__value"
                     rows={keyRecord.declaration.rule?.type === 'json' ? 6 : 2}
                     autoComplete="off"
-                    value={clearing ? '' : drafts.get(environmentId) ?? ''}
+                    value={clearing ? '' : drafts.get(rowEnvironmentId) ?? ''}
                     placeholder={
                       keyRecord.classification === 'secret'
                         ? publishedSet
@@ -250,15 +255,15 @@ export function MatrixRowEditor({
                           : 'Touch to stage an explicit value'
                     }
                     aria-invalid={liveValidation?.level === 'error' ? true : undefined}
-                    aria-describedby={liveValidation === null ? undefined : `matrix-error-${environmentId}`}
+                    aria-describedby={liveValidation === null ? undefined : `matrix-error-${rowEnvironmentId}`}
                     onChange={(event) => {
                       const next = new Map(drafts);
-                      next.set(environmentId, event.target.value);
+                      next.set(rowEnvironmentId, event.target.value);
                       setDrafts(next);
-                      setDirty((current) => new Set(current).add(environmentId));
+                      setDirty((current) => new Set(current).add(rowEnvironmentId));
                       setClears((current) => {
                         const nextClears = new Set(current);
-                        nextClears.delete(environmentId);
+                        nextClears.delete(rowEnvironmentId);
                         return nextClears;
                       });
                     }}
@@ -266,7 +271,7 @@ export function MatrixRowEditor({
                   {liveValidation === null ? null : (
                     <p
                       className={liveValidation.level === 'error' ? 'matrix-cell__error' : 'matrix-editor__hint'}
-                      id={`matrix-error-${environmentId}`}
+                      id={`matrix-error-${rowEnvironmentId}`}
                     >
                       {liveValidation.message}
                     </p>
@@ -289,13 +294,13 @@ export function MatrixRowEditor({
                     onClick={() => {
                       setClears((current) => {
                         const next = new Set(current);
-                        if (next.has(environmentId)) next.delete(environmentId);
-                        else next.add(environmentId);
+                        if (next.has(rowEnvironmentId)) next.delete(rowEnvironmentId);
+                        else next.add(rowEnvironmentId);
                         return next;
                       });
                       setDirty((current) => {
                         const next = new Set(current);
-                        next.delete(environmentId);
+                        next.delete(rowEnvironmentId);
                         return next;
                       });
                     }}
@@ -345,23 +350,23 @@ export function MatrixRowEditor({
           {copyOpen ? (
             <fieldset className="matrix-editor__copy">
               <legend>Copy independent published value to</legend>
-              {environments
-                .filter((candidate) => candidate.id !== environment.id)
-                .map((candidate) => (
-                  <label key={candidate.id}>
+              {rows
+                .filter((row) => row.environmentId !== environmentId)
+                .map((row) => (
+                  <label key={row.environmentId}>
                     <input
                       type="checkbox"
-                      checked={destinations.includes(candidate.id)}
+                      checked={destinations.includes(row.environmentId)}
                       onChange={() => {
                         setDestinations((current) =>
-                          current.includes(candidate.id)
-                            ? current.filter((id) => id !== candidate.id)
-                            : [...current, candidate.id],
+                          current.includes(row.environmentId)
+                            ? current.filter((id) => id !== row.environmentId)
+                            : [...current, row.environmentId],
                         );
                         setProtectedCopyConfirmed(false);
                       }}
                     />
-                    <span>{candidate.name}{protectedEnvironmentIds.includes(candidate.id) ? ' · protected' : ''}</span>
+                    <span>{row.environment.name}{row.protected ? ' · protected' : ''}</span>
                   </label>
                 ))}
               {protectedConfirmationRequired ? (


### PR DESCRIPTION
Closes #243

## Contract
- Return one explicitly ordered `environmentRows` collection from `useMatrixProject`.
- Carry `environmentId`, metadata, values, signals, settings, and pending drafts on every row.
- Preserve canonical raw React Query cache payloads; add identity at the observer `select` boundary.
- Keep the existing three project queries plus four query families per environment and one project-level mutation owner.

## Coverage
- Reorder, removal, partial-loading, duplicate/missing identity, and mismatched returned-identity tests.
- Rendered hook coverage asserts one observer per query and unchanged 11-query shape for two environments.
- Browser reorder flow edits the production row, verifies the production Values link, and confirms the resource shape.

## Generated outputs
None.

## Validation
- `./scripts/ci/build-spa.sh --verify`: typecheck, 254 Vitest tests, production build passed.
- Isolated desktop matrix flow: 7 passed.
- Isolated mobile matrix flow: 7 passed.
- `git diff --check`: passed.
- Standards and issue-spec review: CLEAN in round 3.
- ESLint: this package has no ESLint dependency or script; CI uses TypeScript, Vitest, build, and Playwright gates.