### PR TITLE
Co-locate workspace bearer and health state #245

### DIFF
--- a/docs/handoff/245-workspace-session-state.md
+++ b/docs/handoff/245-workspace-session-state.md
@@ -31,13 +31,13 @@ logs, snapshots, generated output, or durable state.
 
 ## Validation
 
-- `pnpm --dir web exec vitest run src/api/workspace.test.ts src/api/workspaceClient.test.ts src/api/session.test.ts`:
-  28 passed
-- `pnpm --dir web run test`: 262 passed across 24 files
+- `pnpm --dir web exec vitest run src/api/workspace.test.ts src/api/workspaceClient.test.ts src/api/session.test.ts src/app/AuthProvider.test.tsx`:
+  33 passed
+- `pnpm --dir web run test`: 267 passed across 25 files
 - `pnpm --dir web run typecheck`: passed
 - `pnpm --dir web run build`: passed
 - `pnpm --dir web exec playwright test flows/workspace.spec.ts`: 26 passed
   across desktop and mobile against the exact rebuilt bundle
-- two-axis review round 2: standards CLEAN; spec CLEAN
+- two-axis review round 3: standards CLEAN; spec SOUND
 
 No API, database, migration, generated output, or wire contract changed.

--- a/docs/handoff/245-workspace-session-state.md
+++ b/docs/handoff/245-workspace-session-state.md
@@ -1,0 +1,43 @@
+# Issue #245: atomic workspace session state
+
+## Contract
+
+Each canonical remote origin now owns one in-memory `WorkspaceSessionState`:
+
+- `bearer` is the live header credential and remains memory-only;
+- `epoch` identifies the local installation of that credential;
+- `consecutiveFailures` belongs to that epoch, not to bearer text in a second
+  map;
+- replacement installs a new epoch with zero failures in one `Map.set`;
+- close, remote expiry, root-session expiry, logout, and root-session
+  replacement remove the whole aggregate.
+
+Liveness probes and workspace transport requests capture the aggregate they
+started under. Their completion compares the captured epoch with the live
+epoch before it can increment or clear failures, evict a bearer, or report a
+newer session healthy. A step-up may retain the remote session id while rotating
+the bearer; it still receives a new local epoch.
+
+## Root ownership
+
+The session API calls `transitionWorkspaceOwner` when `whoami` observes a
+session id, a login installs a new session, logout succeeds, or `whoami` answers
+401. Re-reading the same root session id preserves workspace health; changing
+or losing it clears all remote workspace aggregates before cached local data is
+reset or invalidated.
+
+No bearer enters TanStack Query cache, mutation cache, browser storage, URLs,
+logs, snapshots, generated output, or durable state.
+
+## Validation
+
+- `pnpm --dir web exec vitest run src/api/workspace.test.ts src/api/workspaceClient.test.ts src/api/session.test.ts`:
+  28 passed
+- `pnpm --dir web run test`: 262 passed across 24 files
+- `pnpm --dir web run typecheck`: passed
+- `pnpm --dir web run build`: passed
+- `pnpm --dir web exec playwright test flows/workspace.spec.ts`: 26 passed
+  across desktop and mobile against the exact rebuilt bundle
+- two-axis review round 2: standards CLEAN; spec CLEAN
+
+No API, database, migration, generated output, or wire contract changed.

--- a/web/src/api/session.ts
+++ b/web/src/api/session.ts
@@ -10,6 +10,7 @@ import type { z } from 'zod';
 
 import { ApiError, ok, parsed } from './client.ts';
 import { useTransport } from './transport.tsx';
