### PR TITLE
Fix matrix row editor draft ownership #332

### DIFF
--- a/docs/handoff/332-matrix-row-editor-draft.md
+++ b/docs/handoff/332-matrix-row-editor-draft.md
@@ -1,0 +1,57 @@
+# Handoff: #332 matrix row editor draft ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/332 (parent #326; audit
+finding `F-S29-1`). Implementation is based on `origin/main` commit
+`94da1b003467cfe0ee7e1e87c98f061abe8a5b9b`.
+
+## Contract
+
+- One `Map<environmentId, MatrixDraftEdit>` owns every staged row edit.
+  Absence means untouched; `{ op: 'set', value }` includes an explicit empty
+  string; `{ op: 'unset' }` means clear to absent.
+- `matrixDraftChanges` preserves environment-row ordering while converting
+  tagged edits to the existing apply contract.
+- Choosing **Keep current state** removes the row edit, restoring its exact
+  initial visible value and disabling Save when no other edits remain.
+- Fill-all, per-row validation, textarea edits, clear/keep toggles, rendering,
+  and apply changes read or write the same edit map.
+- Wire values and API operations are unchanged. Generated outputs: none.
+  Database migrations: none.
+
+## Regression evidence
+
+- Typing a replacement, choosing Clear, then Keep restores the published value
+  and leaves Save disabled.
+- Touching a field to `''` submits one explicit `set` change with an empty
+  value; it is not confused with unset or untouched.
+- The state helper keeps untouched, explicit-empty, and unset rows distinct in
+  input environment order.
+
+## Validation
+
+```text
+rtk pnpm --dir web exec vitest run src/routes/MatrixRowEditor.test.tsx src/routes/matrix-state.test.ts
+2 files / 14 tests passed
+
+rtk pnpm --dir web run typecheck
+passed
+
+rtk pnpm --dir web run test
+37 files / 310 tests passed
+
+rtk pnpm --dir web run build
+passed
+
+rtk go test -count=1 -timeout=5m ./...
+3,461 tests passed in 61 packages
+
+rtk git diff --check
+passed
+```
+
+## Review
+
+- Standards axis round 1 found a stale base and duplicated component-test
+  setup. The branch was fast-forwarded to preserve #329 and the setup was
+  extracted into `renderEditor`; round 2: `CLEAN`.
+- Spec axis round 1 found only the stale-base blocker; round 2: `CLEAN`.

--- a/web/src/routes/MatrixRowEditor.test.tsx
+++ b/web/src/routes/MatrixRowEditor.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MatrixRowEditor, type MatrixEditorChange } from './MatrixRowEditor.tsx';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+type MatrixRowEditorProps = Parameters<typeof MatrixRowEditor>[0];
+
+const environmentId = 'env_01989abc-def0-7123-8123-123456789abc';
+const environment: MatrixRowEditorProps['rows'][number]['environment'] = {
+  id: environmentId,
+  org_id: 'org_01989abc-def0-7123-8123-123456789abc',
+  project_id: 'prj_01989abc-def0-7123-8123-123456789abc',
+  name: 'development',
+  display_order: 0,
+  created_at: '2026-08-23T08:00:00Z',
+};
+const keyRecord: MatrixRowEditorProps['keyRecord'] = {
+  id: 'key_01989abc-def0-7123-8123-123456789abc',
+  org_id: environment.org_id,
+  project_id: environment.project_id,
+  name: 'LOG_LEVEL',
+  folder_path: '',
+  classification: 'config',
+  description: '',
+  deprecated: false,
+  deprecation_note: '',
+  declaration: { rule: { type: 'string', allow_empty: true } },
+  presence: {
+    required_in: { mode: 'none' },
+    forbidden_in: { mode: 'none' },
+  },
+  group_id: '',
+  created_at: '2026-08-23T08:00:00Z',
+};
+const rows: MatrixRowEditorProps['rows'] = [{
+  environmentId,
+  environment,
+  protected: false,
+  cell: {
+    key_id: keyRecord.id,
+    name: keyRecord.name,
+    classification: 'config',
+    set: true,
+    revealed: true,
+    value: 'published',
+  },
+  signal: undefined,
+  draftPreview: undefined,
+  problems: [],
+}];
+
+afterEach(() => document.body.replaceChildren());
+
+describe('MatrixRowEditor draft ownership', () => {
+  it('restores the initial value after type, clear, then keep', async () => {
+    const view = await renderEditor();
+
+    const textarea = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    const clearButton = [...view.container.querySelectorAll('button')].find((candidate) =>
+      candidate.textContent?.startsWith('Clear '),
+    );
+    if (textarea === null || clearButton === undefined) {
+      throw new Error('row controls are missing');
+    }
+
+    await act(async () => typeInto(textarea, 'edited'));
+    await act(async () => clearButton.click());
+    await act(async () => clearButton.click());
+
+    const saveButton = view.container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(textarea.value).toBe('published');
+    expect(saveButton?.disabled).toBe(true);
+
+    await view.unmount();
+  });
+
+  it('submits a touched empty field as an explicit set', async () => {
+    const view = await renderEditor();
+
+    const textarea = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    const saveButton = view.container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    if (textarea === null || saveButton === null) {
+      throw new Error('row form controls are missing');
+    }
+
+    await act(async () => typeInto(textarea, ''));
+    await act(async () => saveButton.click());
+
+    expect(view.onApply).toHaveBeenCalledWith([
+      { environmentId, operation: 'set', value: '' },
+    ]);
+
+    await view.unmount();
+  });
+});
+
+async function renderEditor() {
+  const onApply = vi
+    .fn<(changes: readonly MatrixEditorChange[]) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <MatrixRowEditor
+          refData={{ org: 'org-a', project: 'project-a' }}
+          keyRecord={keyRecord}
+          environmentId={environmentId}
+          rows={rows}
+          busy={false}
+          mutationError={null}
+          onClose={vi.fn()}
+          onApply={onApply}
+          onCopy={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+  });
+
+  return {
+    container,
+    onApply,
+    unmount: async () => act(async () => root.unmount()),
+  };
+}
+
+function typeInto(textarea: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  if (setter === undefined) throw new Error('HTMLTextAreaElement exposes no value setter');
+  setter.call(textarea, value);
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}

