### PR TITLE
Centralize server handler error reduction #337

### DIFF
--- a/api/apigen/apigen.gen.go
+++ b/api/apigen/apigen.gen.go
@@ -23331,6 +23331,20 @@ func (response PutOidcProvider404JSONResponse) VisitPutOidcProviderResponse(w ht
 	return err
 }
 
+type PutOidcProvider409JSONResponse struct{ ConflictJSONResponse }
+
+func (response PutOidcProvider409JSONResponse) VisitPutOidcProviderResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type PutOidcProvider429JSONResponse struct{ TooManyRequestsJSONResponse }
 
 func (response PutOidcProvider429JSONResponse) VisitPutOidcProviderResponse(w http.ResponseWriter) error {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4432,6 +4432,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":

--- a/clients/ts/src/generated/types.gen.ts
+++ b/clients/ts/src/generated/types.gen.ts
@@ -11322,6 +11322,15 @@ export type PutOidcProviderErrors = {
      */
     404: Error;
     /**
+     * The caller is authorized, but the current state refuses: a name already
+     * in use among live siblings, a parent that still has children (deletes
+     * never cascade), or a structural bound reached (`limit_exceeded`, whose
+     * message names the bound). Decided after authorization, so it discloses
+     * nothing a caller could not already read.
+     *
+     */
+    409: Error;
+    /**
      * The instance-wide admission budget or a per-source limit is
      * exhausted. Uniform on every path, with no unbounded work performed.
      *

--- a/docs/handoff/337-central-server-error-reduction.md
+++ b/docs/handoff/337-central-server-error-reduction.md
@@ -1,0 +1,34 @@
+# Handoff: #337 central server error reduction
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/337 (parent #326; audit finding
+`F-S14-1`, including `F-S13-1`). Implementation base:
+`3b342e5a657f8a9d75cfe5d973a89eb23d28f0a2`.
+
+## Contract
+
+- Service errors from the migrated TOTP, recovery, CLI reauthentication,
+  WebAuthn, OIDC, and SAML handlers return to the strict-server response error
+  hook. `writeHandlerError` is their sole error-to-wire reducer and sole fault
+  logger.
+- Intentional operation-specific behavior remains local: reset uniformity;
+  SAML/OIDC pre-auth and callback handling; WebAuthn login and precondition
+  collapse; reauth-TOTP's not-found-to-unauthenticated rule; and workspace
+  handoff lookup policy.
+- Password-policy sentinels carry caller-safe `password` detail, preserving the
+  credential-establishment response bytes without handler classification.
+- OIDC provider update races are central conflicts. The `putOidcProvider`
+  contract now declares `409`; no database migration is required.
+
+## Coverage
+
+- HTTP regression: a machine credential whose account lookup is not found gets
+  contract-valid `404` from `listPasskeys`, with no fault log.
+- Central policy tests validate migrated TOTP/recovery and OIDC sentinel
+  responses against OpenAPI, pin empty TOTP detail, compare SAML conflict bytes,
+  and preserve password detail.
+- Generated outputs: `api/apigen/apigen.gen.go` and
+  `clients/ts/src/generated/types.gen.ts`, regenerated from
+  `api/openapi.yaml` through their owning generators.
+- Local validation: focused server/service/API tests passed; web TypeScript and
+  310 Vitest tests passed; generated client verification passed 13/13; `go vet
+  ./...` passed; full Go passed 3,501 tests across 61 packages.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -249,19 +249,10 @@ func (a *API) LocalLogin(ctx context.Context, req apigen.LocalLoginRequestObject
 }
 
 func (a *API) EstablishCredential(ctx context.Context, req apigen.EstablishCredentialRequestObject) (apigen.EstablishCredentialResponseObject, error) {
-	err := a.Auth.EstablishCredential(ctx, req.Body.Authority, req.Body.Password)
-	switch {
-	case err == nil:
-		return apigen.EstablishCredential204Response{}, nil
-	case passwordPrecondition(err):
-		// The one loud refusal on this path: it is the caller's own input,
-		// evaluated before anything is looked up, so naming the rule helps
-		// the human and reveals nothing.
-		return apigen.EstablishCredential400JSONResponse{
-			BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "password")),
-		}, nil
+	if err := a.Auth.EstablishCredential(ctx, req.Body.Authority, req.Body.Password); err != nil {
+		return nil, err
 	}
-	return nil, err
+	return apigen.EstablishCredential204Response{}, nil
 }
 
 func (a *API) Whoami(ctx context.Context, _ apigen.WhoamiRequestObject) (apigen.WhoamiResponseObject, error) {
@@ -316,11 +307,6 @@ func (a *API) Logout(ctx context.Context, _ apigen.LogoutRequestObject) (apigen.
 func (a *API) EnrolTotpStart(ctx context.Context, req apigen.EnrolTotpStartRequestObject) (apigen.EnrolTotpStartResponseObject, error) {
 	uri, err := a.Auth.EnrolTOTPStart(ctx, bearer(ctx), req.Body.Password)
 	if err != nil {
-		if factorPrecondition(err) {
-			return apigen.EnrolTotpStart400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
-		}
 		return nil, err
 	}
 	return apigen.EnrolTotpStart200JSONResponse{OtpauthUri: uri}, nil
@@ -329,11 +315,6 @@ func (a *API) EnrolTotpStart(ctx context.Context, req apigen.EnrolTotpStartReque
 func (a *API) EnrolTotpConfirm(ctx context.Context, req apigen.EnrolTotpConfirmRequestObject) (apigen.EnrolTotpConfirmResponseObject, error) {
 	result, err := a.Auth.EnrolTOTPConfirm(ctx, bearer(ctx), req.Body.Code)
 	if err != nil {
-		if factorPrecondition(err) {
-			return apigen.EnrolTotpConfirm400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
-		}
 		return nil, err
 	}
 	return sessionResponse(result), nil
@@ -342,11 +323,6 @@ func (a *API) EnrolTotpConfirm(ctx context.Context, req apigen.EnrolTotpConfirmR
 func (a *API) StepUpTotp(ctx context.Context, req apigen.StepUpTotpRequestObject) (apigen.StepUpTotpResponseObject, error) {
 	result, err := a.Auth.StepUpTOTP(ctx, bearer(ctx), req.Body.Code)
 	if err != nil {
-		if factorPrecondition(err) {
-			return apigen.StepUpTotp400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
-		}
 		return nil, err
 	}
 	return sessionResponse(result), nil
@@ -355,11 +331,6 @@ func (a *API) StepUpTotp(ctx context.Context, req apigen.StepUpTotpRequestObject
 func (a *API) RemoveTotp(ctx context.Context, req apigen.RemoveTotpRequestObject) (apigen.RemoveTotpResponseObject, error) {
 	result, err := a.Auth.RemoveTOTP(ctx, bearer(ctx), req.Body.Password)
 	if err != nil {
-		if factorPrecondition(err) {
-			return apigen.RemoveTotp400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
-		}
 		return nil, err
 	}
 	return sessionResponse(result), nil
@@ -370,15 +341,7 @@ func (a *API) RemoveTotp(ctx context.Context, req apigen.RemoveTotpRequestObject
 func (a *API) GetTotpStatus(ctx context.Context, _ apigen.GetTotpStatusRequestObject) (apigen.GetTotpStatusResponseObject, error) {
 	status, err := a.Auth.TOTPStatus(ctx, bearer(ctx))
 	if err != nil {
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.GetTotpStatus401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.GetTotpStatus429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "get totp status", err)
-			return apigen.GetTotpStatus500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return apigen.GetTotpStatus200JSONResponse(apigen.TotpStatus{
 		Confirmed: status.Confirmed,
@@ -389,11 +352,6 @@ func (a *API) GetTotpStatus(ctx context.Context, _ apigen.GetTotpStatusRequestOb
 func (a *API) RegenerateRecoveryCodes(ctx context.Context, req apigen.RegenerateRecoveryCodesRequestObject) (apigen.RegenerateRecoveryCodesResponseObject, error) {
 	codes, result, err := a.Auth.GenerateRecoveryCodes(ctx, bearer(ctx), req.Body.Proof)
 	if err != nil {
-		if factorPrecondition(err) {
-			return apigen.RegenerateRecoveryCodes400JSONResponse{
-				BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, "")),
-			}, nil
-		}
 		return nil, err
 	}
 	resp := recoveryCodesResponse{body: apigen.RecoveryCodesResult{
@@ -409,13 +367,6 @@ func (a *API) RegenerateRecoveryCodes(ctx context.Context, req apigen.Regenerate
 func (a *API) BeginRecovery(ctx context.Context, req apigen.BeginRecoveryRequestObject) (apigen.BeginRecoveryResponseObject, error) {
 	result, err := a.Auth.ConsumeRecoveryCode(ctx, req.Body.Username, req.Body.Code)
 	if err != nil {
-		// The passkey-only floor refusal (A1): consuming the last code on a
-		// passwordless account is refused loudly. Only a caller holding a VALID
-		// code reaches it, so naming the structural state reveals nothing an
-		// enumerator could not already learn — and the refusal is non-destructive.
-		if recoveryPrecondition(err) {
-			return apigen.BeginRecovery400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
-		}
 		return nil, err
 	}
 	return apigen.BeginRecovery200JSONResponse{

--- a/internal/server/cli_reauth.go
+++ b/internal/server/cli_reauth.go
@@ -50,9 +50,6 @@ func (a *API) StartCLIReauth(ctx context.Context, req apigen.StartCLIReauthReque
 func (a *API) ShowCLIReauthTransaction(ctx context.Context, req apigen.ShowCLIReauthTransactionRequestObject) (apigen.ShowCLIReauthTransactionResponseObject, error) {
 	result, err := a.Auth.CLIReauthTransaction(ctx, service.Bearer(bearer(ctx)), req.State)
 	if err != nil {
-		if wireErrorFor(err).code == apigen.ErrorCodeConflict {
-			return apigen.ShowCLIReauthTransaction409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-		}
 		return nil, err
 	}
 	environments := make([]apigen.CLIReauthEnvironmentPolicy, 0, len(result.Environments))
@@ -69,9 +66,6 @@ func (a *API) ShowCLIReauthTransaction(ctx context.Context, req apigen.ShowCLIRe
 func (a *API) ApproveCLIReauth(ctx context.Context, req apigen.ApproveCLIReauthRequestObject) (apigen.ApproveCLIReauthResponseObject, error) {
 	approved, err := a.Auth.ApproveCLIReauth(ctx, service.Bearer(bearer(ctx)), req.Body.State)
 	if err != nil {
-		if wireErrorFor(err).code == apigen.ErrorCodeConflict {
-			return apigen.ApproveCLIReauth409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-		}
 		return nil, err
 	}
 	return apigen.ApproveCLIReauth200JSONResponse{Code: approved.Code, State: approved.State, RedirectUri: approved.RedirectURI}, nil
@@ -80,12 +74,6 @@ func (a *API) ApproveCLIReauth(ctx context.Context, req apigen.ApproveCLIReauthR
 func (a *API) RedeemCLIReauth(ctx context.Context, req apigen.RedeemCLIReauthRequestObject) (apigen.RedeemCLIReauthResponseObject, error) {
 	result, err := a.Auth.RedeemCLIReauth(ctx, req.Body.Code, req.Body.PkceVerifier)
 	if err != nil {
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeConflict:
-			return apigen.RedeemCLIReauth409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.RedeemCLIReauth401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		}
 		return nil, err
 	}
 	windows := make([]apigen.ReauthResult, 0, len(result.Windows))

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -52,8 +53,14 @@ type cliReauthAuth struct{ stubAuth }
 
 type emptyAccountReads struct{ stubAuth }
 
+type missingPasskeyAccount struct{ stubAuth }
+
 func (emptyAccountReads) ListIdentities(context.Context, string) ([]service.ExternalIdentityView, error) {
 	return nil, nil
+}
+
+func (missingPasskeyAccount) ListPasskeys(context.Context, string) ([]service.PasskeyView, error) {
+	return nil, domain.ErrNotFound
 }
 
 func (cliReauthAuth) StartCLIReauth(context.Context, string, service.ReauthIntent, string, string) (service.CLIReauthStart, error) {
@@ -510,6 +517,24 @@ func callNoRedirect(t *testing.T, srv *httptest.Server, path string, cookies ...
 		t.Fatalf("GET %s -> %d: response violates contract: %v", path, resp.StatusCode, err)
 	}
 	return resp
+}
+
+func TestListPasskeysMachineCredentialNotFoundUsesCentralWirePolicy(t *testing.T) {
+	var logs bytes.Buffer
+	srv := httptest.NewServer(server.New(stubReady{}, &server.API{
+		Auth: missingPasskeyAccount{}, Orgs: stubOrgs{}, Providers: stubProviders{}, Version: "test",
+		Projects: stubHierarchy{}, Environments: stubEnvs{}, Values: stubValues{}, Folders: stubFolders{},
+		Log: slog.New(slog.NewJSONHandler(&logs, nil)),
+	}, nil))
+	t.Cleanup(srv.Close)
+
+	resp, payload := call(t, srv, http.MethodGet, "/api/v1/auth/webauthn/credentials", "hik_1_mc_machine", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", resp.StatusCode, payload)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("routine not-found logged as fault: %s", logs.String())
+	}
 }
 
 func TestOIDCBrowserStartAndCallbackRedirect(t *testing.T) {

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -267,25 +267,6 @@ func workspaceHandoffLookupWireErrorFor(err error) WireError {
 	return wireErrorFor(err)
 }
 
-// The helpers below identify the few endpoint-specific precondition families
-// whose timing or enumeration contract deliberately collapses only a subset of
-// otherwise-recognized classes. Keeping the membership here leaves handlers to
-// adapt a decided WireError to generated response types, not classify causes.
-func passwordPrecondition(err error) bool {
-	return errors.Is(err, service.ErrWeakPassword) || errors.Is(err, service.ErrCommonPassword)
-}
-
-func factorPrecondition(err error) bool {
-	return errors.Is(err, service.ErrTOTPAlreadyEnrolled) ||
-		errors.Is(err, service.ErrNoPendingTOTP) ||
-		errors.Is(err, service.ErrNoTOTPFactor) ||
-		errors.Is(err, service.ErrNoProofCredential)
-}
-
-func recoveryPrecondition(err error) bool {
-	return errors.Is(err, service.ErrPasskeyOnlyViolation)
-}
-
 func webauthnPrecondition(err error) bool {
 	return errors.Is(err, service.ErrWebAuthnUnavailable) ||
 		errors.Is(err, service.ErrNoWebAuthnCeremony) ||

--- a/internal/server/errors_internal_test.go
+++ b/internal/server/errors_internal_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/api"
@@ -133,5 +135,77 @@ func TestWirePolicyRedactsDetailUnlessExplicitlyAllowed(t *testing.T) {
 				t.Fatalf("detail = %q, want redacted", *body.Error.Detail)
 			}
 		})
+	}
+}
+
+func renderContractError(t *testing.T, method, path string, err error) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(method, path, nil)
+	(&API{}).writeHandlerError(recorder, request, err)
+	response := recorder.Result()
+	if validationErr := api.ValidateResponse(request, response.StatusCode, response.Header, recorder.Body.Bytes()); validationErr != nil {
+		t.Fatalf("%s %s -> %d violates contract: %v\nbody: %s", method, path, response.StatusCode, validationErr, recorder.Body.String())
+	}
+	return recorder
+}
+
+func TestCentralWirePoliciesFitMigratedOperationContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		err    error
+	}{
+		{"TOTP already enrolled", http.MethodPost, "/api/v1/auth/totp/enrol/start", service.ErrTOTPAlreadyEnrolled},
+		{"no pending TOTP", http.MethodPost, "/api/v1/auth/totp/enrol/confirm", service.ErrNoPendingTOTP},
+		{"no TOTP factor", http.MethodPost, "/api/v1/auth/totp/step-up", service.ErrNoTOTPFactor},
+		{"no proof credential", http.MethodDelete, "/api/v1/auth/totp", service.ErrNoProofCredential},
+		{"passkey-only recovery floor", http.MethodPost, "/api/v1/auth/recovery/begin", service.ErrPasskeyOnlyViolation},
+		{"TOTP account missing", http.MethodGet, "/api/v1/auth/totp", domain.ErrNotFound},
+		{"TOTP status overloaded", http.MethodGet, "/api/v1/auth/totp", admission.ErrOverloaded},
+		{"OIDC provider update raced", http.MethodPut, "/api/v1/instance/oidc-providers/corp", service.ErrProviderRace},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := wireErrorFor(tc.err)
+			recorder := renderContractError(t, tc.method, tc.path, tc.err)
+			if recorder.Code != wirePolicies[policy.code].status {
+				t.Fatalf("status = %d, want central %d for %q", recorder.Code, wirePolicies[policy.code].status, policy.code)
+			}
+			if policy.code == apigen.ErrorCodeBadRequest {
+				var body apigen.Error
+				if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+					t.Fatal(err)
+				}
+				if body.Error.Detail != nil {
+					t.Fatalf("routine TOTP refusal leaked detail %q", *body.Error.Detail)
+				}
+			}
+		})
+	}
+}
+
+func TestCentralConflictBodyIsIdenticalAcrossSAMLHandlers(t *testing.T) {
+	provider := renderContractError(t, http.MethodPut, "/api/v1/instance/saml-providers/corp", service.ErrSAMLProviderRace)
+	spKey := renderContractError(t, http.MethodPost, "/api/v1/instance/saml-sp-keys/rotate", service.ErrSAMLSPKeyRace)
+	if provider.Code != http.StatusConflict || spKey.Code != http.StatusConflict {
+		t.Fatalf("statuses = provider %d, SP key %d; want both 409", provider.Code, spKey.Code)
+	}
+	if provider.Body.String() != spKey.Body.String() {
+		t.Fatalf("conflict bodies differ:\nprovider: %s\nSP key: %s", provider.Body.String(), spKey.Body.String())
+	}
+}
+
+func TestPasswordPolicySentinelsCarryEstablishmentDetail(t *testing.T) {
+	for _, refusal := range []error{service.ErrWeakPassword, service.ErrCommonPassword} {
+		recorder := renderContractError(t, http.MethodPost, "/api/v1/auth/credential/establish", refusal)
+		var body apigen.Error
+		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Error.Detail == nil || *body.Error.Detail != "password" {
+			t.Fatalf("%v detail = %v, want password", refusal, body.Error.Detail)
+		}
 	}
 }

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -210,11 +210,7 @@ func (r oidcLinkStartResponse) VisitLinkIdentityResponse(w http.ResponseWriter) 
 func (a *API) ListIdentities(ctx context.Context, _ apigen.ListIdentitiesRequestObject) (apigen.ListIdentitiesResponseObject, error) {
 	rows, err := a.Auth.ListIdentities(ctx, bearer(ctx))
 	if err != nil {
-		if wireErrorFor(err).code == apigen.ErrorCodeUnauthenticated {
-			return apigen.ListIdentities401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		}
-		a.fault(ctx, "list identities", err)
-		return apigen.ListIdentities500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
+		return nil, err
 	}
 	out := apigen.IdentityList{Identities: make([]apigen.ExternalIdentity, 0, len(rows))}
 	for _, r := range rows {
@@ -233,20 +229,7 @@ func (a *API) LinkIdentity(ctx context.Context, req apigen.LinkIdentityRequestOb
 	browser := req.Body.Browser != nil && *req.Body.Browser
 	result, err := a.Auth.OIDCStart(ctx, req.Body.Provider, "link", "", bearer(ctx), req.Body.Proof, browser)
 	if err != nil {
-		policy := wireErrorFor(err)
-		switch policy.code {
-		case apigen.ErrorCodeNotFound:
-			return apigen.LinkIdentity404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeBadRequest:
-			return apigen.LinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.LinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.LinkIdentity429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "link identity", err)
-			return apigen.LinkIdentity500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	response := oidcLinkStartResponse{body: apigen.OidcStartResult{AuthorizationUrl: result.AuthURL}}
 	if browser {
@@ -261,18 +244,7 @@ func (a *API) UnlinkIdentity(ctx context.Context, req apigen.UnlinkIdentityReque
 	}
 	result, err := a.Auth.UnlinkIdentity(ctx, bearer(ctx), string(req.Id), req.Body.Proof)
 	if err != nil {
-		policy := wireErrorFor(err)
-		switch policy.code {
-		case apigen.ErrorCodeBadRequest:
-			return apigen.UnlinkIdentity400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.UnlinkIdentity401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.UnlinkIdentity429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "unlink identity", err)
-			return apigen.UnlinkIdentity500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return sessionResponse(result), nil
 }
@@ -292,7 +264,7 @@ func providerViewWire(v service.ProviderView) apigen.OidcProvider {
 func (a *API) ListOidcProviders(ctx context.Context, _ apigen.ListOidcProvidersRequestObject) (apigen.ListOidcProvidersResponseObject, error) {
 	rows, err := a.Providers.List(ctx, service.Bearer(bearer(ctx)))
 	if err != nil {
-		return providerListErr(a, ctx, err), nil
+		return nil, err
 	}
 	out := apigen.OidcProviderList{}
 	for _, v := range rows {
@@ -301,37 +273,10 @@ func (a *API) ListOidcProviders(ctx context.Context, _ apigen.ListOidcProvidersR
 	return apigen.ListOidcProviders200JSONResponse(out), nil
 }
 
-func providerListErr(a *API, ctx context.Context, err error) apigen.ListOidcProvidersResponseObject {
-	switch wireErrorFor(err).code {
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.ListOidcProviders401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}
-	case apigen.ErrorCodeForbidden:
-		return apigen.ListOidcProviders403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.ListOidcProviders429JSONResponse{TooManyRequestsJSONResponse: tooMany()}
-	default:
-		a.fault(ctx, "list oidc providers", err)
-		return apigen.ListOidcProviders500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}
-	}
-}
-
 func (a *API) GetOidcProvider(ctx context.Context, req apigen.GetOidcProviderRequestObject) (apigen.GetOidcProviderResponseObject, error) {
 	v, err := a.Providers.Get(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
 	if err != nil {
-		policy := wireErrorFor(err)
-		switch policy.code {
-		case apigen.ErrorCodeNotFound:
-			return apigen.GetOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.GetOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeForbidden:
-			return apigen.GetOidcProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.GetOidcProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "get oidc provider", err)
-			return apigen.GetOidcProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return apigen.GetOidcProvider200JSONResponse(providerViewWire(v)), nil
 }
@@ -347,43 +292,17 @@ func (a *API) PutOidcProvider(ctx context.Context, req apigen.PutOidcProviderReq
 	}
 	v, err := a.Providers.Put(ctx, service.Bearer(bearer(ctx)), string(req.Slug), in)
 	if err != nil {
-		policy := wireErrorFor(err)
-		switch policy.code {
-		case apigen.ErrorCodeBadRequest:
-			return apigen.PutOidcProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.PutOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeForbidden:
-			return apigen.PutOidcProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.PutOidcProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "put oidc provider", err)
-			return apigen.PutOidcProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return apigen.PutOidcProvider200JSONResponse(providerViewWire(v)), nil
 }
 
 func (a *API) DeleteOidcProvider(ctx context.Context, req apigen.DeleteOidcProviderRequestObject) (apigen.DeleteOidcProviderResponseObject, error) {
 	err := a.Providers.Delete(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
-	switch policy := wireErrorFor(err); {
-	case err == nil:
-		return apigen.DeleteOidcProvider204Response{}, nil
-	case policy.code == apigen.ErrorCodeNotFound:
-		return apigen.DeleteOidcProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
+	if err != nil {
+		return nil, err
 	}
-	switch wireErrorFor(err).code {
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.DeleteOidcProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.DeleteOidcProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.DeleteOidcProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "delete oidc provider", err)
-		return apigen.DeleteOidcProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.DeleteOidcProvider204Response{}, nil
 }
 
 func strDeref(p *string) string {

--- a/internal/server/saml.go
+++ b/internal/server/saml.go
@@ -139,21 +139,12 @@ func (a *API) SamlACS(ctx context.Context, req apigen.SamlACSRequestObject) (api
 
 func (a *API) SamlMetadata(ctx context.Context, req apigen.SamlMetadataRequestObject) (apigen.SamlMetadataResponseObject, error) {
 	payload, err := a.SAMLAuth.SAMLMetadata(ctx, string(req.Provider))
-	if err == nil {
-		return apigen.SamlMetadata200ApplicationsamlmetadataXmlResponse{
-			Body: bytes.NewReader(payload), ContentLength: int64(len(payload)),
-		}, nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.SamlMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.SamlMetadata429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "saml metadata", err)
-		return apigen.SamlMetadata500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.SamlMetadata200ApplicationsamlmetadataXmlResponse{
+		Body: bytes.NewReader(payload), ContentLength: int64(len(payload)),
+	}, nil
 }
 
 func samlACSPath(provider string) string {
@@ -211,109 +202,44 @@ func samlSPKeyWire(key service.SAMLSPKeyView) apigen.SamlSpKey {
 
 func (a *API) ListSamlSpKeys(ctx context.Context, _ apigen.ListSamlSpKeysRequestObject) (apigen.ListSamlSpKeysResponseObject, error) {
 	keys, err := a.SAMLProviders.ListSPKeys(ctx, service.Bearer(bearer(ctx)))
-	if err == nil {
-		out := apigen.SamlSpKeyList{Keys: make([]apigen.SamlSpKey, 0, len(keys))}
-		for _, key := range keys {
-			out.Keys = append(out.Keys, samlSPKeyWire(key))
-		}
-		return apigen.ListSamlSpKeys200JSONResponse(out), nil
+	if err != nil {
+		return nil, err
 	}
-	switch wireErrorFor(err).code {
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.ListSamlSpKeys401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.ListSamlSpKeys403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.ListSamlSpKeys429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "list saml sp keys", err)
-		return apigen.ListSamlSpKeys500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
+	out := apigen.SamlSpKeyList{Keys: make([]apigen.SamlSpKey, 0, len(keys))}
+	for _, key := range keys {
+		out.Keys = append(out.Keys, samlSPKeyWire(key))
 	}
+	return apigen.ListSamlSpKeys200JSONResponse(out), nil
 }
 
 func (a *API) RotateSamlSpKey(ctx context.Context, _ apigen.RotateSamlSpKeyRequestObject) (apigen.RotateSamlSpKeyResponseObject, error) {
 	key, err := a.SAMLProviders.RotateSPKey(ctx, service.Bearer(bearer(ctx)))
-	if err == nil {
-		return apigen.RotateSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.RotateSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.RotateSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.RotateSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.RotateSamlSpKey403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.RotateSamlSpKey429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "rotate saml sp key", err)
-		return apigen.RotateSamlSpKey500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.RotateSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
 }
 
 func (a *API) RetireSamlSpKey(ctx context.Context, req apigen.RetireSamlSpKeyRequestObject) (apigen.RetireSamlSpKeyResponseObject, error) {
 	err := a.SAMLProviders.RetireSPKey(ctx, service.Bearer(bearer(ctx)), req.Fingerprint)
-	if err == nil {
-		return apigen.RetireSamlSpKey204Response{}, nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.RetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.RetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.RetireSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.RetireSamlSpKey403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.RetireSamlSpKey429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "retire saml sp key", err)
-		return apigen.RetireSamlSpKey500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.RetireSamlSpKey204Response{}, nil
 }
 
 func (a *API) CompromiseRetireSamlSpKey(ctx context.Context, req apigen.CompromiseRetireSamlSpKeyRequestObject) (apigen.CompromiseRetireSamlSpKeyResponseObject, error) {
 	key, err := a.SAMLProviders.CompromiseRetireSPKey(ctx, service.Bearer(bearer(ctx)), req.Fingerprint)
-	if err == nil {
-		return apigen.CompromiseRetireSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.CompromiseRetireSamlSpKey404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.CompromiseRetireSamlSpKey409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.CompromiseRetireSamlSpKey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.CompromiseRetireSamlSpKey403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.CompromiseRetireSamlSpKey429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "compromise retire saml sp key", err)
-		return apigen.CompromiseRetireSamlSpKey500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.CompromiseRetireSamlSpKey200JSONResponse(samlSPKeyWire(key)), nil
 }
 
 func (a *API) ListSamlProviders(ctx context.Context, _ apigen.ListSamlProvidersRequestObject) (apigen.ListSamlProvidersResponseObject, error) {
 	rows, err := a.SAMLProviders.List(ctx, service.Bearer(bearer(ctx)))
 	if err != nil {
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.ListSamlProviders401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeForbidden:
-			return apigen.ListSamlProviders403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.ListSamlProviders429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "list saml providers", err)
-			return apigen.ListSamlProviders500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	out := apigen.SamlProviderList{Providers: make([]apigen.SamlProvider, 0, len(rows))}
 	for _, row := range rows {
@@ -324,23 +250,10 @@ func (a *API) ListSamlProviders(ctx context.Context, _ apigen.ListSamlProvidersR
 
 func (a *API) GetSamlProvider(ctx context.Context, req apigen.GetSamlProviderRequestObject) (apigen.GetSamlProviderResponseObject, error) {
 	view, err := a.SAMLProviders.Get(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
-	if err == nil {
-		return apigen.GetSamlProvider200JSONResponse(samlProviderWire(view)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.GetSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.GetSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.GetSamlProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.GetSamlProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "get saml provider", err)
-		return apigen.GetSamlProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.GetSamlProvider200JSONResponse(samlProviderWire(view)), nil
 }
 
 func (a *API) PutSamlProvider(ctx context.Context, req apigen.PutSamlProviderRequestObject) (apigen.PutSamlProviderResponseObject, error) {
@@ -358,25 +271,10 @@ func (a *API) PutSamlProvider(ctx context.Context, req apigen.PutSamlProviderReq
 		ForceSignRequests: req.Body.ForceSignRequests, Enabled: req.Body.Enabled,
 		ConfirmedFingerprints: sliceDeref(req.Body.ConfirmedFingerprints), ConfirmedEndpoints: sliceDeref(req.Body.ConfirmedEndpoints),
 	})
-	if err == nil {
-		return apigen.PutSamlProvider200JSONResponse(samlMutationWire(result)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeBadRequest:
-		return apigen.PutSamlProvider400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.PutSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.PutSamlProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.PutSamlProvider409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.PutSamlProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "put saml provider", err)
-		return apigen.PutSamlProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.PutSamlProvider200JSONResponse(samlMutationWire(result)), nil
 }
 
 func (a *API) PatchSamlProvider(ctx context.Context, req apigen.PatchSamlProviderRequestObject) (apigen.PatchSamlProviderResponseObject, error) {
@@ -387,46 +285,18 @@ func (a *API) PatchSamlProvider(ctx context.Context, req apigen.PatchSamlProvide
 		DisplayName: req.Body.DisplayName, AssurancePolicy: req.Body.AssurancePolicy,
 		AllowEmailNameID: req.Body.AllowEmailNameid, ForceSignRequests: req.Body.ForceSignRequests, Enabled: req.Body.Enabled,
 	})
-	if err == nil {
-		return apigen.PatchSamlProvider200JSONResponse(samlProviderWire(view)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.PatchSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.PatchSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.PatchSamlProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.PatchSamlProvider409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.PatchSamlProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "patch saml provider", err)
-		return apigen.PatchSamlProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.PatchSamlProvider200JSONResponse(samlProviderWire(view)), nil
 }
 
 func (a *API) DeleteSamlProvider(ctx context.Context, req apigen.DeleteSamlProviderRequestObject) (apigen.DeleteSamlProviderResponseObject, error) {
 	err := a.SAMLProviders.Delete(ctx, service.Bearer(bearer(ctx)), string(req.Slug))
-	if err == nil {
-		return apigen.DeleteSamlProvider204Response{}, nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.DeleteSamlProvider404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.DeleteSamlProvider401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.DeleteSamlProvider403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.DeleteSamlProvider429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "delete saml provider", err)
-		return apigen.DeleteSamlProvider500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.DeleteSamlProvider204Response{}, nil
 }
 
 func (a *API) RefreshSamlProviderMetadata(ctx context.Context, req apigen.RefreshSamlProviderMetadataRequestObject) (apigen.RefreshSamlProviderMetadataResponseObject, error) {
@@ -441,27 +311,10 @@ func (a *API) RefreshSamlProviderMetadata(ctx context.Context, req apigen.Refres
 		MetadataDocument: document, ConfirmedFingerprints: sliceDeref(req.Body.ConfirmedFingerprints),
 		ConfirmedEndpoints: sliceDeref(req.Body.ConfirmedEndpoints),
 	})
-	if err == nil {
-		return apigen.RefreshSamlProviderMetadata200JSONResponse(samlMutationWire(result)), nil
+	if err != nil {
+		return nil, err
 	}
-	policy := wireErrorFor(err)
-	switch policy.code {
-	case apigen.ErrorCodeNotFound:
-		return apigen.RefreshSamlProviderMetadata404JSONResponse{NotFoundJSONResponse: apigen.NotFoundJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeBadRequest:
-		return apigen.RefreshSamlProviderMetadata400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(policy.body(err))}, nil
-	case apigen.ErrorCodeUnauthenticated:
-		return apigen.RefreshSamlProviderMetadata401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-	case apigen.ErrorCodeForbidden:
-		return apigen.RefreshSamlProviderMetadata403JSONResponse{ForbiddenJSONResponse: apigen.ForbiddenJSONResponse(errorBody(apigen.ErrorCodeForbidden, ""))}, nil
-	case apigen.ErrorCodeConflict:
-		return apigen.RefreshSamlProviderMetadata409JSONResponse{ConflictJSONResponse: apigen.ConflictJSONResponse(errorBody(apigen.ErrorCodeConflict, ""))}, nil
-	case apigen.ErrorCodeTooManyRequests:
-		return apigen.RefreshSamlProviderMetadata429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-	default:
-		a.fault(ctx, "refresh saml provider metadata", err)
-		return apigen.RefreshSamlProviderMetadata500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-	}
+	return apigen.RefreshSamlProviderMetadata200JSONResponse(samlMutationWire(result)), nil
 }
 
 func sliceDeref(values *[]string) []string {

--- a/internal/server/webauthn.go
+++ b/internal/server/webauthn.go
@@ -59,15 +59,7 @@ func (a *API) EnrolPasskeyStart(ctx context.Context, req apigen.EnrolPasskeyStar
 		if webauthnPrecondition(err) {
 			return apigen.EnrolPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.EnrolPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.EnrolPasskeyStart429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey enrol start", err)
-			return apigen.EnrolPasskeyStart500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	m, err := webauthnOptions(raw)
 	if err != nil {
@@ -87,15 +79,7 @@ func (a *API) EnrolPasskeyFinish(ctx context.Context, req apigen.EnrolPasskeyFin
 		if webauthnPrecondition(err) {
 			return apigen.EnrolPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.EnrolPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.EnrolPasskeyFinish429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey enrol finish", err)
-			return apigen.EnrolPasskeyFinish500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return sessionResponse(result), nil
 }
@@ -161,15 +145,7 @@ func (a *API) StepUpPasskeyStart(ctx context.Context, _ apigen.StepUpPasskeyStar
 		if webauthnPrecondition(err) {
 			return apigen.StepUpPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.StepUpPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.StepUpPasskeyStart429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey step-up start", err)
-			return apigen.StepUpPasskeyStart500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	m, err := webauthnOptions(raw)
 	if err != nil {
@@ -189,15 +165,7 @@ func (a *API) StepUpPasskeyFinish(ctx context.Context, req apigen.StepUpPasskeyF
 		if webauthnPrecondition(err) {
 			return apigen.StepUpPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.StepUpPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.StepUpPasskeyFinish429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey step-up finish", err)
-			return apigen.StepUpPasskeyFinish500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return sessionResponse(result), nil
 }
@@ -238,15 +206,7 @@ func (a *API) ReauthPasskeyStart(ctx context.Context, req apigen.ReauthPasskeySt
 		if webauthnPrecondition(err) {
 			return apigen.ReauthPasskeyStart400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.ReauthPasskeyStart401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.ReauthPasskeyStart429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey reauth start", err)
-			return apigen.ReauthPasskeyStart500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	m, err := webauthnOptions(raw)
 	if err != nil {
@@ -277,15 +237,7 @@ func (a *API) ReauthPasskeyFinish(ctx context.Context, req apigen.ReauthPasskeyF
 		if webauthnPrecondition(err) {
 			return apigen.ReauthPasskeyFinish400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.ReauthPasskeyFinish401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.ReauthPasskeyFinish429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey reauth finish", err)
-			return apigen.ReauthPasskeyFinish500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	resp := reauthPasskeyResponse{body: apigen.ReauthResult{
 		SessionId:      result.SessionID,
@@ -314,15 +266,7 @@ func (a *API) ReauthPasskeyFinish(ctx context.Context, req apigen.ReauthPasskeyF
 func (a *API) ListPasskeys(ctx context.Context, _ apigen.ListPasskeysRequestObject) (apigen.ListPasskeysResponseObject, error) {
 	rows, err := a.Auth.ListPasskeys(ctx, bearer(ctx))
 	if err != nil {
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.ListPasskeys401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.ListPasskeys429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "list passkeys", err)
-			return apigen.ListPasskeys500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	out := apigen.PasskeyList{Passkeys: make([]apigen.Passkey, 0, len(rows))}
 	for _, r := range rows {
@@ -343,15 +287,7 @@ func (a *API) RemovePasskey(ctx context.Context, req apigen.RemovePasskeyRequest
 		if webauthnPrecondition(err) {
 			return apigen.RemovePasskey400JSONResponse{BadRequestJSONResponse: apigen.BadRequestJSONResponse(errorBody(apigen.ErrorCodeBadRequest, ""))}, nil
 		}
-		switch wireErrorFor(err).code {
-		case apigen.ErrorCodeUnauthenticated:
-			return apigen.RemovePasskey401JSONResponse{UnauthenticatedJSONResponse: apigen.UnauthenticatedJSONResponse(errorBody(apigen.ErrorCodeUnauthenticated, ""))}, nil
-		case apigen.ErrorCodeTooManyRequests:
-			return apigen.RemovePasskey429JSONResponse{TooManyRequestsJSONResponse: tooMany()}, nil
-		default:
-			a.fault(ctx, "passkey remove", err)
-			return apigen.RemovePasskey500JSONResponse{InternalJSONResponse: apigen.InternalJSONResponse(errorBody(apigen.ErrorCodeInternal, ""))}, nil
-		}
+		return nil, err
 	}
 	return sessionResponse(result), nil
 }

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -114,7 +114,7 @@ const (
 
 // ErrWeakPassword is a loud, specific refusal — password policy is evaluated
 // at set time, where naming the rule helps the human and reveals nothing.
-var ErrWeakPassword = fmt.Errorf("password must be at least %d characters", PasswordMinLength)
+var ErrWeakPassword = passwordPolicyError(fmt.Sprintf("password must be at least %d characters", PasswordMinLength))
 
 // ErrCredentialRace reports a verifier row that moved underneath a
 // compare-and-swap. It is loud rather than retried-into-silence: the caller

--- a/internal/service/password_policy.go
+++ b/internal/service/password_policy.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	_ "embed"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -61,7 +60,12 @@ func commonList() map[string]struct{} {
 // floor it is loud and specific: this is the caller's own input, evaluated
 // before anything is looked up, so naming the rule helps the human and
 // reveals nothing about what exists.
-var ErrCommonPassword = errors.New("that password appears in a list of commonly used passwords; choose another")
+var ErrCommonPassword = passwordPolicyError("that password appears in a list of commonly used passwords; choose another")
+
+type passwordPolicyError string
+
+func (e passwordPolicyError) Error() string    { return string(e) }
+func (passwordPolicyError) SafeDetail() string { return "password" }
 
 // CheckPassword applies the whole policy.
 func CheckPassword(password string) error {


### PR DESCRIPTION
Closes #337.

## Contract and migration

- Routes migrated TOTP, recovery, CLI reauthentication, WebAuthn, OIDC, and SAML service errors through the strict server response-error hook.
- Preserves intentional local policies for pre-auth login/callbacks, cookie clearing, WebAuthn preconditions, reauth-TOTP enumeration, reset uniformity, and workspace handoff lookup.
- Preserves credential-establishment `password` detail through `SafeDetail()` on password-policy sentinels.
- Declares the reachable `putOidcProvider` race as contract-valid `409`.
- Database migrations: none.

## Generated outputs

- `api/apigen/apigen.gen.go` from `api/openapi.yaml`.
- `clients/ts/src/generated/types.gen.ts` from the same OpenAPI source.

## Validation

- Named server regressions: 12 passed.
- Server + service packages: 477 passed.
- API package: 90 passed.
- Full Go: 3,501 passed across 61 packages.
- `go vet ./...`: passed.
- TypeScript client verify: 13 passed.
- Web typecheck + Vitest: 310 passed.
- Documentation verification, build, PWA, live-docs, and fallback-channel gates: passed.
- Standards review: CLEAN.
- Spec review: CLEAN.