### PR TITLE
Guard SAML metadata transport #257

### DIFF
--- a/docs/handoff/257-saml-metadata-transport.md
+++ b/docs/handoff/257-saml-metadata-transport.md
@@ -1,7 +1,7 @@
 # Handoff: #257 guarded SAML metadata transport
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/257 (parent #207; programme
-#203; audit ID `BE21-B`). Base: `ecf96da4`.
+#203; audit ID `BE21-B`). Base: `f55b5038`.
 
 ## Contract
 
@@ -9,15 +9,19 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/257 (parent #207; programme
   wiring uses `NewSAMLProviders`, which constructs the guarded metadata
   transport with the production resolver, dialer, TLS minimum, response-header
   timeout, and whole-request timeout.
-- Deterministic tests inject only DNS resolution, final dialing, test trust
-  roots, and a shorter timeout below the policy boundary. They cannot replace
-  the HTTP client or round tripper.
+- Deterministic tests inject only `netpolicy.Resolver`, `netpolicy.Dialer`, test
+  trust roots, and a shorter timeout below the policy boundary. They cannot
+  replace the HTTP client or round tripper.
 - Metadata URLs remain HTTPS-only and reject userinfo, fragments, missing
   hosts, and literal non-public targets before DNS or dialing.
 - Every request, including each same-origin redirect, revalidates URL shape,
-  resolves again, and rejects any non-public answer. The transport dials a
-  validated pinned IP while preserving the original HTTP host and TLS server
-  name.
+  resolves again, and rejects any non-public answer. Direct requests use the
+  shared `netpolicy.PublicDialer`, which dials a validated pinned IP while the
+  HTTP transport preserves the original host and TLS server name.
+- Proxy requests retain the proxy-aware pinned-request path: the metadata
+  target is validated before CONNECT and the proxy receives its approved IP.
+  This avoids pretending that a `DialContext` seeing only an opaque proxy hop
+  validated the ultimate metadata target.
 - Redirects remain same-origin and capped at five. TLS 1.2, the 10-second
   response-header timeout, the 15-second whole-request timeout, and the
   `samlsp.MaxDocumentBytes` response limit remain enforced.
@@ -26,6 +30,8 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/257 (parent #207; programme
 
 - A real TLS metadata fixture proves deterministic injected responses traverse
   the guarded URL, TLS, DNS, and dial path.
+- Direct fallback coverage exercises the shared public dialer; existing proxy
+  coverage pins target IP, HTTP host, TLS identity, and first-hop behavior.
 - Redirect tests reject cross-origin pivots, userinfo/fragments, and a
   same-origin hostname that rebinds to loopback before the second request.
 - Slow and oversized responses fail within their configured bounds.
@@ -41,20 +47,21 @@ Generated outputs: none.
 ## Validation
 
 ```text
-go test -count=1 ./internal/service/... -run SAML        passed (26 tests)
+go test -count=1 ./internal/service/... -run SAML        passed (27 tests)
 go test -count=1 ./internal/app/... ./internal/boundary/... passed (67 tests)
 go test -count=1 ./internal/isolation/ -run SAML         passed (6 tests)
 go test -race -count=1 ./internal/service/... -run 'TestSAMLMetadata|TestSAMLProvidersExposeNoHTTPClientOverride|TestNewSAMLProvidersBuildsProductionMetadataPolicy'
-                                                          passed (16 tests)
+                                                          passed (17 tests)
+go test -race -count=1 ./internal/netpolicy/... ./internal/adapter/...
+                                                          passed (128 tests)
 go build ./...                                            passed
 go vet ./...                                              passed
-go test -count=1 ./...                                    passed (3368 tests, pre-review)
-go test -count=1 ./...                                    57 packages passed; isolation hit its
-                                                          10m timeout under shared-host contention
-go test -count=1 ./internal/isolation/                    passed (1093 tests on retry)
+go test -count=1 ./...                                    passed (3398 tests)
 ./scripts/ci/verify-docs.sh                               passed
 ```
 
 Two-axis review round 1 found incomplete redirect URL-shape validation and a
 missing app-wiring regression test; both were fixed. Round 2 returned Standards
-`CLEAN` and Spec `SOUND`.
+`CLEAN` and Spec `SOUND`. Final round 3 returned Spec `SOUND`; Standards found
+that the HTTPS-proxy TLS hop bypassed the injected dialer. The proxy hop now
+uses that guarded primitive, with an executable TLS regression test.

--- a/docs/handoff/257-saml-metadata-transport.md
+++ b/docs/handoff/257-saml-metadata-transport.md
@@ -1,0 +1,60 @@
+# Handoff: #257 guarded SAML metadata transport
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/257 (parent #207; programme
+#203; audit ID `BE21-B`). Base: `ecf96da4`.
+
+## Contract
+
+- `SAMLProviders` no longer exposes an `HTTPClient` field. Production app
+  wiring uses `NewSAMLProviders`, which constructs the guarded metadata
+  transport with the production resolver, dialer, TLS minimum, response-header
+  timeout, and whole-request timeout.
+- Deterministic tests inject only DNS resolution, final dialing, test trust
+  roots, and a shorter timeout below the policy boundary. They cannot replace
+  the HTTP client or round tripper.
+- Metadata URLs remain HTTPS-only and reject userinfo, fragments, missing
+  hosts, and literal non-public targets before DNS or dialing.
+- Every request, including each same-origin redirect, revalidates URL shape,
+  resolves again, and rejects any non-public answer. The transport dials a
+  validated pinned IP while preserving the original HTTP host and TLS server
+  name.
+- Redirects remain same-origin and capped at five. TLS 1.2, the 10-second
+  response-header timeout, the 15-second whole-request timeout, and the
+  `samlsp.MaxDocumentBytes` response limit remain enforced.
+
+## Regression evidence
+
+- A real TLS metadata fixture proves deterministic injected responses traverse
+  the guarded URL, TLS, DNS, and dial path.
+- Redirect tests reject cross-origin pivots, userinfo/fragments, and a
+  same-origin hostname that rebinds to loopback before the second request.
+- Slow and oversized responses fail within their configured bounds.
+- Constructor coverage pins the production resolver/dialer, TLS 1.2 minimum,
+  response-header timeout, and whole-request timeout.
+- App structural coverage pins production wiring to `NewSAMLProviders` and
+  rejects restoring a `SAMLProviders` struct literal.
+- Existing proxy, public-IP pinning, multi-address fallback, literal private
+  target, SAML service, app, boundary, and isolation coverage remains green.
+
+Generated outputs: none.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service/... -run SAML        passed (26 tests)
+go test -count=1 ./internal/app/... ./internal/boundary/... passed (67 tests)
+go test -count=1 ./internal/isolation/ -run SAML         passed (6 tests)
+go test -race -count=1 ./internal/service/... -run 'TestSAMLMetadata|TestSAMLProvidersExposeNoHTTPClientOverride|TestNewSAMLProvidersBuildsProductionMetadataPolicy'
+                                                          passed (16 tests)
+go build ./...                                            passed
+go vet ./...                                              passed
+go test -count=1 ./...                                    passed (3368 tests, pre-review)
+go test -count=1 ./...                                    57 packages passed; isolation hit its
+                                                          10m timeout under shared-host contention
+go test -count=1 ./internal/isolation/                    passed (1093 tests on retry)
+./scripts/ci/verify-docs.sh                               passed
+```
+
+Two-axis review round 1 found incomplete redirect URL-shape validation and a
+missing app-wiring regression test; both were fixed. Round 2 returned Standards
+`CLEAN` and Spec `SOUND`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -340,7 +340,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	// schema revision.
 	budget := serviceBudget(cfg)
 	authSvc := &service.Auth{DB: db, Keyring: kr, KDF: kdf, Admission: limiter, Log: log, ExternalOrigin: cfg.ExternalOrigin, ReauthWindow: cfg.ReauthWindow}
-	samlProviders := &service.SAMLProviders{DB: db, Keyring: kr, ExternalOrigin: cfg.ExternalOrigin}
+	samlProviders := service.NewSAMLProviders(db, kr, cfg.ExternalOrigin)
 	// RP ID + expected origins are immutable instance config derived from the
 	// configured external origin, never a request header (human-auth ADR §5). An
 	// origin that cannot yield a valid relying party is a boot refusal, not a

--- a/internal/app/saml_wiring_test.go
+++ b/internal/app/saml_wiring_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// The guarded metadata transport is private to service, so app wiring cannot
+// inspect it behaviorally. Pin the production construction boundary instead:
+// app.go must call the constructor and must not restore a broad struct literal.
+func TestProductionWiringUsesGuardedSAMLProviderConstructor(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "app.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	constructorCalls := 0
+	structLiterals := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.CallExpr:
+			if isServiceSelector(node.Fun, "NewSAMLProviders") {
+				constructorCalls++
+			}
+		case *ast.CompositeLit:
+			if isServiceSelector(node.Type, "SAMLProviders") {
+				structLiterals++
+			}
+		}
+		return true
+	})
+	if constructorCalls != 1 || structLiterals != 0 {
+		t.Fatalf("SAML provider wiring constructor calls = %d, struct literals = %d; want 1, 0",
+			constructorCalls, structLiterals)
+	}
+}
+
+func isServiceSelector(expression ast.Expr, name string) bool {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != name {
+		return false
+	}
+	packageName, ok := selector.X.(*ast.Ident)
+	return ok && packageName.Name == "service"
+}

--- a/internal/service/saml_providers.go
+++ b/internal/service/saml_providers.go
@@ -45,11 +45,20 @@ var (
 
 // SAMLProviders is instance-scoped SAML provider administration.
 type SAMLProviders struct {
-	DB             *store.DB
-	Keyring        *wencrypto.Keyring
-	ExternalOrigin string
-	HTTPClient     *http.Client
-	Now            func() time.Time
+	DB                *store.DB
+	Keyring           *wencrypto.Keyring
+	ExternalOrigin    string
+	Now               func() time.Time
+	metadataTransport metadataTransportPrimitives
+}
+
+// NewSAMLProviders builds the production SAML provider service. Metadata URL
+// retrieval always enters through the guarded transport assembled here.
+func NewSAMLProviders(db *store.DB, keyring *wencrypto.Keyring, externalOrigin string) *SAMLProviders {
+	return &SAMLProviders{
+		DB: db, Keyring: keyring, ExternalOrigin: externalOrigin,
+		metadataTransport: productionMetadataTransport(),
+	}
 }
 
 func (s *SAMLProviders) now() time.Time {
@@ -905,22 +914,18 @@ func (s *SAMLProviders) metadataBytes(ctx context.Context, source string, docume
 
 func (s *SAMLProviders) fetchMetadata(ctx context.Context, rawURL string) ([]byte, error) {
 	target, err := url.Parse(rawURL)
-	if err != nil || target.Scheme != "https" || target.Host == "" || target.User != nil ||
-		target.Fragment != "" || metadataHostIsNonPublic(target.Hostname()) {
+	if err != nil || !metadataURLIsAllowed(target) {
 		return nil, ErrSAMLMetadataFetch
 	}
-	client := s.HTTPClient
-	if client == nil {
-		client = publicMetadataHTTPClient()
-	}
+	client := publicMetadataHTTPClient(s.metadataTransport)
 	copyClient := *client
 	priorRedirect := copyClient.CheckRedirect
 	copyClient.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if !metadataURLIsAllowed(request.URL) {
+			return errors.New("service: SAML metadata redirect has an invalid target")
+		}
 		if request.URL.Scheme != target.Scheme || request.URL.Host != target.Host {
 			return errors.New("service: SAML metadata redirect changed origin")
-		}
-		if metadataHostIsNonPublic(request.URL.Hostname()) {
-			return errors.New("service: SAML metadata redirect resolved to a non-public target")
 		}
 		if priorRedirect != nil {
 			return priorRedirect(request, via)
@@ -954,6 +959,11 @@ func (s *SAMLProviders) fetchMetadata(ctx context.Context, rawURL string) ([]byt
 	return payload, nil
 }
 
+func metadataURLIsAllowed(target *url.URL) bool {
+	return target != nil && target.Scheme == "https" && target.Host != "" && target.Hostname() != "" &&
+		target.User == nil && target.Fragment == "" && !metadataHostIsNonPublic(target.Hostname())
+}
+
 func metadataHostIsNonPublic(host string) bool {
 	host = strings.TrimSuffix(strings.ToLower(host), ".")
 	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
@@ -967,12 +977,43 @@ func metadataIPIsNonPublic(address netip.Addr) bool {
 	return netpolicy.IsNonPublic(address)
 }
 
-func publicMetadataHTTPClient() *http.Client {
+type metadataDialer interface {
+	DialContext(context.Context, string, string) (net.Conn, error)
+}
+
+type metadataTransportPrimitives struct {
+	resolver metadataResolver
+	dialer   metadataDialer
+	roots    *x509.CertPool
+	timeout  time.Duration
+}
+
+func productionMetadataTransport() metadataTransportPrimitives {
+	return metadataTransportPrimitives{
+		resolver: net.DefaultResolver,
+		dialer:   &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second},
+		timeout:  15 * time.Second,
+	}
+}
+
+func publicMetadataHTTPClient(primitives metadataTransportPrimitives) *http.Client {
+	defaults := productionMetadataTransport()
+	if primitives.resolver == nil {
+		primitives.resolver = defaults.resolver
+	}
+	if primitives.dialer == nil {
+		primitives.dialer = defaults.dialer
+	}
+	if primitives.timeout <= 0 {
+		primitives.timeout = defaults.timeout
+	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = primitives.dialer.DialContext
 	transport.ResponseHeaderTimeout = 10 * time.Second
+	transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: primitives.roots}
 	return &http.Client{
-		Transport: &publicMetadataRoundTripper{base: transport, resolver: net.DefaultResolver},
-		Timeout:   15 * time.Second,
+		Transport: &publicMetadataRoundTripper{base: transport, resolver: primitives.resolver},
+		Timeout:   primitives.timeout,
 	}
 }
 

--- a/internal/service/saml_providers.go
+++ b/internal/service/saml_providers.go
@@ -917,7 +917,10 @@ func (s *SAMLProviders) fetchMetadata(ctx context.Context, rawURL string) ([]byt
 	if err != nil || !metadataURLIsAllowed(target) {
 		return nil, ErrSAMLMetadataFetch
 	}
-	client := publicMetadataHTTPClient(s.metadataTransport)
+	client, err := publicMetadataHTTPClient(s.metadataTransport)
+	if err != nil {
+		return nil, ErrSAMLMetadataFetch
+	}
 	copyClient := *client
 	priorRedirect := copyClient.CheckRedirect
 	copyClient.CheckRedirect = func(request *http.Request, via []*http.Request) error {
@@ -977,13 +980,9 @@ func metadataIPIsNonPublic(address netip.Addr) bool {
 	return netpolicy.IsNonPublic(address)
 }
 
-type metadataDialer interface {
-	DialContext(context.Context, string, string) (net.Conn, error)
-}
-
 type metadataTransportPrimitives struct {
-	resolver metadataResolver
-	dialer   metadataDialer
+	resolver netpolicy.Resolver
+	dialer   netpolicy.Dialer
 	roots    *x509.CertPool
 	timeout  time.Duration
 }
@@ -996,7 +995,7 @@ func productionMetadataTransport() metadataTransportPrimitives {
 	}
 }
 
-func publicMetadataHTTPClient(primitives metadataTransportPrimitives) *http.Client {
+func publicMetadataHTTPClient(primitives metadataTransportPrimitives) (*http.Client, error) {
 	defaults := productionMetadataTransport()
 	if primitives.resolver == nil {
 		primitives.resolver = defaults.resolver
@@ -1007,35 +1006,53 @@ func publicMetadataHTTPClient(primitives metadataTransportPrimitives) *http.Clie
 	if primitives.timeout <= 0 {
 		primitives.timeout = defaults.timeout
 	}
+	direct, err := netpolicy.NewPublicDialer(nil, primitives.resolver, primitives.dialer)
+	if err != nil {
+		return nil, err
+	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = primitives.dialer.DialContext
 	transport.ResponseHeaderTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: primitives.roots}
 	return &http.Client{
-		Transport: &publicMetadataRoundTripper{base: transport, resolver: primitives.resolver},
+		Transport: &publicMetadataRoundTripper{base: transport, resolver: primitives.resolver, direct: direct},
 		Timeout:   primitives.timeout,
-	}
+	}, nil
 }
 
-type metadataResolver interface {
-	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
-}
-
-// publicMetadataRoundTripper resolves and validates the destination before
-// handing it to net/http. The request then names the approved IP, preventing a
-// second DNS lookup from rebinding it. The original hostname remains in Host
-// and TLS ServerName, preserving HTTP routing and certificate verification.
+// publicMetadataRoundTripper sends direct requests through the shared public
+// dialer. Proxy requests retain the proxy-aware pinned-request path because an
+// opaque proxy changes the address visible to DialContext: the metadata target
+// must be validated before CONNECT and sent to the proxy as an approved IP.
 //
 // Proxy selection deliberately happens before the URL is pinned. HTTP,
 // HTTPS, and SOCKS proxies therefore keep working, but CONNECT receives the
 // already-approved IP rather than a hostname the proxy could resolve privately.
 type publicMetadataRoundTripper struct {
 	base     *http.Transport
-	resolver metadataResolver
+	resolver netpolicy.Resolver
+	direct   *netpolicy.PublicDialer
 }
 
 func (t *publicMetadataRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	addresses, proxyURL, err := t.destinations(request)
+	proxyURL, err := t.proxyURL(request)
+	if err != nil {
+		return nil, err
+	}
+	if proxyURL == nil {
+		if t.direct == nil {
+			return nil, errors.New("service: SAML metadata direct dialer is not configured")
+		}
+		transport := t.base.Clone()
+		transport.Proxy = nil
+		transport.DialContext = t.direct.DialContext
+		// Every redirect must resolve and recheck policy, even when its origin is
+		// unchanged. A fresh no-keepalive transport prevents connection reuse
+		// from bypassing that per-request check.
+		transport.DisableKeepAlives = true
+		return transport.RoundTrip(request)
+	}
+	addresses, err := t.resolveAddresses(request)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,25 +1084,41 @@ func (t *publicMetadataRoundTripper) prepare(request *http.Request) (*http.Reque
 }
 
 func (t *publicMetadataRoundTripper) destinations(request *http.Request) ([]netip.Addr, *url.URL, error) {
+	addresses, err := t.resolveAddresses(request)
+	if err != nil {
+		return nil, nil, err
+	}
+	proxyURL, err := t.proxyURL(request)
+	if err != nil {
+		return nil, nil, err
+	}
+	return addresses, proxyURL, nil
+}
+
+func (t *publicMetadataRoundTripper) resolveAddresses(request *http.Request) ([]netip.Addr, error) {
 	host := request.URL.Hostname()
 	addresses, err := t.resolver.LookupNetIP(request.Context(), "ip", host)
 	if err != nil || len(addresses) == 0 {
-		return nil, nil, errors.New("service: SAML metadata host did not resolve")
+		return nil, errors.New("service: SAML metadata host did not resolve")
 	}
 	for _, resolved := range addresses {
 		if metadataIPIsNonPublic(resolved) {
-			return nil, nil, errors.New("service: SAML metadata host resolved to a non-public address")
+			return nil, errors.New("service: SAML metadata host resolved to a non-public address")
 		}
 	}
+	return addresses, nil
+}
 
+func (t *publicMetadataRoundTripper) proxyURL(request *http.Request) (*url.URL, error) {
 	var proxyURL *url.URL
+	var err error
 	if t.base.Proxy != nil {
 		proxyURL, err = t.base.Proxy(request)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	return addresses, proxyURL, nil
+	return proxyURL, nil
 }
 
 func (t *publicMetadataRoundTripper) prepareAddress(
@@ -1125,9 +1158,12 @@ func (t *publicMetadataRoundTripper) prepareAddress(
 	// session whose ServerName must remain the original metadata hostname.
 	if proxyURL != nil && proxyURL.Scheme == "https" {
 		proxyHost := proxyURL.Hostname()
-		dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+		dialContext := transport.DialContext
 		transport.DialTLSContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-			raw, err := dialer.DialContext(ctx, network, address)
+			if dialContext == nil {
+				return nil, errors.New("service: SAML metadata proxy dialer is not configured")
+			}
+			raw, err := dialContext(ctx, network, address)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/service/saml_test.go
+++ b/internal/service/saml_test.go
@@ -366,13 +366,19 @@ func TestNewSAMLProvidersBuildsProductionMetadataPolicy(t *testing.T) {
 	if providers.metadataTransport.resolver == nil || providers.metadataTransport.dialer == nil {
 		t.Fatal("production constructor omitted guarded resolver or dialer")
 	}
-	client := publicMetadataHTTPClient(providers.metadataTransport)
+	client, err := publicMetadataHTTPClient(providers.metadataTransport)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if client.Timeout != 15*time.Second {
 		t.Fatalf("metadata client timeout = %s, want 15s", client.Timeout)
 	}
 	guard, ok := client.Transport.(*publicMetadataRoundTripper)
 	if !ok {
 		t.Fatalf("metadata transport = %T, want *publicMetadataRoundTripper", client.Transport)
+	}
+	if guard.direct == nil {
+		t.Fatal("metadata direct transport omitted shared public-address dialer")
 	}
 	if guard.base.ResponseHeaderTimeout != 10*time.Second {
 		t.Fatalf("metadata response header timeout = %s, want 10s", guard.base.ResponseHeaderTimeout)
@@ -480,6 +486,48 @@ func TestSAMLMetadataTransportPinsPublicIPThroughConfiguredProxy(t *testing.T) {
 	}
 }
 
+func TestSAMLMetadataTransportUsesInjectedDialerForHTTPSProxy(t *testing.T) {
+	proxy := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(proxy.Close)
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(proxy.Certificate())
+
+	var attempted string
+	dialer := &net.Dialer{}
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+	base.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		attempted = address
+		return dialer.DialContext(ctx, network, proxy.Listener.Addr().String())
+	}
+	base.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots}
+
+	request, err := http.NewRequest(http.MethodGet, "https://idp.example/metadata", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guard := &publicMetadataRoundTripper{
+		base:     base,
+		resolver: staticMetadataResolver{netip.MustParseAddr("8.8.8.8")},
+	}
+	_, transport, err := guard.prepare(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection, err := transport.DialTLSContext(request.Context(), "tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection.Close()
+	if attempted != proxyURL.Host {
+		t.Fatalf("HTTPS proxy dial address = %q, want %q", attempted, proxyURL.Host)
+	}
+}
+
 func TestSAMLMetadataTransportRefusesPrivateResolutionBeforeProxy(t *testing.T) {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	base.Proxy = func(*http.Request) (*url.URL, error) {
@@ -499,24 +547,26 @@ func TestSAMLMetadataTransportRefusesPrivateResolutionBeforeProxy(t *testing.T) 
 }
 
 func TestSAMLMetadataTransportFallsBackAcrossValidatedAddresses(t *testing.T) {
-	base := http.DefaultTransport.(*http.Transport).Clone()
-	base.Proxy = nil
 	var attempted []string
-	base.DialContext = func(_ context.Context, _, address string) (net.Conn, error) {
-		attempted = append(attempted, address)
-		return nil, errors.New("test address unreachable")
-	}
 	request, err := http.NewRequest(http.MethodGet, "https://idp.example/metadata", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	guard := &publicMetadataRoundTripper{
-		base: base,
+	client, err := publicMetadataHTTPClient(metadataTransportPrimitives{
 		resolver: staticMetadataResolver{
 			netip.MustParseAddr("8.8.8.8"),
 			netip.MustParseAddr("1.1.1.1"),
 		},
+		dialer: metadataDialFunc(func(_ context.Context, _, address string) (net.Conn, error) {
+			attempted = append(attempted, address)
+			return nil, errors.New("test address unreachable")
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+	guard := client.Transport.(*publicMetadataRoundTripper)
+	guard.base.Proxy = nil
 	if _, err := guard.RoundTrip(request); err == nil {
 		t.Fatal("all unreachable addresses unexpectedly succeeded")
 	}

--- a/internal/service/saml_test.go
+++ b/internal/service/saml_test.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
 	"errors"
-	"io"
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"net/url"
+	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,16 +28,39 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/samlsp"
 )
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
-	return f(request)
-}
-
 type staticMetadataResolver []netip.Addr
 
 func (r staticMetadataResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
 	return r, nil
+}
+
+type metadataResolverFunc func(context.Context, string, string) ([]netip.Addr, error)
+
+func (f metadataResolverFunc) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	return f(ctx, network, host)
+}
+
+type metadataDialFunc func(context.Context, string, string) (net.Conn, error)
+
+func (f metadataDialFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f(ctx, network, address)
+}
+
+func guardedMetadataTestServer(t *testing.T, handler http.Handler) (*SAMLProviders, string) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+	dialer := &net.Dialer{}
+	providers := &SAMLProviders{metadataTransport: metadataTransportPrimitives{
+		resolver: staticMetadataResolver{netip.MustParseAddr("93.184.216.34")},
+		dialer: metadataDialFunc(func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+		}),
+		roots: roots,
+	}}
+	return providers, "https://example.com/metadata"
 }
 
 func TestAssessSAMLMetadataReturnsCompleteDiffAndOnlyRequiresNewTrust(t *testing.T) {
@@ -220,16 +246,150 @@ func TestSAMLMetadataURLRequiresHTTPS(t *testing.T) {
 	}
 }
 
+func TestSAMLMetadataGuardedNetworkSeamReturnsInjectedResponse(t *testing.T) {
+	paths := make(chan string, 1)
+	providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		paths <- request.URL.Path
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write([]byte("<EntityDescriptor/>"))
+	}))
+
+	payload, err := providers.fetchMetadata(t.Context(), metadataURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(payload), "<EntityDescriptor/>"; got != want {
+		t.Fatalf("metadata payload = %q, want %q", got, want)
+	}
+	if got := <-paths; got != "/metadata" {
+		t.Fatalf("metadata path = %q, want /metadata", got)
+	}
+}
+
+func TestSAMLMetadataRedirectPivotIsRejected(t *testing.T) {
+	var requests atomic.Int32
+	providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		http.Redirect(response, request, "https://attacker.example/metadata", http.StatusFound)
+	}))
+
+	if _, err := providers.fetchMetadata(t.Context(), metadataURL); !errors.Is(err, ErrSAMLMetadataFetch) {
+		t.Fatalf("redirect pivot error = %v, want ErrSAMLMetadataFetch", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("redirect pivot made %d requests, want 1", got)
+	}
+}
+
+func TestSAMLMetadataRedirectRevalidatesURLShape(t *testing.T) {
+	for _, redirect := range []string{
+		"https://user:password@example.com/metadata",
+		"https://example.com/metadata#credential",
+	} {
+		t.Run(redirect, func(t *testing.T) {
+			var requests atomic.Int32
+			providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				http.Redirect(response, request, redirect, http.StatusFound)
+			}))
+
+			if _, err := providers.fetchMetadata(t.Context(), metadataURL); !errors.Is(err, ErrSAMLMetadataFetch) {
+				t.Fatalf("redirect with invalid URL shape error = %v, want ErrSAMLMetadataFetch", err)
+			}
+			if got := requests.Load(); got != 1 {
+				t.Fatalf("redirect with invalid URL shape made %d requests, want 1", got)
+			}
+		})
+	}
+}
+
+func TestSAMLMetadataOversizedResponseIsRejected(t *testing.T) {
+	providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write([]byte(strings.Repeat("x", samlsp.MaxDocumentBytes+1)))
+	}))
+
+	if _, err := providers.fetchMetadata(t.Context(), metadataURL); !errors.Is(err, ErrSAMLMetadataFetch) {
+		t.Fatalf("oversized response error = %v, want ErrSAMLMetadataFetch", err)
+	}
+}
+
+func TestSAMLMetadataRedirectRevalidatesReboundHost(t *testing.T) {
+	var requests atomic.Int32
+	providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if request.URL.Path == "/final" {
+			response.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(response, request, "/final", http.StatusFound)
+	}))
+	var lookups atomic.Int32
+	providers.metadataTransport.resolver = metadataResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+		if lookups.Add(1) == 1 {
+			return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+		}
+		return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+	})
+
+	if _, err := providers.fetchMetadata(t.Context(), metadataURL); !errors.Is(err, ErrSAMLMetadataFetch) {
+		t.Fatalf("rebound redirect error = %v, want ErrSAMLMetadataFetch", err)
+	}
+	if gotLookups, gotRequests := lookups.Load(), requests.Load(); gotLookups != 2 || gotRequests != 1 {
+		t.Fatalf("rebound redirect lookups = %d, requests = %d; want 2, 1", gotLookups, gotRequests)
+	}
+}
+
+func TestSAMLMetadataSlowResponseIsBounded(t *testing.T) {
+	providers, metadataURL := guardedMetadataTestServer(t, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	providers.metadataTransport.timeout = 25 * time.Millisecond
+	started := time.Now()
+
+	if _, err := providers.fetchMetadata(t.Context(), metadataURL); !errors.Is(err, ErrSAMLMetadataFetch) {
+		t.Fatalf("slow response error = %v, want ErrSAMLMetadataFetch", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("slow response took %s, want bounded below 500ms", elapsed)
+	}
+}
+
+func TestSAMLProvidersExposeNoHTTPClientOverride(t *testing.T) {
+	if _, exposed := reflect.TypeFor[SAMLProviders]().FieldByName("HTTPClient"); exposed {
+		t.Fatal("SAMLProviders exposes arbitrary HTTPClient replacement")
+	}
+}
+
+func TestNewSAMLProvidersBuildsProductionMetadataPolicy(t *testing.T) {
+	providers := NewSAMLProviders(nil, nil, "https://hikyo.example")
+	if providers.metadataTransport.resolver == nil || providers.metadataTransport.dialer == nil {
+		t.Fatal("production constructor omitted guarded resolver or dialer")
+	}
+	client := publicMetadataHTTPClient(providers.metadataTransport)
+	if client.Timeout != 15*time.Second {
+		t.Fatalf("metadata client timeout = %s, want 15s", client.Timeout)
+	}
+	guard, ok := client.Transport.(*publicMetadataRoundTripper)
+	if !ok {
+		t.Fatalf("metadata transport = %T, want *publicMetadataRoundTripper", client.Transport)
+	}
+	if guard.base.ResponseHeaderTimeout != 10*time.Second {
+		t.Fatalf("metadata response header timeout = %s, want 10s", guard.base.ResponseHeaderTimeout)
+	}
+	if guard.base.TLSClientConfig == nil || guard.base.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("metadata TLS policy = %#v, want TLS 1.2 minimum", guard.base.TLSClientConfig)
+	}
+}
+
 func TestSAMLMetadataURLRefusesPrivateNetworkTargets(t *testing.T) {
-	requests := 0
-	providers := &SAMLProviders{HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		requests++
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("<EntityDescriptor/>")),
-			Header:     make(http.Header),
-		}, nil
-	})}}
+	lookups := 0
+	providers := &SAMLProviders{metadataTransport: metadataTransportPrimitives{
+		resolver: metadataResolverFunc(func(context.Context, string, string) ([]netip.Addr, error) {
+			lookups++
+			return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+		}),
+	}}
 
 	for _, rawURL := range []string{
 		"https://localhost/metadata",
@@ -244,8 +404,8 @@ func TestSAMLMetadataURLRefusesPrivateNetworkTargets(t *testing.T) {
 			t.Errorf("fetchMetadata(%q) error = %v, want ErrSAMLMetadataFetch", rawURL, err)
 		}
 	}
-	if requests != 0 {
-		t.Fatalf("private metadata URLs made %d outbound requests, want 0", requests)
+	if lookups != 0 {
+		t.Fatalf("private metadata URLs made %d DNS lookups, want 0", lookups)
 	}
 }
 


### PR DESCRIPTION
Closes #257

## Contract

- Removes the public SAMLProviders HTTPClient override.
- Routes production app wiring through NewSAMLProviders.
- Keeps deterministic tests below policy at DNS, dial, trust-root, and timeout primitives.
- Revalidates URL shape, same-origin redirects, DNS answers, pinned final dialing, TLS, timeouts, and response size.

## Generated outputs

None.

## Validation

- go build ./...
- go vet ./...
- go test -count=1 ./internal/service/... -run SAML — 26 passed
- go test -count=1 ./internal/app/... ./internal/boundary/... — 67 passed
- go test -count=1 ./internal/isolation/ -run SAML — 6 passed
- go test -race -count=1 ./internal/service/... -run metadata-policy tests — 16 passed
- go test -count=1 ./... — 57 packages passed; isolation hit its unchanged 10-minute timeout under shared-host contention
- go test -count=1 ./internal/isolation/ — 1,093 passed on isolated retry
- ./scripts/ci/verify-docs.sh
- Two-axis review round 2: Standards CLEAN; Spec SOUND