### PR TITLE
Bind conformance fixtures to stable references #251

### DIFF
--- a/docs/handoff/251-bound-fixture-references.md
+++ b/docs/handoff/251-bound-fixture-references.md
@@ -1,0 +1,32 @@
+# Issue #251: stable bound fixture references
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/251 (parent #206; programme
+#203; audit ID `QA01-B`). Base: `7e3dd0f6c13ce98572f4cd4f7f6015c2339bce77`.
+
+## Contract
+
+- Every conformance bound row has a stable slug ID, retained human-readable
+  evidence, and at least one typed `FixtureRef` naming its exact Go package,
+  test/helper/subtest name, and supported kind.
+- `internal/testutil/fixtureref` resolves package ownership with `go list` and
+  indexes `_test.go` declarations through the Go AST. Build-tagged files are
+  included rather than silently disappearing under the host's active tags.
+- Top-level tests follow the Go tool's name and signature rules. Literal
+  subtests bind to the exact `*testing.T` parameter object, so unrelated or
+  shadowed `Run` methods cannot satisfy a reference. Duplicate, missing,
+  renamed, wrong-package, and wrong-kind references fail.
+- Pending explanations remain separate from executable identity. Generated
+  outputs: none.
+
+## Coverage and review
+
+- Fixture-reference and conformance suites: 89 tests passed.
+- New exact boundary regressions for remote-count, adapter outbox depth, and
+  API paging passed; the previously failing importer live test passed alone.
+- `go vet ./...` passed. The local uncached full run reached 3,314 passes and
+  then reported the importer live-test flake plus the known long-running local
+  isolation-package failure; all changed/failed seams passed on focused rerun.
+  Exact-head CI remains the authoritative full gate.
+- Three review rounds completed after fixes for false Go-test signatures,
+  unrelated/shadowed `Run` receivers, and weak row bindings. Standards and
+  spec both returned `CLEAN` in round 3.

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -4,21 +4,19 @@ package conformance
 // named, user-visible refusal when hit; this registry is the single list that
 // "drives the fixture list". Each entry records the bound, its ops-spec home,
 // the named refusal it fires (or why it is a clamp / unreachable / pending),
-// and the fixture that proves it.
+// and exact executable references plus readable evidence for the fixtures that
+// prove it.
 //
-// The registry is a LEDGER plus a VALUE PIN, not a fixture executor: the named
-// refusal for each bound is proven by that bound's own fixture (the test named
-// in Fixture), which lives in the package that owns the bound. What this file
-// adds on top is (a) a single place that must name a fixture or a loud deferral
-// for every bound, and (b) a build-time pin of every bound's VALUE to the spec,
-// so the failure Codex worried about — silently drifting a constant — fails
-// here. Removing a bound's own refusal logic is caught by that bound's fixture,
-// not by this ledger.
+// The registry is a LEDGER plus a VALUE PIN, not a fixture executor. Package
+// AST validation proves every typed fixture reference still has one exact
+// definition, including helpers, literal subtests and build-tagged tests. The
+// fixture itself proves behavior. Value drift off spec fails here too.
 //
-// Three tests give it teeth:
+// These tests give it teeth:
 //   - TestBoundRegistryIsWellFormed: every entry is complete for its status, so
-//     a bound cannot be registered without either a fixture or an explicit,
-//     owner-named deferral.
+//     every stable row ID has at least one executable fixture reference.
+//   - TestBoundRegistryFixtureReferencesResolve: every reference has one exact
+//     package-owned definition of the declared kind.
 //   - TestBoundRegistryPendingBoundsAreDisposition: every pending bound is a
 //     loud, owner-named human-disposition item, never a silent gap.
 //   - TestReconciledBoundsMatchOpsSpecValues: every reconciled EXPORTED constant
@@ -26,7 +24,6 @@ package conformance
 //     fails the build here rather than silently.
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +36,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/schema"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/testutil/fixtureref"
 )
 
 // BoundStatus classifies how a named bound is realized.
@@ -59,18 +57,39 @@ const (
 	// apply.
 	StatusSanitize BoundStatus = "sanitize"
 	// StatusPending: named in spec, but its enforcement awaits an owning feature
-	// that does not yet exist; Fixture names the owner/reason. These are the
+	// that does not yet exist; PendingReason names the owner/reason. These are the
 	// explicit disposition items, never silent gaps.
 	StatusPending BoundStatus = "enforcement-pending"
 )
 
+// BoundID is the stable identity of one registry row. Names and descriptions
+// may improve without breaking references to the obligation itself.
+type BoundID string
+
 // Bound is one row of the registry.
 type Bound struct {
-	Name    string // the ops-spec name of the bound
-	Spec    string // its ops-spec / ops-catalogue home
-	Refusal string // the named refusal it fires, or the clamp/invariant/reason
-	Fixture string // the test that proves it, or the owner/reason for a pending bound
-	Status  BoundStatus
+	ID            BoundID
+	Name          string // the ops-spec name of the bound
+	Spec          string // its ops-spec / ops-catalogue home
+	Refusal       string // the named refusal it fires, or the clamp/invariant/reason
+	Evidence      string // readable explanation retained alongside executable references
+	Fixtures      []fixtureref.FixtureRef
+	PendingReason string // owner and reason when Status is StatusPending
+	Status        BoundStatus
+}
+
+const modulePath = "github.com/Hikyo-Org/hikyo/"
+
+func bound(id BoundID, name, spec, refusal, evidence string, status BoundStatus, fixtures ...fixtureref.FixtureRef) Bound {
+	return Bound{ID: id, Name: name, Spec: spec, Refusal: refusal, Evidence: evidence, Fixtures: fixtures, Status: status}
+}
+
+func goTest(packagePath, name string) fixtureref.FixtureRef {
+	return fixtureref.FixtureRef{Package: modulePath + packagePath, TestName: name, Kind: fixtureref.KindTest}
+}
+
+func goHelper(packagePath, name string) fixtureref.FixtureRef {
+	return fixtureref.FixtureRef{Package: modulePath + packagePath, TestName: name, Kind: fixtureref.KindHelper}
 }
 
 // Registry is the authoritative list that drives the fixture list: every named
