### PR TITLE
Model display-once machine credential minting #244

### DIFF
--- a/docs/handoff/244-machine-mint-lifecycle.md
+++ b/docs/handoff/244-machine-mint-lifecycle.md
@@ -57,3 +57,10 @@ Pre-commit results on Node 24:
 - 25 web test files and 257 tests passed;
 - the production web build passed;
 - TypeScript client typecheck and all 12 client tests passed.
+
+After integrating current `main`, web typecheck, the production build, all 269
+web tests, client typecheck, and all 12 client tests passed. The rebuilt binary
+passed the machine-access flow in both desktop and mobile projects. One
+mobile-light pinned-assertion run hit the 30-second harness timeout after 20
+passes; that case passed alone in 1.8 seconds, and the display-once case it had
+skipped passed alone in 995 milliseconds.

--- a/docs/handoff/244-machine-mint-lifecycle.md
+++ b/docs/handoff/244-machine-mint-lifecycle.md
@@ -1,0 +1,59 @@
+# Handoff: #244 machine-credential mint lifecycle
+
+Issue #244 replaces `MachineAccess`'s independent mint flags with one closed,
+display-once lifecycle:
+
+```text
+idle → reviewing(request) → submitting(request) → disclosed(request, result)
+                                      ↘ failed(request, error) → submitting(request)
+```
+
+## What changed
+
+- `mintLifecycle.ts` owns review, submit, disclosure, failure, retry,
+  confirmation, dismissal, and clearing transitions. Only `disclosed` can hold
+  the minted value; no transition history is retained.
+- `MachineAccess` keeps a synchronous lifecycle ref beside React state. A
+  second submit is rejected before another transport starts, and async success,
+  failure, and clipboard completion are addressed to the request that began
+  them. Completion from an obsolete request is ignored.
+- Requests freeze only the non-secret fields needed by review and retry:
+  session and project address, account id/name, rotation intent, and
+  disclosure-environment id/name pairs.
+- Close returns the lifecycle to `idle`; project navigation clears it; a new
+  review replaces it; and `MachineAccess` observes the current session id so a
+  session transition clears the lifecycle without remounting unrelated routes.
+- The mint transport remains a plain async call. It does not use TanStack
+  QueryCache or MutationCache, and a focused test inspects both caches after a
+  sentinel mint.
+
+## Contract and migration
+
+No HTTP, generated-client, persistence, or migration change. Credential
+metadata is still refreshed from the ordinary listing after the display-once
+response. No generated output changed.
+
+## Validation
+
+Run with the repository-pinned Node version (`.nvmrc`):
+
+```sh
+pnpm --dir clients/ts install --frozen-lockfile
+pnpm --dir web install --frozen-lockfile
+pnpm --dir web run typecheck
+pnpm --dir web run test
+pnpm --dir web run build
+pnpm --dir web exec playwright test e2e/flows/machine-access.spec.ts
+```
+
+The lifecycle transition table covers sentinel plaintext, close/navigation/
+session clearing, new review, double submit, obsolete completion, failure retry,
+and stored-confirmation dismissal. The existing browser mint flow covers real
+delayed responses, Escape/Back remasking, and display-once removal.
+
+Pre-commit results on Node 24:
+
+- web typecheck passed;
+- 25 web test files and 257 tests passed;
+- the production web build passed;
+- TypeScript client typecheck and all 12 client tests passed.

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -238,6 +238,18 @@ test.describe('machine access', () => {
     expect(value.startsWith(hint), 'the row shows a prefix of the minted value').toBe(true);
     expect(hint.length, 'the hint is far shorter than the value').toBeLessThan(value.length / 2);
 
+    // Reopening creates a fresh reviewing lifecycle. The disclosed component
+    // above was unmounted, and its old plaintext cannot be revived by the new
+    // review before another credential is deliberately submitted.
+    await expansion
+      .getByRole('button', { name: `Mint credential for ${seed.machine.mintable}` })
+      .click();
+    const freshDialog = page.getByRole('dialog');
+    await expect(freshDialog).toBeVisible();
+    await expect(freshDialog.getByText(value, { exact: true })).toHaveCount(0);
+    await freshDialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(freshDialog).toBeHidden();
+
     // Revoking is the other half of rotation, and it bites at the next request
     // rather than at expiry.
     await revokeMinted(page);

--- a/web/src/api/identities.test.ts
+++ b/web/src/api/identities.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  dismissDecision,
   expiryLabel,
   grantWideningReach,
   lastUsedLabel,
@@ -153,24 +152,6 @@ describe('parseClaimNumber', () => {
     // 2^53 + 1 rounds to 2^53 — a DIFFERENT, existing repository id.
     expect(parseClaimNumber('9007199254740993')).toBeNull();
     expect(parseClaimNumber('9007199254740991')).toBe(9_007_199_254_740_991);
-  });
-});
-
-describe('dismissDecision', () => {
-  it('ignores a dismissal while the mint is in flight', () => {
-    // Escape reaches a native <dialog> even when Cancel is disabled. Unmounting
-    // here would lose a value the server may already have committed.
-    expect(dismissDecision({ busy: true, hasValue: false, stored: false })).toBe('ignore');
-    expect(dismissDecision({ busy: true, hasValue: true, stored: true })).toBe('ignore');
-  });
-
-  it('holds the dialog open until the value is confirmed stored', () => {
-    expect(dismissDecision({ busy: false, hasValue: true, stored: false })).toBe('hold-back');
-  });
-
-  it('closes once there is nothing to lose', () => {
-    expect(dismissDecision({ busy: false, hasValue: false, stored: false })).toBe('close');
-    expect(dismissDecision({ busy: false, hasValue: true, stored: true })).toBe('close');
   });
 });
 