+import { transitionWorkspaceOwner } from './workspace.ts';
 
 /**
  * loginFailureText turns a login failure into something true.
@@ -54,9 +55,12 @@ export function useSession(): UseQueryResult<WhoAmI | null> {
     queryKey: sessionKey,
     queryFn: async () => {
       try {
-        return await parsed(whoamiOp, {});
+        const session = await parsed(whoamiOp, {});
+        transitionWorkspaceOwner(session.session.id);
+        return session;
       } catch (err) {
         if (err instanceof ApiError && err.status === 401) {
+          transitionWorkspaceOwner(undefined);
           return null;
         }
         throw err;
@@ -117,7 +121,10 @@ export function useLogin() {
       }
       return result;
     },
-    onSuccess: () => queries.invalidateQueries(),
+    onSuccess: (result) => {
+      transitionWorkspaceOwner(result.session.id);
+      return queries.invalidateQueries();
+    },
   });
 }
 
@@ -130,6 +137,9 @@ export function useLogout() {
     // ended. `resetQueries`, not `clear`: clearing empties the cache but
     // leaves mounted observers holding their last result, so the chrome would
     // keep rendering a signed-out principal until something else refetched.
-    onSuccess: () => queries.resetQueries(),
+    onSuccess: () => {
+      transitionWorkspaceOwner(undefined);
+      return queries.resetQueries();
+    },
   });
 }

--- a/web/src/api/workspace.test.ts
+++ b/web/src/api/workspace.test.ts
@@ -4,6 +4,7 @@ import {
   forgetWorkspace,
   probeWorkspace,
   rememberWorkspace,
+  transitionWorkspaceOwner,
   workspaceBearer,
   type WorkspaceBearer,
 } from './workspace.ts';
@@ -36,9 +37,28 @@ function sessionList(): Response {
   );
 }
 
+function deferredResponse(): {
+  readonly promise: Promise<Response>;
+  readonly resolve: (response: Response) => void;
+  readonly reject: (error: Error) => void;
+} {
+  let resolveResponse = (_response: Response): void => {
+    throw new Error('deferred response was not initialized');
+  };
+  let rejectResponse = (_error: Error): void => {
+    throw new Error('deferred response was not initialized');
+  };
+  const promise = new Promise<Response>((resolve, reject) => {
+    resolveResponse = resolve;
+    rejectResponse = reject;
+  });
+  return { promise, resolve: resolveResponse, reject: rejectResponse };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   forgetWorkspace(bearer.origin);
+  transitionWorkspaceOwner(undefined);
 });
 
 // A blip must not cost a ceremony, and a re-established workspace is a NEW
@@ -96,16 +116,8 @@ describe('probeWorkspace strike counting', () => {
 // let the old probe's verdict delete the NEW session.
 describe('probeWorkspace session identity', () => {
   it('ignores a completion about a session that has been replaced', async () => {
-    let settle: (r: Response) => void = () => {};
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        () =>
-          new Promise<Response>((resolve) => {
-            settle = resolve;
-          }),
-      ),
-    );
+    const response = deferredResponse();
+    vi.stubGlobal('fetch', vi.fn(() => response.promise));
     rememberWorkspace(bearer);
     const inFlight = probeWorkspace(bearer);
 
@@ -114,7 +126,7 @@ describe('probeWorkspace session identity', () => {
     rememberWorkspace(replacement);
 
     // S1's probe now fails. It must not touch S2.
-    settle(new Response(null, { status: 401 }));
+    response.resolve(new Response(null, { status: 401 }));
     expect(await inFlight).toBe(false);
     expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
   });
@@ -122,18 +134,10 @@ describe('probeWorkspace session identity', () => {
   // A step-up ELEVATES in place: same session id, a freshly rotated value. A
   // probe fired with the pre-elevation value must not, on its stale 401, take
   // down the live elevated bearer that shares its session id — the drop is keyed
-  // by value, not session, exactly as the transport's kill path is.
+  // by local epoch, exactly as the transport's kill path is.
   it('ignores a stale 401 for a value the same session has since rotated', async () => {
-    let settle: (r: Response) => void = () => {};
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        () =>
-          new Promise<Response>((resolve) => {
-            settle = resolve;
-          }),
-      ),
-    );
+    const response = deferredResponse();
+    vi.stubGlobal('fetch', vi.fn(() => response.promise));
     rememberWorkspace(bearer);
     const inFlight = probeWorkspace(bearer);
 
@@ -141,43 +145,30 @@ describe('probeWorkspace session identity', () => {
     const elevated: WorkspaceBearer = { ...bearer, value: 'hik_ws_elevated' };
     rememberWorkspace(elevated);
 
-    settle(new Response(null, { status: 401 }));
+    response.resolve(new Response(null, { status: 401 }));
     expect(await inFlight).toBe(false);
     expect(workspaceBearer(bearer.origin)?.value).toBe('hik_ws_elevated');
     expect(workspaceBearer(bearer.origin)?.session).toBe('ses_1');
   });
 
   it('does not report a stale successful probe as health for the replacement session', async () => {
-    let settle: (r: Response) => void = () => {};
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        () =>
-          new Promise<Response>((resolve) => {
-            settle = resolve;
-          }),
-      ),
-    );
+    const response = deferredResponse();
+    vi.stubGlobal('fetch', vi.fn(() => response.promise));
     rememberWorkspace(bearer);
     const inFlight = probeWorkspace(bearer);
 
     rememberWorkspace({ ...bearer, session: 'ses_2', value: 'hik_ws_second' });
 
-    settle(sessionList());
+    response.resolve(sessionList());
     expect(await inFlight).toBe(false);
     expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
   });
 
   it('does not spend a stale failed probe against a replacement epoch', async () => {
-    let rejectOld: (reason: Error) => void = () => {};
+    const response = deferredResponse();
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<Response>((_resolve, reject) => {
-            rejectOld = reject;
-          }),
-      )
+      .mockImplementationOnce(() => response.promise)
       .mockRejectedValue(new TypeError('Failed to fetch'));
     vi.stubGlobal('fetch', fetchMock);
     rememberWorkspace(bearer);
@@ -187,11 +178,48 @@ describe('probeWorkspace session identity', () => {
     // this adversarial case proves old async work cannot mutate replacement.
     const replacement = { ...bearer, session: 'ses_2' };
     rememberWorkspace(replacement);
-    rejectOld(new TypeError('Failed to fetch'));
+    response.reject(new TypeError('Failed to fetch'));
 
     expect(await inFlight).toBe(false);
     expect(await probeWorkspace(replacement)).toBe(true);
     expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
+  });
+});
+
+describe('root session ownership', () => {
+  it('preserves workspace health while the root session epoch is unchanged', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    );
+    transitionWorkspaceOwner('browser_1');
+    rememberWorkspace(bearer);
+    expect(await probeWorkspace(bearer)).toBe(true);
+
+    transitionWorkspaceOwner('browser_1');
+
+    expect(await probeWorkspace(bearer)).toBe(false);
+    expect(workspaceBearer(bearer.origin)).toBeUndefined();
+  });
+
+  it.each([
+    ['logout or expiry', undefined],
+    ['session replacement', 'browser_2'],
+  ])('removes the whole workspace aggregate on %s', async (_transition, nextSession) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    );
+    transitionWorkspaceOwner('browser_1');
+    rememberWorkspace(bearer);
+    expect(await probeWorkspace(bearer)).toBe(true);
+
+    transitionWorkspaceOwner(nextSession);
+
+    expect(workspaceBearer(bearer.origin)).toBeUndefined();
+    const reopened = { ...bearer, session: 'ses_2' };
+    rememberWorkspace(reopened);
+    expect(await probeWorkspace(reopened)).toBe(true);
   });
 });
 

--- a/web/src/api/workspace.test.ts
+++ b/web/src/api/workspace.test.ts
@@ -72,6 +72,23 @@ describe('probeWorkspace strike counting', () => {
     expect(await probeWorkspace(bearer)).toBe(false);
     expect(workspaceBearer(bearer.origin)).toBeUndefined();
   });
+
+  it('removes bearer and health together when the workspace is closed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    );
+    rememberWorkspace(bearer);
+    expect(await probeWorkspace(bearer)).toBe(true);
+
+    forgetWorkspace(bearer.origin);
+    expect(workspaceBearer(bearer.origin)).toBeUndefined();
+
+    const reopened = { ...bearer, session: 'ses_2' };
+    rememberWorkspace(reopened);
+    expect(await probeWorkspace(reopened)).toBe(true);
+    expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
+  });
 });
 
 // A probe is asynchronous and the human is not. Closing a workspace and opening
@@ -128,6 +145,53 @@ describe('probeWorkspace session identity', () => {
     expect(await inFlight).toBe(false);
     expect(workspaceBearer(bearer.origin)?.value).toBe('hik_ws_elevated');
     expect(workspaceBearer(bearer.origin)?.session).toBe('ses_1');
+  });
+
+  it('does not report a stale successful probe as health for the replacement session', async () => {
+    let settle: (r: Response) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            settle = resolve;
+          }),
+      ),
+    );
+    rememberWorkspace(bearer);
+    const inFlight = probeWorkspace(bearer);
+
+    rememberWorkspace({ ...bearer, session: 'ses_2', value: 'hik_ws_second' });
+
+    settle(sessionList());
+    expect(await inFlight).toBe(false);
+    expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
+  });
+
+  it('does not spend a stale failed probe against a replacement epoch', async () => {
+    let rejectOld: (reason: Error) => void = () => {};
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((_resolve, reject) => {
+            rejectOld = reject;
+          }),
+      )
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+    rememberWorkspace(bearer);
+    const inFlight = probeWorkspace(bearer);
+
+    // Epoch, not bearer text, owns the strike count. Reusing the same value in
+    // this adversarial case proves old async work cannot mutate replacement.
+    const replacement = { ...bearer, session: 'ses_2' };
+    rememberWorkspace(replacement);
+    rejectOld(new TypeError('Failed to fetch'));
+
+    expect(await inFlight).toBe(false);
+    expect(await probeWorkspace(replacement)).toBe(true);
+    expect(workspaceBearer(bearer.origin)?.session).toBe('ses_2');
   });
 });
 

--- a/web/src/api/workspace.ts
+++ b/web/src/api/workspace.ts
@@ -41,76 +41,89 @@ export type WorkspaceBearer = {
 };
 
 /**
- * The bearer store: a module-level Map and nothing else.
+ * The workspace session store: one module-level Map and nothing else.
  *
  * Never a cookie, never localStorage, never sessionStorage — the ADR's rule,
  * and the reason is stated plainly there: in-memory narrows the AT-REST window,
  * it is not non-stealability. A reload is a re-establishment, which costs one
  * popup and one passkey tap.
  */