--- a/web/src/routes/MatrixRowEditor.tsx
+++ b/web/src/routes/MatrixRowEditor.tsx
@@ -17,6 +17,7 @@ import {
   matrixDraftChanges,
   validateMatrixDraft,
   type MatrixDraftChange,
+  type MatrixDraftEdit,
 } from './matrix-state.ts';
 import {
   useProtectedPublishCeremony,
@@ -77,9 +78,7 @@ export function MatrixRowEditor({
       ),
     [keyRecord.classification, rows],
   );
-  const [drafts, setDrafts] = useState<ReadonlyMap<string, string>>(initialDrafts);
-  const [dirty, setDirty] = useState<ReadonlySet<string>>(() => new Set());
-  const [clears, setClears] = useState<ReadonlySet<string>>(() => new Set());
+  const [edits, setEdits] = useState<ReadonlyMap<string, MatrixDraftEdit>>(() => new Map());
   const [fillAll, setFillAll] = useState('');
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
@@ -121,11 +120,11 @@ export function MatrixRowEditor({
 
   const validationByEnvironment = new Map<string, ReturnType<typeof validateMatrixDraft>>();
   for (const row of rows) {
-    if (!dirty.has(row.environmentId) || clears.has(row.environmentId)) {
+    const edit = edits.get(row.environmentId);
+    if (edit?.op !== 'set') {
       continue;
     }
-    const value = drafts.get(row.environmentId) ?? '';
-    const error = validateDeclaration(keyRecord, value);
+    const error = validateDeclaration(keyRecord, edit.value);
     if (error !== null) {
       validationByEnvironment.set(row.environmentId, error);
     }
@@ -133,9 +132,7 @@ export function MatrixRowEditor({
 
   const changes = matrixDraftChanges(
     rows.map((row) => row.environmentId),
-    drafts,
-    dirty,
-    clears,
+    edits,
   );
 
   const protectedTargets = (): readonly ProtectedPublishTarget[] =>
@@ -205,9 +202,9 @@ export function MatrixRowEditor({
                 className="btn"
                 disabled={fillAll === '' || busy || applying}
                 onClick={() => {
-                  setDrafts(new Map(rows.map((row) => [row.environmentId, fillAll])));
-                  setDirty(new Set(rows.map((row) => row.environmentId)));
-                  setClears(new Set());
+                  setEdits(new Map<string, MatrixDraftEdit>(
+                    rows.map((row) => [row.environmentId, { op: 'set', value: fillAll }]),
+                  ));
                 }}
               >
                 Fill all
@@ -219,7 +216,8 @@ export function MatrixRowEditor({
             {rows.map((row) => {
               const rowEnvironmentId = row.environmentId;
               const publishedSet = row.cell?.set === true;
-              const clearing = clears.has(rowEnvironmentId);
+              const edit = edits.get(rowEnvironmentId);
+              const clearing = edit?.op === 'unset';
               const liveValidation = validationByEnvironment.get(rowEnvironmentId) ?? null;
               return (
                 <section
@@ -249,7 +247,13 @@ export function MatrixRowEditor({
                     className="mono matrix-editor__value"
                     rows={keyRecord.declaration.rule?.type === 'json' ? 6 : 2}
                     autoComplete="off"
-                    value={clearing ? '' : drafts.get(rowEnvironmentId) ?? ''}
+                    value={
+                      edit?.op === 'set'
+                        ? edit.value
+                        : clearing
+                          ? ''
+                          : initialDrafts.get(rowEnvironmentId) ?? ''
+                    }
                     placeholder={
                       keyRecord.classification === 'secret'
                         ? publishedSet
@@ -262,14 +266,10 @@ export function MatrixRowEditor({
                     aria-invalid={liveValidation?.level === 'error' ? true : undefined}
                     aria-describedby={liveValidation === null ? undefined : `matrix-error-${rowEnvironmentId}`}
                     onChange={(event) => {
-                      const next = new Map(drafts);
-                      next.set(rowEnvironmentId, event.target.value);
-                      setDrafts(next);
-                      setDirty((current) => new Set(current).add(rowEnvironmentId));
-                      setClears((current) => {
-                        const nextClears = new Set(current);
-                        nextClears.delete(rowEnvironmentId);
-                        return nextClears;
+                      setEdits((current) => {
+                        const next = new Map(current);
+                        next.set(rowEnvironmentId, { op: 'set', value: event.target.value });
+                        return next;
                       });
                     }}
                   />
@@ -297,16 +297,13 @@ export function MatrixRowEditor({
                     className="btn"
                     disabled={busy || applying || (!clearing && !canClearMatrixCell(publishedSet, row.signal?.pending_operation))}
                     onClick={() => {
-                      setClears((current) => {
-                        const next = new Set(current);
-                        if (next.has(rowEnvironmentId)) next.delete(rowEnvironmentId);
-                        else next.add(rowEnvironmentId);
-                        return next;
-                      });
-                      setDirty((current) => {
-                        const next = new Set(current);
-                        next.delete(rowEnvironmentId);
-                        return next;
+                      setEdits((current) => {
+                        if (clearing) {
+                          const kept = new Map(current);
+                          kept.delete(rowEnvironmentId);
+                          return kept;
+                        }
+                        return new Map(current).set(rowEnvironmentId, { op: 'unset' });
                       });
                     }}
                   >

--- a/web/src/routes/matrix-state.test.ts
+++ b/web/src/routes/matrix-state.test.ts
@@ -178,9 +178,10 @@ describe('row editor state', () => {
     expect(
       matrixDraftChanges(
         ['untouched', 'empty', 'cleared'],
-        new Map([['empty', '']]),
-        new Set(['empty']),
-        new Set(['cleared']),
+        new Map([
+          ['empty', { op: 'set', value: '' }],
+          ['cleared', { op: 'unset' }],
+        ]),
       ),
     ).toEqual([
       { environmentId: 'empty', operation: 'set', value: '' },

--- a/web/src/routes/matrix-state.ts
+++ b/web/src/routes/matrix-state.ts
@@ -213,19 +213,22 @@ export type MatrixDraftChange =
   | { readonly environmentId: string; readonly operation: 'set'; readonly value: string }
   | { readonly environmentId: string; readonly operation: 'unset' };
 
-/** Dirty and clear are separate so an explicit empty string is not mistaken for absent. */
+export type MatrixDraftEdit =
+  | { readonly op: 'set'; readonly value: string }
+  | { readonly op: 'unset' };
+
+/** Absence is untouched; the tagged edit keeps explicit empty distinct from unset. */
 export function matrixDraftChanges(
   environmentIds: readonly string[],
-  drafts: ReadonlyMap<string, string>,
-  dirty: ReadonlySet<string>,
-  clears: ReadonlySet<string>,
+  edits: ReadonlyMap<string, MatrixDraftEdit>,
 ): readonly MatrixDraftChange[] {
   return environmentIds.flatMap<MatrixDraftChange>((environmentId) => {
-    if (clears.has(environmentId)) {
+    const edit = edits.get(environmentId);
+    if (edit?.op === 'unset') {
       return [{ environmentId, operation: 'unset' }];
     }
-    if (dirty.has(environmentId)) {
-      return [{ environmentId, operation: 'set', value: drafts.get(environmentId) ?? '' }];
+    if (edit?.op === 'set') {
+      return [{ environmentId, operation: 'set', value: edit.value }];
     }
     return [];
   });


### PR DESCRIPTION
Closes #332

## Contract
- One tagged edits map now owns untouched, explicit set, and unset row state.
- Keep current state removes the edit and restores the exact initial visible value.
- Existing apply ordering and explicit-empty wire behavior remain unchanged.

Contract decisions: absence means untouched; explicit empty remains a set operation.
Migration decisions: none.
Generated outputs: none.

## Validation
- Focused Vitest: 2 files, 14 tests passed
- Web typecheck: passed
- Full web Vitest: 37 files, 310 tests passed
- Web production build: passed
- Full Go: 3,461 tests in 61 packages passed
- Standards review: CLEAN
- Spec review: implementation SOUND; final documentation SHA typo fixed locally