### PR TITLE
test: make auth provider query wait deterministic #233

### DIFF
--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -227,8 +227,9 @@ describe('AuthProvider', () => {
         <Probe />
       </AuthProvider>,
     );
-    await settle(30);
-    expect(text(container, 'private')).toContain(id('ses', '00'));
+    await vi.waitFor(() => {
+      expect(text(container, 'private')).toContain(id('ses', '00'));
+    });
 
     await act(async () => globalThis.dispatchEvent(new Event('focus')));
     expect(text(container, 'state')).toBe('transitioning');


### PR DESCRIPTION
Follow-up for #233 post-merge verification.

Main CI run 32594178445 exposed a deterministic synchronization failure in `web/src/app/AuthProvider.test.tsx`: the test flushed microtasks with `settle(30)`, but TanStack Query publishes the observed data asynchronously.

This keeps the same user-visible assertion and waits for it with Vitest’s bounded `vi.waitFor`.

Validation:
- focused test failed before the fix
- focused file passed 30/30 repetitions after the fix
- web typecheck passed
- all 260 web tests passed
- production web build passed
- standards review CLEAN
- behavioral review CLEAN