### PR TITLE
Share keyed boot prefix with local admin #328

### DIFF
--- a/docs/handoff/328-admin-keyed-boot-prefix.md
+++ b/docs/handoff/328-admin-keyed-boot-prefix.md
@@ -1,0 +1,59 @@
+# Handoff: #328 shared keyed boot prefix
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/328 (parent #326; audit
+finding `F-S34-1`). Implementation is based on `origin/main` commit
+`0068c499c155b05086fc1cf62927962532d90b6d`.
+
+## Contract
+
+- `openKeyed` owns the startup sequence shared by server and local-admin
+  commands: process hardening, optional migration with pre-migration export and
+  durable record, exact schema check, root-key resolution, datastore open,
+  keyring load, and unfinished-root-rotation warning.
+- `bootResources` and `bootGuard` preserve exact-once datastore cleanup on
+  shared-prefix failure. Successful server boot transfers ownership to
+  `Server`; successful admin authentication transfers ownership to its returned
+  cleanup function.
+- Local-admin configuration remains environment-only and auto-migration remains
+  enabled by default. No admin `--auto-migrate` flag was added, so operators
+  cannot create a divergent CLI-only migration policy.
+- Server error wrapping, migration ordering, root-key zeroing, wire/audit values,
+  and SQLite/PostgreSQL store behavior are unchanged.
+
+Generated outputs: none. Database migrations: none.
+
+## Regression evidence
+
+- A pending migration plus configured backup recipient now produces one `.age`
+  archive and one durable `backup.exported` instance event whose trigger is
+  exactly `pre-migration` through `adminAuth`.
+- A dual-wrapped root-key state now emits the same unfinished-rotation warning
+  through `adminAuth` as server boot.
+- Admin datastore ownership tests cover failure after acquisition and successful
+  transfer to the returned cleanup function with exact close counts.
+
+## Validation
+
+```text
+rtk go test -count=1 ./internal/app
+Go test: 48 passed in 1 package
+
+rtk go test -count=1 ./internal/app ./internal/crypto
+Go test: 179 passed in 2 packages
+
+rtk go test -count=1 ./...
+Go test: 3459 passed in 61 packages
+
+rtk go vet ./...
+passed
+
+rtk git diff --check
+passed
+```
+
+## Review
+
+- Standards axis: `CLEAN` with no documented violations or baseline smells.
+- Spec axis: first pass found that the audit regression checked only the event
+  type. The test now pins `payload.trigger == TriggerPreMigration`; round 2:
+  `CLEAN`.

--- a/internal/app/admin.go
+++ b/internal/app/admin.go
@@ -9,13 +9,9 @@ import (
 	"log/slog"
 
 	"github.com/Hikyo-Org/hikyo/internal/config"
-	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
-	"github.com/Hikyo-Org/hikyo/internal/store"
-	"github.com/Hikyo-Org/hikyo/internal/store/keyring"
-	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
 )
 
 // `hikyo admin create` — the first-administrator bootstrap.
