### PR TITLE
Admit pinned workload reveal-history #196

### DIFF
--- a/api/artifact_admission_test.go
+++ b/api/artifact_admission_test.go
@@ -54,6 +54,57 @@ func TestAuthorizationOperationArtifactEligibilityDerivesFromEmbeddedContract(t 
 	}
 }
 
+func TestWorkloadRevealHistoryWireSurfaceStaysPinBound(t *testing.T) {
+	loadOnce.Do(load)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	// This is intentionally set equality over every machine-credential route.
+	// All routes except delivery are non-value-bearing for a read-only workload;
+	// delivery's post-release presence-only behavior is proved end-to-end in
+	// TestWorkloadRevealHistoryPinSQLite/Postgres.
+	wantMachine := map[string]string{
+		"exportDefinitions":       "non-value-bearing definitions",
+		"checkDefinitions":        "non-value-bearing definitions",
+		"createDefinitionsPlan":   "not reachable with workload read",
+		"getDefinitionsPlan":      "not reachable with workload read",
+		"applyDefinitionsPlan":    "not reachable with workload read",
+		"getDefinitionsSettings":  "non-value-bearing settings",
+		"getMachineReveal":        "non-value-bearing settings",
+		"fetchDelivery":           "pin-bound value delivery",
+		"reconcileOfflineRecords": "write-only disclosure records",
+		"publishPendingChanges":   "not reachable with workload read",
+		"getRevision":             "non-value-bearing revision metadata",
+	}
+	seen := make(map[string]bool, len(wantMachine))
+	for _, operation := range operations {
+		if !operation.AdmitsArtifact(ArtifactMachineCredential) {
+			continue
+		}
+		classification, expected := wantMachine[operation.ID]
+		if !expected {
+			t.Fatalf("unclassified machine-credential operation %s (%s %s)", operation.ID, operation.Method, operation.Path)
+		}
+		if classification == "" {
+			t.Fatalf("machine-credential operation %s has an empty workload disclosure classification", operation.ID)
+		}
+		seen[operation.ID] = true
+	}
+	for operation := range wantMachine {
+		if !seen[operation] {
+			t.Fatalf("classified workload operation %s no longer admits machine credentials", operation)
+		}
+	}
+
+	for _, operation := range operations {
+		if operation.ID == "rollbackRevision" || operation.ID == "createRevisionPin" || operation.ID == "exportValues" {
+			if operation.AdmitsArtifact(ArtifactMachineCredential) {
+				t.Fatalf("historical value-control operation %s admits machine credentials", operation.ID)
+			}
+		}
+	}
+}
+
 func TestCollectOperationsRejectsMissingOrEmptyArtifactEligibility(t *testing.T) {
 	const base = `
 openapi: 3.1.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8234,14 +8234,10 @@ paths:
       x-hikyo-class: tenant
       x-hikyo-operation: value.export-reveal
       x-hikyo-formula: [read@environment, reveal@environment]
-      # Human-session only, and the omission is a decision. A machine principal
-      # CAN export - `read` alone returns `config` plaintext and `secret`
-      # write-presence - but the route's declared formula is the revealing one,
-      # and no machine class in the permission ADR's allowlists may hold
-      # `reveal` today: machine `reveal` arrives through the source-of-truth
-      # ADR's explicit per-project operator opt-in, which is not modelled yet.
-      # Declaring an eligibility the registry cannot honour would be a lie on
-      # the wire; this joins when the opt-in lands.
+      # Human-session only on the current wire contract. Machine credentials
+      # receive secret material through delivery.fetch; workload
+      # reveal-history is therefore bound to its active non-current pin rather
+      # than exposed as an unpinned bulk-export route.
       x-hikyo-artifacts: [human-session]
       x-hikyo-min-revision: 1
       requestBody:

--- a/docs/handoff/196-workload-reveal-history-pin.md
+++ b/docs/handoff/196-workload-reveal-history-pin.md
@@ -1,0 +1,53 @@
+# #196 — workload reveal-history under a pin
+
+## Outcome
+
+Workload principals may now receive `reveal-history` at environment scope only
+when both live conditions hold:
+
+1. The project's machine-reveal opt-in is enabled.
+2. That workload has an unexpired pin whose revision differs from the
+   environment's latest snapshot revision.
+
+Automation principals remain excluded because revision pins name workload
+principals. No migration or new audit event was added.
+
+## Refusal order
+
+The shared grant writer applies the locked order:
+
+1. Opt-in off → `ErrMachineRevealOptIn`.
+2. Opt-in on without an active non-current pin →
+   `ErrMachineRevealHistoryPin` (`conflict`, HTTP 409).
+3. Existing machine scope and project confinement checks.
+4. Existing widening formula: actor holds `manage-identities`, holds
+   `reveal-history` over newly reachable environments, and presents a live
+   mint reauthentication window.
+
+The pin state read is one `hikyo:authn-resolution` query under the target
+principal lock. It returns the pin revision, expiry, and latest revision; the
+service evaluates liveness against its injected clock. Missing and malformed
+state fails closed.
+
+## Release behavior
+
+`Pins.Release` does not delete the grant. Existing use-time mechanics make it
+inert:
+
+- delivery no longer selects a historical snapshot, so current secret
+  plaintext requires `reveal`, not `reveal-history`;
+- release advances the pin generation, moving the workload cursor once;
+- disabling the project opt-in strips both disclosure atoms.
+
+The public workload surface remains pin-bound: `delivery.fetch` admits machine
+credentials; rollback, pin mutation, and values export remain human-session
+routes. Revision detail is machine-readable metadata and contains no values.
+
+## Verification
+
+Paired SQLite/Postgres E2E coverage proves opt-in precedence, absent/current/
+expired pin refusal, current-becoming-historical admission, disclosure-authority
+and reauthentication gates, both audit rows, historical plaintext delivery,
+release inertness, one cursor movement, retained grant row, and automation
+refusal. `TestWorkloadRevealHistoryWireSurfaceStaysPinBound` pins the public
+artifact boundary.

--- a/docs/handoff/v1-launch-blockers.md
+++ b/docs/handoff/v1-launch-blockers.md
@@ -31,7 +31,10 @@ motivated it: `docs/handoff/v1-readiness-audit.md`.
 
 ## Not done / follow-ups
 
-- Workload `reveal-history` under a pin (permission-model ADR: "`reveal-history` only where a pin requires it") is not grantable — the pre-existing machine allowlist refuses it outright; this PR only adds the opt-in conjunct at the chokepoint for both disclosure atoms. Follow-up ticket needed.
+- ~~Workload `reveal-history` under a pin was not grantable.~~ Resolved by #196:
+  the grant API admits it only under the project opt-in and an active
+  non-current workload pin; releasing the pin leaves the row inert and moves
+  the delivery cursor.
 
 - Codex cross-model review (gpt-5.6-sol, high): R1 NOT CLEAN (1 BLOCKING / 5 HIGH) → fixed in `fix: address cross-model review R1…` → R2 one item open → R3 **SOUND-WITH-DISPOSITIONS** (#3, the CLI zero-window browser handoff). The owner chose to implement #3; the handoff slice had its own R1 (1 BLOCKING / 3 HIGH / 1 MEDIUM → fixed: dispatch by enrolment, honest TOTP scope, act-bound units, passkey-binding e2e) → R2 SOUND-WITH-DISPOSITIONS (residuals fixed) → R3 **SOUND-WITH-DISPOSITIONS** (no slice-blocking items). PR #194.
 - Remaining owner disposition: OIDC re-run reauthentication is not implemented for any disclosure ceremony (browser or handoff) — a pre-existing gap of the reveal ceremony (`Ceremony.tsx` offers passkey/TOTP only); follow-up ticket.

--- a/docs/site/src/content/docs/docs/compose.mdx
+++ b/docs/site/src/content/docs/docs/compose.mdx
@@ -150,6 +150,10 @@ hikyo project-settings machine-reveal set --enabled true   # project-settings + 
 hikyo access grant add --principal <mch_...> --capability reveal --env <env-id>
 ```
 
+A workload pinned to a non-current revision needs `reveal-history` instead;
+that grant is accepted only while the active pin requires historical delivery.
+Releasing the pin leaves the grant row in place but makes it inert.
+
 Withdrawing the opt-in (`--enabled false`) stops every machine secret delivery
 in the project on the next fetch without touching any grant. `--config-only`
 remains the explicit no-secrets projection.

--- a/docs/site/src/content/docs/docs/machine-identities.mdx
+++ b/docs/site/src/content/docs/docs/machine-identities.mdx
@@ -24,8 +24,10 @@ Record the returned stable ID. List its grants before minting a credential.
 ## Secret delivery: the machine-reveal opt-in
 
 A workload or automation principal may hold `reveal` only under the project's
-explicit machine-reveal opt-in. It is off by default, and while it is off every
-machine fetch in the project delivers configuration and secret presence only.
+explicit machine-reveal opt-in. A workload may also hold `reveal-history`, but
+only while an active pin routes that workload to a non-current revision. The
+opt-in is off by default; while it is off every machine fetch delivers
+configuration and secret presence only.
 
 ```bash
 hikyo project-settings machine-reveal get
@@ -33,11 +35,24 @@ hikyo project-settings machine-reveal set --enabled true
 hikyo access grant add --principal <mch_...> --capability reveal --env <env-id>
 ```
 
+After pinning a workload to a non-current revision, grant its historical
+delivery atom separately:
+
+```bash
+hikyo access grant add --principal <mch_...> --capability reveal-history --env <env-id>
+```
+
+The grant is refused without a live non-current pin. Releasing the pin leaves
+the row visible for audit and reversal, but makes it inert and moves the
+workload cursor. Automation principals cannot hold this atom because pins name
+workloads.
+
 Enabling needs `project-settings` and `reveal` at project scope and a
 second factor; it admits a standing decryption capability onto machine
 principals, which the command says before it writes. Withdrawing it
-(`--enabled false`) makes every machine `reveal` grant in the project inert on
-the next fetch and moves every machine cursor; grant rows are untouched.
+(`--enabled false`) makes every machine `reveal` and workload `reveal-history`
+grant in the project inert on the next fetch and moves every machine cursor;
+grant rows are untouched.
 
 ## Bearer credential
 

--- a/internal/authz/federation.go
+++ b/internal/authz/federation.go
@@ -32,6 +32,7 @@ type (
 	Binding             = authn.Binding
 	FederationIssuer    = authn.FederationIssuer
 	NewFederationIssuer = authn.NewFederationIssuer
+	WorkloadPinState    = authn.WorkloadPinState
 )
 
 // BindingPredicate is the binding-specific half of federated validation:
@@ -203,6 +204,11 @@ func (a *TxAuthorizer) ReactivateBinding(ctx context.Context, id string, at time
 // PinGeneration reads the conditional cursor's pin component.
 func (a *TxAuthorizer) PinGeneration(ctx context.Context, p domain.PrincipalID, env domain.EnvID) (int64, error) {
 	return a.r.PinGeneration(ctx, p, env)
+}
+
+// WorkloadPinState reads the conditional reveal-history admission fact.
+func (a *TxAuthorizer) WorkloadPinState(ctx context.Context, p domain.PrincipalID, env domain.EnvID) (WorkloadPinState, error) {
+	return a.r.WorkloadPinState(ctx, p, env)
 }
 
 // SetPinGeneration advances it. #52 owns pin creation, reassignment and release.

--- a/internal/domain/permission.go
+++ b/internal/domain/permission.go
@@ -243,13 +243,11 @@ func IsCredentialLifetime(l CredentialLifetime) bool {
 // principals): the grant API refuses a capability outside its class's list.
 //
 // `reveal` and `reveal-history` are absent from the workload and automation
-// lists on purpose. The ADR admits them ONLY under the source-of-truth ADR's
-// explicit per-project operator opt-in (reveal) and only where a pin requires
-// it (reveal-history). Neither mechanism exists yet, so the list is the
-// fail-closed subset: a machine reveal grant is refused by name until #17/#58
-// ship the opt-in. Widening the list without the opt-in would hand every
-// automation credential a standing decryption capability, which is exactly
-// what the ADR says must be a deliberate per-project act.
+// lists on purpose. Both are conditionally admitted outside this unconditional
+// allowlist: `reveal` under the source-of-truth ADR's per-project operator
+// opt-in, and workload `reveal-history` only under that opt-in while an active
+// pin requires historical delivery. Keeping both conditions live avoids
+// turning either disclosure atom into a standing class capability.
 var machineAllowlists = map[PrincipalClass]map[Capability]bool{
 	ClassWorkload: {CapRead: true},
 	ClassAutomation: {
@@ -282,6 +280,13 @@ var machineRevealByOptIn = map[PrincipalClass]bool{
 // machine-reveal opt-in can admit `reveal` onto.
 func MachineMayHoldRevealByOptIn(c PrincipalClass) bool {
 	return machineRevealByOptIn[c]
+}
+
+// MachineMayHoldRevealHistoryByPin reports whether class c may hold
+// `reveal-history` while an active non-current pin requires it. Pins name a
+// workload principal, so the automation condition is currently unsatisfiable.
+func MachineMayHoldRevealHistoryByPin(c PrincipalClass) bool {
+	return c == ClassWorkload
 }
 
 // MachineClasses returns the closed machine class set, sorted.

--- a/internal/isolation/delivery_e2e_test.go
+++ b/internal/isolation/delivery_e2e_test.go
@@ -1049,8 +1049,15 @@ func runDeliveryPinnedNonCurrent(t *testing.T, db *store.DB) {
 		t.Error("`reveal` delivered a pinned non-current secret; it requires `reveal-history`")
 	}
 
-	// `reveal-history` delivers it, and the disclosure names the pinned revision.
-	seedMachineReveal(t, db, "g_wl_revh", sa.Principal, domain.CapRevealHistory, envA1)
+	// `reveal-history` now lands through the real grant API. The active
+	// non-current pin is the conditional admission fact; the actor's session
+	// supplies the existing widening ceremony.
+	if _, err := grantSvcWithAuth(db).Create(t.Context(),
+		service.Bearer(sessionWithWindows(t, db, identRevatr, envA1)), service.GrantSpec{
+			Target: sa.Principal, Capability: domain.CapRevealHistory, Scope: envScope(envA1),
+		}); err != nil {
+		t.Fatalf("grant reveal-history under the active pin: %v", err)
+	}
 	res, err = del.Fetch(t.Context(), minted.Value, env, "", service.FetchOptions{})
 	if err != nil {
 		t.Fatalf("pinned fetch with reveal-history: %v", err)

--- a/internal/isolation/grants_e2e_test.go
+++ b/internal/isolation/grants_e2e_test.go
@@ -296,9 +296,10 @@ func runMachineAllowlist(t *testing.T, db *store.DB) {
 		// `reveal` is admitted onto a workload only under the source-of-truth
 		// ADR's per-project operator opt-in; the seeded project has it off, so
 		// the refusal names the opt-in (machine_reveal_e2e_test covers the on
-		// side). `reveal-history` stays off the workload allowlist outright.
+		// side). `reveal-history` uses the same opt-in before its pin-specific
+		// admission rule, so the off-state refusal has the same precedence.
 		{"workload_reveal", mchWork, domain.CapReveal, envScope(envA1), service.ErrMachineRevealOptIn},
-		{"workload_reveal_history", mchWork, domain.CapRevealHistory, envScope(envA1), service.ErrMachineCapability},
+		{"workload_reveal_history", mchWork, domain.CapRevealHistory, envScope(envA1), service.ErrMachineRevealOptIn},
 		{"workload_edit", mchWork, domain.CapEdit, prjScope(), service.ErrMachineCapability},
 		// The automation class holds edit/publish/definitions-edit; mch_a1 is
 		// backfilled to that class by migration 00010.

--- a/internal/isolation/identities_e2e_test.go
+++ b/internal/isolation/identities_e2e_test.go
@@ -95,26 +95,11 @@ const (
 	revealOnly  = domain.PrincipalID("usr_rvonly")
 )
 
-// seedMachineReveal writes a disclosure grant straight to the table.
-//
-// It has to bypass the grant API, and the reason is a real collision worth
-// stating rather than hiding: the permission model's machine allowlists
-// (#55, domain/permission.go) refuse `reveal` and `reveal-history` to a
-// machine principal BY NAME until the source-of-truth ADR's per-project
-// machine-reveal opt-in ships (#17/#58). So no API path can currently produce
-// a reveal-reaching service account — and the ADR's mint and widen formulas
-// are written against exactly that state.
-//
-// Rather than widen the allowlist (which would hand every automation
-// credential a standing decryption capability, the thing the ADR insists must
-// be a deliberate per-project act), the fixture seeds the row directly. The
-// gates under test read the grant table, so they see the same state the
-// opt-in will eventually produce through the API.
 // seedMachineReveal writes a disclosure grant onto a machine principal by raw
-// SQL AND turns the project's machine-reveal opt-in on: a machine `reveal`
-// exists only under that opt-in (source-of-truth ADR), and the delivery path
-// reads it live, so a fixture that seeded the grant alone would be seeding a
-// state the product cannot reach.
+// SQL and turns the project's machine-reveal opt-in on. Tests that exercise
+// the grant surface use Grants.Create; this helper is for mint/delivery tests
+// that need an already-established disclosure state without consuming the
+// widening ceremony they are independently testing.
 func seedMachineReveal(t *testing.T, db *store.DB, id string, p domain.PrincipalID, cap domain.Capability, env domain.EnvID) {
 	t.Helper()
 	execRaw(t, db, `UPDATE projects SET machine_reveal = TRUE WHERE id = 'prj_a1'`)
@@ -936,12 +921,9 @@ func runMachineGrantWidening(t *testing.T, db *store.DB) {
 		t.Fatalf("the refusal must name manage-identities: %v", err)
 	}
 
-	// The per-class split is exercised through the MINT gate rather than
-	// here, and the reason is worth recording: #55's machine allowlist
-	// refuses `reveal-history` to a workload principal BY NAME before this
-	// gate runs, so the grant API cannot currently reach the historical case
-	// at all. Both gates call the same Auth.RequireDisclosureAuthority, so
-	// the split is proven once — see runMintDisclosureGate.
+	// The historical half of this grant-widening rule is exercised through the
+	// real grant API in machine_reveal_history_e2e_test.go. The mint half stays
+	// pinned above because both call the same RequireDisclosureAuthority seam.
 
 	// NARROWING is never a widening: the revoke needs no disclosure right.
 	if err := g.Revoke(ctx, service.LocalPrincipal(identAdmin), service.GrantSpec{

--- a/internal/isolation/machine_reveal_history_e2e_test.go
+++ b/internal/isolation/machine_reveal_history_e2e_test.go
@@ -1,0 +1,201 @@
+package isolation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestWorkloadRevealHistoryPinSQLite(t *testing.T) {
+	runWorkloadRevealHistoryPin(t, seededDB(t, openSQLite))
+}
+
+func TestWorkloadRevealHistoryPinPostgres(t *testing.T) {
+	runWorkloadRevealHistoryPin(t, seededDB(t, openPostgres))
+}
+
+// runWorkloadRevealHistoryPin exercises the grant and delivery seams together:
+// the grant exists only while an active pin routes historical material, then
+// stays stored but becomes inert when releasing the pin moves the cursor.
+func runWorkloadRevealHistoryPin(t *testing.T, db *store.DB) {
+	identityFixtures(t, db)
+	seedDeliveryCatalogue(t, db) // revision 1
+	ctx := t.Context()
+	env := scopeEnv(orgA, prjA1, envA1)
+	identities := identitySvc(db)
+	grants := grantSvcWithAuth(db)
+	pins := &service.Pins{DB: db, Keyring: probeKeyring(t, db)}
+
+	// Both disclosure atoms share the project opt-in. The pin authority also
+	// holds the rights Pins.Set and delivery's recorded-authority recheck need.
+	execRaw(t, db, `UPDATE projects SET machine_reveal = TRUE WHERE id = 'prj_a1'`)
+	for _, stmt := range []string{
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_rh_pin', 'usr_ident', 'pin', 'org_a', 'prj_a1', 'env_a1', ` + ts + `)`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_rh_pin_authority', 'usr_ident', 'reveal-history', 'org_a', 'prj_a1', 'env_a1', ` + ts + `)`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_rh_settings', 'usr_idrev', 'project-settings', 'org_a', 'prj_a1', NULL, ` + ts + `)`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_rh_project_reveal', 'usr_idrev', 'reveal', 'org_a', 'prj_a1', NULL, ` + ts + `)`,
+		// usr_rvonly can grant an unheld atom but still lacks the disclosure
+		// authority needed by the stricter machine-widening formula.
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_rh_org_mm', 'usr_rvonly', 'manage-members', 'org_a', NULL, NULL, ` + ts + `)`,
+	} {
+		execRaw(t, db, stmt)
+	}
+	seedOrigins(t, db)
+
+	workload, err := identities.CreateServiceAccount(ctx, service.LocalPrincipal(identAdmin),
+		prjScope(), "pinned-historian", domain.ClassWorkload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := identities.MintCredential(ctx, service.LocalPrincipal(identAdmin),
+		prjScope(), workload.ID, service.MintRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantMachineRead(t, db, workload.Principal, envA1)
+	spec := service.GrantSpec{
+		Target: workload.Principal, Capability: domain.CapRevealHistory, Scope: envScope(envA1),
+	}
+
+	// Opt-in on is not enough: absent, current, and expired pins do not require
+	// historical delivery and therefore cannot justify a reveal-history grant.
+	if _, err := grants.Create(ctx, service.LocalPrincipal(identRevatr), spec); !errors.Is(err, service.ErrMachineRevealHistoryPin) {
+		t.Fatalf("grant without a pin: got %v, want ErrMachineRevealHistoryPin", err)
+	} else if !strings.Contains(err.Error(), string(envA1)) {
+		t.Fatalf("pin refusal does not name %s: %v", envA1, err)
+	}
+	if _, err := pins.Set(ctx, service.LocalPrincipal(identAdmin), env,
+		service.SetPinRequest{WorkloadPrincipalID: workload.Principal, Revision: 1}); err != nil {
+		t.Fatalf("pin current revision: %v", err)
+	}
+	if _, err := grants.Create(ctx, service.LocalPrincipal(identRevatr), spec); !errors.Is(err, service.ErrMachineRevealHistoryPin) {
+		t.Fatalf("grant with a current pin: got %v, want ErrMachineRevealHistoryPin", err)
+	}
+	execRaw(t, db, `UPDATE revision_pins SET expires_at = '2000-01-01T00:00:00.000000Z' WHERE workload_principal_id = '`+string(workload.Principal)+`'`)
+	if _, err := grants.Create(ctx, service.LocalPrincipal(identRevatr), spec); !errors.Is(err, service.ErrMachineRevealHistoryPin) {
+		t.Fatalf("grant with an expired pin: got %v, want ErrMachineRevealHistoryPin", err)
+	}
+
+	// Restore liveness, then overtake revision 1. The stored current pin now
+	// requires reveal-history without being rewritten.
+	execRaw(t, db, `UPDATE revision_pins SET expires_at = '2999-01-01T00:00:00.000000Z' WHERE workload_principal_id = '`+string(workload.Principal)+`'`)
+	publishDeliveryValues(t, db, envA1, map[string]string{"DATABASE_URL": "postgres://dev-v2"})
+	if latest := latestRevision(t, db, string(envA1)); latest != 2 {
+		t.Fatalf("latest revision = %d, want 2", latest)
+	}
+
+	// Model a grant waiting on the target-principal lock until the pin expires:
+	// the first clock read supplies the write timestamp, while the pin check
+	// must take a fresh reading after the lock instead of reusing it.
+	clockReads := 0
+	grantsAfterWait := grantSvcWithAuth(db)
+	grantsAfterWait.Now = func() time.Time {
+		clockReads++
+		if clockReads == 1 {
+			return time.Date(2998, 12, 31, 23, 59, 59, 0, time.UTC)
+		}
+		return time.Date(2999, 1, 1, 0, 0, 1, 0, time.UTC)
+	}
+	if _, err := grantsAfterWait.Create(ctx, service.LocalPrincipal(identRevatr), spec); !errors.Is(err, service.ErrMachineRevealHistoryPin) {
+		t.Fatalf("grant whose pin expires while awaiting its lock: got %v, want ErrMachineRevealHistoryPin", err)
+	}
+
+	// The pin-specific admission does not weaken the existing widening gate.
+	if _, err := grants.Create(ctx, service.LocalPrincipal(revealOnly), spec); !errors.Is(err, service.ErrDisclosureAuthority) {
+		t.Fatalf("grant without actor reveal-history: got %v, want ErrDisclosureAuthority", err)
+	}
+	if _, err := grants.Create(ctx, service.LocalPrincipal(identRevatr), spec); !errors.Is(err, service.ErrReauthRequired) {
+		t.Fatalf("grant without a live mint window: got %v, want ErrReauthRequired", err)
+	}
+	actor := service.Bearer(sessionWithWindows(t, db, identRevatr, envA1))
+	if _, err := grants.Create(ctx, actor, spec); err != nil {
+		t.Fatalf("grant under active historical pin: %v", err)
+	}
+	if n := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events WHERE type = 'grant.created' AND payload LIKE '%reveal-history%'`); n != 1 {
+		t.Fatalf("grant.created audit rows = %d, want 1", n)
+	}
+	if n := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events WHERE type = 'identity.grant_widened' AND payload LIKE '%reveal-history%'`); n != 1 {
+		t.Fatalf("identity.grant_widened audit rows = %d, want 1", n)
+	}
+
+	delivery := deliverySvc(t, db)
+	beforeRelease, err := delivery.Fetch(ctx, credential.Value, env, "", service.FetchOptions{})
+	if err != nil {
+		t.Fatalf("fetch through historical pin: %v", err)
+	}
+	if value := deliveredByName(beforeRelease.Keys)["DATABASE_PASSWORD"].Value; value == nil || *value != "dev-secret" {
+		t.Fatalf("historical secret = %v, want revision-1 plaintext", value)
+	}
+
+	// The opt-in remains a live conjunct after the grant. Withdrawing it strips
+	// reveal-history and moves the cursor; re-enabling restores pinned delivery.
+	settings := settingsSvc(t, db)
+	operator := service.LocalPrincipal(identRevatr)
+	if _, err := settings.SetMachineReveal(ctx, operator, prjScope(), false); err != nil {
+		t.Fatalf("withdraw machine reveal: %v", err)
+	}
+	withoutOptIn, err := delivery.Fetch(ctx, credential.Value, env, beforeRelease.Cursor, service.FetchOptions{})
+	if err != nil {
+		t.Fatalf("fetch after opt-in withdrawal: %v", err)
+	}
+	if withoutOptIn.Current {
+		t.Fatal("opt-in withdrawal left the historical cursor current")
+	}
+	if value := deliveredByName(withoutOptIn.Keys)["DATABASE_PASSWORD"].Value; value != nil {
+		t.Fatal("reveal-history disclosed while the machine-reveal opt-in was off")
+	}
+	if _, err := settings.SetMachineReveal(ctx, operator, prjScope(), true); err != nil {
+		t.Fatalf("restore machine reveal: %v", err)
+	}
+	restored, err := delivery.Fetch(ctx, credential.Value, env, withoutOptIn.Cursor, service.FetchOptions{})
+	if err != nil {
+		t.Fatalf("fetch after opt-in restore: %v", err)
+	}
+	if restored.Current {
+		t.Fatal("opt-in restore left the presence-only cursor current")
+	}
+	if value := deliveredByName(restored.Keys)["DATABASE_PASSWORD"].Value; value == nil || *value != "dev-secret" {
+		t.Fatalf("restored historical secret = %v, want revision-1 plaintext", value)
+	}
+
+	if _, err := pins.Release(ctx, service.LocalPrincipal(identAdmin), env, workload.Principal); err != nil {
+		t.Fatalf("release pin: %v", err)
+	}
+	if !held(t, db, workload.Principal, domain.CapRevealHistory, envScope(envA1)) {
+		t.Fatal("pin release deleted the reveal-history grant")
+	}
+	afterRelease, err := delivery.Fetch(ctx, credential.Value, env, restored.Cursor, service.FetchOptions{})
+	if err != nil {
+		t.Fatalf("fetch after pin release: %v", err)
+	}
+	if afterRelease.Current {
+		t.Fatal("pin release left the historical cursor current")
+	}
+	if value := deliveredByName(afterRelease.Keys)["DATABASE_PASSWORD"].Value; value != nil {
+		t.Fatal("stale reveal-history grant disclosed current secret after pin release")
+	}
+	repeat, err := delivery.Fetch(ctx, credential.Value, env, afterRelease.Cursor, service.FetchOptions{})
+	if err != nil {
+		t.Fatalf("repeat fetch after pin release: %v", err)
+	}
+	if !repeat.Current {
+		t.Fatal("pin release moved the cursor more than once")
+	}
+
+	// Automation cannot satisfy a workload-only pin condition.
+	automation, err := identities.CreateServiceAccount(ctx, service.LocalPrincipal(identAdmin),
+		prjScope(), "automation-historian", domain.ClassAutomation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := grants.Create(ctx, service.LocalPrincipal(identRevatr), service.GrantSpec{
+		Target: automation.Principal, Capability: domain.CapRevealHistory, Scope: envScope(envA1),
+	}); !errors.Is(err, service.ErrMachineCapability) {
+		t.Fatalf("automation reveal-history: got %v, want ErrMachineCapability", err)
+	}
+}

--- a/internal/isolation/testdata/annotated_queries.json
+++ b/internal/isolation/testdata/annotated_queries.json
@@ -1435,6 +1435,12 @@
   },
   {
     "engine": "postgres",
+    "name": "WorkloadPinState",
+    "annotation": "authn-resolution",
+    "hash": "d4f2496c0094b063c110558adc1f66c63441085d56f0895dfb2fa77596f7af07"
+  },
+  {
+    "engine": "postgres",
     "name": "WorkspaceHandoffByCode",
     "annotation": "authn-resolution",
     "hash": "18eeec5b43f932cc2828ba14de2eef6d15435d357d13feb424c657018ddacf9b"
@@ -2884,6 +2890,12 @@
     "name": "UpdateSAMLProviderCAS",
     "annotation": "authn-resolution",
     "hash": "d061f9058bee068f5994e147f82ab3b9c36661b4fbbd4f7b3ceb9b6217392904"
+  },
+  {
+    "engine": "sqlite",
+    "name": "WorkloadPinState",
+    "annotation": "authn-resolution",
+    "hash": "cc5eb6a9795415b433cd31c766637b8965b4561d625db16da0f3869a10f1db0f"
   },
   {
     "engine": "sqlite",

--- a/internal/service/grants.go
+++ b/internal/service/grants.go
@@ -66,6 +66,9 @@ var (
 	// opt-in, never a default"). The grant API names the opt-in so the
 	// operator learns which act admits it, rather than a bare allowlist refusal.
 	ErrMachineRevealOptIn = fmt.Errorf("%w: service: reveal on a machine principal requires the project's machine-reveal opt-in", domain.ErrConflict)
+	// ErrMachineRevealHistoryPin refuses `reveal-history` on a workload unless
+	// an active pin routes a non-current revision to that workload.
+	ErrMachineRevealHistoryPin = fmt.Errorf("%w: service: reveal-history on a workload requires an active non-current revision pin", domain.ErrConflict)
 	// ErrMachineScope refuses a machine grant that is SHALLOWER than its
 	// class admits — a workload outside an explicit (project, environment),
 	// or automation above project depth. The allowlist bounds which
@@ -287,7 +290,7 @@ func (s *Grants) grantOneWithInvalidation(
 		return zero, nil, err
 	}
 
-	class, err := lockAndClassify(ctx, az, spec.Target, spec.Capability, spec.Scope)
+	class, err := lockAndClassify(ctx, az, spec.Target, spec.Capability, spec.Scope, s.now)
 	if err != nil {
 		return zero, nil, err
 	}
@@ -605,7 +608,7 @@ func hasOrigin(ctx context.Context, az *authz.TxAuthorizer, grantID string, o au
 // read no row and both insert. Resolving the class also proves the principal
 // exists: granting to a principal that is not there writes a row nothing can
 // ever evaluate.
-func lockAndClassify(ctx context.Context, az *authz.TxAuthorizer, target domain.PrincipalID, capability domain.Capability, scope domain.Scope) (domain.PrincipalClass, error) {
+func lockAndClassify(ctx context.Context, az *authz.TxAuthorizer, target domain.PrincipalID, capability domain.Capability, scope domain.Scope, now func() time.Time) (domain.PrincipalClass, error) {
 	if err := az.LockTargetPrincipal(ctx, target); err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			return "", ErrUnknownPrincipal
@@ -620,7 +623,7 @@ func lockAndClassify(ctx context.Context, az *authz.TxAuthorizer, target domain.
 		return "", err
 	}
 	if class == domain.ClassHuman {
-		if err := checkPrincipalClass(class, capability, false); err != nil {
+		if err := checkPrincipalClass(class, capability, false, false, scope.Env); err != nil {
 			return "", err
 		}
 		return class, nil
@@ -638,7 +641,22 @@ func lockAndClassify(ctx context.Context, az *authz.TxAuthorizer, target domain.
 		}
 		optIn = err == nil && st.Enabled
 	}
-	if err := checkPrincipalClass(class, capability, optIn); err != nil {
+	activeHistoricalPin := false
+	if capability == domain.CapRevealHistory && domain.MachineMayHoldRevealHistoryByPin(class) && optIn && scope.Env != "" {
+		state, err := az.WorkloadPinState(ctx, target, scope.Env)
+		switch {
+		case err == nil:
+			// Read the clock only after the target lock and pin query. A grant
+			// waiting on that lock must not retain a pre-expiry timestamp and
+			// admit a pin that expired while it waited.
+			activeHistoricalPin = now().Before(state.ExpiresAt) && state.Revision != state.LatestRevision
+		case errors.Is(err, domain.ErrNotFound):
+			// Absence is the expected closed state, not a storage failure.
+		default:
+			return "", err
+		}
+	}
+	if err := checkPrincipalClass(class, capability, optIn, activeHistoricalPin, scope.Env); err != nil {
 		return "", err
 	}
 	if err := checkMachineScope(class, scope); err != nil {
@@ -1261,7 +1279,7 @@ func checkGrantable(capability domain.Capability, at domain.Level) error {
 // only what its class's list admits, which is what makes "no machine principal
 // may hold manage-members, manage-projects, project-settings or any instance
 // capability" a refusal rather than a convention.
-func checkPrincipalClass(class domain.PrincipalClass, capability domain.Capability, machineRevealOptIn bool) error {
+func checkPrincipalClass(class domain.PrincipalClass, capability domain.Capability, machineRevealOptIn, activeHistoricalPin bool, env domain.EnvID) error {
 	if capability == domain.CapSCIMProvision {
 		// Machine-only AND system-created: the provisioning connection's own
 		// grant is written with its SCIM binding (#73) and retired with it.
@@ -1293,6 +1311,15 @@ func checkPrincipalClass(class domain.PrincipalClass, capability domain.Capabili
 	if capability == domain.CapReveal && domain.MachineMayHoldRevealByOptIn(class) {
 		if !machineRevealOptIn {
 			return fmt.Errorf("%w: class %q may hold %q only under the project's machine-reveal opt-in, which is off", ErrMachineRevealOptIn, class, capability)
+		}
+		return nil
+	}
+	if capability == domain.CapRevealHistory && domain.MachineMayHoldRevealHistoryByPin(class) {
+		if !machineRevealOptIn {
+			return fmt.Errorf("%w: class %q may hold %q only under the project's machine-reveal opt-in, which is off", ErrMachineRevealOptIn, class, capability)
+		}
+		if !activeHistoricalPin {
+			return fmt.Errorf("%w: class %q may hold %q at %s only while it is pinned to a non-current revision there", ErrMachineRevealHistoryPin, class, capability, env)
 		}
 		return nil
 	}
@@ -1414,6 +1441,7 @@ func renderScope(s domain.Scope) string {
 func (s *Grants) BreakGlassGrant(ctx context.Context, spec GrantSpec) (GrantResult, error) {
 	var out GrantResult
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+		now := s.now()
 		level, err := spec.Scope.Level()
 		if err != nil {
 			return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
@@ -1426,11 +1454,11 @@ func (s *Grants) BreakGlassGrant(ctx context.Context, spec GrantSpec) (GrantResu
 		// The machine allowlists are normative for every writer, including
 		// this one: break-glass exists to restore human administration, not to
 		// hand a CI runner an instance capability by the back door.
-		if _, err := lockAndClassify(ctx, az, spec.Target, spec.Capability, spec.Scope); err != nil {
+		if _, err := lockAndClassify(ctx, az, spec.Target, spec.Capability, spec.Scope, s.now); err != nil {
 			return err
 		}
 		out, err = writeGrantRow(ctx, az, spec,
-			authz.Origin{Kind: domain.OriginBreakGlass, Subject: breakGlassSubject}, s.now())
+			authz.Origin{Kind: domain.OriginBreakGlass, Subject: breakGlassSubject}, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/scim.go
+++ b/internal/service/scim.go
@@ -482,7 +482,7 @@ func (s *SCIM) applyMappings(
 			// lock first, then the principal class and the normative machine
 			// allowlists. A sync must not take a shortcut past a rule a human
 			// grant cannot.
-			if _, err := lockAndClassify(ctx, az, target, capability, scope); err != nil {
+			if _, err := lockAndClassify(ctx, az, target, capability, scope, s.now); err != nil {
 				return nil, 0, err
 			}
 			out, err := writeGrantRow(ctx, az, spec, origin, now)

--- a/internal/store/authn/federation.go
+++ b/internal/store/authn/federation.go
@@ -71,6 +71,14 @@ type FederationIssuer struct {
 	UpdatedBy        domain.PrincipalID
 }
 
+// WorkloadPinState is the live grant-time fact that conditionally admits
+// reveal-history onto a workload principal.
+type WorkloadPinState struct {
+	Revision       int64
+	LatestRevision int64
+	ExpiresAt      time.Time
+}
+
 // NewFederationIssuer is one issuer configuration.
 type NewFederationIssuer struct {
 	ID               string
@@ -370,6 +378,38 @@ func (r *Resolver) PinGeneration(ctx context.Context, p domain.PrincipalID, env 
 		return 0, nil
 	}
 	return gen, err
+}
+
+// WorkloadPinState reads the workload's pin and the environment's current
+// revision in one transaction-local query. No row remains a real not-found:
+// unlike PinGeneration, absence is the refusal fact the caller must observe.
+func (r *Resolver) WorkloadPinState(ctx context.Context, p domain.PrincipalID, env domain.EnvID) (WorkloadPinState, error) {
+	if r.sq != nil {
+		row, err := r.sq.WorkloadPinState(ctx, sqlitegen.WorkloadPinStateParams{
+			WorkloadPrincipalID: string(p), EnvironmentID: string(env),
+		})
+		if err != nil {
+			return WorkloadPinState{}, notFoundOr(err)
+		}
+		// Revision pins are written by the tenant store with its canonical
+		// RFC3339Nano codec, not authn's fixed-width SQLite timestamp codec.
+		expires, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
+		if err != nil {
+			return WorkloadPinState{}, err
+		}
+		return WorkloadPinState{
+			Revision: row.Revision, LatestRevision: row.LatestRevision, ExpiresAt: expires,
+		}, nil
+	}
+	row, err := r.pg.WorkloadPinState(ctx, pggen.WorkloadPinStateParams{
+		WorkloadPrincipalID: string(p), EnvironmentID: string(env),
+	})
+	if err != nil {
+		return WorkloadPinState{}, notFoundOr(err)
+	}
+	return WorkloadPinState{
+		Revision: row.Revision, LatestRevision: row.LatestRevision, ExpiresAt: row.ExpiresAt.Time,
+	}, nil
 }
 
 // SetPinGeneration advances the cursor's pin component. #52 owns pin creation,

--- a/internal/store/pggen/federation.sql.go
+++ b/internal/store/pggen/federation.sql.go
@@ -330,3 +330,40 @@ func (q *Queries) UpdateFederationIssuer(ctx context.Context, arg UpdateFederati
 	}
 	return result.RowsAffected(), nil
 }
+
+const workloadPinState = `-- name: WorkloadPinState :one
+SELECT pin.revision, pin.expires_at, latest.revision AS latest_revision
+FROM revision_pins AS pin
+JOIN snapshots AS latest
+  ON latest.org_id = pin.org_id
+ AND latest.project_id = pin.project_id
+ AND latest.environment_id = pin.environment_id
+ AND latest.revision = (
+      SELECT MAX(candidate.revision)
+      FROM snapshots AS candidate
+      WHERE candidate.org_id = pin.org_id
+        AND candidate.project_id = pin.project_id
+        AND candidate.environment_id = pin.environment_id
+ )
+WHERE pin.workload_principal_id = $1
+  AND pin.environment_id = $2
+`
+
+type WorkloadPinStateParams struct {
+	WorkloadPrincipalID string
+	EnvironmentID       string
+}
+
+type WorkloadPinStateRow struct {
+	Revision       int64
+	ExpiresAt      pgtype.Timestamptz
+	LatestRevision int64
+}
+
+// hikyo:authn-resolution
+func (q *Queries) WorkloadPinState(ctx context.Context, arg WorkloadPinStateParams) (WorkloadPinStateRow, error) {
+	row := q.db.QueryRow(ctx, workloadPinState, arg.WorkloadPrincipalID, arg.EnvironmentID)
+	var i WorkloadPinStateRow
+	err := row.Scan(&i.Revision, &i.ExpiresAt, &i.LatestRevision)
+	return i, err
+}

--- a/internal/store/queries/postgres/federation.sql
+++ b/internal/store/queries/postgres/federation.sql
@@ -74,6 +74,24 @@ SELECT generation FROM pin_generations
 WHERE principal_id = sqlc.arg(principal_id) AND environment_id = sqlc.arg(environment_id);
 
 -- hikyo:authn-resolution
+-- name: WorkloadPinState :one
+SELECT pin.revision, pin.expires_at, latest.revision AS latest_revision
+FROM revision_pins AS pin
+JOIN snapshots AS latest
+  ON latest.org_id = pin.org_id
+ AND latest.project_id = pin.project_id
+ AND latest.environment_id = pin.environment_id
+ AND latest.revision = (
+      SELECT MAX(candidate.revision)
+      FROM snapshots AS candidate
+      WHERE candidate.org_id = pin.org_id
+        AND candidate.project_id = pin.project_id
+        AND candidate.environment_id = pin.environment_id
+ )
+WHERE pin.workload_principal_id = sqlc.arg(workload_principal_id)
+  AND pin.environment_id = sqlc.arg(environment_id);
+
+-- hikyo:authn-resolution
 -- name: SetPinGeneration :exec
 INSERT INTO pin_generations (principal_id, environment_id, generation)
 VALUES (sqlc.arg(principal_id), sqlc.arg(environment_id), sqlc.arg(generation))

--- a/internal/store/queries/sqlite/federation.sql
+++ b/internal/store/queries/sqlite/federation.sql
@@ -108,6 +108,26 @@ WHERE id = ? AND kind = 'oidc-federation';
 SELECT generation FROM pin_generations
 WHERE principal_id = ? AND environment_id = ?;
 
+-- The grant-time conditional admission for workload reveal-history. The pin
+-- and latest snapshot are read in one authn-resolution query under the target
+-- principal lock; the service evaluates expiry against its canonical clock.
+-- hikyo:authn-resolution
+-- name: WorkloadPinState :one
+SELECT pin.revision, pin.expires_at, latest.revision AS latest_revision
+FROM revision_pins AS pin
+JOIN snapshots AS latest
+  ON latest.org_id = pin.org_id
+ AND latest.project_id = pin.project_id
+ AND latest.environment_id = pin.environment_id
+ AND latest.revision = (
+      SELECT MAX(candidate.revision)
+      FROM snapshots AS candidate
+      WHERE candidate.org_id = pin.org_id
+        AND candidate.project_id = pin.project_id
+        AND candidate.environment_id = pin.environment_id
+ )
+WHERE pin.workload_principal_id = ? AND pin.environment_id = ?;
+
 -- The generation writer. #52 owns pin creation, reassignment and release; this
 -- is the counter each of those must advance, and it exists now because the
 -- cursor is bound to it now.

--- a/internal/store/sqlitegen/federation.sql.go
+++ b/internal/store/sqlitegen/federation.sql.go
@@ -370,3 +370,42 @@ func (q *Queries) UpdateFederationIssuer(ctx context.Context, arg UpdateFederati
 	}
 	return result.RowsAffected()
 }
+
+const workloadPinState = `-- name: WorkloadPinState :one
+SELECT pin.revision, pin.expires_at, latest.revision AS latest_revision
+FROM revision_pins AS pin
+JOIN snapshots AS latest
+  ON latest.org_id = pin.org_id
+ AND latest.project_id = pin.project_id
+ AND latest.environment_id = pin.environment_id
+ AND latest.revision = (
+      SELECT MAX(candidate.revision)
+      FROM snapshots AS candidate
+      WHERE candidate.org_id = pin.org_id
+        AND candidate.project_id = pin.project_id
+        AND candidate.environment_id = pin.environment_id
+ )
+WHERE pin.workload_principal_id = ? AND pin.environment_id = ?
+`
+
+type WorkloadPinStateParams struct {
+	WorkloadPrincipalID string
+	EnvironmentID       string
+}
+
+type WorkloadPinStateRow struct {
+	Revision       int64
+	ExpiresAt      string
+	LatestRevision int64
+}
+
+// The grant-time conditional admission for workload reveal-history. The pin
+// and latest snapshot are read in one authn-resolution query under the target
+// principal lock; the service evaluates expiry against its canonical clock.
+// hikyo:authn-resolution
+func (q *Queries) WorkloadPinState(ctx context.Context, arg WorkloadPinStateParams) (WorkloadPinStateRow, error) {
+	row := q.db.QueryRowContext(ctx, workloadPinState, arg.WorkloadPrincipalID, arg.EnvironmentID)
+	var i WorkloadPinStateRow
+	err := row.Scan(&i.Revision, &i.ExpiresAt, &i.LatestRevision)
+	return i, err
+}

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -565,10 +565,10 @@ export function MachineAccess() {
  *
  * It is a toggle with a ceremony both ways. Enabling states, at opt-in time,
  * what the machine-identities ADR requires it to state: a machine principal
- * holding reveal is a standing decryption capability, and a CI runner holding
- * it is that capability in the most-attacked box in the system. Withdrawing
- * states the other half: every machine reveal grant in the project goes inert
- * on the next fetch, and every machine cursor moves. The write is
+ * holding reveal is a standing decryption capability, while workload
+ * reveal-history is admitted only for an active non-current pin. Withdrawing
+ * states the other half: both disclosure atoms go inert on the next fetch,
+ * and every machine cursor moves. The write is
  * project-settings ∧ reveal at project depth, so it is MFA-mandatory; a
  * session short of that is told so by the server and the strip repeats it.
  */
@@ -619,8 +619,8 @@ function PolicyStrip({ project }: { project: ProjectRef }) {
             Machine secret delivery (per-project opt-in): {enabled ? 'on' : 'off'}.
           </strong>{' '}
           {enabled
-            ? 'Workload and automation principals in this project may hold reveal, and a credential holding it receives secret plaintext on fetch — a standing decryption capability.'
-            : 'Every workload delivery on this project is configuration and secret presence only, and the grant API refuses reveal on a machine principal until this is on.'}
+            ? 'Workload and automation principals may hold reveal; a workload may also hold reveal-history while pinned to a non-current revision. Either can deliver secret plaintext.'
+            : 'Every workload delivery is configuration and secret presence only; the grant API refuses both machine disclosure capabilities until this is on.'}
         </span>
         <button
           type="button"
@@ -681,13 +681,14 @@ function MachineRevealDialog({
         <>
           <p>
             A machine principal holding <strong>reveal</strong> is a standing decryption capability:
-            no second factor, no ceremony, every fetch delivers plaintext while the grant stands. A
-            CI runner holding it is that capability in the most-attacked box in the system.
+            no second factor, no ceremony, every current fetch delivers plaintext while the grant
+            stands. A CI runner holding it is that capability in the most-attacked box in the system.
           </p>
           <p>
-            Enabling admits <strong>reveal</strong> grants onto this project&apos;s workload and
-            automation principals; each grant still runs its own widening ceremony naming the
-            environments it reaches. Nothing is granted by this act alone.
+            Enabling admits <strong>reveal</strong> grants onto workload and automation principals.
+            It also admits <strong>reveal-history</strong> onto a workload only while that workload
+            has an active non-current pin. Each grant still runs its own widening ceremony. Nothing
+            is granted by this act alone.
           </p>
           <label className="ceremony__ack">
             <input
@@ -702,10 +703,10 @@ function MachineRevealDialog({
         </>
       ) : (
         <p>
-          Withdrawing makes every machine <strong>reveal</strong> grant in this project inert on the
-          next fetch and moves every machine cursor: workloads keep receiving configuration and
-          secret presence, and nothing else, until the opt-in is enabled again. The grant rows stay
-          where they are so the withdrawal is reversible by the same act.
+          Withdrawing makes every machine <strong>reveal</strong> and{' '}
+          <strong>reveal-history</strong> grant in this project inert on the next fetch and moves
+          every machine cursor. Workloads keep receiving configuration and secret presence only.
+          Grant rows stay where they are so the withdrawal is reversible by the same act.
         </p>
       )}
       {failure !== null ? (
@@ -1668,9 +1669,9 @@ function BindingDialog({
  * warning therefore names two numbers the operator cannot see anywhere else:
  * how many live credentials that is, and exactly which keys become reachable.
  *
- * Only `read` is offered, and that is the permission model rather than a
- * simplification: a workload principal's allowlist admits `read` and nothing
- * else, so a `reveal` control here would be refused every time it was pressed.
+ * Only `read` is offered in this setup journey. Conditional disclosure grants
+ * are separate operator acts: `reveal` needs the live project opt-in, while
+ * `reveal-history` additionally needs an active non-current workload pin.
  */
 function GrantDialog({
   project,


### PR DESCRIPTION
## Summary
- admit reveal-history grants for workload principals only while an active non-current revision pin exists
- keep pin release non-revoking while making the stored grant immediately inert in delivery
- add exhaustive machine-route closure, paired SQLite/PostgreSQL coverage, docs, and generated query pins

## Validation
- HIKYO_TEST_POSTGRES_DSN=... go test ./... (4,536 passed)
- HIKYO_TEST_POSTGRES_DSN=... go test -count=1 -v ./internal/isolation/ (2,130 passed)
- go build ./...
- go vet ./...
- go test -count=1 -tags ui ./internal/server/... ./internal/webui/... (227 passed)
- pnpm --dir web typecheck
- pnpm --dir web test (295 passed)
- pnpm --dir clients/ts verify (12 passed)
- pnpm --dir docs/site verify

Closes #196