-const bearers = new Map<string, WorkspaceBearer>();
+export type WorkspaceSessionReference = {
+  readonly bearer: WorkspaceBearer;
+  readonly epoch: number;
+};
+
+type WorkspaceSessionState = WorkspaceSessionReference & {
+  consecutiveFailures: number;
+};
+
+const workspaceSessions = new Map<string, WorkspaceSessionState>();
 const listeners = new Set<() => void>();
 let snapshot: readonly WorkspaceBearer[] = [];
+let nextWorkspaceEpoch = 0;
 
 function publish(): void {
-  snapshot = [...bearers.values()];
+  snapshot = [...workspaceSessions.values()].map((state) => state.bearer);
   for (const listener of listeners) {
     listener();
   }
 }
 
 export function workspaceBearer(origin: string): WorkspaceBearer | undefined {
-  return bearers.get(origin);
+  return workspaceSessions.get(origin)?.bearer;
+}
+
+/** Captures the aggregate identity an asynchronous workspace request belongs to. */
+export function workspaceSession(origin: string): WorkspaceSessionReference | undefined {
+  return workspaceSessions.get(origin);
+}
+
+function workspaceSessionFor(bearer: WorkspaceBearer): WorkspaceSessionState | undefined {
+  const session = workspaceSessions.get(bearer.origin);
+  if (
+    session === undefined ||
+    session.bearer.session !== bearer.session ||
+    session.bearer.value !== bearer.value
+  ) {
+    return undefined;
+  }
+  return session;
 }
 
 export function forgetWorkspace(origin: string): void {
-  // The strike count goes with the bearer VALUE. A workspace that is
-  // re-established after a run of unreachable probes is a NEW credential, and
-  // letting it inherit the old count would kill it on its first blip instead of
-  // its second. Read the held value before deleting the bearer, or the count
-  // outlives the credential it belonged to.
-  const held = bearers.get(origin);
-  if (held !== undefined) {
-    failures.delete(held.value);
-  }
-  if (bearers.delete(origin)) {
+  // One delete removes bearer identity and health together. A later session at
+  // this origin receives a new epoch and starts with its full strike allowance.
+  if (workspaceSessions.delete(origin)) {
     publish();
   }
 }
 
 /**
- * dropWorkspaceValue drops the bearer for one origin ONLY IF it is still the
- * exact VALUE the caller is talking about — the transport's 401/403 kill path
- * and the liveness probe's terminal drop both route through it (#71).
+ * dropWorkspaceSession drops one origin ONLY IF the captured aggregate is
+ * still current. The transport's 401 kill path and liveness probe both use it.
  *
- * Keyed by the value, not the session id, for two reasons that are really one:
- * a probe is asynchronous and the human is not, and a step-up ELEVATES in place
- * — same session id, a freshly ROTATED value. A stale verdict about a value
- * that has since been rotated (by a reconnect OR a step-up) must be a no-op, or
- * a 401 for the dead pre-rotation value would take down the live post-rotation
- * bearer that shares its session id. Only a verdict whose value is still the one
- * we hold is a verdict about the live credential.
+ * The aggregate reference is the epoch boundary. Comparing bearer text is not
+ * enough: even an adversarial value collision must not let old asynchronous
+ * work mutate a replacement session.
  */
-export function dropWorkspaceValue(origin: string, value: string): void {
-  const held = bearers.get(origin);
-  if (held === undefined || held.value !== value) {
+export function dropWorkspaceSession(session: WorkspaceSessionReference): void {
+  if (workspaceSessions.get(session.bearer.origin) !== session) {
     return;
   }
-  forgetWorkspace(origin);
+  workspaceSessions.delete(session.bearer.origin);
+  publish();
 }
 
-/** strike counts one unreachable probe, keyed by the bearer VALUE. */
-function strike(bearer: WorkspaceBearer): boolean {
-  const held = bearers.get(bearer.origin);
-  if (held === undefined || held.value !== bearer.value) {
+/** Counts one unreachable probe only against the aggregate that launched it. */
+function strike(session: WorkspaceSessionState): boolean {
+  if (workspaceSessions.get(session.bearer.origin) !== session) {
     return false;
   }
-  const next = (failures.get(bearer.value) ?? 0) + 1;
-  failures.set(bearer.value, next);
-  if (next < UNREACHABLE_STRIKES) {
+  session.consecutiveFailures += 1;
+  if (session.consecutiveFailures < UNREACHABLE_STRIKES) {
     return true;
   }
-  dropWorkspaceValue(bearer.origin, bearer.value);
+  dropWorkspaceSession(session);
   return false;
 }
 
@@ -150,6 +163,10 @@ export const livenessPollMs = LIVENESS_POLL_MS;
  * claim a workspace that is not there.
  */
 export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> {
+  const session = workspaceSessionFor(bearer);
+  if (session === undefined) {
+    return false;
+  }
   let response: Response;
   try {
     response = await fetch(`${bearer.origin}/api/v1/me/sessions`, {
@@ -172,12 +189,12 @@ export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> 
     // a run of them is: whatever the cause, a workspace this shell cannot
     // reach is not a workspace, and claiming it is open is the one thing the
     // card must not do.
-    return strike(bearer);
+    return strike(session);
   }
   // Only a 401 is the session dying (revoked, expired, origin-binding mismatch —
   // all ErrUnauthenticated).
   if (response.status === 401) {
-    dropWorkspaceValue(bearer.origin, bearer.value);
+    dropWorkspaceSession(session);
     return false;
   }
   // A 403 is NOT death and NOT unreachability — it is a "forbidden" from a
@@ -188,7 +205,7 @@ export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> 
   // session — so a forbidden never becomes a false reconnect. It does not clear
   // the strike count either: it is not the clean answer that proves liveness.
   if (response.status === 403) {
-    return true;
+    return workspaceSessions.get(bearer.origin) === session;
   }
   // ONLY A WELL-FORMED SUCCESS CLEARS THE STRIKE COUNT. Anything else is a
   // strike: a 404 or a 500 is not this endpoint answering, and a 200 carrying
@@ -197,14 +214,17 @@ export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> 
   // ends up claiming a workspace nobody can use, which is the exact failure the
   // strike counter exists to prevent.
   if (!response.ok) {
-    return strike(bearer);
+    return strike(session);
   }
   try {
     zSessionList.parse(await response.json());
   } catch {
-    return strike(bearer);
+    return strike(session);
   }
-  failures.delete(bearer.value);
+  if (workspaceSessions.get(bearer.origin) !== session) {
+    return false;
+  }
+  session.consecutiveFailures = 0;
   return true;
 }
 
@@ -216,9 +236,6 @@ const UNREACHABLE_STRIKES = 2;
  * probe still running when the next is due has already answered the question.
  */
 const PROBE_TIMEOUT_MS = 4_000;
-
-/** Strike counts, keyed by bearer VALUE so a rotated credential starts at zero. */
-const failures = new Map<string, number>();
 
 /** WorkspaceError is a refusal this shell can put in front of a human. */
 export class WorkspaceError extends Error {
@@ -501,19 +518,17 @@ export async function openPrepared(prepared: PreparedWorkspace): Promise<Workspa
 /**
  * rememberWorkspace installs a redeemed bearer as the live one for its origin.
  *
- * It is the ONLY writer of the store, so "which credential is current" has one
- * answer and the probe path can compare against it. Replacing an origin's
- * bearer clears the outgoing VALUE's strike count with it: a new credential
- * starts with its full allowance, and the old value's count can never be spent
- * against it — including across a step-up, which rotates the value under a
- * stable session id.
+ * It is the ONLY writer of the store, so bearer identity and health change in
+ * one Map write. Every replacement gets a new local epoch and zero failures;
+ * old asynchronous work retains the outgoing aggregate reference and cannot
+ * spend a strike, clear health, or evict the replacement.
  */
 export function rememberWorkspace(bearer: WorkspaceBearer): void {
-  const previous = bearers.get(bearer.origin);
-  if (previous !== undefined) {
-    failures.delete(previous.value);
-  }
-  failures.delete(bearer.value);
-  bearers.set(bearer.origin, bearer);
+  nextWorkspaceEpoch += 1;
+  workspaceSessions.set(bearer.origin, {
+    bearer,
+    epoch: nextWorkspaceEpoch,
+    consecutiveFailures: 0,
+  });
   publish();
 }

--- a/web/src/api/workspace.ts
+++ b/web/src/api/workspace.ts
@@ -61,6 +61,8 @@ const workspaceSessions = new Map<string, WorkspaceSessionState>();
 const listeners = new Set<() => void>();
 let snapshot: readonly WorkspaceBearer[] = [];
 let nextWorkspaceEpoch = 0;
+let workspaceOwnerKnown = false;
+let workspaceOwnerSession: string | undefined;
 
 function publish(): void {
   snapshot = [...workspaceSessions.values()].map((state) => state.bearer);
@@ -76,6 +78,10 @@ export function workspaceBearer(origin: string): WorkspaceBearer | undefined {
 /** Captures the aggregate identity an asynchronous workspace request belongs to. */
 export function workspaceSession(origin: string): WorkspaceSessionReference | undefined {
   return workspaceSessions.get(origin);
+}
+
+function isCurrentWorkspaceSession(session: WorkspaceSessionReference): boolean {
+  return workspaceSessions.get(session.bearer.origin)?.epoch === session.epoch;
 }
 
 function workspaceSessionFor(bearer: WorkspaceBearer): WorkspaceSessionState | undefined {
@@ -98,6 +104,28 @@ export function forgetWorkspace(origin: string): void {
   }
 }
 
+function forgetAllWorkspaces(): void {
+  if (workspaceSessions.size === 0) {
+    return;
+  }
+  workspaceSessions.clear();
+  publish();
+}
+
+/**
+ * Moves workspace ownership with the root browser session. Login replacement,
+ * logout, and expiry all call this boundary; a new owner receives no remote
+ * bearer or health state from the session that ended.
+ */
+export function transitionWorkspaceOwner(sessionID: string | undefined): void {
+  if (workspaceOwnerKnown && workspaceOwnerSession === sessionID) {
+    return;
+  }
+  workspaceOwnerKnown = true;
+  workspaceOwnerSession = sessionID;
+  forgetAllWorkspaces();
+}
+
 /**
  * dropWorkspaceSession drops one origin ONLY IF the captured aggregate is
  * still current. The transport's 401 kill path and liveness probe both use it.
@@ -107,7 +135,7 @@ export function forgetWorkspace(origin: string): void {
  * work mutate a replacement session.
  */
 export function dropWorkspaceSession(session: WorkspaceSessionReference): void {
-  if (workspaceSessions.get(session.bearer.origin) !== session) {
+  if (!isCurrentWorkspaceSession(session)) {
     return;
   }
   workspaceSessions.delete(session.bearer.origin);
@@ -116,7 +144,7 @@ export function dropWorkspaceSession(session: WorkspaceSessionReference): void {
 
 /** Counts one unreachable probe only against the aggregate that launched it. */
 function strike(session: WorkspaceSessionState): boolean {
-  if (workspaceSessions.get(session.bearer.origin) !== session) {
+  if (!isCurrentWorkspaceSession(session)) {
     return false;
   }
   session.consecutiveFailures += 1;
@@ -205,7 +233,7 @@ export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> 
   // session — so a forbidden never becomes a false reconnect. It does not clear
   // the strike count either: it is not the clean answer that proves liveness.
   if (response.status === 403) {
-    return workspaceSessions.get(bearer.origin) === session;
+    return isCurrentWorkspaceSession(session);
   }
   // ONLY A WELL-FORMED SUCCESS CLEARS THE STRIKE COUNT. Anything else is a
   // strike: a 404 or a 500 is not this endpoint answering, and a 200 carrying
@@ -221,7 +249,7 @@ export async function probeWorkspace(bearer: WorkspaceBearer): Promise<boolean> 
   } catch {
     return strike(session);
   }
-  if (workspaceSessions.get(bearer.origin) !== session) {
+  if (!isCurrentWorkspaceSession(session)) {
     return false;
   }
   session.consecutiveFailures = 0;

--- a/web/src/api/workspaceClient.test.ts
+++ b/web/src/api/workspaceClient.test.ts
@@ -125,7 +125,10 @@ test('a 401 for a value that was already rotated leaves the replacement alone', 
 test('a stale 401 cannot drop a replacement epoch even if bearer text matches', async () => {
   seed('secret-1', 'ses_1');
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-    expect((input as Request).headers.get('Authorization')).toBe('Bearer secret-1');
+    if (!(input instanceof Request)) {
+      throw new Error('workspace client did not issue a Request');
+    }
+    expect(input.headers.get('Authorization')).toBe('Bearer secret-1');
     seed('secret-1', 'ses_2');
     return new Response('{}', { status: 401, headers: { 'Content-Type': 'application/json' } });
   });

--- a/web/src/api/workspaceClient.test.ts
+++ b/web/src/api/workspaceClient.test.ts
@@ -121,3 +121,17 @@ test('a 401 for a value that was already rotated leaves the replacement alone', 
   expect(workspaceBearer(ORIGIN)?.session).toBe('ses_1');
   expect(workspaceBearer(ORIGIN)?.value).toBe('secret-2');
 });
+
+test('a stale 401 cannot drop a replacement epoch even if bearer text matches', async () => {
+  seed('secret-1', 'ses_1');
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    expect((input as Request).headers.get('Authorization')).toBe('Bearer secret-1');
+    seed('secret-1', 'ses_2');
+    return new Response('{}', { status: 401, headers: { 'Content-Type': 'application/json' } });
+  });
+
+  await createWorkspaceClient(ORIGIN).get({ url: '/api/v1/x' });
+
+  expect(workspaceBearer(ORIGIN)?.session).toBe('ses_2');
+  expect(workspaceBearer(ORIGIN)?.value).toBe('secret-1');
+});

--- a/web/src/api/workspaceClient.ts
+++ b/web/src/api/workspaceClient.ts
@@ -1,6 +1,11 @@
 import { createClient, createConfig, type Client } from '@hikyo/runtime-core';
 
-import { dropWorkspaceValue, workspaceBearer, WorkspaceError } from './workspace.ts';
+import {
+  dropWorkspaceSession,
+  workspaceSession,
+  WorkspaceError,
+  type WorkspaceSessionReference,
+} from './workspace.ts';
 
 /**
  * The workspace tier's DATA transport (#71, multi-instance ADR § What the
@@ -46,16 +51,13 @@ export function createWorkspaceClient(origin: string): Client {
     }),
   );
 
-  // Which bearer VALUE each in-flight request was sent under, so a 401 for a
-  // credential that has since been rotated cannot drop its replacement. Keyed
-  // by the Request object the interceptors share; entries fall away with the
-  // request. The value, not the session id — a step-up rotates the value under
-  // a stable session id, and only the exact value that was rejected is dead.
-  const sentUnder = new WeakMap<Request, string>();
+  // Which aggregate epoch each in-flight request was sent under. Bearer text is
+  // not an identity: only the captured aggregate may consume its 401 verdict.
+  const sentUnder = new WeakMap<Request, WorkspaceSessionReference>();
 
   client.interceptors.request.use((request) => {
-    const bearer = workspaceBearer(origin);
-    if (bearer === undefined) {
+    const session = workspaceSession(origin);
+    if (session === undefined) {
       // FAIL CLOSED. No bearer means no workspace: rather than let a call go
       // out unauthenticated (or, worse, pick up an ambient credential), refuse
       // it here. The provider renders the reconnect state whenever the bearer
@@ -66,8 +68,8 @@ export function createWorkspaceClient(origin: string): Client {
         'This workspace is no longer connected. Reconnect to the remote to continue.',
       );
     }
-    request.headers.set('Authorization', `Bearer ${bearer.value}`);
-    sentUnder.set(request, bearer.value);
+    request.headers.set('Authorization', `Bearer ${session.bearer.value}`);
+    sentUnder.set(request, session);
     return request;
   });
 
@@ -83,13 +85,13 @@ export function createWorkspaceClient(origin: string): Client {
     // de-allowlist is not a 403 either: it strips the CORS headers, so the
     // browser blocks the response and the liveness probe catches it.)
     if (response.status === 401) {
-      const value = sentUnder.get(request);
-      if (value !== undefined) {
+      const session = sentUnder.get(request);
+      if (session !== undefined) {
         // The remote has stopped honouring this bearer. Drop it now — the
         // kill switch bites at the next request the ADR promises, and this is
         // that request — so the shell shows "reconnect" without waiting for
         // the liveness poll to notice.
-        dropWorkspaceValue(origin, value);
+        dropWorkspaceSession(session);
       }
     }
     return response;

--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -9,7 +9,7 @@ import {
   workspaceBearer,
   type WorkspaceBearer,
 } from '../api/workspace.ts';
-import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { renderForm, settle, settleTask } from '../testkit/renderForm.tsx';
 import { AuthProvider, useAuth, type WhoAmI } from './AuthProvider.tsx';
 
 type Deferred<T> = {
@@ -173,7 +173,7 @@ describe('AuthProvider', () => {
     expect(text(container, 'private')).toBe('');
 
     await act(async () => replacement.resolve(json(identity('01', '11'))));
-    await settle(30);
+    await settleTask();
     expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
     expect(text(container, 'marker')).toBe('');
     expect(workspaceBearer(workspace.origin)).toBeUndefined();
@@ -249,7 +249,7 @@ describe('AuthProvider', () => {
         <Probe />
       </AuthProvider>,
     );
-    await settle(30);
+    await settleTask();
     expect(text(container, 'private')).toContain(id('ses', '00'));
 
     await act(async () => globalThis.dispatchEvent(new Event('focus')));

--- a/web/src/testkit/renderForm.tsx
+++ b/web/src/testkit/renderForm.tsx
@@ -55,6 +55,15 @@ export async function settle(rounds = 10): Promise<void> {
   }
 }
 
+/** Flush promise work that schedules a TanStack/React notification task. */
+export async function settleTask(): Promise<void> {
+  await settle();
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+  await settle();
+}
+
 /** A 201 JSON response, the shape the create routes answer with. */
 export function created(body: unknown): Response {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
Closes #245.

## Summary
- replace separate bearer/failure maps with one in-memory per-origin workspace session aggregate
- capture a local epoch for probes and transport requests so stale completions cannot mutate or report health for replacements
- bind aggregate lifetime to the root AuthProvider session epoch; login replacement, logout, expiry, and cross-tab replacement clear all workspace state
- preserve canonical-origin keying, two-strike liveness behavior, and same-session step-up rotation

## Contract and migration
- in-memory only; no persistence or data migration
- no bearer enters QueryCache, MutationCache, storage, URL, logs, or snapshots
- generated outputs: none

## Validation
- scoped Vitest: 33 passed
- full web Vitest: 267 passed across 25 files
- web typecheck: passed
- web production build: passed
- workspace Playwright: 26 passed across desktop and mobile against exact rebuilt bundle
- docs verification: passed
- review round 3: Standards CLEAN; Spec SOUND