### PR TITLE
fix(auth): classify reauthentication window bindings #335

### DIFF
--- a/docs/handoff/335-reauth-window-binding.md
+++ b/docs/handoff/335-reauth-window-binding.md
@@ -1,0 +1,36 @@
+# Handoff: #335 reauthentication-window binding classifier
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/335 (parent #326; audit finding
+`F-S07-1`).
+
+## Contract
+
+- The four persisted binding columns form exactly one of three modes: unbound,
+  operation-bound `(operation, key set)`, or adapter-bound `(purpose,
+  operation, environment set)`.
+- Partial or contradictory rows fail closed with `ErrReauthUnitMismatch`; a
+  key-set-only row can no longer inherit unbound-window authority.
+- Disclosure consumption applies each mode through the shared classifier.
+  CLI disclosure approval intentionally accepts unbound sliding windows and
+  exact single-decision ceremonies, but refuses operation-bound windows.
+- Existing CLI audit cause strings and approved-window JSON fields are
+  unchanged. Generated outputs: none.
+
+## Coverage
+
+- The classifier table covers all three valid modes plus key-set-only and
+  purpose-without-environment-set refusals.
+- SQLite and PostgreSQL isolation fixtures pin consume refusal for a
+  key-set-only row and CLI refusal for an operation-bound sliding window.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service/...                         237 passed
+go test -count=1 ./internal/isolation                         1,112 passed
+go vet ./internal/service/... ./internal/isolation/...        passed
+go test -count=1 ./...                         3,496 passed / 61 packages
+go vet ./...                                                   passed
+gofmt -l <changed Go files>                                    clean
+git diff --check                                               clean
+```

--- a/docs/handoff/335-reauth-window-binding.md
+++ b/docs/handoff/335-reauth-window-binding.md
@@ -29,7 +29,7 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/335 (parent #326; audit finding
 go test -count=1 ./internal/service/...                         237 passed
 go test -count=1 ./internal/isolation                         1,112 passed
 go vet ./internal/service/... ./internal/isolation/...        passed
-go test -count=1 ./...                         3,496 passed / 61 packages
+go test -count=1 ./...                         3,501 passed / 61 packages
 go vet ./...                                                   passed
 gofmt -l <changed Go files>                                    clean
 git diff --check                                               clean

--- a/internal/isolation/reauth_e2e_test.go
+++ b/internal/isolation/reauth_e2e_test.go
@@ -149,6 +149,46 @@ func TestAdapterReauthWindowExactBindingPostgres(t *testing.T) {
 	runAdapterReauthWindowExactBinding(t, seededDB(t, openPostgres))
 }
 
+func TestInvalidReauthWindowBindingSQLite(t *testing.T) {
+	runInvalidReauthWindowBinding(t, seededDB(t, openSQLite))
+}
+
+func TestInvalidReauthWindowBindingPostgres(t *testing.T) {
+	runInvalidReauthWindowBinding(t, seededDB(t, openPostgres))
+}
+
+func runInvalidReauthWindowBinding(t *testing.T, db *store.DB) {
+	auth, _, password := bootstrapFactorAdmin(t, db)
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	auth.Now = func() time.Time { return now }
+	auth.ReauthWindow = 5 * time.Minute
+	login, err := auth.LocalLogin(t.Context(), "factor-admin", password, service.ArtifactCLI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tx.Write(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+		epoch, err := az.CredentialEpoch(ctx)
+		if err != nil {
+			return err
+		}
+		return az.OpenReauthWindow(ctx, authz.NewReauthWindow{
+			ID: "raw_invalid_binding", SessionID: login.SessionID, EnvironmentID: "env_prod",
+			CeremonyID: "totp_invalid", FactorClass: "totp", AuthenticatedAt: now,
+			WindowExpiresAt: now.Add(5 * time.Minute), HardExpiresAt: now.Add(10 * time.Minute),
+			CredentialEpoch: epoch, CreatedAt: now, BoundKeySet: "DATABASE_URL",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = consumeWindowFor(t, auth, db, login.SessionID, "env_prod",
+		string(authz.OpValueReveal), []string{"DATABASE_URL"}, now.Add(time.Second))
+	if !errors.Is(err, service.ErrReauthUnitMismatch) {
+		t.Fatalf("keyset-only window consumed with error %v, want ErrReauthUnitMismatch", err)
+	}
+}
+
 func TestAdapterReauthTOTPMixedPolicySQLite(t *testing.T) {
 	runAdapterReauthTOTPMixedPolicy(t, seededDB(t, openSQLite))
 }
@@ -1115,6 +1155,14 @@ func runCLIDisclosureReauthHandoff(t *testing.T, db *store.DB) {
 	if transaction.Purpose != string(service.PurposeReveal) || transaction.Operation != string(authz.OpValueReveal) || strings.Join(transaction.KeyIDs, "\n") != service.CanonicalKeySet(secretKeys) {
 		t.Fatalf("transaction = %+v", transaction)
 	}
+	// A workspace step-up's operation-bound sliding window cannot be widened
+	// into a CLI handoff. The CLI policy accepts only an environment-wide
+	// sliding window or the handoff's own exact single-decision ceremony.
+	execRaw(t, db, `UPDATE reauth_windows SET bound_operation = 'value.reveal', bound_key_set = 'DATABASE_URL' WHERE session_id = '`+browserWindow.SessionID+`'`)
+	if _, err := auth.ApproveCLIReauth(t.Context(), service.Bearer(browserWindow.SessionToken), start.State); !errors.Is(err, service.ErrReauthUnitMismatch) {
+		t.Fatalf("operation-bound sliding window approved for CLI handoff: %v, want ErrReauthUnitMismatch", err)
+	}
+	execRaw(t, db, `UPDATE reauth_windows SET bound_operation = '', bound_key_set = '' WHERE session_id = '`+browserWindow.SessionID+`'`)
 	approved, err := auth.ApproveCLIReauth(t.Context(), service.Bearer(browserWindow.SessionToken), start.State)
 	if err != nil {
 		t.Fatalf("approve: %v", err)

--- a/internal/service/cli_reauth.go
+++ b/internal/service/cli_reauth.go
@@ -369,13 +369,22 @@ func (s *Auth) ApproveCLIReauth(ctx context.Context, actor Actor, state string) 
 			if effective <= 0 && (w.FactorClass != "webauthn" || !w.SingleDecision) {
 				return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthRequired)
 			}
+			kind, windowBinding, bindingErr := windowBindingKind(w)
+			if bindingErr != nil {
+				if adapter {
+					return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthRequired)
+				}
+				return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthUnitMismatch)
+			}
 			if !adapter {
 				// The browser ran the disclosure ceremony: a single-decision
 				// passkey window carries its ceremony's pinned (purpose,
 				// environment, key set) binding, which must equal the handoff's
 				// unit byte-exact; a sliding window is unbound by construction and
-				// is accepted as the environment-wide consent it is.
-				if w.BoundPurpose != "" || w.BoundEnvironmentSet != "" {
+				// is accepted as the environment-wide consent it is. An
+				// operation-bound window belongs to its original step-up and cannot
+				// be widened into a CLI handoff.
+				if kind != reauthWindowUnbound {
 					return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthUnitMismatch)
 				}
 				if w.SingleDecision {
@@ -387,7 +396,8 @@ func (s *Auth) ApproveCLIReauth(ctx context.Context, actor Actor, state string) 
 						return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthUnitMismatch)
 					}
 				}
-			} else if w.BoundPurpose != string(binding.purpose) || w.BoundOperation != string(binding.operation) || w.BoundEnvironmentSet != binding.environmentSet {
+			} else if kind != reauthWindowAdapterBound || windowBinding.purpose != binding.purpose ||
+				windowBinding.operation != binding.operation || windowBinding.environmentSet != binding.environmentSet {
 				return captureCLIReauthFailure(ctx, az, "approve", detail, "reauth_required", ErrReauthRequired)
 			}
 			if w.SingleDecision {

--- a/internal/service/reauth.go
+++ b/internal/service/reauth.go
@@ -43,6 +43,37 @@ var (
 	ErrReauthWindowSpent = errors.New("service: this reauthentication has already been spent")
 )
 
+type reauthWindowBindingKind uint8
+
+const (
+	reauthWindowUnbound reauthWindowBindingKind = iota + 1
+	reauthWindowOperationBound
+	reauthWindowAdapterBound
+)
+
+// windowBindingKind parses the four persisted binding columns as one closed
+// shape. Rows outside these three modes are corrupt or contradictory and must
+// never inherit unbound-window authority through a partial string match.
+func windowBindingKind(w authz.ReauthWindow) (reauthWindowBindingKind, reauthIntentBinding, error) {
+	binding := reauthIntentBinding{
+		purpose:        ReauthPurpose(w.BoundPurpose),
+		operation:      authz.Operation(w.BoundOperation),
+		environmentID:  w.EnvironmentID,
+		keySet:         w.BoundKeySet,
+		environmentSet: w.BoundEnvironmentSet,
+	}
+	switch {
+	case w.BoundPurpose == "" && w.BoundOperation == "" && w.BoundKeySet == "" && w.BoundEnvironmentSet == "":
+		return reauthWindowUnbound, binding, nil
+	case w.BoundPurpose == "" && w.BoundOperation != "" && w.BoundEnvironmentSet == "":
+		return reauthWindowOperationBound, binding, nil
+	case w.BoundPurpose != "" && w.BoundOperation != "" && w.BoundKeySet == "" && w.BoundEnvironmentSet != "":
+		return reauthWindowAdapterBound, binding, nil
+	default:
+		return 0, reauthIntentBinding{}, fmt.Errorf("%w: invalid reauthentication window binding", ErrReauthUnitMismatch)
+	}
+}
+
 // ConsumeReauthWindow is the disclosure-time half of the reauthentication gate.
 // It runs inside the disclosure's own transaction; the future reveal path calls
 // it before disclosing the enumerated keys in one environment.
@@ -115,19 +146,25 @@ func (s *Auth) consumeReauthWindow(ctx context.Context, az *authz.TxAuthorizer, 
 	if w.CredentialEpoch != epoch || !now.Before(w.HardExpiresAt) || !now.Before(w.WindowExpiresAt) {
 		return ErrReauthWindowExpired
 	}
-	// The exact binding, consumed rather than merely stored. An unnamed
-	// operation ("" — every caller that has no operation-scoped consent to
-	// present) can never equal a bound one, so a bound window fails closed for
-	// it rather than being treated as unbound.
-	if w.BoundPurpose != "" || w.BoundEnvironmentSet != "" {
-		if w.BoundPurpose != string(binding.purpose) || string(binding.operation) != w.BoundOperation ||
-			w.BoundKeySet != binding.keySet || w.BoundEnvironmentSet != binding.environmentSet {
+	// Classify all four persisted columns together before applying the mode's
+	// policy. A partial row cannot fall through as an unbound window.
+	kind, windowBinding, err := windowBindingKind(w)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case reauthWindowUnbound:
+	case reauthWindowOperationBound:
+		if binding.operation != windowBinding.operation || binding.keySet != windowBinding.keySet {
 			return ErrReauthUnitMismatch
 		}
-	} else if w.BoundOperation != "" {
-		if string(binding.operation) != w.BoundOperation || w.BoundKeySet != binding.keySet {
+	case reauthWindowAdapterBound:
+		if binding.purpose != windowBinding.purpose || binding.operation != windowBinding.operation ||
+			binding.environmentSet != windowBinding.environmentSet {
 			return ErrReauthUnitMismatch
 		}
+	default:
+		return ErrReauthUnitMismatch
 	}
 	if w.SingleDecision {
 		// The unit is fixed before the ceremony and cannot grow after it, and it

--- a/internal/service/reauth_binding_test.go
+++ b/internal/service/reauth_binding_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+)
+
+func TestWindowBindingKind(t *testing.T) {
+	tests := []struct {
+		name               string
+		window             authz.ReauthWindow
+		wantKind           reauthWindowBindingKind
+		wantPurpose        ReauthPurpose
+		wantOperation      authz.Operation
+		wantKeySet         string
+		wantEnvironmentSet string
+		wantError          bool
+	}{
+		{name: "unbound", wantKind: reauthWindowUnbound},
+		{
+			name: "operation bound",
+			window: authz.ReauthWindow{
+				BoundOperation: string(authz.OpValueReveal),
+				BoundKeySet:    "API_KEY\nDATABASE_URL",
+			},
+			wantKind:      reauthWindowOperationBound,
+			wantOperation: authz.OpValueReveal,
+			wantKeySet:    "API_KEY\nDATABASE_URL",
+		},
+		{
+			name: "adapter bound",
+			window: authz.ReauthWindow{
+				BoundPurpose:        string(PurposeAdapter),
+				BoundOperation:      string(authz.OpAdapterSync),
+				BoundEnvironmentSet: "env_prod\nenv_stage",
+			},
+			wantKind:           reauthWindowAdapterBound,
+			wantPurpose:        PurposeAdapter,
+			wantOperation:      authz.OpAdapterSync,
+			wantEnvironmentSet: "env_prod\nenv_stage",
+		},
+		{
+			name:      "key set without operation",
+			window:    authz.ReauthWindow{BoundKeySet: "DATABASE_URL"},
+			wantError: true,
+		},
+		{
+			name: "purpose without environment set",
+			window: authz.ReauthWindow{
+				BoundPurpose:   string(PurposeAdapter),
+				BoundOperation: string(authz.OpAdapterSync),
+			},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kind, binding, err := windowBindingKind(test.window)
+			if test.wantError {
+				if err == nil {
+					t.Fatal("windowBindingKind() error = nil, want refusal")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("windowBindingKind() error = %v", err)
+			}
+			if kind != test.wantKind {
+				t.Errorf("kind = %v, want %v", kind, test.wantKind)
+			}
+			if binding.purpose != test.wantPurpose || binding.operation != test.wantOperation ||
+				binding.keySet != test.wantKeySet || binding.environmentSet != test.wantEnvironmentSet {
+				t.Errorf("binding = %+v, want purpose=%q operation=%q keySet=%q environmentSet=%q",
+					binding, test.wantPurpose, test.wantOperation, test.wantKeySet, test.wantEnvironmentSet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #335

## Contract and migration

- Classifies persisted reauthentication-window bindings as exactly unbound, operation-bound, or adapter-bound.
- Refuses partial and contradictory rows fail-closed.
- Keeps CLI policy distinct: operation-bound windows cannot authorize a CLI disclosure handoff.
- No schema or migration change. Existing wire, audit-cause, and handoff JSON fields remain unchanged.

## Generated outputs

None.

## Validation

- go test -count=1 ./internal/service/... — 237 passed
- go test -count=1 ./internal/isolation — 1,112 passed
- integrated go test -count=1 ./... — 3,501 passed across 61 packages
- integrated go vet ./... — passed
- gofmt and git diff --check — clean
- Two-axis review — spec CLEAN; standards CLEAN after one documentation fix