### PR TITLE
fix(audit): enforce closed registry taxonomies #338

### DIFF
--- a/docs/handoff/338-audit-registry-enums.md
+++ b/docs/handoff/338-audit-registry-enums.md
@@ -1,0 +1,48 @@
+# Handoff: #338 audit registry closed taxonomies
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/338 (parent #326; audit
+finding `F-S16-1`). Integrated base:
+`3b342e5a657f8a9d75cfe5d973a89eb23d28f0a2`.
+
+## Contract
+
+- Sixteen `KindString` audit fields that previously described closed
+  taxonomies only in comments now declare their accepted values through
+  `FieldSpec.Enum`. Unknown values therefore fail the emitting operation at
+  the existing audit validation boundary.
+- Current producer values remain valid. `settings.org_read.query` includes the
+  emitted `count` variant, `auth.credential_authority_minted.issued_by`
+  includes recovery issuance, authority delivery includes `stdout`, and
+  `auth.oidc_refused.cause` includes `window-zero`, `no-possession`, and
+  `downgrade`.
+- Open vocabularies remain open: provider-qualified authentication methods and
+  adapter authority principal IDs are unchanged.
+- Event bytes, schema versions, ordering, trail selection, and dual-dialect
+  behavior are unchanged. Database migrations: none. Generated outputs: none.
+
+## Regression evidence
+
+- The 16-case public `Validate` regression was red before registry closure:
+  every field exposed an empty enum and accepted an out-of-taxonomy string.
+- Each case now pins the exact accepted taxonomy, proves a current valid event
+  still validates, and proves an unknown value is refused with the closed-set
+  error.
+
+## Validation
+
+```text
+rtk go test -count=1 ./internal/audit                     33 passed
+rtk go test -count=1 ./internal/isolation -run '^(TestAuditCore|TestPostgresAuditExport|TestPostgresDurabilityBootRefusal|TestInvariantAudit|TestSCIM)'
+                                                             85 passed
+rtk go test -count=1 ./...                              3506 passed / 61 packages
+rtk go vet ./...                                        passed
+rtk gofmt -l <changed-go-files>                         clean
+rtk git diff --check                                    clean
+```
+
+## Review
+
+- Standards round 1 found a non-copyable wrapped validation command in this
+  handoff; fixed. Round 2: `CLEAN`.
+- Spec round 1 found the live `stdout` delivery producer was missing and the
+  required prose-only enum guard was absent; both fixed. Round 2: `CLEAN`.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -97,6 +98,22 @@ func TestRegistryWellFormed(t *testing.T) {
 		if spec.Outcomes[OutcomeDisconnected] && typ != EventAuditExportCompleted {
 			t.Errorf("%s: disconnected outcome licensed outside audit.export_completed", typ)
 		}
+	}
+
+	source, err := os.ReadFile("registry.go")
+	if err != nil {
+		t.Fatalf("read registry source: %v", err)
+	}
+	for i, line := range strings.Split(string(source), "\n") {
+		if !strings.Contains(line, "Kind: KindString") || !strings.Contains(line, "//") || !strings.Contains(line, "|") || strings.Contains(line, "Enum:") {
+			continue
+		}
+		// Authentication methods are intentionally open: OIDC and SAML values
+		// include provider-controlled issuer/entity identifiers.
+		if strings.Contains(line, `"method":`) {
+			continue
+		}
+		t.Errorf("registry.go:%d: KindString field closes values only in prose: %s", i+1, strings.TrimSpace(line))
 	}
 }
 