@@ -168,35 +164,23 @@ func runAdminCreate(ctx context.Context, cfg *config.Config, log *slog.Logger, a
 // root key is read from the same sources the server uses; `admin` has no
 // --root-key-file of its own.
 func adminAuth(ctx context.Context, cfg *config.Config, log *slog.Logger) (*service.Auth, func(), error) {
+	return adminAuthWithResources(ctx, cfg, log, defaultBootResources())
+}
+
+func adminAuthWithResources(ctx context.Context, cfg *config.Config, log *slog.Logger, resources bootResources) (*service.Auth, func(), error) {
 	sc := storeConfig(cfg)
-	if cfg.AutoMigrate {
-		if err := migrate.Run(ctx, sc); err != nil {
-			return nil, nil, err
-		}
-	}
-	if err := migrate.Check(ctx, sc); err != nil {
-		return nil, nil, err
-	}
-	root, err := resolveRootKey(cfg, log)
+	guard := &bootGuard{log: log}
+	defer guard.cleanup()
+	db, kr, err := openKeyed(ctx, cfg, log, sc, resources, guard)
 	if err != nil {
-		return nil, nil, err
-	}
-	db, err := store.Open(ctx, sc)
-	if err != nil {
-		crypto.Zero(root)
-		return nil, nil, err
-	}
-	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
-	if err != nil {
-		db.Close()
 		return nil, nil, err
 	}
 	kdf, limiter, err := AuthComponents(cfg)
 	if err != nil {
-		db.Close()
 		return nil, nil, err
 	}
-	return &service.Auth{DB: db, Keyring: kr, KDF: kdf, Admission: limiter, Log: log}, func() { db.Close() }, nil
+	guard.disarm()
+	return &service.Auth{DB: db, Keyring: kr, KDF: kdf, Admission: limiter, Log: log}, func() { _ = resources.closeDatabase(db) }, nil
 }
 
 // runAdminReset is the break-glass recovery verb: `hikyo admin reset-credential

--- a/internal/app/admin_test.go
+++ b/internal/app/admin_test.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestAdminAuthRunsPreMigrationExport(t *testing.T) {
+	cfg := devConfig(t)
+	fixture := &storeFixture{sc: storeConfig(cfg), dir: filepath.Dir(cfg.Store.Path)}
+	pendingMigration(t, fixture)
+
+	_, recipient, err := backup.GenerateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupDir := filepath.Join(fixture.dir, "backups")
+	cfg.BackupDir = backupDir
+	cfg.BackupRecipients = []string{recipient}
+
+	_, closeDB, err := adminAuth(t.Context(), cfg, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeDB()
+
+	if n := archiveCount(t, backupDir); n != 1 {
+		t.Fatalf("admin pre-migration export published %d archives, want 1", n)
+	}
+	db, err := store.Open(t.Context(), fixture.sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var recorded int64
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM audit_instance_events
+		WHERE type = ? AND json_extract(payload, '$.trigger') = ?`,
+		"backup.exported", string(service.TriggerPreMigration)).Scan(&recorded); err != nil {
+		t.Fatal(err)
+	}
+	if recorded != 1 {
+		t.Fatalf("admin pre-migration backup.exported events = %d, want 1", recorded)
+	}
+}
+
+func TestAdminAuthWarnsWhenRootRotationPending(t *testing.T) {
+	cfg := devConfig(t)
+	auth, closeDB, err := adminAuth(t.Context(), cfg, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newRoot, err := crypto.GenerateRootKey()
+	if err != nil {
+		closeDB()
+		t.Fatal(err)
+	}
+	defer crypto.Zero(newRoot)
+	wrapper, err := auth.Keyring.PrepareRootKeyRotation(t.Context(), newRoot)
+	if err != nil {
+		closeDB()
+		t.Fatal(err)
+	}
+	wrapper.CreatedAt = store.CanonTime(time.Now())
+	if _, err := auth.DB.SQLiteWrite().ExecContext(t.Context(), `
+		INSERT INTO master_keys (version, root_key_epoch, state, blob, created_at)
+		VALUES (?, ?, 'active', ?, ?)`, wrapper.Version, wrapper.RootKeyEpoch,
+		wrapper.Blob, wrapper.CreatedAt.Format(time.RFC3339Nano)); err != nil {
+		closeDB()
+		t.Fatal(err)
+	}
+	closeDB()
+
+	var logged strings.Builder
+	log := slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	_, closeDB, err = adminAuth(t.Context(), cfg, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeDB()
+
+	if !strings.Contains(logged.String(), "root key rotation is UNFINISHED") {
+		t.Fatalf("admin auth did not warn about pending root rotation; got %q", logged.String())
+	}
+}
+
+func TestAdminAuthResourceOwnership(t *testing.T) {
+	t.Run("failure after database acquisition closes it", func(t *testing.T) {
+		record := &bootResourceRecord{}
+		cfg := devConfig(t)
+		cfg.Argon2MemoryKiB = 1
+
+		_, _, err := adminAuthWithResources(t.Context(), cfg, testLogger(), recordingBootResources(record))
+		if err == nil {
+			t.Fatal("admin auth with invalid password parameters succeeded")
+		}
+		if record.databaseCloses != 1 {
+			t.Fatalf("database closes = %d, want 1", record.databaseCloses)
+		}
+	})
+
+	t.Run("success transfers ownership to returned cleanup", func(t *testing.T) {
+		record := &bootResourceRecord{}
+		auth, closeDB, err := adminAuthWithResources(t.Context(), devConfig(t), testLogger(), recordingBootResources(record))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.databaseCloses != 0 {
+			t.Fatalf("database closes before cleanup = %d, want 0", record.databaseCloses)
+		}
+		if err := auth.DB.Ping(t.Context()); err != nil {
+			t.Fatalf("database closed before cleanup: %v", err)
+		}
+
+		closeDB()
+		if record.databaseCloses != 1 {
+			t.Fatalf("database closes after cleanup = %d, want 1", record.databaseCloses)
+		}
+		if err := auth.DB.Ping(t.Context()); err == nil {
+			t.Fatal("database remained open after cleanup")
+		}
+	})
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -201,9 +201,10 @@ type bootGuard struct {
 }
 
 // bootResources is the narrow seam for resources whose acquisition can leave
-// Boot with something to release. Service construction and wiring stay local
-// to boot; tests replace only these constructors and cleanup functions so they
-// can inject failures at the ownership boundaries and count releases.
+// boot or a local-admin command with something to release. Service construction
+// and wiring stay local to their caller; tests replace only these constructors
+// and cleanup functions so they can inject failures at ownership boundaries and
+// count releases.
 type bootResources struct {
 	openDatabase       func(context.Context, store.Config) (*store.DB, error)
 	closeDatabase      func(*store.DB) error
@@ -253,21 +254,71 @@ func (g *bootGuard) disarm() {
 	g.closers = nil
 }
 
+// openKeyed owns the startup prefix shared by server and local-admin commands:
+// harden before key material exists, migrate with the pre-migration safety
+// record, verify the exact schema, resolve the root, open the datastore, load
+// the keyring, and warn about unfinished root rotation. Callers supply the
+// resource guard so every error after datastore acquisition closes it exactly
+// once.
+func openKeyed(ctx context.Context, cfg *config.Config, log *slog.Logger, sc store.Config, resources bootResources, guard *bootGuard) (*store.DB, *crypto.Keyring, error) {
+	if err := crypto.HardenProcess(); err != nil {
+		return nil, nil, err
+	}
+
+	var migrationRecord preMigrationRecord
+	if cfg.AutoMigrate {
+		var err error
+		if migrationRecord, err = beforeMigration(ctx, cfg, log, sc); err != nil {
+			return nil, nil, err
+		}
+		if err := migrate.Run(ctx, sc); err != nil {
+			return nil, nil, err
+		}
+	}
+	// Always verify exact schema match — with auto-migrate off this catches
+	// pending migrations; in both modes it catches a database migrated by a
+	// newer binary (Run applies nothing there and the schema stays ahead).
+	if err := migrate.Check(ctx, sc); err != nil {
+		return nil, nil, err
+	}
+	recordPreMigration(ctx, cfg, log, migrationRecord)
+
+	root, err := resolveRootKey(cfg, log)
+	if err != nil {
+		return nil, nil, err
+	}
+	db, err := resources.openDatabase(ctx, sc)
+	if err != nil {
+		crypto.Zero(root)
+		return nil, nil, err
+	}
+	guard.add(func() error { return resources.closeDatabase(db) })
+
+	// LoadKeyring consumes root: it is zeroed before this returns.
+	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if kr.RootRotationPending() {
+		// A root rotation is half-done — the master is dual-wrapped under two
+		// roots. Bootable under either, but warned on every server or admin start
+		// until `rotate-root-key --finalize` completes it.
+		log.Warn("root key rotation is UNFINISHED: the master is dual-wrapped under the old and new roots; run `hikyo rotate-root-key --verify` then `--finalize` to complete it")
+	}
+	return db, kr, nil
+}
+
 // Boot runs the fail-closed startup sequence: process hardening before any
 // key material exists, migrations (auto-apply by default; with auto-apply
 // disabled a pending migration state refuses to serve), datastore open with
 // the boot-enforced pragma policy, keyring load (root key read, master key
-// unwrapped or minted, root key zeroed — `hikyo server` is the only mode that
-// does this), then the listener. Any error means the process must exit
-// without serving.
+// unwrapped or minted, root key zeroed), then the listener. Any error means the
+// process must exit without serving.
 func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, error) {
 	return boot(ctx, cfg, log, defaultBootResources())
 }
 
 func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources bootResources) (*Server, error) {
-	if err := crypto.HardenProcess(); err != nil {
-		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-	}
 	sc := storeConfig(cfg)
 
 	// Every resource acquired below has one temporary owner — this guard —
@@ -276,47 +327,9 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	guard := &bootGuard{log: log}
 	defer guard.cleanup()
 
-	var migrationRecord preMigrationRecord
-	if cfg.AutoMigrate {
-		var err error
-		if migrationRecord, err = beforeMigration(ctx, cfg, log, sc); err != nil {
-			return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-		}
-		if err := migrate.Run(ctx, sc); err != nil {
-			return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-		}
-	}
-	// Always verify exact schema match — with auto-migrate off this catches
-	// pending migrations; in both modes it catches a database migrated by a
-	// newer binary (Run applies nothing there and the schema stays ahead).
-	if err := migrate.Check(ctx, sc); err != nil {
-		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-	}
-	recordPreMigration(ctx, cfg, log, migrationRecord)
-
-	root, err := resolveRootKey(cfg, log)
+	db, kr, err := openKeyed(ctx, cfg, log, sc, resources, guard)
 	if err != nil {
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-	}
-
-	db, err := resources.openDatabase(ctx, sc)
-	if err != nil {
-		crypto.Zero(root)
-		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-	}
-	// Registered immediately after Open so every later error path releases it.
-	guard.add(func() error { return resources.closeDatabase(db) })
-
-	// LoadKeyring consumes root: it is zeroed before this returns.
-	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
-	if err != nil {
-		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
-	}
-	if kr.RootRotationPending() {
-		// A root rotation is half-done — the master is dual-wrapped under two
-		// roots. Bootable under either, but warned on every start until
-		// `rotate-root-key --finalize` (encryption-model ADR § Rotation).
-		log.Warn("root key rotation is UNFINISHED: the master is dual-wrapped under the old and new roots; run `hikyo rotate-root-key --verify` then `--finalize` to complete it")
 	}
 
 	// The secret-scanning ruleset compiles once at boot; a Load error refuses to

--- a/internal/crypto/harden_unix.go
+++ b/internal/crypto/harden_unix.go
@@ -8,9 +8,9 @@ import (
 )
 
 // HardenProcess applies the key-material hardening the encryption-model ADR fixes
-// for the server process: no core dumps anywhere, and on Linux additionally
-// no same-uid ptrace attach or /proc/<pid>/mem read (PR_SET_DUMPABLE=0).
-// Called before any key material enters the process.
+// for every process mode that loads the keyring: no core dumps anywhere, and on
+// Linux additionally no same-uid ptrace attach or /proc/<pid>/mem read
+// (PR_SET_DUMPABLE=0). Called before any key material enters the process.
 func HardenProcess() error {
 	if err := syscall.Setrlimit(syscall.RLIMIT_CORE, &syscall.Rlimit{Cur: 0, Max: 0}); err != nil {
 		return fmt.Errorf("crypto: RLIMIT_CORE=0: %w", err)


### PR DESCRIPTION
Closes #328

## Contract and migration decisions

- `openKeyed` now owns the server/admin startup prefix: process hardening, pre-migration export and recording, migration, exact schema check, root-key resolution, datastore/keyring open, and unfinished-rotation warning.
- `RunMigrate` remains DDL-only and never loads root-key material.
- Admin remains environment-only with auto-migration enabled by default; no divergent admin `--auto-migrate` flag was added.
- Server error wrapping, root-key zeroing, ordering, audit/wire values, and dual-dialect behavior remain unchanged.
- Database migrations: none.
- Generated outputs: none.

## Validation

- `rtk go test -count=1 ./internal/app` — 48 passed
- `rtk go test -count=1 ./internal/app ./internal/crypto` — 179 passed
- `rtk go test -count=1 ./...` — 3459 passed across 61 packages
- `rtk go vet ./...` — passed
- `rtk git diff --check` — passed

## Review

- Standards axis: CLEAN
- Spec axis: CLEAN after pinning the audit payload trigger to `TriggerPreMigration`