--- a/web/src/api/identities.ts
+++ b/web/src/api/identities.ts
@@ -162,8 +162,8 @@ const zMinted = mintMachineCredentialOp.response.pick({ value: true, clamped: tr
  * collection, so a mint run through it would leave the plaintext credential
  * reachable from the query client long after the dialog that showed it closed —
  * a second copy of a value whose whole contract is that there is one. A plain
- * async call leaves the value in exactly one place: the component that renders
- * it once.
+ * async call leaves the value in exactly one place: the ephemeral
+ * `MachineAccess` lifecycle that renders it once.
  */
 export async function mintCredential(
   p: ProjectRef,
@@ -381,35 +381,6 @@ export function parseClaimNumber(raw: string): number | null {
   }
   const value = Number(raw.trim());
   return Number.isSafeInteger(value) ? value : null;
-}
-
-/**
- * dismissDecision is what a dismissal attempt on the mint dialog does.
- *
- * Three outcomes, and the first is the one that is easy to miss: **while the
- * mint is in flight there is no dismissal at all.** Escape reaches a native
- * `<dialog>` even when the Cancel button is disabled, and unmounting mid-flight
- * would let a value the server DID commit arrive at a component that no longer
- * exists — losing it exactly as thoroughly as never minting it, while leaving a
- * live credential behind. After that, a shown value holds the dialog open until
- * the operator confirms they stored it, because there is no second look.
- *
- * It is a function rather than three `if`s in a handler so the rule can be
- * checked without a DOM: the failure it guards against is invisible in a
- * screenshot.
- */
-export function dismissDecision(input: {
-  busy: boolean;
-  hasValue: boolean;
-  stored: boolean;
-}): 'ignore' | 'hold-back' | 'close' {
-  if (input.busy) {
-    return 'ignore';
-  }
-  if (input.hasValue && !input.stored) {
-    return 'hold-back';
-  }
-  return 'close';
 }
 
 /** isoDay renders an instant as the calendar day, which is all these surfaces show. */

--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -117,6 +117,17 @@ function text(container: HTMLElement, testId: string): string {
   return container.querySelector(`[data-testid="${testId}"]`)?.textContent ?? '';
 }
 
+async function expectTextEventually(
+  container: HTMLElement,
+  testId: string,
+  expected: string,
+): Promise<void> {
+  await vi.waitFor(async () => {
+    await settle();
+    expect(text(container, testId)).toContain(expected);
+  });
+}
+
 const unmounts: Array<() => Promise<void>> = [];
 
 async function renderAuth(node: ReactNode) {
@@ -227,8 +238,7 @@ describe('AuthProvider', () => {
         <Probe />
       </AuthProvider>,
     );
-    await settle(30);
-    expect(text(container, 'private')).toContain(id('ses', '00'));
+    await expectTextEventually(container, 'private', id('ses', '00'));
 
     await act(async () => globalThis.dispatchEvent(new Event('focus')));
     expect(text(container, 'state')).toBe('transitioning');

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from 'react';
 import { useParams } from 'react-router';
 
 import type { FederatedClaimPin, GrantResult } from '@hikyo/client';
@@ -8,7 +16,6 @@ import {
   BINDING_LIFETIMES,
   bindingFailureText,
   CI_EVENTS,
-  dismissDecision,
   expiryLabel,
   FEDERATION_PRESETS,
   grantFailureText,
@@ -42,7 +49,16 @@ import {
   type ServiceAccount,
 } from '../api/identities.ts';
 import { useMachineReveal, useSetMachineReveal } from '../api/machineReveal.ts';
+import { useSession } from '../api/session.ts';
 import { runPasskeyCeremony, useEnvironments } from '../api/values.ts';
+import {
+  idleMintLifecycle,
+  mintLifecycleAtBoundary,
+  type MintBoundary,
+  transitionMintLifecycle,
+  type MintLifecycle,
+  type MintLifecycleEvent,
+} from './mintLifecycle.ts';
 import { useModalDialog } from './useModalDialog.ts';
 
 /**
@@ -74,9 +90,16 @@ import { useModalDialog } from './useModalDialog.ts';
 type Tab = 'accounts' | 'federation' | 'kubernetes';
 
 type Dialog =
-  | { kind: 'mint'; account: ServiceAccount; rotating: boolean }
   | { kind: 'binding'; account: ServiceAccount }
   | { kind: 'grant'; account: ServiceAccount };
+
+type MintTransitionResult = {
+  readonly state: MintLifecycle;
+  readonly accepted: boolean;
+};
+
+type MoveMint = (event: MintLifecycleEvent) => MintTransitionResult;
+type IsMintSubmitting = (requestId: number) => boolean;
 
 const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'accounts', label: 'Service accounts' },
@@ -94,6 +117,8 @@ export function MachineAccess() {
   const accountsQuery = useServiceAccounts(project);
   const grantsQuery = useProjectGrants(project);
   const machineRevealQuery = useMachineReveal(project.org, project.project);
+  const session = useSession();
+  const liveSessionId = session.data?.session.id ?? null;
   const machineReveal = machineRevealQuery.data?.enabled ?? false;
   const environmentsQuery = useEnvironments({ ...project, environment: '' });
 
@@ -110,6 +135,58 @@ export function MachineAccess() {
   const [dialog, setDialog] = useState<Dialog | null>(null);
   const [refusal, setRefusal] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [mintLifecycle, setMintLifecycle] = useState<MintLifecycle>(idleMintLifecycle);
+  const mintLifecycleRef = useRef<MintLifecycle>(idleMintLifecycle);
+  const mintBoundary: MintBoundary = {
+    sessionId: liveSessionId,
+    org: project.org,
+    project: project.project,
+  };
+  const mintBoundaryRef = useRef<MintBoundary>(mintBoundary);
+  mintBoundaryRef.current = mintBoundary;
+  const mintRequestId = useRef(0);
+
+  const moveMint = useCallback<MoveMint>((event) => {
+    const current = mintLifecycleRef.current;
+    const next = transitionMintLifecycle(current, event);
+    mintLifecycleRef.current = next;
+    if (next !== current) {
+      setMintLifecycle(next);
+    }
+    return { state: next, accepted: next !== current };
+  }, []);
+  const isMintSubmitting = useCallback<IsMintSubmitting>(
+    (requestId) => {
+      const current = mintLifecycleAtBoundary(
+        mintLifecycleRef.current,
+        mintBoundaryRef.current,
+      );
+      return current.kind === 'submitting' && current.request.id === requestId;
+    },
+    [],
+  );
+
+  // A project route is a new mint boundary. Clear before any completion from
+  // the old route can publish its display-once response into this one.
+  useEffect(() => {
+    moveMint({ type: 'clear', reason: 'navigation' });
+  }, [moveMint, project.org, project.project]);
+
+  // Session replacement is a harder boundary than navigation: even if the
+  // route remains mounted, no disclosure from the old browser session may
+  // survive into the new one.
+  useEffect(() => {
+    moveMint({ type: 'clear', reason: 'session-transition' });
+  }, [moveMint, session.data?.session.id]);
+
+  // Wipe the synchronous ref on unmount too, so an already-resolving promise
+  // sees idle and drops its late result.
+  useEffect(
+    () => () => {
+      mintLifecycleRef.current = idleMintLifecycle;
+    },
+    [],
+  );
 
   const revoke = useRevokeCredential(project);
   const now = useMemo(() => new Date(), []);
@@ -130,6 +207,27 @@ export function MachineAccess() {
   const bindings = (rows: readonly MachineCredential[]) =>
     showable(rows).filter((c) => c.kind === 'oidc-federation');
 
+  const reviewMint = (account: ServiceAccount, rotating: boolean) => {
+    if (liveSessionId === null) {
+      setRefusal('The current session could not be read. Reload before minting a credential.');
+      return;
+    }
+    mintRequestId.current += 1;
+    moveMint({
+      type: 'review',
+      request: {
+        id: mintRequestId.current,
+        sessionId: liveSessionId,
+        org: project.org,
+        project: project.project,
+        accountId: account.id,
+        accountName: account.name,
+        rotating,
+        reach: postStateReach(scopeFor(account)).map(({ id, name }) => ({ id, name })),
+      },
+    });
+  };
+
   const allBindings = accounts.flatMap((sa) =>
     bindings(credentialsFor(sa)).map((credential) => ({ account: sa, credential })),
   );
@@ -144,6 +242,7 @@ export function MachineAccess() {
    * a warning that understates what the operator is about to do.
    */
   const inputsReady =
+    liveSessionId !== null &&
     accountsQuery.isSuccess &&
     grantsQuery.isSuccess &&
     environmentsQuery.isSuccess &&
@@ -171,6 +270,8 @@ export function MachineAccess() {
       },
     );
   };
+
+  const activeMintLifecycle = mintLifecycleAtBoundary(mintLifecycle, mintBoundary);
 
   return (
     <section className="card card--wide machine" aria-labelledby="machine-title">
@@ -324,7 +425,7 @@ export function MachineAccess() {
                         bindings={bindings(rows)}
                         now={now}
                         ready={inputsReady}
-                        onMint={(rotating) => setDialog({ kind: 'mint', account: sa, rotating })}
+                        onMint={(rotating) => reviewMint(sa, rotating)}
                         onBind={() => setDialog({ kind: 'binding', account: sa })}
                         onGrant={() => setDialog({ kind: 'grant', account: sa })}
                         onRevoke={(credential) => doRevoke(sa, credential)}
@@ -410,13 +511,11 @@ export function MachineAccess() {
         ) : null}
       </div>
 
-      {dialog?.kind === 'mint' ? (
+      {activeMintLifecycle.kind !== 'idle' ? (
         <MintDialog
-          project={project}
-          account={dialog.account}
-          rotating={dialog.rotating}
-          reach={postStateReach(scopeFor(dialog.account))}
-          onClose={() => setDialog(null)}
+          lifecycle={activeMintLifecycle}
+          move={moveMint}
+          isSubmitting={isMintSubmitting}
         />
       ) : null}
 
@@ -955,8 +1054,9 @@ function useNavigationGuard(active: boolean, onAttempt: () => void) {
 }
 
 /**
- * MintDialog is the display-once ceremony, and it is the only component in the
- * SPA that ever holds a credential value.
+ * MintDialog renders the display-once ceremony. Its parent lifecycle is the
+ * only SPA state that can ever hold a credential value, and only while that
+ * lifecycle is `disclosed`.
  *
  * The step-up names the POST-STATE formula rather than what the mint adds: a
  * mint adds no grants, so a replacement credential is not a smaller act than a
@@ -965,41 +1065,38 @@ function useNavigationGuard(active: boolean, onAttempt: () => void) {
  * reauthentication, which the panel says in words rather than performing a
  * ceremony that authorises nothing.
  */
-function MintDialog({
-  project,
-  account,
-  rotating,
-  reach,
-  onClose,
+export function MintDialog({
+  lifecycle,
+  move,
+  isSubmitting,
 }: {
-  project: ProjectRef;
-  account: ServiceAccount;
-  rotating: boolean;
-  reach: readonly MachineEnvScope[];
-  onClose: () => void;
+  lifecycle: Exclude<MintLifecycle, { readonly kind: 'idle' }>;
+  move: MoveMint;
+  isSubmitting: IsMintSubmitting;
 }) {
   const dialog = useModalDialog();
-  const refresh = useRefreshAccount(project);
-  const [value, setValue] = useState<string | null>(null);
-  const [clamped, setClamped] = useState(false);
-  const [stored, setStored] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [failure, setFailure] = useState<string | null>(null);
-  const [heldBack, setHeldBack] = useState(false);
-  const [copied, setCopied] = useState<string | null>(null);
+  const request = lifecycle.request;
+  const refresh = useRefreshAccount({ org: request.org, project: request.project });
   const confirmation = useRef<HTMLInputElement>(null);
+  const disclosed = lifecycle.kind === 'disclosed' ? lifecycle : null;
+  const disclosedValue = disclosed?.result.value ?? null;
+  const busy = lifecycle.kind === 'submitting';
+  const failure = lifecycle.kind === 'failed' ? lifecycle.error : null;
 
   // The panel the value arrives on replaces the control that was focused, so
   // focus goes to the one decision left: the stored-confirmation checkbox.
   useEffect(() => {
-    if (value !== null) {
+    if (disclosedValue !== null) {
       confirmation.current?.focus();
     }
-  }, [value]);
+  }, [disclosedValue]);
 
   const run = async () => {
-    setBusy(true);
-    setFailure(null);
+    const started = move({ type: 'submit' });
+    if (!started.accepted || started.state.kind !== 'submitting') {
+      return;
+    }
+    const active = started.state.request;
     // `issued` is the difference between "nothing happened" and "something may
     // have". Once the request leaves, a failure says nothing about whether the
     // server committed — and a mint that committed and whose response was lost
@@ -1009,47 +1106,43 @@ function MintDialog({
       // One reauthentication per environment the account reaches in the
       // post-state, which is exactly the set the server will consume. An empty
       // reach runs no ceremony because there is no disclosure to authorise.
-      for (const environment of reach) {
+      for (const environment of active.reach) {
         await runPasskeyCeremony({
           operation: 'mint',
           environmentId: environment.id,
           keyIds: [],
         });
+        if (!isSubmitting(active.id)) {
+          return;
+        }
+      }
+      if (!isSubmitting(active.id)) {
+        return;
       }
       issued = true;
-      const minted = await mintCredential(project, account.id);
-      setValue(minted.value);
-      setClamped(minted.clamped);
-      refresh(account.id);
+      const minted = await mintCredential(
+        { org: active.org, project: active.project },
+        active.accountId,
+      );
+      move({ type: 'succeeded', requestId: active.id, result: minted });
+      refresh(active.accountId);
     } catch (error) {
       if (issued) {
         // Re-read the rows so the operator can see — and revoke — whatever may
         // have landed.
-        refresh(account.id);
-        setFailure(mintFailureText(error));
+        refresh(active.accountId);
+        move({ type: 'failed', requestId: active.id, error: mintFailureText(error) });
       } else {
-        setFailure(identityRefusalText(error));
+        move({ type: 'failed', requestId: active.id, error: identityRefusalText(error) });
       }
-    } finally {
-      setBusy(false);
     }
   };
 
-  const dismiss = () => {
-    switch (dismissDecision({ busy, hasValue: value !== null, stored })) {
-      case 'ignore':
-        return;
-      case 'hold-back':
-        setHeldBack(true);
-        return;
-      default:
-        onClose();
-    }
-  };
+  const dismiss = () => move({ type: 'dismiss' });
 
   // Back, reload and tab close are dismissals too — an in-flight mint or an
   // unstored value must not be lost to a navigation the buttons would refuse.
-  useNavigationGuard(busy || (value !== null && !stored), dismiss);
+  useNavigationGuard(busy || (disclosed !== null && !disclosed.stored), dismiss);
 
   return (
     <dialog
@@ -1062,10 +1155,10 @@ function MintDialog({
         dismiss();
       }}
     >
-      {value === null ? (
+      {disclosed === null ? (
         <>
           <h2 className="ceremony__title" id="mint-title">
-            {`${rotating ? 'rotate' : 'mint'} credential · ${account.name}`}
+            {`${request.rotating ? 'rotate' : 'mint'} credential · ${request.accountName}`}
           </h2>
           <p className="ceremony__stepup">
             <span className="alert__glyph" aria-hidden="true">
@@ -1079,11 +1172,11 @@ function MintDialog({
             </span>
           </p>
           <p className="ceremony__scope">
-            {reach.length === 0
+            {request.reach.length === 0
               ? 'This account reaches no plaintext in the resulting post-state, so no disclosure capability and no reauthentication are required. Its deliveries stay configuration and secret presence only.'
-              : `This account decrypts ${reach.map((r) => r.name).join(', ')}. Each takes its own passkey reauthentication before the value is minted.`}
+              : `This account decrypts ${request.reach.map((r) => r.name).join(', ')}. Each takes its own passkey reauthentication before the value is minted.`}
           </p>
-          {rotating ? (
+          {request.rotating ? (
             <p className="ceremony__lede">
               The prior value is never returned. The predecessor keeps authenticating until you
               revoke it — rotation and revocation are separate, deliberate acts, so a mint that
@@ -1107,11 +1200,11 @@ function MintDialog({
             >
               {busy
                 ? 'Minting…'
-                : reach.length === 0
+                : request.reach.length === 0
                   ? 'Mint credential'
                   : 'Use a passkey and mint'}
             </button>
-            <button className="btn" type="button" onClick={onClose} disabled={busy}>
+            <button className="btn" type="button" onClick={dismiss} disabled={busy}>
               Cancel
             </button>
           </div>
@@ -1121,8 +1214,8 @@ function MintDialog({
           <h2 className="ceremony__title" id="mint-title">
             Credential minted — shown exactly once
           </h2>
-          <p className="mono machine__token">{value}</p>
-          {clamped ? (
+          <p className="mono machine__token">{disclosed.result.value}</p>
+          {disclosed.result.clamped ? (
             <p className="notice" role="status">
               <span className="alert__glyph" aria-hidden="true">
                 !
@@ -1148,23 +1241,31 @@ function MintDialog({
             type="button"
             onClick={() => {
               void navigator.clipboard
-                .writeText(value)
+                .writeText(disclosed.result.value)
                 .then(() =>
-                  setCopied(
-                    'Copied. The clipboard is now the only copy outside its target system.',
-                  ),
+                  move({
+                    type: 'copy-status',
+                    requestId: request.id,
+                    message: 'Copied. The clipboard is now the only copy outside its target system.',
+                  }),
                 )
-                .catch(() => setCopied('This browser refused clipboard access, so nothing was copied.'));
+                .catch(() =>
+                  move({
+                    type: 'copy-status',
+                    requestId: request.id,
+                    message: 'This browser refused clipboard access, so nothing was copied.',
+                  }),
+                );
             }}
           >
             Copy to clipboard
           </button>
-          {copied === null ? null : (
+          {disclosed.copyStatus === null ? null : (
             <p className="notice" role="status">
               <span className="alert__glyph" aria-hidden="true">
                 ⧉
               </span>
-              <span>{copied}</span>
+              <span>{disclosed.copyStatus}</span>
             </p>
           )}
           <div className="field chk">
@@ -1172,15 +1273,14 @@ function MintDialog({
               id="mint-stored"
               type="checkbox"
               ref={confirmation}
-              checked={stored}
+              checked={disclosed.stored}
               onChange={(event) => {
-                setStored(event.target.checked);
-                setHeldBack(false);
+                move({ type: 'confirm-stored', stored: event.target.checked });
               }}
             />
             <label htmlFor="mint-stored">I have stored this credential in its target system.</label>
           </div>
-          {heldBack ? (
+          {disclosed.heldBack ? (
             <p className="alert" role="alert">
               <span className="alert__glyph" aria-hidden="true">
                 !

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -49,7 +49,7 @@ import {
   type ServiceAccount,
 } from '../api/identities.ts';
 import { useMachineReveal, useSetMachineReveal } from '../api/machineReveal.ts';
-import { useSession } from '../api/session.ts';
+import { useAuth } from '../app/AuthProvider.tsx';
 import { runPasskeyCeremony, useEnvironments } from '../api/values.ts';
 import {
   idleMintLifecycle,
@@ -117,8 +117,8 @@ export function MachineAccess() {
   const accountsQuery = useServiceAccounts(project);
   const grantsQuery = useProjectGrants(project);
   const machineRevealQuery = useMachineReveal(project.org, project.project);
-  const session = useSession();
-  const liveSessionId = session.data?.session.id ?? null;
+  const auth = useAuth();
+  const liveSessionId = auth.identity?.session.id ?? null;
   const machineReveal = machineRevealQuery.data?.enabled ?? false;
   const environmentsQuery = useEnvironments({ ...project, environment: '' });
 
@@ -177,7 +177,7 @@ export function MachineAccess() {
   // survive into the new one.
   useEffect(() => {
     moveMint({ type: 'clear', reason: 'session-transition' });
-  }, [moveMint, session.data?.session.id]);
+  }, [liveSessionId, moveMint]);
 
   // Wipe the synchronous ref on unmount too, so an already-resolving promise
   // sees idle and drops its late result.

--- a/web/src/routes/MintDialog.test.tsx
+++ b/web/src/routes/MintDialog.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { act, useRef, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { MintDialog } from './MachineAccess.tsx';
+import {
+  transitionMintLifecycle,
+  type MintLifecycle,
+  type MintLifecycleEvent,
+  type MintRequest,
+} from './mintLifecycle.ts';
+
+const SENTINEL = 'hik_1_wl_SENTINEL_PLAINTEXT';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const REQUEST: MintRequest = {
+  id: 1,
+  sessionId: 'ses_first',
+  org: 'org_acme',
+  project: 'prj_payments',
+  accountId: 'mch_worker',
+  accountName: 'worker',
+  rotating: false,
+  reach: [],
+};
+
+function MintHarness() {
+  const [lifecycle, setLifecycle] = useState<MintLifecycle>({
+    kind: 'reviewing',
+    request: REQUEST,
+  });
+  const lifecycleRef = useRef<MintLifecycle>(lifecycle);
+  const move = (event: MintLifecycleEvent) => {
+    const current = lifecycleRef.current;
+    const next = transitionMintLifecycle(current, event);
+    lifecycleRef.current = next;
+    if (next !== current) {
+      setLifecycle(next);
+    }
+    return { state: next, accepted: next !== current };
+  };
+  const isSubmitting = (requestId: number) =>
+    lifecycleRef.current.kind === 'submitting' && lifecycleRef.current.request.id === requestId;
+
+  return lifecycle.kind === 'idle' ? null : (
+    <MintDialog lifecycle={lifecycle} move={move} isSubmitting={isSubmitting} />
+  );
+}
+
+describe('MintDialog', () => {
+  it('renders display-once plaintext without entering its QueryCache or MutationCache', async () => {
+    const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) =>
+      Promise.resolve(
+        new Response(JSON.stringify({ value: SENTINEL, clamped: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container, client } = await renderForm(<MintHarness />);
+    const button = container.querySelector('button');
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('the mint dialog has no submit button');
+    }
+    await act(async () => button.click());
+    await settle();
+
+    expect(container.querySelector('.machine__token')?.textContent).toBe(SENTINEL);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(client.getQueryCache().getAll()).toEqual([]);
+    expect(client.getMutationCache().getAll()).toEqual([]);
+  });
+});

--- a/web/src/routes/mintLifecycle.test.ts
+++ b/web/src/routes/mintLifecycle.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  idleMintLifecycle,
+  mintLifecycleAtBoundary,
+  transitionMintLifecycle,
+  type MintLifecycle,
+  type MintBoundary,
+  type MintRequest,
+} from './mintLifecycle.ts';
+
+const SENTINEL = 'hik_1_wl_SENTINEL_PLAINTEXT';
+const CLEAR_REASONS: ReadonlyArray<'close' | 'navigation' | 'session-transition'> = [
+  'close',
+  'navigation',
+  'session-transition',
+];
+const OTHER_BOUNDARIES: ReadonlyArray<{ readonly label: string; readonly value: MintBoundary }> = [
+  {
+    label: 'session',
+    value: { sessionId: 'ses_second', org: 'org_acme', project: 'prj_payments' },
+  },
+  {
+    label: 'organisation route',
+    value: { sessionId: 'ses_first', org: 'org_other', project: 'prj_payments' },
+  },
+  {
+    label: 'project route',
+    value: { sessionId: 'ses_first', org: 'org_acme', project: 'prj_other' },
+  },
+];
+
+const request = (id: number, accountId = 'mch_first'): MintRequest => ({
+  id,
+  sessionId: 'ses_first',
+  org: 'org_acme',
+  project: 'prj_payments',
+  accountId,
+  accountName: accountId === 'mch_first' ? 'first worker' : 'second worker',
+  rotating: false,
+  reach: [{ id: 'env_prod', name: 'production' }],
+});
+
+function submitting(input: MintRequest): MintLifecycle {
+  const reviewing = transitionMintLifecycle(idleMintLifecycle, { type: 'review', request: input });
+  return transitionMintLifecycle(reviewing, { type: 'submit' });
+}
+
+function disclosed(input: MintRequest): MintLifecycle {
+  return transitionMintLifecycle(submitting(input), {
+    type: 'succeeded',
+    requestId: input.id,
+    result: { value: SENTINEL, clamped: false },
+  });
+}
+
+describe('MintLifecycle', () => {
+  it('makes plaintext reachable only from disclosed', () => {
+    const reviewed = transitionMintLifecycle(idleMintLifecycle, {
+      type: 'review',
+      request: request(1),
+    });
+    const pending = transitionMintLifecycle(reviewed, { type: 'submit' });
+    const shown = transitionMintLifecycle(pending, {
+      type: 'succeeded',
+      requestId: 1,
+      result: { value: SENTINEL, clamped: true },
+    });
+
+    expect([idleMintLifecycle.kind, reviewed.kind, pending.kind, shown.kind]).toEqual([
+      'idle',
+      'reviewing',
+      'submitting',
+      'disclosed',
+    ]);
+    expect(JSON.stringify(idleMintLifecycle)).not.toContain(SENTINEL);
+    expect(JSON.stringify(reviewed)).not.toContain(SENTINEL);
+    expect(JSON.stringify(pending)).not.toContain(SENTINEL);
+    expect(JSON.stringify(shown)).toContain(SENTINEL);
+  });
+
+  it.each(CLEAR_REASONS)(
+    '%s clears disclosed plaintext without retaining transition history',
+    (reason) => {
+      const cleared = transitionMintLifecycle(disclosed(request(1)), { type: 'clear', reason });
+
+      expect(cleared).toEqual({ kind: 'idle' });
+      expect(JSON.stringify(cleared)).not.toContain(SENTINEL);
+    },
+  );
+
+  it('a new mint replaces disclosed state with non-secret review fields', () => {
+    const next = transitionMintLifecycle(disclosed(request(1)), {
+      type: 'review',
+      request: request(2, 'mch_second'),
+    });
+
+    expect(next).toEqual({ kind: 'reviewing', request: request(2, 'mch_second') });
+    expect(JSON.stringify(next)).not.toContain(SENTINEL);
+  });
+
+  it.each(OTHER_BOUNDARIES)(
+    'masks disclosed plaintext synchronously when the $label changes',
+    ({ value }) => {
+      const shown = disclosed(request(1));
+      const masked = mintLifecycleAtBoundary(shown, value);
+
+      expect(masked).toEqual({ kind: 'idle' });
+      expect(JSON.stringify(masked)).not.toContain(SENTINEL);
+    },
+  );
+
+  it('ignores double submit and a late response from an obsolete request', () => {
+    const first = submitting(request(1));
+    const duplicate = transitionMintLifecycle(first, { type: 'submit' });
+    expect(duplicate).toBe(first);
+
+    const secondReview = transitionMintLifecycle(first, {
+      type: 'review',
+      request: request(2, 'mch_second'),
+    });
+    const second = transitionMintLifecycle(secondReview, { type: 'submit' });
+    const stale = transitionMintLifecycle(second, {
+      type: 'succeeded',
+      requestId: 1,
+      result: { value: SENTINEL, clamped: false },
+    });
+
+    expect(stale).toBe(second);
+    expect(JSON.stringify(stale)).not.toContain(SENTINEL);
+
+    const current = transitionMintLifecycle(stale, {
+      type: 'succeeded',
+      requestId: 2,
+      result: { value: 'hik_1_wl_CURRENT', clamped: false },
+    });
+    expect(current.kind).toBe('disclosed');
+  });
+
+  it('failure and retry preserve only the intended non-secret request', () => {
+    const intended = request(1);
+    const failed = transitionMintLifecycle(submitting(intended), {
+      type: 'failed',
+      requestId: intended.id,
+      error: 'The credential may have been minted; check the list.',
+    });
+
+    expect(failed).toEqual({
+      kind: 'failed',
+      request: intended,
+      error: 'The credential may have been minted; check the list.',
+    });
+    expect(JSON.stringify(failed)).not.toContain(SENTINEL);
+
+    const retried = transitionMintLifecycle(failed, { type: 'submit' });
+    expect(retried).toEqual({ kind: 'submitting', request: intended });
+  });
+
+  it('dismissal holds an unstored disclosure, then clears it after confirmation', () => {
+    const pending = submitting(request(1));
+    expect(transitionMintLifecycle(pending, { type: 'dismiss' })).toBe(pending);
+
+    const shown = disclosed(request(1));
+    const held = transitionMintLifecycle(shown, { type: 'dismiss' });
+    expect(held.kind).toBe('disclosed');
+    if (held.kind !== 'disclosed') {
+      throw new Error('dismissal did not retain the disclosure');
+    }
+    expect(held.heldBack).toBe(true);
+    expect(held.result.value).toBe(SENTINEL);
+
+    const stored = transitionMintLifecycle(held, { type: 'confirm-stored', stored: true });
+    const closed = transitionMintLifecycle(stored, { type: 'dismiss' });
+    expect(closed).toEqual({ kind: 'idle' });
+    expect(JSON.stringify(closed)).not.toContain(SENTINEL);
+  });
+});

--- a/web/src/routes/mintLifecycle.ts
+++ b/web/src/routes/mintLifecycle.ts
@@ -1,0 +1,127 @@
+/**
+ * Non-secret inputs frozen when the operator opens mint review.
+ *
+ * Keep this narrower than ServiceAccount and MachineEnvScope: retry needs the
+ * addressed account, the review labels, and the disclosure environments. It
+ * must not inherit unrelated query data or any credential response field.
+ */
+export type MintRequest = {
+  readonly id: number;
+  readonly sessionId: string;
+  readonly org: string;
+  readonly project: string;
+  readonly accountId: string;
+  readonly accountName: string;
+  readonly rotating: boolean;
+  readonly reach: readonly { readonly id: string; readonly name: string }[];
+};
+
+export type MintResult = {
+  readonly value: string;
+  readonly clamped: boolean;
+};
+
+export type MintLifecycle =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'reviewing'; readonly request: MintRequest }
+  | { readonly kind: 'submitting'; readonly request: MintRequest }
+  | { readonly kind: 'failed'; readonly request: MintRequest; readonly error: string }
+  | {
+      readonly kind: 'disclosed';
+      readonly request: MintRequest;
+      readonly result: MintResult;
+      readonly stored: boolean;
+      readonly heldBack: boolean;
+      readonly copyStatus: string | null;
+    };
+
+export type MintLifecycleEvent =
+  | { readonly type: 'review'; readonly request: MintRequest }
+  | { readonly type: 'submit' }
+  | { readonly type: 'succeeded'; readonly requestId: number; readonly result: MintResult }
+  | { readonly type: 'failed'; readonly requestId: number; readonly error: string }
+  | { readonly type: 'confirm-stored'; readonly stored: boolean }
+  | { readonly type: 'copy-status'; readonly requestId: number; readonly message: string }
+  | { readonly type: 'dismiss' }
+  | {
+      readonly type: 'clear';
+      readonly reason: 'close' | 'navigation' | 'session-transition';
+    };
+
+export const idleMintLifecycle: MintLifecycle = { kind: 'idle' };
+
+export type MintBoundary = {
+  readonly sessionId: string | null;
+  readonly org: string;
+  readonly project: string;
+};
+
+/** Mask lifecycle state synchronously when its route or session no longer owns it. */
+export function mintLifecycleAtBoundary(
+  state: MintLifecycle,
+  boundary: MintBoundary,
+): MintLifecycle {
+  if (state.kind === 'idle') {
+    return state;
+  }
+  return state.request.sessionId === boundary.sessionId &&
+    state.request.org === boundary.org &&
+    state.request.project === boundary.project
+    ? state
+    : idleMintLifecycle;
+}
+
+/**
+ * Closed mint state machine.
+ *
+ * Invalid events return the same object. Callers use that identity to avoid
+ * starting a second transport while React is still scheduling the first
+ * submitting render. Async completion is request-addressed, so an old response
+ * cannot put plaintext back after navigation, a new mint, or a session exit.
+ */
+export function transitionMintLifecycle(
+  state: MintLifecycle,
+  event: MintLifecycleEvent,
+): MintLifecycle {
+  switch (event.type) {
+    case 'review':
+      return { kind: 'reviewing', request: event.request };
+    case 'submit':
+      return state.kind === 'reviewing' || state.kind === 'failed'
+        ? { kind: 'submitting', request: state.request }
+        : state;
+    case 'succeeded':
+      return state.kind === 'submitting' && state.request.id === event.requestId
+        ? {
+            kind: 'disclosed',
+            request: state.request,
+            result: event.result,
+            stored: false,
+            heldBack: false,
+            copyStatus: null,
+          }
+        : state;
+    case 'failed':
+      return state.kind === 'submitting' && state.request.id === event.requestId
+        ? { kind: 'failed', request: state.request, error: event.error }
+        : state;
+    case 'confirm-stored':
+      return state.kind === 'disclosed'
+        ? { ...state, stored: event.stored, heldBack: false }
+        : state;
+    case 'copy-status':
+      return state.kind === 'disclosed' && state.request.id === event.requestId
+        ? { ...state, copyStatus: event.message }
+        : state;
+    case 'dismiss':
+      if (state.kind === 'submitting' || state.kind === 'idle') {
+        return state;
+      }
+      if (state.kind === 'disclosed' && !state.stored) {
+        return { ...state, heldBack: true };
+      }
+      return idleMintLifecycle;
+    case 'clear':
+      return state.kind === 'idle' ? state : idleMintLifecycle;
+  }
+}


### PR DESCRIPTION
Closes #244.

## What changed

- Replaces independent machine-credential mint flags with one closed lifecycle: `idle`, `reviewing`, `submitting`, `disclosed`, or `failed`.
- Keeps the plaintext credential only in `disclosed`, clears it on dismissal, navigation, unmount, new mint, and browser-session transition, and rejects stale or duplicate async completions.
- Keeps minting on the plain async transport so credential values never enter TanStack query or mutation caches.
- Adds transition, real-component cache, delayed-response/remasking browser coverage, and the required handoff note.

## Contract and migration

No HTTP contract, generated client, persistence, or migration change. No generated output changed.

## Validation

- Three review rounds: standards clean and spec clean.
- Web typecheck, production build, 27 test files / 269 tests green.
- TypeScript client typecheck and 12 tests green.
- Rebuilt-binary machine-access browser flow covered desktop and mobile; one local harness timeout passed immediately on isolated rerun, as did the case it skipped.