@@ -348,6 +365,98 @@ func TestValidateRefusals(t *testing.T) {
 		if !strings.Contains(err.Error(), c.want) {
 			t.Errorf("%s: error %q does not mention %q", c.name, err, c.want)
 		}
+	}
+}
+
+func TestValidateRefusesValuesOutsideClosedTaxonomies(t *testing.T) {
+	cases := []struct {
+		name    string
+		typ     EventType
+		outcome Outcome
+		trail   Trail
+		scope   domain.Scope
+		field   string
+		payload Payload
+		want    []string
+	}{
+		{"grant resolution", EventGrantDenied, OutcomeDenied, TrailTenant, domain.Scope{Org: "org_a"}, "resolution",
+			Payload{"operation": "environment.read", "formula": "read@environment", "resolution": "resolvable"},
+			[]string{"resolvable", "unresolvable"}},
+		{"login artifact", EventAuthLogin, OutcomeSuccess, TrailInstance, domain.Scope{}, "artifact",
+			Payload{"method": "local-password", "artifact": "browser", "subject_resolved": true},
+			[]string{"cli", "browser"}},
+		{"login assurance", EventAuthLogin, OutcomeSuccess, TrailInstance, domain.Scope{}, "assurance",
+			Payload{"method": "local-password", "artifact": "browser", "subject_resolved": true, "assurance": "single-factor"},
+			[]string{"single-factor", "multi-factor"}},
+		{"authority issuer", EventAuthAuthorityMinted, OutcomeSuccess, TrailInstance, domain.Scope{}, "issued_by",
+			Payload{"authority_id": "cea_a", "account_id": "acc_a", "issued_by": "bootstrap", "delivery": "terminal"},
+			[]string{"bootstrap", "credential-reset", "break-glass", "recovery"}},
+		{"authority delivery", EventAuthAuthorityMinted, OutcomeSuccess, TrailInstance, domain.Scope{}, "delivery",
+			Payload{"authority_id": "cea_a", "account_id": "acc_a", "issued_by": "bootstrap", "delivery": "stdout"},
+			[]string{"file", "terminal", "stdout", "response"}},
+		{"throttle scope", EventAuthThrottleCrossed, OutcomeFailure, TrailInstance, domain.Scope{}, "scope",
+			Payload{"scope": "account", "subject_resolved": true},
+			[]string{"account", "source-ip", "instance"}},
+		{"OIDC purpose", EventOIDCLogin, OutcomeSuccess, TrailInstance, domain.Scope{}, "purpose",
+			Payload{"method": "oidc:issuer", "purpose": "login", "account_id": "acc_a", "assurance": "single-factor", "provider_id": "idp_a", "provider_row_version": 1},
+			[]string{"login", "reauth"}},
+		{"OIDC assurance", EventOIDCLogin, OutcomeSuccess, TrailInstance, domain.Scope{}, "assurance",
+			Payload{"method": "oidc:issuer", "purpose": "login", "account_id": "acc_a", "assurance": "single-factor", "provider_id": "idp_a", "provider_row_version": 1},
+			[]string{"single-factor", "multi-factor"}},
+		{"OIDC refusal cause", EventOIDCRefused, OutcomeFailure, TrailInstance, domain.Scope{}, "cause",
+			Payload{"cause": "mixup"},
+			[]string{"mixup", "nonce", "purpose", "state", "issuer", "audience", "signature", "epoch", "idp-error", "expired", "unknown-identity", "no-assurance-policy", "no-auth-time", "binding", "jit-refused", "reconciliation", "window-zero", "no-possession", "downgrade"}},
+		{"provider change", EventOIDCProviderChanged, OutcomeSuccess, TrailInstance, domain.Scope{}, "change",
+			Payload{"provider_id": "idp_a", "change": "created", "sessions_swept": 0},
+			[]string{"created", "updated", "deleted"}},
+		{"provider query", EventOIDCProviderRead, OutcomeSuccess, TrailInstance, domain.Scope{}, "query",
+			Payload{"query": "get", "row_count": 1},
+			[]string{"get", "list"}},
+		{"reset issuer", EventAuthCredentialResetIssued, OutcomeFailure, TrailInstance, domain.Scope{}, "issued_by",
+			Payload{"target_principal": "usr_a", "issued_by": "credential-reset", "authority": "network"},
+			[]string{"credential-reset", "break-glass"}},
+		{"reset authority", EventAuthCredentialResetIssued, OutcomeFailure, TrailInstance, domain.Scope{}, "authority",
+			Payload{"target_principal": "usr_a", "issued_by": "credential-reset", "authority": "network"},
+			[]string{"network", "local-host"}},
+		{"organization query", EventOrgRead, OutcomeSuccess, TrailInstance, domain.Scope{}, "query",
+			Payload{"query": "count", "row_count": 1},
+			[]string{"get", "list", "count"}},
+		{"origin allowlist change", EventRemoteOriginAllowlistChanged, OutcomeSuccess, TrailInstance, domain.Scope{}, "change",
+			Payload{"origin": "https://example.com", "change": "added", "sessions_revoked": 0},
+			[]string{"added", "removed"}},
+		{"handoff stage", EventRemoteHandoffFailed, OutcomeFailure, TrailInstance, domain.Scope{}, "stage",
+			Payload{"handoff_id": "hnd_a", "origin": "https://example.com", "stage": "start", "cause": "origin-not-allowed"},
+			[]string{"start", "callback", "redeem"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			spec, ok := Spec(c.typ)
+			if !ok {
+				t.Fatalf("%s is not registered", c.typ)
+			}
+			if got := spec.Schema[c.field].Enum; !slices.Equal(got, c.want) {
+				t.Fatalf("%s field %q enum = %v, want %v", c.typ, c.field, got, c.want)
+			}
+
+			e := Event{
+				ID:            "evt_0198b6de-0000-7000-8000-000000000001",
+				Type:          c.typ,
+				SchemaVersion: 1,
+				OccurredAt:    time.Now().UTC(),
+				Actor:         Actor{Class: ActorSystem},
+				Outcome:       c.outcome,
+				Origin:        OriginSystem,
+				Payload:       c.payload,
+			}
+			if err := Validate(e, c.trail, c.scope); err != nil {
+				t.Fatalf("valid event refused: %v", err)
+			}
+			e.Payload[c.field] = "outside-taxonomy"
+			if err := Validate(e, c.trail, c.scope); err == nil || !strings.Contains(err.Error(), "outside the closed set") {
+				t.Fatalf("invalid %s accepted or returned wrong error: %v", c.field, err)
+			}
+		})
 	}
 }
 