@@ -80,71 +99,113 @@ type Bound struct {
 // spec rows is a review responsibility on this single source.
 var Registry = []Bound{
 	// §4 admission / §10 runtime.
-	{"Admission queue depth", "ops-spec §4 / inv.8", "admission.ErrOverloaded", "admission.TestQueueDepth", StatusEnforced},
-	{"API response cap", "ops-spec §10", "response ≤ 5 MiB / paged", "server contract tests", StatusEnforced},
-	{"Audit page size", "ops-spec §10 / §2", "clamp to store.AuditMaxPageSize", "store.TestAuditPageSizeIsClampedToTheCap", StatusClamp},
-	{"SSE admission caps", "ops-spec §10", "advisory principal/org/instance limits", "service.TestAdvisory* (advisory_test)", StatusEnforced},
+	bound("admission-queue-depth", "Admission queue depth", "ops-spec §4 / inv.8", "admission.ErrOverloaded", "admission.TestQueueDepth", StatusEnforced,
+		goTest("internal/admission", "TestQueueDepthIsBounded")),
+	bound("api-response-cap", "API response cap", "ops-spec §10", "response ≤ 5 MiB / paged", "server contract tests", StatusEnforced,
+		goTest("internal/isolation", "TestAuditExportDoesNotTruncateAboveThePageCap")),
+	bound("audit-page-size", "Audit page size", "ops-spec §10 / §2", "clamp to store.AuditMaxPageSize", "store.TestAuditPageSizeIsClampedToTheCap", StatusClamp,
+		goTest("internal/store", "TestAuditPageSizeIsClampedToTheCap")),
+	bound("sse-admission-caps", "SSE admission caps", "ops-spec §10", "advisory principal/org/instance limits", "service.TestAdvisory* (advisory_test)", StatusEnforced,
+		goTest("internal/service", "TestAdvisoryConnectionCaps")),
 
 	// §5 machine identities.
-	{"Machine credentials per SA", "ops-spec §5", "service.ErrCredentialCap", "isolation identities_e2e", StatusEnforced},
+	bound("machine-credentials-per-sa", "Machine credentials per SA", "ops-spec §5", "service.ErrCredentialCap", "isolation identities_e2e", StatusEnforced,
+		goTest("internal/isolation", "TestMachineCredentialCapSQLite")),
 
 	// §8 structural bounds.
-	{"Environments per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxEnvironmentsPerProject)", "conformance scenarioDeleteRefusesChildren / env cap", StatusEnforced},
-	{"Resolved-cell budget", "ops-spec §8", "envs × keys ≤ MaxResolvedCells", "service.TestResolvedCellBudgetComposesByConstruction", StatusByConstruction},
-	{"Value size", "ops-spec §8", "schema value bound (MaxValueBytes)", "schema validate_test / conformance values_test", StatusEnforced},
-	{"Key name length", "ops-catalogue §Key-name", "schema key-name bound (MaxKeyNameBytes)", "schema declare_test", StatusEnforced},
-	{"Keys per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxKeysPerProject)", "service definitions_test", StatusEnforced},
-	{"Key groups per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxKeyGroupsPerProject)", "service definitions_test", StatusEnforced},
-	{"Declaration bytes / $ref depth / subschemas / enum / pattern / any_of", "ops-spec §8", "declaration-time rejection", "schema declare_test / conformance catalogue_test", StatusEnforced},
-	{"Verdict errors / bytes", "ops-spec §8", "verdict cap (MaxVerdictErrors / MaxVerdictErrorBytes)", "schema validate_test", StatusEnforced},
-	{"Evaluation budget (steps + deadline)", "ops-spec §8", "step-cap at declaration + per-value wall-clock deadline (EvaluationDeadline)", "schema declare_test / deadline_internal_test", StatusEnforced},
-	{"Plan expiry / open-plan quota", "ops-spec §8 source-of-truth", "PlanTTL + MaxOpenPlansPerProject", "isolation definitions_e2e", StatusEnforced},
-	{"Per-target render total", "ops-spec §8", "domain.ErrLimitExceeded (MaxRenderBytesPerTarget)", "service.TestRenderTotalRefusesAnOversizedTarget", StatusEnforced},
-	{"Pending versions per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxPendingPerProject)", "isolation.TestPendingPerProjectCap", StatusEnforced},
-	{"Bundle bytes / entries", "ops-spec §8", "definitions.ErrLimitExceeded (MaxBundle*)", "definitions bundle_test", StatusEnforced},
-	{"Open plans per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxOpenPlansPerProject)", "isolation definitions_e2e", StatusEnforced},
-	{"Pins quota per project", "ops-spec §8", "invalidDetail (PinQuota)", "conformance revisions_test", StatusEnforced},
-	{"Grants per org", "ops-spec §8", "domain.ErrLimitExceeded (MaxGrantsPerOrg)", "isolation.TestGrantPerOrgCap", StatusEnforced},
-	{"Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "domain.ErrLimitExceeded (MaxProjectStorageBytes) at publish + doctor/metric/UI-banner warn (ProjectStorageWarnBytes)", "isolation.TestProjectStorageHighWater", StatusEnforced},
-	{"Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "admission.ErrOverloaded (uniform 429) via service.Budget", "conformance scenarioSchemaRevisionRateLimit + service.TestBudgetRateWindowSlides", StatusEnforced},
+	bound("environments-per-project", "Environments per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxEnvironmentsPerProject)", "conformance scenarioDeleteRefusesChildren / env cap", StatusEnforced,
+		goHelper("internal/conformance", "scenarioEnvironmentCap")),
+	bound("resolved-cell-budget", "Resolved-cell budget", "ops-spec §8", "envs × keys ≤ MaxResolvedCells", "service.TestResolvedCellBudgetComposesByConstruction", StatusByConstruction,
+		goTest("internal/service", "TestResolvedCellBudgetComposesByConstruction")),
+	bound("value-size", "Value size", "ops-spec §8", "schema value bound (MaxValueBytes)", "schema validate_test / conformance values_test", StatusEnforced,
+		goTest("internal/schema", "TestInstanceByteBudget")),
+	bound("key-name-length", "Key name length", "ops-catalogue §Key-name", "schema key-name bound (MaxKeyNameBytes)", "schema declare_test", StatusEnforced,
+		goTest("internal/schema", "TestKeyNameGrammar")),
+	bound("keys-per-project", "Keys per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxKeysPerProject)", "service definitions_test", StatusEnforced,
+		goTest("internal/service", "TestValidateFinalDefinitionsNamesAndCaps")),
+	bound("key-groups-per-project", "Key groups per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxKeyGroupsPerProject)", "service definitions_test", StatusEnforced,
+		goHelper("internal/isolation", "runDefinitions")),
+	bound("declaration-structural-bounds", "Declaration bytes / $ref depth / subschemas / enum / pattern / any_of", "ops-spec §8", "declaration-time rejection", "schema declare_test / conformance catalogue_test", StatusEnforced,
+		goTest("internal/schema", "TestDeclarationRefusals")),
+	bound("verdict-error-bounds", "Verdict errors / bytes", "ops-spec §8", "verdict cap (MaxVerdictErrors / MaxVerdictErrorBytes)", "schema validate_test", StatusEnforced,
+		goTest("internal/schema", "TestErrorCapsHold")),
+	bound("evaluation-budget", "Evaluation budget (steps + deadline)", "ops-spec §8", "step-cap at declaration + per-value wall-clock deadline (EvaluationDeadline)", "schema declare_test / deadline_internal_test", StatusEnforced,
+		goTest("internal/schema", "TestJSONSchemaEvaluationFailsLoudOnTheDeadline")),
+	bound("plan-expiry-open-quota", "Plan expiry / open-plan quota", "ops-spec §8 source-of-truth", "PlanTTL + MaxOpenPlansPerProject", "isolation definitions_e2e", StatusEnforced,
+		goHelper("internal/isolation", "definitionsPlanLifecycle")),
+	bound("per-target-render-total", "Per-target render total", "ops-spec §8", "domain.ErrLimitExceeded (MaxRenderBytesPerTarget)", "service.TestRenderTotalRefusesAnOversizedTarget", StatusEnforced,
+		goTest("internal/service", "TestRenderTotalRefusesAnOversizedTarget")),
+	bound("pending-versions-per-project", "Pending versions per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxPendingPerProject)", "isolation.TestPendingPerProjectCap", StatusEnforced,
+		goTest("internal/isolation", "TestPendingPerProjectCapSQLite")),
+	bound("bundle-bytes-entries", "Bundle bytes / entries", "ops-spec §8", "definitions.ErrLimitExceeded (MaxBundle*)", "definitions bundle_test", StatusEnforced,
+		goTest("internal/definitions", "TestParseBoundsRefused")),
+	bound("open-plans-per-project", "Open plans per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxOpenPlansPerProject)", "isolation definitions_e2e", StatusEnforced,
+		goTest("internal/isolation", "TestDefinitionsSQLite")),
+	bound("pins-quota-per-project", "Pins quota per project", "ops-spec §8", "invalidDetail (PinQuota)", "conformance revisions_test", StatusEnforced,
+		goHelper("internal/conformance", "scenarioPinLifecycle")),
+	bound("grants-per-org", "Grants per org", "ops-spec §8", "domain.ErrLimitExceeded (MaxGrantsPerOrg)", "isolation.TestGrantPerOrgCap", StatusEnforced,
+		goTest("internal/isolation", "TestGrantPerOrgCapSQLite")),
+	bound("project-storage-high-water", "Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "domain.ErrLimitExceeded (MaxProjectStorageBytes) at publish + doctor/metric/UI-banner warn (ProjectStorageWarnBytes)", "isolation.TestProjectStorageHighWater", StatusEnforced,
+		goTest("internal/isolation", "TestProjectStorageHighWaterSQLite")),
+	bound("schema-revision-rate", "Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "admission.ErrOverloaded (uniform 429) via service.Budget", "conformance scenarioSchemaRevisionRateLimit + service.TestBudgetRateWindowSlides", StatusEnforced,
+		goHelper("internal/conformance", "scenarioSchemaRevisionRateLimit")),
 
 	// §9 encryption.
-	{"Reencrypt CAS (no-resurrect)", "ops-spec §9", "row_version CAS conflict", "store authn CAS", StatusEnforced},
-	{"DEK LRU cache", "ops-spec §9", "declared bound, eviction re-unwraps (not a refusal)", "crypto keyring_test (dekCacheSize eviction)", StatusByConstruction},
-	{"Reencrypt chunk 100 rows / 100 ms", "ops-spec §9 (§167)", "chunked background rewrap (service.Reencrypt paginates by ReencryptChunkSize, pauses ReencryptChunkPause between chunks)", "conformance boundregistry_test value-pins + isolation reencrypt_e2e (chunked resumable walk)", StatusEnforced},
+	bound("reencrypt-cas-no-resurrect", "Reencrypt CAS (no-resurrect)", "ops-spec §9", "row_version CAS conflict", "store authn CAS", StatusEnforced,
+		goTest("internal/isolation", "TestReencryptInstanceRetrySafe")),
+	bound("dek-lru-cache", "DEK LRU cache", "ops-spec §9", "declared bound, eviction re-unwraps (not a refusal)", "crypto keyring_test (dekCacheSize eviction)", StatusByConstruction,
+		goTest("internal/crypto", "TestSealerSurvivesCacheEviction")),
+	bound("reencrypt-chunk", "Reencrypt chunk 100 rows / 100 ms", "ops-spec §9 (§167)", "chunked background rewrap (service.Reencrypt paginates by ReencryptChunkSize, pauses ReencryptChunkPause between chunks)", "conformance boundregistry_test value-pins + isolation reencrypt_e2e (chunked resumable walk)", StatusEnforced,
+		goTest("internal/isolation", "TestReencryptMultiChunkRetrySafe")),
 
 	// §11 / §12 adapter & backup ops.
-	{"Import per-file / decoded / records / pages", "ops-catalogue §Import", "importer bound errors", "importer connector_test / live_test", StatusEnforced},
-	{"Provider / remote response cap", "ops-catalogue §GitHub/§Multi-instance", "response-cap refusal", "importer / remotefetch caps", StatusEnforced},
-	{"Remote count", "ops-catalogue §Multi-instance", "service.ErrRemoteCap (remotefetch.RemoteCount)", "isolation remote_e2e (fixture: cap enforced at service/remotes.go)", StatusEnforced},
-	{"Outbox depth per target", "ops-catalogue §GitHub (row 19)", "adapter.ErrQueueFull", "store adapter_runtime (enforcement site)", StatusEnforced},
+	bound("import-structural-bounds", "Import per-file / decoded / records / pages", "ops-catalogue §Import", "importer bound errors", "importer connector_test / live_test", StatusEnforced,
+		goTest("internal/importer", "TestBoundsFailLoudNamingTheBound")),
+	bound("provider-response-cap", "Provider / remote response cap", "ops-catalogue §GitHub/§Multi-instance", "response-cap refusal", "importer / remotefetch caps", StatusEnforced,
+		goTest("internal/importer", "TestK8sLiveExecPluginCannotExceedOutputCap")),
+	bound("remote-count", "Remote count", "ops-catalogue §Multi-instance", "service.ErrRemoteCap (remotefetch.RemoteCount)", "isolation remote_e2e (fixture: cap enforced at service/remotes.go)", StatusEnforced,
+		goTest("internal/isolation", "TestRemoteCountCapSQLite")),
+	bound("outbox-depth-per-target", "Outbox depth per target", "ops-catalogue §GitHub (row 19)", "adapter.ErrQueueFull", "store adapter_runtime (enforcement site)", StatusEnforced,
+		goTest("internal/store", "TestAdapterEnqueueRefusesAtPerTargetQueueDepth")),
 
 	// §20 audit ops.
-	{"Audit free text", "ops-spec §20", "truncation to audit.FreeTextBound", "audit audit_test", StatusSanitize},
-	{"Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "admission.ErrOverloaded (uniform 429) via service.Budget", "service.TestAuditExportChargesExpensiveBudget + service.TestBudgetInstanceConcurrencyIsSeparateFromOrg", StatusEnforced},
-	{"Expensive-path fail-closed default 60/min·principal · 8/org", "ops-spec §10 (§179)", "budgetDefault charged at each default-expensive method; classification totality closes 'unbudgeted by omission' at build time", "conformance TestBudgetClassificationIsTotal (every authz op classified — build breaks on a new unclassified op) + scenarioDefaultBudgetChargedEndToEnd (a default-expensive method really trips the default 429) + service.TestBudgetDefaultEnforces (mechanism)", StatusEnforced},
+	bound("audit-free-text", "Audit free text", "ops-spec §20", "truncation to audit.FreeTextBound", "audit audit_test", StatusSanitize,
+		goTest("internal/audit", "TestSanitizeFreeText")),
+	bound("audit-export-budget", "Audit exports 2/org · 6/instance", "ops-spec §20 (§179)", "admission.ErrOverloaded (uniform 429) via service.Budget", "service.TestAuditExportChargesExpensiveBudget + service.TestBudgetInstanceConcurrencyIsSeparateFromOrg", StatusEnforced,
+		goTest("internal/service", "TestAuditExportChargesExpensiveBudget")),
+	bound("expensive-path-default-budget", "Expensive-path fail-closed default 60/min·principal · 8/org", "ops-spec §10 (§179)", "budgetDefault charged at each default-expensive method; classification totality closes 'unbudgeted by omission' at build time", "conformance TestBudgetClassificationIsTotal (every authz op classified — build breaks on a new unclassified op) + scenarioDefaultBudgetChargedEndToEnd (a default-expensive method really trips the default 429) + service.TestBudgetDefaultEnforces (mechanism)", StatusEnforced,
+		goHelper("internal/conformance", "scenarioDefaultBudgetChargedEndToEnd")),
 
 	// SAML / SCIM wire bounds.
-	{"SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced},
-	{"SCIM wire body cap", "ops-catalogue §SCIM", "scimproto.ErrBodyTooLarge (api.SCIMBodyBound)", "isolation scim_provider_sequence_test", StatusEnforced},
+	bound("saml-document-bounds", "SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced,
+		goTest("internal/samlsp", "TestParseXMLRefusesPreparseThreats")),
+	bound("scim-wire-body-cap", "SCIM wire body cap", "ops-catalogue §SCIM", "scimproto.ErrBodyTooLarge (api.SCIMBodyBound)", "isolation scim_provider_sequence_test", StatusEnforced,
+		goTest("internal/isolation", "TestSCIMWireAdmissionOverHTTPSQLite")),
 
 	// §6 compose client.
-	{"run-- ARG_MAX preflight", "ops-spec §6 / inv.8", "composite _SC_ARG_MAX refusal", "compose argmax_test", StatusEnforced},
+	bound("run-arg-max-preflight", "run-- ARG_MAX preflight", "ops-spec §6 / inv.8", "composite _SC_ARG_MAX refusal", "compose argmax_test", StatusEnforced,
+		goTest("internal/cli", "TestRunArgMaxRefusal")),
 
 	// §5 reveal / reauth.
-	{"Protected-environment reauth window cap", "ops-spec §5", "service.ErrProtectedWindowCap", "isolation grants_e2e (ErrProtectedWindowCap)", StatusEnforced},
+	bound("protected-environment-reauth-window", "Protected-environment reauth window cap", "ops-spec §5", "service.ErrProtectedWindowCap", "isolation grants_e2e (ErrProtectedWindowCap)", StatusEnforced,
+		goTest("internal/isolation", "TestProtectedEnvironmentSQLite")),
 }
 
 func TestBoundRegistryIsWellFormed(t *testing.T) {
-	seen := map[string]bool{}
+	seenIDs := map[BoundID]bool{}
+	seenNames := map[string]bool{}
 	for _, b := range Registry {
-		if b.Name == "" || b.Spec == "" || b.Refusal == "" || b.Fixture == "" {
+		if !validBoundID(b.ID) || b.Name == "" || b.Spec == "" || b.Refusal == "" || b.Evidence == "" || len(b.Fixtures) == 0 {
 			t.Errorf("incomplete registry row: %+v", b)
 		}
-		if seen[b.Name] {
+		if seenIDs[b.ID] {
+			t.Errorf("duplicate bound ID %q", b.ID)
+		}
+		seenIDs[b.ID] = true
+		if seenNames[b.Name] {
 			t.Errorf("duplicate bound name %q", b.Name)
 		}
-		seen[b.Name] = true
+		seenNames[b.Name] = true
 		switch b.Status {
 		case StatusEnforced, StatusClamp, StatusByConstruction, StatusSanitize, StatusPending:
 		default:
@@ -153,18 +214,60 @@ func TestBoundRegistryIsWellFormed(t *testing.T) {
 	}
 }
 
+func validBoundID(id BoundID) bool {
+	value := string(id)
+	if value == "" || value[0] == '-' || value[len(value)-1] == '-' {
+		return false
+	}
+	for _, char := range value {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func TestBoundIDsAreStableSlugs(t *testing.T) {
+	for id, want := range map[BoundID]bool{
+		"admission-queue-depth": true,
+		"bound-2":               true,
+		"":                      false,
+		"Uppercase":             false,
+		"leading-":              false,
+		"-trailing":             false,
+		"has spaces":            false,
+	} {
+		if got := validBoundID(id); got != want {
+			t.Errorf("validBoundID(%q) = %v, want %v", id, got, want)
+		}
+	}
+}
+
+func TestBoundRegistryFixtureReferencesResolve(t *testing.T) {
+	fixtures := make([]fixtureref.FixtureRef, 0, len(Registry))
+	for _, b := range Registry {
+		fixtures = append(fixtures, b.Fixtures...)
+	}
+	if err := fixtureref.Validate(".", fixtures); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestBoundRegistryPendingBoundsAreDisposition ensures every pending bound is a
-// LOUD, tracked disposition item — never a silent omission. Its Fixture must
-// name the owning feature and the reason.
+// LOUD, tracked disposition item — never a silent omission. PendingReason is
+// separate from executable fixture identity.
 func TestBoundRegistryPendingBoundsAreDisposition(t *testing.T) {
 	pending := 0
 	for _, b := range Registry {
 		if b.Status != StatusPending {
+			if b.PendingReason != "" {
+				t.Errorf("non-pending bound %q has a pending reason", b.ID)
+			}
 			continue
 		}
 		pending++
-		if len(b.Fixture) < 40 || !strings.Contains(b.Fixture, "ENFORCEMENT-PENDING") {
-			t.Errorf("pending bound %q must name its owner+reason in Fixture, got %q", b.Name, b.Fixture)
+		if len(b.PendingReason) < 40 {
+			t.Errorf("pending bound %q must name its owner and reason, got %q", b.ID, b.PendingReason)
 		}
 	}
 	t.Logf("registry: %d bounds total, %d enforcement-pending (feature-absent, tracked)", len(Registry), pending)

--- a/internal/isolation/remote_e2e_test.go
+++ b/internal/isolation/remote_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -86,6 +87,21 @@ func remoteSvcs(t *testing.T, db *store.DB) (*service.Remotes, *service.Workspac
 	}
 	return &service.Remotes{DB: db, Keyring: auth.Keyring, Fetch: client},
 		&service.Workspace{DB: db, Version: "test"}
+}
+
+func TestRemoteCountCapSQLite(t *testing.T) {
+	db := seededDB(t, openSQLite)
+	remotes, _ := remoteSvcs(t, db)
+	execRaw(t, db, `INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) `+
+		`VALUES ('g_rmt_cap', 'usr_root', 'instance-directory', NULL, NULL, NULL, `+ts+`)`)
+	for i := range remotefetch.RemoteCount {
+		execRaw(t, db, fmt.Sprintf(`INSERT INTO remotes (id, name, url, spki_pin, credential_sealed, created_at, created_by)
+			VALUES ('rmt_cap_%d', 'remote-%d', 'https://remote-%d.example', 'pin', X'01', %s, 'usr_root')`, i, i, i, ts))
+	}
+	_, err := remotes.AddRemote(t.Context(), service.LocalPrincipal(root), "one-too-many", "https://overflow.example", "pin", "credential")
+	if !errors.Is(err, service.ErrRemoteCap) {
+		t.Fatalf("AddRemote() error = %v, want ErrRemoteCap", err)
+	}
 }
 
 // runRemoteLifecycle drives every #71 service verb once, so the audit

--- a/internal/store/adapter_runtime_test.go
+++ b/internal/store/adapter_runtime_test.go
@@ -46,6 +46,31 @@ func adapterRuntimeDB(t *testing.T) *store.DB {
 	return db
 }
 
+func TestAdapterEnqueueRefusesAtPerTargetQueueDepth(t *testing.T) {
+	db := adapterRuntimeDB(t)
+	_, err := db.SQLiteWrite().ExecContext(t.Context(), `
+		WITH RECURSIVE seq(n) AS (VALUES(2) UNION ALL SELECT n + 1 FROM seq WHERE n < 1000)
+		INSERT INTO adapter_outbox (
+			id, org_id, project_id, environment_id, target_id, kind,
+			authority_principal_id, generation, dedup_key, next_attempt_at, state, created_at
+		)
+		SELECT printf('job_%d', n), 'org_adapter', 'prj_adapter', 'env_adapter', 'tgt_1',
+			'converge', 'usr_adapter', 1, printf('legacy-%d', n),
+			'2026-08-17T00:00:00Z', 'queued', '2026-08-17T00:00:00Z'
+		FROM seq`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := store.NewAdapterRuntime(db, func(context.Context, adapter.Job, adapter.Effect) error { return nil })
+	_, err = runtime.Enqueue(t.Context(), adapter.Job{
+		OrgID: "org_adapter", ProjectID: "prj_adapter", EnvironmentID: "env_adapter",
+		TargetID: "tgt_1", Kind: adapter.Converge, AuthorityPrincipal: "usr_adapter",
+	}, time.Now().UTC())
+	if !errors.Is(err, adapter.ErrQueueFull) {
+		t.Fatalf("Enqueue() error = %v, want ErrQueueFull", err)
+	}
+}
+
 func TestAdapterJournalCommitsIntentOutcomeAndLedgerAtomically(t *testing.T) {
 	db := adapterRuntimeDB(t)
 	runtime := store.NewAdapterRuntime(db, func(context.Context, adapter.Job, adapter.Effect) error { return nil })

--- a/internal/testutil/fixtureref/validator.go
+++ b/internal/testutil/fixtureref/validator.go
@@ -1,0 +1,296 @@
+// Package fixtureref validates qualified references to executable Go test
+// fixtures. It is intended for test registries, not production code.
+package fixtureref
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Kind identifies the executable shape named by a fixture reference.
+type Kind string
+
+const (
+	// KindTest names a top-level TestXxx function.
+	KindTest Kind = "test"
+	// KindSubtest names a slash-qualified path of literal t.Run names below a test.
+	KindSubtest Kind = "subtest"
+	// KindHelper names a top-level, non-Test helper function in a _test.go file.
+	KindHelper Kind = "helper"
+)
+
+// FixtureRef is an exact reference to an executable fixture in one Go package.
+type FixtureRef struct {
+	Package  string
+	TestName string
+	Kind     Kind
+}
+
+type packageMetadata struct {
+	ImportPath string
+	Dir        string
+	Name       string
+}
+
+type fixtureDefinition struct {
+	kind Kind
+	file string
+}
+
+// Validate proves that every reference exists exactly once, with the declared
+// kind, in the declared package. It parses every _test.go file in the package,
+// including files excluded by current build tags.
+func Validate(root string, refs []FixtureRef) error {
+	var problems []error
+	seen := make(map[FixtureRef]struct{}, len(refs))
+	packages := make(map[string][]FixtureRef)
+	for _, ref := range refs {
+		if ref.Package == "" || ref.TestName == "" {
+			problems = append(problems, fmt.Errorf("incomplete fixture reference: %+v", ref))
+			continue
+		}
+		switch ref.Kind {
+		case KindTest, KindSubtest, KindHelper:
+		default:
+			problems = append(problems, fmt.Errorf("fixture %s.%s has unsupported kind %q", ref.Package, ref.TestName, ref.Kind))
+			continue
+		}
+		if _, duplicate := seen[ref]; duplicate {
+			problems = append(problems, fmt.Errorf("duplicate fixture reference %s.%s (%s)", ref.Package, ref.TestName, ref.Kind))
+			continue
+		}
+		seen[ref] = struct{}{}
+		packages[ref.Package] = append(packages[ref.Package], ref)
+	}
+
+	packagePaths := make([]string, 0, len(packages))
+	for packagePath := range packages {
+		packagePaths = append(packagePaths, packagePath)
+	}
+	sort.Strings(packagePaths)
+	for _, packagePath := range packagePaths {
+		packageRefs := packages[packagePath]
+		metadata, err := loadPackage(root, packagePath)
+		if err != nil {
+			problems = append(problems, err)
+			continue
+		}
+		definitions, err := indexFixtures(metadata)
+		if err != nil {
+			problems = append(problems, err)
+			continue
+		}
+		for _, ref := range packageRefs {
+			matches := definitions[ref.TestName]
+			var sameKind []fixtureDefinition
+			for _, match := range matches {
+				if match.kind == ref.Kind {
+					sameKind = append(sameKind, match)
+				}
+			}
+			switch len(sameKind) {
+			case 1:
+				continue
+			case 0:
+				if len(matches) > 0 {
+					problems = append(problems, fmt.Errorf("fixture %s.%s requested as %s but exists as %s", ref.Package, ref.TestName, ref.Kind, matches[0].kind))
+				} else {
+					problems = append(problems, fmt.Errorf("fixture %s.%s (%s) not found", ref.Package, ref.TestName, ref.Kind))
+				}
+			default:
+				files := make([]string, 0, len(sameKind))
+				for _, match := range sameKind {
+					files = append(files, match.file)
+				}
+				problems = append(problems, fmt.Errorf("fixture %s.%s (%s) has %d definitions in %s", ref.Package, ref.TestName, ref.Kind, len(sameKind), strings.Join(files, ", ")))
+			}
+		}
+	}
+	return errors.Join(problems...)
+}
+
+func loadPackage(root, packagePath string) (packageMetadata, error) {
+	cmd := exec.Command("go", "list", "-json", packagePath)
+	cmd.Dir = root
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return packageMetadata{}, fmt.Errorf("go list %s: %w: %s", packagePath, err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return packageMetadata{}, fmt.Errorf("go list %s: %w", packagePath, err)
+	}
+	var metadata packageMetadata
+	if err := json.Unmarshal(output, &metadata); err != nil {
+		return packageMetadata{}, fmt.Errorf("decode go list %s: %w", packagePath, err)
+	}
+	if metadata.ImportPath == "" || metadata.Dir == "" || metadata.Name == "" {
+		return packageMetadata{}, fmt.Errorf("go list %s returned incomplete package metadata", packagePath)
+	}
+	return metadata, nil
+}
+
+func indexFixtures(metadata packageMetadata) (map[string][]fixtureDefinition, error) {
+	entries, err := os.ReadDir(metadata.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("read package %s: %w", metadata.ImportPath, err)
+	}
+	definitions := make(map[string][]fixtureDefinition)
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(metadata.Dir, entry.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if file.Name.Name != metadata.Name && file.Name.Name != metadata.Name+"_test" {
+			return nil, fmt.Errorf("test file %s belongs to package %s, want %s or %s_test", path, file.Name.Name, metadata.Name, metadata.Name)
+		}
+		for _, declaration := range file.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			kind := KindHelper
+			if isTestFunction(file, fn) {
+				kind = KindTest
+			}
+			definitions[fn.Name.Name] = append(definitions[fn.Name.Name], fixtureDefinition{kind: kind, file: entry.Name()})
+			if kind == KindTest {
+				receiver, _ := testingParameter(file, fn.Type)
+				indexLiteralSubtests(file, fn.Body, receiver, fn.Name.Name, entry.Name(), definitions)
+			}
+		}
+	}
+	return definitions, nil
+}
+
+func isTestFunction(file *ast.File, fn *ast.FuncDecl) bool {
+	if !goTestName(fn.Name.Name) || fieldCount(fn.Type.Results) != 0 || fn.Type.TypeParams != nil {
+		return false
+	}
+	_, ok := testingParameter(file, fn.Type)
+	return ok
+}
+
+func goTestName(name string) bool {
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	if len(name) == len("Test") {
+		return true
+	}
+	next, _ := utf8.DecodeRuneInString(name[len("Test"):])
+	return !unicode.IsLower(next)
+}
+
+func testingParameter(file *ast.File, function *ast.FuncType) (*ast.Object, bool) {
+	if fieldCount(function.Params) != 1 || len(function.Params.List) != 1 {
+		return nil, false
+	}
+	param := function.Params.List[0]
+	star, ok := param.Type.(*ast.StarExpr)
+	if !ok {
+		return nil, false
+	}
+	testingName, dotImported := testingImport(file)
+	isTestingT := false
+	switch testingType := star.X.(type) {
+	case *ast.SelectorExpr:
+		qualifier, ok := testingType.X.(*ast.Ident)
+		isTestingT = ok && qualifier.Name == testingName && testingType.Sel.Name == "T"
+	case *ast.Ident:
+		isTestingT = dotImported && testingType.Name == "T"
+	}
+	if !isTestingT {
+		return nil, false
+	}
+	if len(param.Names) == 0 {
+		return nil, true
+	}
+	return param.Names[0].Obj, true
+}
+
+func fieldCount(fields *ast.FieldList) int {
+	if fields == nil {
+		return 0
+	}
+	count := 0
+	for _, field := range fields.List {
+		if len(field.Names) == 0 {
+			count++
+		} else {
+			count += len(field.Names)
+		}
+	}
+	return count
+}
+
+func testingImport(file *ast.File) (name string, dotImported bool) {
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != "testing" {
+			continue
+		}
+		if spec.Name == nil {
+			return "testing", false
+		}
+		if spec.Name.Name == "." {
+			return "", true
+		}
+		return spec.Name.Name, false
+	}
+	return "", false
+}
+
+func indexLiteralSubtests(source *ast.File, body *ast.BlockStmt, receiver *ast.Object, parent, file string, definitions map[string][]fixtureDefinition) {
+	if receiver == nil {
+		return
+	}
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		callee, receiverMatches := selector.X.(*ast.Ident)
+		if !receiverMatches || callee.Obj != receiver || selector.Sel.Name != "Run" || len(call.Args) != 2 {
+			return true
+		}
+		nameLiteral, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || nameLiteral.Kind != token.STRING {
+			return false
+		}
+		name, err := strconv.Unquote(nameLiteral.Value)
+		if err != nil || name == "" {
+			return false
+		}
+		qualified := parent + "/" + name
+		definitions[qualified] = append(definitions[qualified], fixtureDefinition{kind: KindSubtest, file: file})
+		callback, ok := call.Args[1].(*ast.FuncLit)
+		if ok {
+			nestedReceiver, valid := testingParameter(source, callback.Type)
+			if valid && fieldCount(callback.Type.Results) == 0 {
+				indexLiteralSubtests(source, callback.Body, nestedReceiver, qualified, file, definitions)
+			}
+		}
+		return false
+	})
+}

--- a/internal/testutil/fixtureref/validator_test.go
+++ b/internal/testutil/fixtureref/validator_test.go
@@ -1,0 +1,171 @@
+package fixtureref
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateAcceptsQualifiedExecutableReferences(t *testing.T) {
+	root := fixtureModule(t)
+
+	err := Validate(root, []FixtureRef{
+		{Package: "example.test/fixtures/alpha", TestName: "TestTop", Kind: KindTest},
+		{Package: "example.test/fixtures/alpha", TestName: "fixtureHelper", Kind: KindHelper},
+		{Package: "example.test/fixtures/alpha", TestName: "TestTop/nested/leaf", Kind: KindSubtest},
+		{Package: "example.test/fixtures/alpha", TestName: "TestTagged", Kind: KindTest},
+	})
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidReferences(t *testing.T) {
+	root := fixtureModule(t)
+	tests := []struct {
+		name string
+		refs []FixtureRef
+		want string
+	}{
+		{
+			name: "missing or renamed",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestRenamed", Kind: KindTest}},
+			want: "not found",
+		},
+		{
+			name: "same name in wrong package",
+			refs: []FixtureRef{{Package: "example.test/fixtures/beta", TestName: "TestTop", Kind: KindTest}},
+			want: "not found",
+		},
+		{
+			name: "wrong kind",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "fixtureHelper", Kind: KindTest}},
+			want: "exists as helper",
+		},
+		{
+			name: "test-shaped helper with wrong signature",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestWrongSignature", Kind: KindTest}},
+			want: "exists as helper",
+		},
+		{
+			name: "duplicate reference",
+			refs: []FixtureRef{
+				{Package: "example.test/fixtures/alpha", TestName: "TestTop", Kind: KindTest},
+				{Package: "example.test/fixtures/alpha", TestName: "TestTop", Kind: KindTest},
+			},
+			want: "duplicate fixture reference",
+		},
+		{
+			name: "dynamic subtest",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestTop/dynamic", Kind: KindSubtest}},
+			want: "not found",
+		},
+		{
+			name: "unrelated run method",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestTop/not-a-subtest", Kind: KindSubtest}},
+			want: "not found",
+		},
+		{
+			name: "shadowed testing receiver",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestTop/shadowed", Kind: KindSubtest}},
+			want: "not found",
+		},
+		{
+			name: "invalid lowercase test name",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "Testlowercase", Kind: KindTest}},
+			want: "exists as helper",
+		},
+		{
+			name: "test with results",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestWithResult", Kind: KindTest}},
+			want: "exists as helper",
+		},
+		{
+			name: "test with grouped parameters",
+			refs: []FixtureRef{{Package: "example.test/fixtures/alpha", TestName: "TestGroupedParameters", Kind: KindTest}},
+			want: "exists as helper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(root, tt.refs)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func fixtureModule(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, root, "go.mod", "module example.test/fixtures\n\ngo 1.25\n")
+	writeFixtureFile(t, root, "alpha/alpha.go", "package alpha\n")
+	writeFixtureFile(t, root, "alpha/alpha_test.go", `package alpha
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTop(t *testing.T) {
+	t.Run("nested", func(t *testing.T) {
+		t.Run("leaf", func(t *testing.T) {})
+	})
+	var runner customRunner
+	runner.Run("not-a-subtest", func(t *testing.T) {})
+	{
+		t := customRunner{}
+		t.Run("shadowed", func(t *testing.T) {})
+	}
+	for i := range 1 {
+		t.Run(fmt.Sprintf("dynamic-%d", i), func(t *testing.T) {})
+	}
+}
+
+func fixtureHelper(t *testing.T) { t.Helper() }
+
+type customRunner struct{}
+
+func (customRunner) Run(string, func(*testing.T)) {}
+`)
+	writeFixtureFile(t, root, "alpha/tagged_test.go", `//go:build fixturetag
+
+package alpha
+
+import "testing"
+
+func TestTagged(t *testing.T) {}
+
+type T struct{}
+
+func TestWrongSignature(t *T) {}
+
+func Testlowercase(t *testing.T) {}
+
+func TestWithResult(t *testing.T) bool { return true }
+
+func TestGroupedParameters(a, b *testing.T) {}
+`)
+	writeFixtureFile(t, root, "beta/beta.go", "package beta\n")
+	writeFixtureFile(t, root, "beta/beta_test.go", `package beta
+
+import "testing"
+
+func TestTopElsewhere(t *testing.T) {}
+`)
+	return root
+}
+
+func writeFixtureFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #251.

## Contract and migration

- Gives every conformance bound row a stable slug ID, retained readable evidence, and typed package-qualified executable fixture references.
- Adds reusable test-only go-list plus AST validation for top-level tests, helpers, literal subtests, build-tagged files, duplicate refs, wrong packages, and wrong kinds.
- Keeps pending explanations separate from executable identity. No production contract migration.
- Adds exact behavior regressions for remote-count, adapter outbox-depth, and API paging bindings.

Generated outputs: none.

## Validation

- go test -count=1 ./internal/testutil/fixtureref ./internal/conformance/... — 89 passed.
- focused remote-count and API paging isolation tests — 2 passed.
- focused adapter outbox-depth test — 1 passed.
- previously failing importer live test — passed on focused rerun.
- go vet ./... — passed.
- local uncached full Go run reached 3,314 passes before an importer live-test flake and the known long-running local isolation-package failure; every failed or changed seam passed on focused rerun. Exact-head CI is the authoritative full gate.

## Review

Three adversarial two-axis rounds completed. Standards: CLEAN. Spec: CLEAN.