### PR TITLE
CI: derive analysis shard matrices from plan keys #330

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -862,6 +862,7 @@ jobs:
     outputs:
       fuzz_plan: ${{ steps.plan.outputs.fuzz_plan }}
       race_plan: ${{ steps.plan.outputs.race_plan }}
+      shards: ${{ steps.plan.outputs.shards }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -888,15 +889,18 @@ jobs:
 
           race_plan='[]'
           fuzz_plan='[]'
-          for shard in 0 1 2; do
+          shard_count=3
+          shard=0
+          while [ "$shard" -lt "$shard_count" ]; do
             race_shard=$(go run "$trusted_planner" race --root . \
-              --shard "$shard" --shards 3 | jq -Rsc 'split("\n") | map(select(length > 0))')
+              --shard "$shard" --shards "$shard_count" | jq -Rsc 'split("\n") | map(select(length > 0))')
             fuzz_shard=$(go run "$trusted_planner" fuzz --root . \
-              --shard "$shard" --shards 3 | jq -Rsc 'split("\n") | map(select(length > 0))')
+              --shard "$shard" --shards "$shard_count" | jq -Rsc 'split("\n") | map(select(length > 0))')
             race_plan=$(jq -cn --argjson plan "$race_plan" --argjson shard "$race_shard" \
               '$plan + [$shard]')
             fuzz_plan=$(jq -cn --argjson plan "$fuzz_plan" --argjson shard "$fuzz_shard" \
               '$plan + [$shard]')
+            shard=$((shard + 1))
           done
 
           if [ "$(printf '%s' "$race_plan" | jq 'flatten | length')" -eq 0 ] ||
@@ -907,6 +911,7 @@ jobs:
           {
             echo "race_plan=$race_plan"
             echo "fuzz_plan=$fuzz_plan"
+            echo "shards=$(printf '%s' "$race_plan" | jq -c 'keys')"
           } >>"$GITHUB_OUTPUT"
 
   # Race detector as its own context: a concurrent server with transaction
@@ -924,7 +929,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2]
+        shard: ${{ fromJSON(needs.analysis_shards.outputs.shards) }}
     services:
       postgres:
         image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
@@ -1011,7 +1016,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2]
+        shard: ${{ fromJSON(needs.analysis_shards.outputs.shards) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/handoff/330-analysis-shard-matrix.md
+++ b/docs/handoff/330-analysis-shard-matrix.md
@@ -1,0 +1,29 @@
+# Issue #330 — analysis shard matrix ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/330 (parent #326; audit
+finding `F-S35-1`).
+
+**State: implemented.** The trusted analysis planner now owns the shard count
+used by both its plans and the race/fuzz job matrices.
+
+## Contract
+
+- `analysis_shards` keeps the sole workflow shard-count literal and passes it
+  to both planner modes.
+- The plan's JSON array keys become the `shards` job output. Both downstream
+  matrices consume that output through
+  `fromJSON(needs.analysis_shards.outputs.shards)`.
+- `ci_job_registry_test.go` parses matrix nodes and refuses either shard job
+  unless it uses the shared output expression.
+- Aggregate job IDs, cache keys, package assignment, and fuzz-target assignment
+  are unchanged.
+- Contract or migration decisions: none. Generated outputs: none.
+
+## Validation
+
+- `go test -count=1 ./scripts/ci`: 7 passed.
+- `./scripts/ci/analysis-shards_test.sh`: complete/disjoint plans passed.
+- `./scripts/ci/check-required-jobs_test.sh`: success/skip and refusal fixtures
+  passed.
+- `go test -count=1 ./...`: 3,454 passed in 61 packages.
+- Standards review: CLEAN. Issue #330 spec review: CLEAN.

--- a/scripts/ci/ci_job_registry_test.go
+++ b/scripts/ci/ci_job_registry_test.go
@@ -32,8 +32,13 @@ type workflow struct {
 }
 
 type workflowJob struct {
-	Needs yaml.Node `yaml:"needs"`
-	If    string    `yaml:"if"`
+	Needs    yaml.Node        `yaml:"needs"`
+	If       string           `yaml:"if"`
+	Strategy workflowStrategy `yaml:"strategy"`
+}
+
+type workflowStrategy struct {
+	Matrix map[string]yaml.Node `yaml:"matrix"`
 }
 
 var planReference = regexp.MustCompile(`fromJSON\(needs\.changes\.outputs\.plan\)(?:\['([^']+)'\]|\.([A-Za-z0-9_-]+))`)
@@ -263,6 +268,17 @@ func validateRegistry(gotRegistry registry, workflowData []byte) error {
 	sort.Strings(wantNeeds)
 	if !reflect.DeepEqual(directNeeds, wantNeeds) {
 		return fmt.Errorf("ci-required needs mismatch: workflow=%v registry=%v", directNeeds, wantNeeds)
+	}
+
+	const shardMatrix = "${{ fromJSON(needs.analysis_shards.outputs.shards) }}"
+	for _, job := range []string{"race_shard", "fuzz_shard"} {
+		if _, registered := gotRegistry.Jobs[job]; !registered {
+			continue
+		}
+		shard := gotWorkflow.Jobs[job].Strategy.Matrix["shard"]
+		if shard.Kind != yaml.ScalarNode || shard.Value != shardMatrix {
+			return fmt.Errorf("job %q shard matrix must be %q", job, shardMatrix)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Closes #330

## Contract

- `analysis_shards` owns the sole workflow shard-count literal.
- Its plan keys are emitted as `shards`; race and fuzz matrices consume `fromJSON(needs.analysis_shards.outputs.shards)`.
- The CI job registry test refuses either shard matrix when it drifts from that shared expression.
- Aggregate job IDs, cache keys, package assignment, and fuzz-target assignment remain unchanged.

Contract or migration decisions: none.

Generated outputs: none.

## Validation

- `go test -count=1 ./scripts/ci` — 7 passed
- `./scripts/ci/analysis-shards_test.sh` — passed
- `./scripts/ci/check-required-jobs_test.sh` — passed
- `go test -count=1 ./...` — 3,454 passed in 61 packages
- `./scripts/ci/verify-docs.sh` — passed
- Standards review — CLEAN
- Issue #330 spec review — CLEAN