--- a/internal/audit/registry.go
+++ b/internal/audit/registry.go
@@ -794,7 +794,7 @@ var registry = map[EventType]TypeSpec{
 			// never a missing-grant enumeration (authorization oracle).
 			"operation":  {Kind: KindString, Required: true},
 			"formula":    {Kind: KindString, Required: true},
-			"resolution": {Kind: KindString, Required: true}, // resolvable | unresolvable
+			"resolution": {Kind: KindString, Required: true, Enum: []string{"resolvable", "unresolvable"}},
 			// Unresolvable denials only: the addressed identifiers as
 			// caller-asserted claims — no chain exists, so none is recorded.
 			"claimed_org":     {Kind: KindFreeText},
@@ -837,10 +837,10 @@ var registry = map[EventType]TypeSpec{
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
 			"method":           {Kind: KindString, Required: true}, // local-password | …
-			"artifact":         {Kind: KindString, Required: true}, // cli | browser
+			"artifact":         {Kind: KindString, Required: true, Enum: []string{"cli", "browser"}},
 			"subject_resolved": {Kind: KindBool, Required: true},
 			"account_id":       {Kind: KindString},
-			"assurance":        {Kind: KindString}, // single-factor | multi-factor
+			"assurance":        {Kind: KindString, Enum: []string{"single-factor", "multi-factor"}},
 			"cause":            {Kind: KindString}, // failures only, by class never by detail
 		},
 	},
