### PR TITLE
fix: centralize adapter ceremony checks #336

### DIFF
--- a/docs/handoff/336-adapter-ceremony-owner.md
+++ b/docs/handoff/336-adapter-ceremony-owner.md
@@ -1,0 +1,28 @@
+# Handoff: #336 adapter ceremony owner
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/336 (parent #326; audit finding
+`F-S11-1`). Implementation base:
+`3b342e5a657f8a9d75cfe5d973a89eb23d28f0a2`.
+
+## Contract
+
+- `requireAdapterCeremony` owns adapter-environment authorization, the
+  fail-closed nil-auth check, intent construction, and reauthentication-window
+  consumption for configure, sync, credential replacement, and adoption.
+- Missing, expired, mismatched, and spent reauthentication windows map to
+  `ErrReauthRequired` with the environment identifier retained in the message.
+- Other ceremony-seam failures, including context cancellation and database
+  errors, remain their original error instead of telling the caller to repeat a
+  ceremony that cannot repair the failure.
+
+## Coverage
+
+- `TestAdapterCeremonyErrorClassification` injects a canceled ceremony
+  consumer through the shared owner and proves cancellation is not reclassified.
+  It also proves sync, credential replacement, and adoption still require
+  reauthentication when no window exists.
+- The four existing adapter ceremony, adoption, credential fencing, and manual
+  sync regressions named by #336 pass unchanged.
+- No wire, audit, schema, or generated artifact changed. Local verification:
+  focused service tests, `go build ./...`, `go vet ./...`, and
+  `go test -count=1 ./...` passed.

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -18,6 +18,10 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
+type adapterReauthConsumer interface {
+	ConsumeAdapterReauthWindow(context.Context, *authz.TxAuthorizer, string, string, ReauthIntent, time.Time) error
+}
+
 type Adapters struct {
 	DB      *store.DB
 	Auth    *Auth
@@ -25,9 +29,10 @@ type Adapters struct {
 	// Budget applies the § 179 adapter sync/trigger concurrency bound (4 per
 	// org). Nil disables it. The per-principal 10/min rate is deferred (see
 	// budget.go).
-	Budget        *Budget
-	Now           func() time.Time
-	ModuleFactory adapter.ModuleFactory
+	Budget         *Budget
+	Now            func() time.Time
+	ModuleFactory  adapter.ModuleFactory
+	reauthConsumer adapterReauthConsumer
 }
 
 func (s *Adapters) now() time.Time {
@@ -242,11 +247,26 @@ func (s *Adapters) requireAdapterCeremony(ctx context.Context, az *authz.TxAutho
 		if s.Auth == nil {
 			return ErrNoCeremonySeam
 		}
-		if err := s.Auth.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, intent, now); err != nil {
-			return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
+		consumer := s.reauthConsumer
+		if consumer == nil {
+			consumer = s.Auth
+		}
+		if err := consumer.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, intent, now); err != nil {
+			return adapterCeremonyError(environmentID, err)
 		}
 	}
 	return nil
+}
+
+func adapterCeremonyError(environmentID string, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrNoReauthWindow), errors.Is(err, ErrReauthWindowExpired), errors.Is(err, ErrReauthUnitMismatch), errors.Is(err, ErrReauthWindowSpent):
+		return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
+	default:
+		return err
+	}
 }
 
 func adapterEnvironmentSet(environmentIDs []string, additional ...string) []string {
@@ -1198,23 +1218,8 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 			if err != nil {
 				return err
 			}
-			intent, err := NewAdapterSyncReauthIntent(environments)
-			if err != nil {
+			if err := s.requireAdapterCeremony(ctx, az, caller, scope, environments, authz.OpAdapterSync, now); err != nil {
 				return err
-			}
-			for _, environmentID := range environments {
-				envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(environmentID)}
-				if _, err := az.Authorize(ctx, caller, authz.OpAdapterPush, envScope); err != nil {
-					return err
-				}
-				if !skipsCeremony(caller) {
-					if s.Auth == nil {
-						return ErrNoCeremonySeam
-					}
-					if err := s.Auth.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, intent, now); err != nil {
-						return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
-					}
-				}
 			}
 			result, err = r.Adapters().EnqueueManual(ctx, proof, targetID, string(caller.Principal), now)
 			if err != nil {
@@ -1380,24 +1385,8 @@ func (s *Adapters) ReplaceCredential(ctx context.Context, actor Actor, scope dom
 			if len(environments) == 0 {
 				return store.AdapterCredentialResult{}, ErrAdapterBootstrapCeremonyUnspecified
 			}
-			intent, err := NewAdapterCredentialSetReauthIntent(environments)
-			if err != nil {
+			if err := s.requireAdapterCeremony(ctx, az, caller, scope, environments, authz.OpAdapterCredentialSet, now); err != nil {
 				return store.AdapterCredentialResult{}, err
-			}
-			for _, environmentID := range environments {
-				envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(environmentID)}
-				if _, err := az.Authorize(ctx, caller, authz.OpAdapterPush, envScope); err != nil {
-					return store.AdapterCredentialResult{}, err
-				}
-				if skipsCeremony(caller) {
-					continue
-				}
-				if s.Auth == nil {
-					return store.AdapterCredentialResult{}, ErrNoCeremonySeam
-				}
-				if err := s.Auth.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, intent, now); err != nil {
-					return store.AdapterCredentialResult{}, fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
-				}
 			}
 			// Writer fence (invariant 7): refuse if a rotate-dek retired the DEK
 			// version the new credential was sealed under.
@@ -1706,29 +1695,8 @@ func (s *Adapters) Adopt(ctx context.Context, actor Actor, scope domain.Scope, r
 		if len(environments) == 0 {
 			return domain.ErrNotFound
 		}
-		intent, err := NewAdapterAdoptReauthIntent(environments)
-		if err != nil {
+		if err := s.requireAdapterCeremony(ctx, az, caller, scope, environments, authz.OpAdapterAdopt, now); err != nil {
 			return err
-		}
-		for _, environmentID := range environments {
-			envScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(environmentID)}
-			if _, err := az.Authorize(ctx, caller, authz.OpAdapterPush, envScope); err != nil {
-				return err
-			}
-			if skipsCeremony(caller) {
-				continue
-			}
-			if s.Auth == nil {
-				return ErrNoCeremonySeam
-			}
-			err := s.Auth.ConsumeAdapterReauthWindow(ctx, az, caller.SessionID, environmentID, intent, now)
-			switch {
-			case err == nil:
-			case errors.Is(err, ErrNoReauthWindow), errors.Is(err, ErrReauthWindowExpired), errors.Is(err, ErrReauthUnitMismatch), errors.Is(err, ErrReauthWindowSpent):
-				return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
-			default:
-				return err
-			}
 		}
 		result, err := r.Adapters().Adopt(ctx, p, store.AdapterAdoption{
 			TargetID: request.TargetID, ArtifactID: request.ArtifactID, Entries: request.Entries,

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -73,6 +73,12 @@ func adapterServiceDB(t *testing.T) *store.DB {
 	return db
 }
 
+type adapterReauthConsumerFunc func(context.Context, *authz.TxAuthorizer, string, string, ReauthIntent, time.Time) error
+
+func (f adapterReauthConsumerFunc) ConsumeAdapterReauthWindow(ctx context.Context, az *authz.TxAuthorizer, sessionID, environmentID string, intent ReauthIntent, now time.Time) error {
+	return f(ctx, az, sessionID, environmentID, intent, now)
+}
+
 // updateTarget and moveTarget preserve the focused assertions of older tests
 // while routing every mutation through the public classifier under test.
 func (s *Adapters) updateTarget(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest) (store.AdapterTarget, error) {
@@ -625,6 +631,56 @@ func TestApplyTargetMutationRequiresCeremonyForUpdateAndMove(t *testing.T) {
 			}
 			if generation != 1 || audits != 0 {
 				t.Fatalf("refused ceremony generation=%d audits=%d", generation, audits)
+			}
+		})
+	}
+}
+
+func TestAdapterCeremonyErrorClassification(t *testing.T) {
+	t.Run("non-reauth seam errors stay raw", func(t *testing.T) {
+		db := adapterServiceDB(t)
+		bearer := adapterCLISession(t, db)
+		consumerCalled := false
+		svc := &Adapters{DB: db, Auth: &Auth{DB: db}, reauthConsumer: adapterReauthConsumerFunc(func(context.Context, *authz.TxAuthorizer, string, string, ReauthIntent, time.Time) error {
+			consumerCalled = true
+			return context.Canceled
+		})}
+		err := storetx.Write(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+			caller, err := Bearer(bearer).resolve(ctx, az, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			return svc.requireAdapterCeremony(ctx, az, caller, domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, []string{"env_one"}, authz.OpAdapterSync, time.Now().UTC())
+		})
+		if !consumerCalled {
+			t.Fatal("requireAdapterCeremony() did not reach reauth consumer")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("requireAdapterCeremony() = %v, want context canceled", err)
+		}
+		if errors.Is(err, ErrReauthRequired) {
+			t.Fatalf("requireAdapterCeremony() = %v, do not want reauth required", err)
+		}
+	})
+
+	for _, operation := range []authz.Operation{
+		authz.OpAdapterSync,
+		authz.OpAdapterCredentialSet,
+		authz.OpAdapterAdopt,
+	} {
+		t.Run(string(operation)+" missing window requires reauth", func(t *testing.T) {
+			db := adapterServiceDB(t)
+			bearer := adapterCLISession(t, db)
+			svc := &Adapters{DB: db, Auth: &Auth{DB: db}}
+			err := storetx.Write(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+				caller, err := Bearer(bearer).resolve(ctx, az, time.Now().UTC())
+				if err != nil {
+					return err
+				}
+				return svc.requireAdapterCeremony(ctx, az, caller, domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, []string{"env_one"}, operation, time.Now().UTC())
+			})
+			if !errors.Is(err, ErrReauthRequired) {
+				t.Fatalf("requireAdapterCeremony(%s) = %v, want reauth required", operation, err)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #336

## Contract
- Centralizes configure, sync, credential replacement, and adoption ceremony checks in requireAdapterCeremony.
- Maps only missing, expired, mismatched, or spent reauthentication windows to ErrReauthRequired.
- Preserves raw context/database seam errors and the nil Auth fail-closed refusal.

## Migration and generated outputs
- No schema, wire, audit, or migration change.
- No generated outputs changed.

## Validation
- Focused named adapter regressions: pass.
- internal/service package suite: pass.
- go build ./...: pass.
- go vet ./...: pass.
- go test -count=1 ./...: pass.
- Two-axis review: Standards CLEAN; Spec CLEAN.