### PR TITLE
Normalize SQLite adapter timestamps #327

### DIFF
--- a/docs/handoff/327-adapter-timestamp-format.md
+++ b/docs/handoff/327-adapter-timestamp-format.md
@@ -1,0 +1,46 @@
+# Issue #327 — SQLite adapter timestamp format
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/327 (parent #326; audit
+finding `F-S04-2` §1).
+
+**State: implemented.** SQLite adapter repositories and the adapter runtime
+now write one fixed-width, microsecond UTC timestamp representation wherever
+timestamps are compared lexically.
+
+## Contract
+
+- `adapterTimestamp` owns adapter timestamp conversion for both dialects.
+- SQLite uses `2006-01-02T15:04:05.000000Z`; PostgreSQL continues to pass a
+  canonical `time.Time` to native `TIMESTAMPTZ` columns.
+- Repository adapter jobs, runtime adapter jobs, and provider-lease comparisons
+  use the same SQLite representation. Whole-second and sub-second timestamps
+  therefore sort in wall-clock order.
+- Existing wire and audit timestamp contracts remain unchanged.
+
+## Migration
+
+Migration `00034_adapter_timestamp_format.sql` normalizes SQLite
+`adapter_targets.provider_lease_expires_at` and
+`adapter_outbox.next_attempt_at`/`lease_expires_at` to six fractional digits.
+The repository currently has no historical deployment data, but the one-shot
+migration keeps upgrades deterministic. `CanonTime` already limits stored
+precision to microseconds, so normalization only pads known RFC3339Nano forms
+and loses no precision. PostgreSQL needs no migration.
+
+Generated outputs: none.
+
+## Validation
+
+```text
+TestAdapterStampsCompareLexicallyAcrossBridges                 passed
+TestAdapterClaimDueReplaysExpiredLeaseOnly                     passed
+TestAdapterEnqueueClearsExpiredProviderWriteFence              passed
+TestSQLiteAdapterTimestampMigrationNormalizesLexicalColumns    passed
+go test -count=1 ./internal/store                               47 passed
+go test -count=1 ./internal/store/migrate                       10 passed
+go test -count=1 ./...                                          3456 passed in 61 packages
+git diff --cached --check                                       passed
+```
+
+Two-axis review found one standards issue (this handoff was missing), now
+fixed. Specification review returned `CLEAN`.

--- a/internal/store/adapter_runtime_test.go
+++ b/internal/store/adapter_runtime_test.go
@@ -796,6 +796,47 @@ func TestAdapterClaimDueReplaysExpiredLeaseOnly(t *testing.T) {
 	}
 }
 