@@ -886,8 +886,8 @@ var registry = map[EventType]TypeSpec{
 		Schema: Schema{
 			"authority_id": {Kind: KindString, Required: true},
 			"account_id":   {Kind: KindString, Required: true},
-			"issued_by":    {Kind: KindString, Required: true}, // bootstrap | credential-reset | break-glass | recovery
-			"delivery":     {Kind: KindString, Required: true}, // file | terminal | response
+			"issued_by":    {Kind: KindString, Required: true, Enum: []string{"bootstrap", "credential-reset", "break-glass", "recovery"}},
+			"delivery":     {Kind: KindString, Required: true, Enum: []string{"file", "terminal", "stdout", "response"}},
 		},
 	},
 	EventAuthCredentialEstablished: {
@@ -919,7 +919,7 @@ var registry = map[EventType]TypeSpec{
 		Outcomes:      map[Outcome]bool{OutcomeFailure: true},
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
-			"scope":            {Kind: KindString, Required: true}, // account | source-ip | instance
+			"scope":            {Kind: KindString, Required: true, Enum: []string{"account", "source-ip", "instance"}},
 			"subject_resolved": {Kind: KindBool, Required: true},
 			"account_id":       {Kind: KindString},
 		},
@@ -1039,9 +1039,9 @@ var registry = map[EventType]TypeSpec{
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
 			"method":               {Kind: KindString, Required: true}, // oidc:<issuer>
-			"purpose":              {Kind: KindString, Required: true}, // login | reauth
+			"purpose":              {Kind: KindString, Required: true, Enum: []string{"login", "reauth"}},
 			"account_id":           {Kind: KindString, Required: true},
-			"assurance":            {Kind: KindString, Required: true}, // single-factor | multi-factor
+			"assurance":            {Kind: KindString, Required: true, Enum: []string{"single-factor", "multi-factor"}},
 			"provider_id":          {Kind: KindString, Required: true},
 			"acr":                  {Kind: KindString},              // provider-asserted, raw (A12)
 			"amr":                  {Kind: KindString},              // provider-asserted, raw joined (A12)
@@ -1054,11 +1054,12 @@ var registry = map[EventType]TypeSpec{
 		Outcomes:      map[Outcome]bool{OutcomeFailure: true},
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
-			// Closed cause enum, by class never by detail: mixup | nonce |
-			// purpose | state | issuer | audience | signature | epoch |
-			// idp-error | expired | unknown-identity | no-assurance-policy |
-			// no-auth-time | binding | jit-refused | reconciliation.
-			"cause":       {Kind: KindString, Required: true},
+			// Closed cause enum, by class never by detail.
+			"cause": {Kind: KindString, Required: true, Enum: []string{
+				"mixup", "nonce", "purpose", "state", "issuer", "audience", "signature", "epoch",
+				"idp-error", "expired", "unknown-identity", "no-assurance-policy", "no-auth-time", "binding",
+				"jit-refused", "reconciliation", "window-zero", "no-possession", "downgrade",
+			}},
 			"provider_id": {Kind: KindString},
 		},
 	},
@@ -1105,8 +1106,8 @@ var registry = map[EventType]TypeSpec{
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
 			"provider_id":    {Kind: KindString, Required: true},
-			"change":         {Kind: KindString, Required: true}, // created | updated | deleted
-			"sessions_swept": {Kind: KindInt, Required: true},    // federated sessions deleted (A3/A4)
+			"change":         {Kind: KindString, Required: true, Enum: []string{"created", "updated", "deleted"}},
+			"sessions_swept": {Kind: KindInt, Required: true}, // federated sessions deleted (A3/A4)
 		},
 	},
 	EventOIDCProviderRead: {
@@ -1115,7 +1116,7 @@ var registry = map[EventType]TypeSpec{
 		Outcomes:      map[Outcome]bool{OutcomeSuccess: true},
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
-			"query":     {Kind: KindString, Required: true}, // get | list
+			"query":     {Kind: KindString, Required: true, Enum: []string{"get", "list"}},
 			"row_count": {Kind: KindInt, Required: true},
 		},
 	},
