### PR TITLE
Fix known environment registry completeness #329

### DIFF
--- a/docs/handoff/329-known-env-completeness.md
+++ b/docs/handoff/329-known-env-completeness.md
@@ -1,0 +1,36 @@
+# Handoff: #329 known environment completeness
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/329 (parent #326; audit
+finding `F-S25-1`).
+
+## Contract
+
+- `knownEnv` recognizes the consumed server keys `HIKYO_NEW_ROOT_KEY_FILE` and
+  `HIKYO_DIRECTORY_PROXY` and the consumed client keys `HIKYO_TOKEN` and
+  `HIKYO_COMPOSE_DOCKER`.
+- A repository-source guard scans non-test Go files under `internal/` and
+  `cmd/` for literal `HIKYO_*` getter calls and reports every consumed key that
+  is absent from `knownEnv`.
+- `internal/operator/` remains excluded because the operator has a separate
+  environment surface.
+- Unknown `HIKYO_*` keys continue to warn; recognized consumed keys do not.
+- Contract and migration decisions: no external contract or datastore
+  migration changes.
+- Generated outputs: none.
+
+## Validation
+
+```text
+go test -count=1 ./internal/config -run
+  'TestKnownEnvCoversEveryGetenv|TestConsumedServerEnvKeysDoNotWarn'  2 passed
+go test -count=1 ./internal/config                               33 passed
+go vet ./...                                                      passed
+go test -count=1 ./...                     3,456 passed in 61 packages
+```
+
+## Review
+
+Round 1 found that `LookupEnv` could evade the source guard and that indexed
+test-pair assertions obscured their expected values. The guard now recognizes
+both getter forms and the regression uses named expectations. Round 2 returned
+Standards `CLEAN` and Spec `SOUND`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,6 +127,8 @@ var knownEnv = map[string]bool{
 	"HIKYO_EXTERNAL_ORIGIN":            true,
 	"HIKYO_TRUSTED_PROXY_CIDRS":        true,
 	"HIKYO_ROOT_KEY":                   true,
+	"HIKYO_NEW_ROOT_KEY_FILE":          true,
+	"HIKYO_DIRECTORY_PROXY":            true,
 	"HIKYO_ARGON2_MEMORY_KIB":          true,
 	"HIKYO_ARGON2_TIME":                true,
 	"HIKYO_ARGON2_PARALLELISM":         true,
@@ -146,14 +148,16 @@ var knownEnv = map[string]bool{
 	// mistyped HIKYO_PROJEKT that produced no warning would silently target
 	// the wrong project, which is the class of mistake the explicit-first
 	// context model exists to prevent.
-	"HIKYO_STATE_DIR":    true,
-	"HIKYO_TRUST_BUNDLE": true,
-	"HIKYO_CONTEXT":      true,
-	"HIKYO_INSTANCE":     true,
-	"HIKYO_ORG":          true,
-	"HIKYO_PROJECT":      true,
-	"HIKYO_ENV":          true,
-	"XDG_STATE_HOME":     true,
+	"HIKYO_STATE_DIR":      true,
+	"HIKYO_TRUST_BUNDLE":   true,
+	"HIKYO_CONTEXT":        true,
+	"HIKYO_INSTANCE":       true,
+	"HIKYO_ORG":            true,
+	"HIKYO_PROJECT":        true,
+	"HIKYO_ENV":            true,
+	"HIKYO_TOKEN":          true,
+	"HIKYO_COMPOSE_DOCKER": true,
+	"XDG_STATE_HOME":       true,
 }
 
 const devSQLitePath = "hikyo-dev.db"

--- a/internal/config/knownenv_test.go
+++ b/internal/config/knownenv_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestKnownEnvCoversEveryGetenv(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	fileSet := token.NewFileSet()
+	missing := map[string][]string{}
+
+	for _, root := range []string{"internal", "cmd"} {
+		err := filepath.WalkDir(filepath.Join(repoRoot, root), func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if path == filepath.Join(repoRoot, "internal", "operator") {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", path, err)
+			}
+			ast.Inspect(parsed, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || len(call.Args) == 0 || !isEnvironmentLookup(call.Fun) {
+					return true
+				}
+				literal, ok := call.Args[0].(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					return true
+				}
+				key, err := strconv.Unquote(literal.Value)
+				if err != nil || !strings.HasPrefix(key, "HIKYO_") || knownEnv[key] {
+					return true
+				}
+				position := fileSet.Position(literal.Pos())
+				missing[key] = append(missing[key], fmt.Sprintf("%s:%d", position.Filename, position.Line))
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	keys := make([]string, 0, len(missing))
+	for key := range missing {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		t.Errorf("knownEnv is missing %s, consumed at %s", key, strings.Join(missing[key], ", "))
+	}
+}
+
+func isEnvironmentLookup(expr ast.Expr) bool {
+	switch fn := expr.(type) {
+	case *ast.Ident:
+		return fn.Name == "getenv" || fn.Name == "lookupEnv"
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == "Getenv" || fn.Sel.Name == "LookupEnv"
+	default:
+		return false
+	}
+}
+
+func TestConsumedServerEnvKeysDoNotWarn(t *testing.T) {
+	const (
+		newRootKeyFile = "/run/credentials/hikyo-new-root-key"
+		directoryProxy = "https://proxy.example.com"
+	)
+	pairs := []string{
+		"HIKYO_NEW_ROOT_KEY_FILE", newRootKeyFile,
+		"HIKYO_DIRECTORY_PROXY", directoryProxy,
+	}
+	cfg, warnings, err := Load("server", []string{"--dev"}, env(pairs...), environFrom(pairs...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("consumed server environment keys must not warn, got %v", warnings)
+	}
+	if cfg.NewRootKeyFile != newRootKeyFile {
+		t.Fatalf("NewRootKeyFile = %q, want %q", cfg.NewRootKeyFile, newRootKeyFile)
+	}
+	if cfg.DirectoryProxy != directoryProxy {
+		t.Fatalf("DirectoryProxy = %q, want %q", cfg.DirectoryProxy, directoryProxy)
+	}
+}


### PR DESCRIPTION
Closes #329

## Contract

- Registers HIKYO_NEW_ROOT_KEY_FILE, HIKYO_DIRECTORY_PROXY, HIKYO_TOKEN, and HIKYO_COMPOSE_DOCKER.
- Adds a source guard covering literal HIKYO environment lookups in non-test internal/ and cmd/ Go code.
- Keeps internal/operator/ separate and preserves unknown-key warnings.
- Contract/migration decision: no external contract or datastore migration change.
- Generated outputs: none.

## Validation

- Focused regression: 2 passed.
- internal/config: 33 passed.
- go vet ./...: passed.
- go test -count=1 ./...: 3,456 passed in 61 packages.

## Review

Two-axis review round 2: Standards CLEAN; Spec SOUND.