+func TestAdapterStampsCompareLexicallyAcrossBridges(t *testing.T) {
+	db := adapterRuntimeDB(t)
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_adapter','usr_adapter','manage-adapters','org_adapter','prj_adapter',NULL,'2026-08-17T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+
+	repoTime := time.Date(2026, time.August, 17, 12, 34, 5, 0, time.UTC)
+	runtimeTime := repoTime.Add(500 * time.Microsecond)
+	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	var repoJob store.AdapterEnqueueResult
+	if err := storetx.Write(t.Context(), db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
+		proof, err := az.Authorize(ctx, authz.Identity{Principal: "usr_adapter"}, authz.OpAdapterSync, scope)
+		if err != nil {
+			return err
+		}
+		repoJob, err = repos.Adapters().EnqueueManual(ctx, proof, "tgt_1", "usr_adapter", repoTime)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeJob, err := store.NewAdapterRuntime(db, nil).Enqueue(t.Context(), adapter.Job{
+		OrgID: "org_adapter", ProjectID: "prj_adapter", EnvironmentID: "env_adapter", TargetID: "tgt_1",
+		Kind: adapter.Converge, AuthorityPrincipal: "usr_adapter",
+	}, runtimeTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var repoStamp, runtimeStamp string
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT next_attempt_at FROM adapter_outbox WHERE id=?`, repoJob.JobID).Scan(&repoStamp); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT next_attempt_at FROM adapter_outbox WHERE id=?`, runtimeJob.ID).Scan(&runtimeStamp); err != nil {
+		t.Fatal(err)
+	}
+	if repoStamp >= runtimeStamp {
+		t.Fatalf("timestamp order disagrees with wall clock: repo=%q runtime=%q", repoStamp, runtimeStamp)
+	}
+}
+
 func TestAdapterGateRechecksAuthorityAndGeneration(t *testing.T) {
 	db := adapterRuntimeDB(t)
 	authorized := true

--- a/internal/store/migrate/adapter_timestamp_migration_test.go
+++ b/internal/store/migrate/adapter_timestamp_migration_test.go
@@ -1,0 +1,58 @@
+package migrate
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+func TestSQLiteAdapterTimestampMigrationNormalizesLexicalColumns(t *testing.T) {
+	cfg := store.Config{Engine: store.EngineSQLite, Path: filepath.Join(t.TempDir(), "adapter-timestamps.db")}
+	if err := RunUpTo(t.Context(), cfg, 33); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", store.SQLiteDSN(cfg.Path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := []string{
+		`INSERT INTO orgs (id,name,active,metadata,created_at) VALUES ('org_adapter','Adapter',1,'{}','2026-08-17T00:00:00Z')`,
+		`INSERT INTO projects (id,org_id,name,created_at) VALUES ('prj_adapter','org_adapter','Adapter','2026-08-17T00:00:00Z')`,
+		`INSERT INTO environments (id,org_id,project_id,name,note,created_at,display_order) VALUES ('env_adapter','org_adapter','prj_adapter','prod','','2026-08-17T00:00:00Z',0)`,
+		`INSERT INTO principals (id,kind,created_at) VALUES ('usr_adapter','human','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapters (id,org_id,project_id,provider,origin,authority_principal_id,state,created_at) VALUES ('adp_1','org_adapter','prj_adapter','forgejo','https://git.example','usr_adapter','active','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_targets (id,org_id,project_id,environment_id,adapter_id,destination_kind,destination_owner,destination_name,destination_id,name_prefix,generation,state,sync_status,provider_lease_job_id,provider_lease_effect_id,provider_lease_expires_at,created_at) VALUES ('tgt_1','org_adapter','prj_adapter','env_adapter','adp_1','repository','acme','app',42,'',1,'active','converging','job_1','effect_1','2026-08-17T12:34:05Z','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,authority_principal_id,generation,dedup_key,next_attempt_at,lease_owner,lease_expires_at,state,created_at) VALUES ('job_1','org_adapter','prj_adapter','env_adapter','tgt_1','converge','usr_adapter',1,'tgt_1','2026-08-17T12:34:05.1Z','worker_1','2026-08-17T12:34:05.123456Z','running','2026-08-17T00:00:00Z')`,
+	}
+	for _, statement := range statements {
+		if _, err := db.ExecContext(t.Context(), statement); err != nil {
+			db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Run(t.Context(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	db, err = sql.Open("sqlite", store.SQLiteDSN(cfg.Path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var providerLease, nextAttempt, jobLease string
+	if err := db.QueryRowContext(t.Context(), `SELECT provider_lease_expires_at FROM adapter_targets WHERE id='tgt_1'`).Scan(&providerLease); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRowContext(t.Context(), `SELECT next_attempt_at,lease_expires_at FROM adapter_outbox WHERE id='job_1'`).Scan(&nextAttempt, &jobLease); err != nil {
+		t.Fatal(err)
+	}
+	if providerLease != "2026-08-17T12:34:05.000000Z" || nextAttempt != "2026-08-17T12:34:05.100000Z" || jobLease != "2026-08-17T12:34:05.123456Z" {
+		t.Fatalf("normalized timestamps = provider %q, next %q, lease %q", providerLease, nextAttempt, jobLease)
+	}
+}

--- a/internal/store/migrations/sqlite/00034_adapter_timestamp_format.sql
+++ b/internal/store/migrations/sqlite/00034_adapter_timestamp_format.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- SQLite compares these adapter scheduling and lease timestamps lexically.
+-- Normalize the RFC3339Nano forms written by repository paths to the fixed
+-- six-digit UTC form used by the adapter runtime. CanonTime limits persisted
+-- precision to microseconds, so padding these known forms is lossless.
+UPDATE adapter_targets
+SET provider_lease_expires_at = CASE
+    WHEN length(provider_lease_expires_at) = 20
+        THEN substr(provider_lease_expires_at, 1, 19) || '.000000Z'
+    WHEN instr(provider_lease_expires_at, '.') = 20
+         AND substr(provider_lease_expires_at, -1) = 'Z'
+         AND length(provider_lease_expires_at) BETWEEN 22 AND 27
+        THEN substr(provider_lease_expires_at, 1, 20)
+             || substr(substr(provider_lease_expires_at, 21, length(provider_lease_expires_at) - 21) || '000000', 1, 6)
+             || 'Z'
+    ELSE provider_lease_expires_at
+END
+WHERE provider_lease_expires_at IS NOT NULL;
+
+UPDATE adapter_outbox
+SET next_attempt_at = CASE
+        WHEN length(next_attempt_at) = 20
+            THEN substr(next_attempt_at, 1, 19) || '.000000Z'
+        WHEN instr(next_attempt_at, '.') = 20
+             AND substr(next_attempt_at, -1) = 'Z'
+             AND length(next_attempt_at) BETWEEN 22 AND 27
+            THEN substr(next_attempt_at, 1, 20)
+                 || substr(substr(next_attempt_at, 21, length(next_attempt_at) - 21) || '000000', 1, 6)
+                 || 'Z'
+        ELSE next_attempt_at
+    END,
+    lease_expires_at = CASE
+        WHEN length(lease_expires_at) = 20
+            THEN substr(lease_expires_at, 1, 19) || '.000000Z'
+        WHEN instr(lease_expires_at, '.') = 20
+             AND substr(lease_expires_at, -1) = 'Z'
+             AND length(lease_expires_at) BETWEEN 22 AND 27
+            THEN substr(lease_expires_at, 1, 20)
+                 || substr(substr(lease_expires_at, 21, length(lease_expires_at) - 21) || '000000', 1, 6)
+                 || 'Z'
+        ELSE lease_expires_at
+    END;

--- a/internal/store/repos_adapters.go
+++ b/internal/store/repos_adapters.go
@@ -631,7 +631,7 @@ func (d sqliteAdoptDB) Exec(ctx context.Context, query string, args ...any) (int
 	return result.RowsAffected()
 }
 func (sqliteAdoptDB) SQL(sqliteQuery, _ string) string { return sqliteQuery }
-func (sqliteAdoptDB) Stamp(value time.Time) any        { return CanonTime(value).Format(timeFormat) }
+func (sqliteAdoptDB) Stamp(value time.Time) any        { return adapterTimestamp(EngineSQLite, value) }
 
 type pgAdoptDB struct{ db pggen.DBTX }
 
@@ -893,7 +893,7 @@ func (r sqliteAdapters) TeardownTarget(ctx context.Context, p authz.Proof, targe
 		return AdapterTeardownResult{}, err
 	}
 	var target adapterTeardownTarget
-	err = r.db.QueryRowContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.state='active'`, CanonTime(at).Format(timeFormat), targetID, chain.Org, chain.Project).Scan(
+	err = r.db.QueryRowContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.state='active'`, adapterTimestamp(EngineSQLite, at), targetID, chain.Org, chain.Project).Scan(
 		&target.adapterID, &target.targetID, &target.environmentID, &target.authority, &target.generation, &target.activeJob, &target.providerBusy)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AdapterTeardownResult{}, ErrNotFound
@@ -940,7 +940,7 @@ func (r sqliteAdapters) TeardownAdapter(ctx context.Context, p authz.Proof, adap
 	} else if err != nil {
 		return AdapterTeardownBatch{}, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=? AND t.org_id=? AND t.project_id=? AND t.state='active' ORDER BY t.id`, CanonTime(at).Format(timeFormat), adapterID, chain.Org, chain.Project)
+	rows, err := r.db.QueryContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=? AND t.org_id=? AND t.project_id=? AND t.state='active' ORDER BY t.id`, adapterTimestamp(EngineSQLite, at), adapterID, chain.Org, chain.Project)
 	if err != nil {
 		return AdapterTeardownBatch{}, err
 	}


### PR DESCRIPTION
Closes #327

## Summary

- route repository and runtime adapter timestamps through one fixed-width SQLite representation
- normalize lexically compared SQLite adapter scheduling and lease columns in migration 00034
- prove repo/runtime ordering across whole-second and sub-second stamps

## Contract and migration decisions

- SQLite persists adapter comparison timestamps as `2006-01-02T15:04:05.000000Z`
- PostgreSQL keeps native `time.Time` / `TIMESTAMPTZ` behavior
- add a one-shot SQLite migration for deterministic consistency, despite no historical deployment data
- generated outputs: none

## Validation

- `go test -count=1 -run "^(TestAdapterStampsCompareLexicallyAcrossBridges|TestAdapterClaimDueReplaysExpiredLeaseOnly|TestAdapterEnqueueClearsExpiredProviderWriteFence)$" ./internal/store` — 3 passed
- `go test -count=1 ./internal/store` — 47 passed
- `go test -count=1 ./internal/store/migrate` — 10 passed
- `go test -count=1 ./...` — 3,456 passed in 61 packages
- `./scripts/ci/verify-docs.sh` — passed, including Astro, PWA/offline, live docs, and fallback gates
- two-axis review round 2 — Standards `CLEAN`; Spec `CLEAN`