@@ -1181,13 +1182,13 @@ var registry = map[EventType]TypeSpec{
 		Trails:   map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
 			"target_principal": {Kind: KindString, Required: true},
-			"issued_by":        {Kind: KindString, Required: true}, // credential-reset | break-glass
-			"authority":        {Kind: KindString, Required: true}, // network | local-host
-			"target_account":   {Kind: KindString},                 // absent for an unknown-target failure
-			"authority_id":     {Kind: KindString},                 // success only
-			"delivery":         {Kind: KindString},                 // success only
-			"sessions_revoked": {Kind: KindBool},                   // success only
-			"cause":            {Kind: KindString},                 // failures only, by class
+			"issued_by":        {Kind: KindString, Required: true, Enum: []string{"credential-reset", "break-glass"}},
+			"authority":        {Kind: KindString, Required: true, Enum: []string{"network", "local-host"}},
+			"target_account":   {Kind: KindString}, // absent for an unknown-target failure
+			"authority_id":     {Kind: KindString}, // success only
+			"delivery":         {Kind: KindString}, // success only
+			"sessions_revoked": {Kind: KindBool},   // success only
+			"cause":            {Kind: KindString}, // failures only, by class
 		},
 	},
 	EventAuthEffectiveWindowLowered: {
@@ -1212,7 +1213,7 @@ var registry = map[EventType]TypeSpec{
 		Outcomes:      map[Outcome]bool{OutcomeSuccess: true},
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
-			"query":     {Kind: KindString, Required: true}, // get | list
+			"query":     {Kind: KindString, Required: true, Enum: []string{"get", "list", "count"}},
 			"row_count": {Kind: KindInt, Required: true},
 		},
 	},
@@ -2216,7 +2217,7 @@ var registry = map[EventType]TypeSpec{
 		Trails:        map[Trail]bool{TrailInstance: true},
 		Schema: Schema{
 			"origin": {Kind: KindString, Required: true},
-			"change": {Kind: KindString, Required: true}, // added | removed
+			"change": {Kind: KindString, Required: true, Enum: []string{"added", "removed"}},
 			// Removal only: the workspace sessions the SAME transaction
 			// killed. A trail recording the config change without its blast
 			// radius would understate a kill switch.
@@ -2281,7 +2282,7 @@ var registry = map[EventType]TypeSpec{
 			// rather than a nullable one nobody fills.
 			"handoff_id": {Kind: KindString, Required: true},
 			"origin":     {Kind: KindString, Required: true},
-			"stage":      {Kind: KindString, Required: true}, // start | callback | redeem
+			"stage":      {Kind: KindString, Required: true, Enum: []string{"start", "callback", "redeem"}},
 			"cause":      {Kind: KindString, Required: true}, // by class, never by detail
 		},
 	},


### PR DESCRIPTION
Closes #338

## Contract

- Sixteen prose-only `KindString` taxonomies now use `FieldSpec.Enum` and refuse unknown values fail-closed.
- Current producer values remain valid, including organization `count`, recovery issuance, `stdout` delivery, and all 19 OIDC refusal causes.
- Open provider-qualified methods and adapter authority principal IDs remain open.
- Event bytes, schema versions, ordering, trails, and dual-dialect behavior are unchanged.

## Decisions and generated outputs

- Database migrations: none.
- Generated outputs: none.
- Contract migration: none; this enforces the existing closed taxonomy.

## Validation

- `rtk go test -count=1 ./internal/audit` — 33 passed.
- Named audit, invariant, and SCIM isolation checks — 85 passed.
- `rtk go test -count=1 ./...` — 3,506 passed across 61 packages.
- `rtk go vet ./...`, gofmt, and diff checks passed.

## Review

- Standards round 2: CLEAN.
- Spec round 2: CLEAN.
- Detailed handoff: `docs/handoff/338-audit-registry-enums.md`.