### PR TITLE
Centralize SCIM release settlement #340

### DIFF
--- a/docs/handoff/340-scim-release-settlement-owner.md
+++ b/docs/handoff/340-scim-release-settlement-owner.md
@@ -1,0 +1,27 @@
+# Handoff: #340 SCIM release settlement owner
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/340 (parent #326; audit finding
+`F-S08-1`). Implementation base:
+`052cc9b23ec325473eae48753102ad04a04b506a`.
+
+## Contract
+
+- `releaseAndSettle` owns SCIM-origin release, session-generation advancement,
+  session sweeping, and lockout-retention attention entry in one transaction.
+- Deprovision and user deletion use `advanceAlways`; every other trigger uses
+  `advanceIfAuthorityChanged`.
+- Release events remain before attention events. Audit payloads, wire contracts,
+  failure behavior, and SQLite/PostgreSQL storage remain unchanged.
+- Mapping deletion and narrowing share one member loop. Narrowing supplies a
+  grant filter; deletion supplies no filter.
+
+## Coverage
+
+- Existing `TestSCIMLockoutAcrossEveryReleasePath{SQLite,Postgres}` covers all
+  six triggers, retention conversion, attention entry, audit order, and cure.
+- Existing deprovision coverage proves zero-delta deprovision still advances.
+- `TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance{SQLite,Postgres}`
+  proves an origin-only narrowing preserves effective grants and sessions.
+- No schema, API, domain, migration, wire, or generated artifact changed.
+- Local validation passed: focused service tests, all named SQLite/PostgreSQL
+  SCIM regressions, and `go test -count=1 ./...`.

--- a/internal/isolation/scim_audit_coverage_test.go
+++ b/internal/isolation/scim_audit_coverage_test.go
@@ -240,6 +240,75 @@ func runSCIMMappingWidenAndNarrow(t *testing.T, db *store.DB) {
 	}
 }
 
+// TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance proves the
+// conditional half of the release settlement policy. Narrowing can release an
+// origin without changing effective authority when another mapping still holds
+// every affected grant row; that must not kill the user's sessions.
+func TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvanceSQLite(t *testing.T) {
+	runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t, seededDB(t, openSQLite))
+}
+
+func TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvancePostgres(t *testing.T) {
+	runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t, seededDB(t, openPostgres))
+}
+
+func runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t *testing.T, db *store.DB) {
+	s := scimSvc(db)
+	ctx := t.Context()
+	bindingID, token := newSCIMBinding(t, db, "narrow-no-delta")
+	wire := service.SCIMCredentialActor(token, bindingID)
+
+	user, err := s.CreateUser(ctx, wire, orgA, bindingID, service.DesiredUser{
+		Active: true, UserName: "narrow-no-delta@example.test",
+		ExternalID: "ext-narrow-no-delta", SubjectRaw: "ext-narrow-no-delta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal := principalOf(t, db, accountOf(t, db, user.ID))
+
+	var narrowed service.SCIMMappingSpec
+	for i, name := range []string{"Primary", "Overlap"} {
+		group, err := s.CreateGroup(ctx, wire, orgA, bindingID, service.DesiredGroup{
+			DisplayName: name, Members: []string{user.ID},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		spec := service.SCIMMappingSpec{
+			GroupID: group.ID, Template: domain.TemplatePublisher, ProjectID: string(prjA1),
+		}
+		if _, err := s.CreateMapping(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, spec); err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			narrowed = spec
+		}
+	}
+
+	generationBefore := queryInt(t, db,
+		`SELECT session_generation FROM principals WHERE id = '`+string(principal)+`'`)
+	narrowed.Template = domain.TemplateViewer
+	result, err := s.UpdateMapping(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, narrowed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.OriginsReleased == 0 {
+		t.Fatal("narrowing must release the first mapping's no-longer-covered origins")
+	}
+	for _, capability := range []domain.Capability{domain.CapEdit, domain.CapPublish, domain.CapPin} {
+		if !held(t, db, principal, capability, domain.Scope{Org: orgA, Project: prjA1}) {
+			t.Fatalf("overlapping mapping must keep %s effective after narrowing", capability)
+		}
+	}
+	generationAfter := queryInt(t, db,
+		`SELECT session_generation FROM principals WHERE id = '`+string(principal)+`'`)
+	if generationAfter != generationBefore {
+		t.Fatalf("origin-only narrowing must not advance the session generation: %d -> %d",
+			generationBefore, generationAfter)
+	}
+}
+
 // TestSCIMLockoutAcrossEveryReleasePath is SC3.i: the lockout family across
 // EVERY trigger — deprovision, member removal, group delete, mapping delete and
 // binding delete — each converting, raising its attention state, emitting the
@@ -388,6 +457,38 @@ func runOneLockoutPath(
 	}
 	if got := auditCount(t, db, "scim.lockout_retention"); got <= entriesBefore {
 		t.Fatalf("%s: the retention must be audited on entry", name)
+	}
+	// The release event precedes attention entry. Binding deletion then clears
+	// that transient state through the audited exit path before removing the
+	// binding, so its sequence has the additional clear event.
+	rawSequence := queryStrings(t, db,
+		`SELECT type || ',' FROM audit_tenant_events WHERE type = 'scim.lockout_retention' OR `+
+			`(type IN ('grant.modified', 'grant.revoked') AND `+
+			`payload LIKE '%"target_principal":"`+string(principal)+`"%') OR `+
+			`(type IN ('scim.attention_entered', 'scim.attention_cleared') AND `+
+			`payload LIKE '%"state":"lockout_retention"%') ORDER BY seq`)
+	sequence := strings.Split(strings.TrimSuffix(rawSequence, ","), ",")
+	lastRelease, entered, cleared := -1, -1, -1
+	modified := false
+	for i, typ := range sequence {
+		switch typ {
+		case "scim.lockout_retention", "grant.modified", "grant.revoked":
+			lastRelease = i
+			modified = modified || typ == "grant.modified"
+		case "scim.attention_entered":
+			entered = i
+		case "scim.attention_cleared":
+			cleared = i
+		}
+	}
+	if !modified || entered <= lastRelease {
+		t.Fatalf("%s: release events must include grant.modified and precede attention entry: %v", name, sequence)
+	}
+	if name == "binding_deleted" && cleared <= entered {
+		t.Fatalf("%s: binding teardown must clear attention after entry: %v", name, sequence)
+	}
+	if name != "binding_deleted" && cleared >= 0 {
+		t.Fatalf("%s: live binding cleared lockout attention during release: %v", name, sequence)
 	}
 
 	// The CURE: the moment the org gains another holder, that same transaction

--- a/internal/service/scim_admin.go
+++ b/internal/service/scim_admin.go
@@ -575,28 +575,15 @@ func (s *SCIM) DeleteBinding(ctx context.Context, actor Actor, org domain.OrgID,
 			if err != nil {
 				return err
 			}
-			outcome, evs, err := releaseSCIMOrigins(ctx, az, now, releaseArgs{
-				binding: id, org: org, principal: principal,
+			outcome, evs, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
+				binding: id, org: org,
 				match: matchBinding(id), cause: domain.CauseBindingDelete,
-			})
+			}, advanceIfAuthorityChanged, now)
 			if err != nil {
 				return err
 			}
 			events = append(events, evs...)
 			releasedOrigins += outcome.Released
-			if outcome.AuthorityChanged() {
-				if err := advanceAndSweep(ctx, az, principal); err != nil {
-					return err
-				}
-			}
-			for _, grantID := range outcome.Retained {
-				ev, err := s.enterAttention(ctx, r, c,
-					domain.AttentionLockoutRetention, grantID, domain.CauseBindingDelete, now)
-				if err != nil {
-					return err
-				}
-				events = append(events, ev...)
-			}
 		}
 
 		s.markTeardown(ctx, r, az, p, c, connection, "origins-released", releasedOrigins)

--- a/internal/service/scim_mapping.go
+++ b/internal/service/scim_mapping.go
@@ -277,7 +277,13 @@ func (s *SCIM) UpdateMapping(ctx context.Context, actor Actor, org domain.OrgID,
 		// widening half re-reads the members' rows.
 		dropped := missing(before, after)
 		if len(dropped) > 0 {
-			evs, count, err := s.releaseRowCapabilities(ctx, r, az, c, row, dropped, now)
+			drop := map[domain.Capability]bool{}
+			for _, capability := range dropped {
+				drop[capability] = true
+			}
+			evs, count, err := s.releaseRow(ctx, r, az, c, row,
+				func(g domain.Grant) bool { return drop[g.Capability] },
+				domain.CauseMappingDelete, now)
 			if err != nil {
 				return err
 			}
@@ -339,7 +345,7 @@ func (s *SCIM) DeleteMapping(ctx context.Context, actor Actor, org domain.OrgID,
 			return err
 		}
 		now := s.now()
-		events, released, err := s.releaseRow(ctx, r, az, c, row, domain.CauseMappingDelete, now)
+		events, released, err := s.releaseRow(ctx, r, az, c, row, nil, domain.CauseMappingDelete, now)
 		if err != nil {
 			return err
 		}
@@ -468,11 +474,13 @@ func (s *SCIM) applyRowToMembers(
 	return events, created, affected, nil
 }
 
-// releaseRow releases every origin keyed on one mapping row, for every member
-// of its group, under §2.4.
+// releaseRow releases origins keyed on one mapping row, for every member of its
+// group, under §2.4. A nil grant filter releases the whole row; narrowing passes
+// the no-longer-covered capabilities so it shares the same lifecycle owner.
 func (s *SCIM) releaseRow(
 	ctx context.Context, r store.Repos, az *authz.TxAuthorizer,
-	c scimContext, row store.SCIMMapping, cause domain.SCIMCause, now time.Time,
+	c scimContext, row store.SCIMMapping, grant func(domain.Grant) bool,
+	cause domain.SCIMCause, now time.Time,
 ) ([]grantEventInput, int, error) {
 	members, err := r.SCIM().GroupMembers(ctx, c.proof, c.binding.ID, row.GroupID)
 	if err != nil {
@@ -489,82 +497,16 @@ func (s *SCIM) releaseRow(
 		if err != nil {
 			return nil, 0, err
 		}
-		outcome, evs, err := releaseSCIMOrigins(ctx, az, now, releaseArgs{
-			binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID), principal: principal,
+		outcome, evs, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
+			binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID),
 			match: matchMappingRows(c.binding.ID, map[string]bool{row.ID: true}), cause: cause,
-		})
+			grant: grant,
+		}, advanceIfAuthorityChanged, now)
 		if err != nil {
 			return nil, 0, err
 		}
 		events = append(events, evs...)
 		released += outcome.Released
-		if outcome.AuthorityChanged() {
-			if err := advanceAndSweep(ctx, az, principal); err != nil {
-				return nil, 0, err
-			}
-		}
-		for _, grantID := range outcome.Retained {
-			ev, err := s.enterAttention(ctx, r, c, domain.AttentionLockoutRetention, grantID, cause, now)
-			if err != nil {
-				return nil, 0, err
-			}
-			events = append(events, ev...)
-		}
-	}
-	return events, released, nil
-}
-
-// releaseRowCapabilities is the NARROWING half: release only the origins the
-// row no longer covers, leaving the ones it still does. It reuses the same
-// algorithm with a grant filter rather than a second release path, because two
-// release paths is how a lockout conversion goes missing from one of them.
-func (s *SCIM) releaseRowCapabilities(
-	ctx context.Context, r store.Repos, az *authz.TxAuthorizer,
-	c scimContext, row store.SCIMMapping, dropped []domain.Capability, now time.Time,
-) ([]grantEventInput, int, error) {
-	members, err := r.SCIM().GroupMembers(ctx, c.proof, c.binding.ID, row.GroupID)
-	if err != nil {
-		return nil, 0, err
-	}
-	drop := map[domain.Capability]bool{}
-	for _, capability := range dropped {
-		drop[capability] = true
-	}
-	var events []grantEventInput
-	released := 0
-	for _, m := range members {
-		user, err := r.SCIM().User(ctx, c.proof, c.binding.ID, m.UserID)
-		if err != nil {
-			return nil, 0, err
-		}
-		principal, err := principalForAccount(ctx, az, user.AccountID)
-		if err != nil {
-			return nil, 0, err
-		}
-		outcome, evs, err := releaseSCIMOrigins(ctx, az, now, releaseArgs{
-			binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID), principal: principal,
-			match: matchMappingRows(c.binding.ID, map[string]bool{row.ID: true}),
-			grant: func(g domain.Grant) bool { return drop[g.Capability] },
-			cause: domain.CauseMappingDelete,
-		})
-		if err != nil {
-			return nil, 0, err
-		}
-		events = append(events, evs...)
-		released += outcome.Released
-		if outcome.AuthorityChanged() {
-			if err := advanceAndSweep(ctx, az, principal); err != nil {
-				return nil, 0, err
-			}
-		}
-		for _, grantID := range outcome.Retained {
-			ev, err := s.enterAttention(ctx, r, c,
-				domain.AttentionLockoutRetention, grantID, domain.CauseMappingDelete, now)
-			if err != nil {
-				return nil, 0, err
-			}
-			events = append(events, ev...)
-		}
 	}
 	return events, released, nil
 }

--- a/internal/service/scim_origin_release.go
+++ b/internal/service/scim_origin_release.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
 // The §2.4 universal release algorithm (#73, scim-provisioning ADR).
@@ -112,10 +113,9 @@ func (o releaseOutcome) AuthorityChanged() bool { return o.RowsRevoked > 0 }
 // because every caller sets all of them and a positional mistake between two
 // string ids is invisible at the call site.
 type releaseArgs struct {
-	binding   string
-	org       domain.OrgID
-	principal domain.PrincipalID
-	match     releaseMatch
+	binding string
+	org     domain.OrgID
+	match   releaseMatch
 	// grant, when set, narrows the release to grant rows it accepts. It exists
 	// for the ONE trigger that is not "release everything this key holds":
 	// narrowing a mapping row releases the no-longer-covered part (§5.4) while
@@ -125,6 +125,17 @@ type releaseArgs struct {
 	grant func(domain.Grant) bool
 	cause domain.SCIMCause
 }
+
+// advancePolicy names the two session-generation rules a SCIM release can
+// carry. Deprovision and user deletion always advance because the IdP declared
+// the human gone; every other release advances only when effective authority
+// changed.
+type advancePolicy uint8
+
+const (
+	advanceIfAuthorityChanged advancePolicy = iota
+	advanceAlways
+)
 
 // accepts reports whether a grant row is in scope for this release.
 func (a releaseArgs) accepts(g domain.Grant) bool {
@@ -137,7 +148,8 @@ func (a releaseArgs) accepts(g domain.Grant) bool {
 // human gone") and some only when authority moved. Folding the advance in here
 // would force one of the two to be wrong.
 func releaseSCIMOrigins(
-	ctx context.Context, az *authz.TxAuthorizer, now time.Time, args releaseArgs,
+	ctx context.Context, az *authz.TxAuthorizer, principal domain.PrincipalID,
+	now time.Time, args releaseArgs,
 ) (releaseOutcome, []grantEventInput, error) {
 	var out releaseOutcome
 	var events []grantEventInput
@@ -145,13 +157,13 @@ func releaseSCIMOrigins(
 	// Lock first, read second: the release is a read-then-write over the
 	// target's grant rows, and every grant writer in the system takes this lock
 	// as its first statement.
-	if err := az.LockTargetPrincipal(ctx, args.principal); err != nil {
+	if err := az.LockTargetPrincipal(ctx, principal); err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			return out, nil, nil // the principal went away; nothing holds anything
 		}
 		return out, nil, err
 	}
-	rows, err := az.GrantOriginsForPrincipal(ctx, args.principal)
+	rows, err := az.GrantOriginsForPrincipal(ctx, principal)
 	if err != nil {
 		return out, nil, err
 	}
@@ -212,7 +224,7 @@ func releaseSCIMOrigins(
 		// and the release commit together.
 		convert := false
 		if survivors == 0 {
-			cause, err := wouldLockOut(ctx, az, args.principal, st.grant.Grant)
+			cause, err := wouldLockOut(ctx, az, principal, st.grant.Grant)
 			if err != nil {
 				return out, nil, err
 			}
@@ -220,7 +232,7 @@ func releaseSCIMOrigins(
 		}
 
 		for _, o := range doomed {
-			ok, err := az.ReleaseGrantOrigin(ctx, id, args.principal, o)
+			ok, err := az.ReleaseGrantOrigin(ctx, id, principal, o)
 			if err != nil {
 				return out, nil, err
 			}
@@ -244,7 +256,7 @@ func releaseSCIMOrigins(
 					Binding: args.binding, Cause: args.cause,
 				}.Subject(),
 			}
-			if err := az.AddGrantOrigin(ctx, originID, id, args.principal, retention, now); err != nil {
+			if err := az.AddGrantOrigin(ctx, originID, id, principal, retention, now); err != nil {
 				return out, nil, err
 			}
 			out.Retained = append(out.Retained, id)
@@ -254,12 +266,12 @@ func releaseSCIMOrigins(
 					object: audit.Object{Type: "grant", ID: id},
 					payload: audit.Payload{
 						"binding":   args.binding,
-						"principal": string(args.principal),
+						"principal": string(principal),
 						"grant_id":  id,
 						"cause":     string(args.cause),
 					},
 				},
-				grantModifiedEvent(args, st.grant, doomed),
+				grantModifiedEvent(args, principal, st.grant, doomed),
 			)
 			continue
 		}
@@ -271,16 +283,58 @@ func releaseSCIMOrigins(
 		if remaining > 0 {
 			out.ManualRemains = out.ManualRemains ||
 				(st.grant.Grant.Scope.Org == args.org && hasManualOrigin(st.origins))
-			events = append(events, grantModifiedEvent(args, st.grant, doomed))
+			events = append(events, grantModifiedEvent(args, principal, st.grant, doomed))
 			continue
 		}
-		if _, err := az.DeleteGrantRow(ctx, id, args.principal); err != nil {
+		if _, err := az.DeleteGrantRow(ctx, id, principal); err != nil {
 			return out, nil, err
 		}
 		out.RowsRevoked++
-		events = append(events, grantRevokedEvent(args, st.grant, doomed))
+		events = append(events, grantRevokedEvent(args, principal, st.grant, doomed))
 	}
 	return out, events, nil
+}
+
+// releaseAndSettle owns the complete release lifecycle: release origins,
+// advance sessions under the caller's policy, then raise attention for every
+// retention conversion. Keeping those writes together makes a retention origin
+// without its warning unrepresentable through a SCIM release path.
+//
+// Release events stay before attention events. That order is part of the audit
+// contract and is deliberately preserved while the duplicated caller ceremony
+// moves here.
+func (s *SCIM) releaseAndSettle(
+	ctx context.Context, r store.Repos, az *authz.TxAuthorizer, c scimContext,
+	principal domain.PrincipalID, args releaseArgs, policy advancePolicy, now time.Time,
+) (releaseOutcome, []grantEventInput, error) {
+	outcome, events, err := releaseSCIMOrigins(ctx, az, principal, now, args)
+	if err != nil {
+		return releaseOutcome{}, nil, err
+	}
+
+	advance := outcome.AuthorityChanged()
+	switch policy {
+	case advanceIfAuthorityChanged:
+	case advanceAlways:
+		advance = true
+	default:
+		return releaseOutcome{}, nil, fmt.Errorf("service: invalid SCIM release advance policy %d", policy)
+	}
+	if advance {
+		if err := advanceAndSweep(ctx, az, principal); err != nil {
+			return releaseOutcome{}, nil, err
+		}
+	}
+
+	for _, grantID := range outcome.Retained {
+		ev, err := s.enterAttention(ctx, r, c,
+			domain.AttentionLockoutRetention, grantID, args.cause, now)
+		if err != nil {
+			return releaseOutcome{}, nil, err
+		}
+		events = append(events, ev...)
+	}
+	return outcome, events, nil
 }
 
 // wouldLockOut reports whether revoking this exact row would leave the org with
@@ -308,16 +362,20 @@ func wouldLockOut(ctx context.Context, az *authz.TxAuthorizer, target domain.Pri
 	return remaining == 0, nil
 }
 
-func grantModifiedEvent(args releaseArgs, row authz.GrantRow, released []authz.Origin) grantEventInput {
+func grantModifiedEvent(
+	args releaseArgs, principal domain.PrincipalID, row authz.GrantRow, released []authz.Origin,
+) grantEventInput {
 	return grantEventInput{
 		typ:     audit.EventGrantModified,
 		object:  audit.Object{Type: "grant", ID: row.ID},
-		payload: scimGrantPayload(args, row, released, false),
+		payload: scimGrantPayload(args, principal, row, released, false),
 	}
 }
 
-func grantRevokedEvent(args releaseArgs, row authz.GrantRow, released []authz.Origin) grantEventInput {
-	p := scimGrantPayload(args, row, released, true)
+func grantRevokedEvent(
+	args releaseArgs, principal domain.PrincipalID, row authz.GrantRow, released []authz.Origin,
+) grantEventInput {
+	p := scimGrantPayload(args, principal, row, released, true)
 	p["origins_remaining"] = 0
 	// The row died, so the generation advance and the session sweep happen —
 	// either here, when authority moved, or unconditionally at the caller.
@@ -333,9 +391,12 @@ func grantRevokedEvent(args releaseArgs, row authz.GrantRow, released []authz.Or
 // release, including the origin fields §10 adds to the `grant.*` category:
 // which binding, which mapping row and which IdP group moved. That is what
 // makes "why can they?" answerable from the trail and not only from the row.
-func scimGrantPayload(args releaseArgs, row authz.GrantRow, released []authz.Origin, revoked bool) audit.Payload {
+func scimGrantPayload(
+	args releaseArgs, principal domain.PrincipalID, row authz.GrantRow,
+	released []authz.Origin, revoked bool,
+) audit.Payload {
 	p := audit.Payload{
-		"target_principal": string(args.principal),
+		"target_principal": string(principal),
 		"capability":       string(row.Grant.Capability),
 		"scope":            renderScope(row.Grant.Scope),
 		"origin_kind":      string(domain.OriginSCIM),

--- a/internal/service/scim_wire.go
+++ b/internal/service/scim_wire.go
@@ -603,27 +603,15 @@ func (s *SCIM) deprovision(
 	if err != nil {
 		return nil, err
 	}
-	outcome, events, err := releaseSCIMOrigins(ctx, az, now, releaseArgs{
-		binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID), principal: principal,
+	outcome, events, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
+		binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID),
 		match: func(k domain.SCIMOriginKey) bool {
 			return k.Binding == c.binding.ID && !keep[k.MappingRow]
 		},
 		cause: cause,
-	})
+	}, advanceAlways, now)
 	if err != nil {
 		return nil, err
-	}
-	// UNCONDITIONAL, and deliberately not gated on outcome.AuthorityChanged():
-	// the zero-grant-delta case is exactly the one the rule exists for.
-	if err := advanceAndSweep(ctx, az, principal); err != nil {
-		return nil, err
-	}
-	for _, grantID := range outcome.Retained {
-		ev, err := s.enterAttention(ctx, r, c, domain.AttentionLockoutRetention, grantID, cause, now)
-		if err != nil {
-			return nil, err
-		}
-		events = append(events, ev...)
 	}
 	if outcome.ManualRemains {
 		ev, err := s.enterAttention(ctx, r, c, domain.AttentionManualGrantsRemain, user.ID, cause, now)

--- a/internal/service/scim_wire_groups.go
+++ b/internal/service/scim_wire_groups.go
@@ -350,24 +350,12 @@ func (s *SCIM) releaseGroupOrigins(
 	ctx context.Context, r store.Repos, az *authz.TxAuthorizer, c scimContext,
 	principal domain.PrincipalID, groupID string, cause domain.SCIMCause, now time.Time,
 ) ([]grantEventInput, int, error) {
-	outcome, events, err := releaseSCIMOrigins(ctx, az, now, releaseArgs{
-		binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID), principal: principal,
+	outcome, events, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
+		binding: c.binding.ID, org: domain.OrgID(c.binding.OrgID),
 		match: matchGroup(c.binding.ID, groupID), cause: cause,
-	})
+	}, advanceIfAuthorityChanged, now)
 	if err != nil {
 		return nil, 0, err
-	}
-	if outcome.AuthorityChanged() {
-		if err := advanceAndSweep(ctx, az, principal); err != nil {
-			return nil, 0, err
-		}
-	}
-	for _, grantID := range outcome.Retained {
-		ev, err := s.enterAttention(ctx, r, c, domain.AttentionLockoutRetention, grantID, cause, now)
-		if err != nil {
-			return nil, 0, err
-		}
-		events = append(events, ev...)
 	}
 	return events, outcome.Released, nil
 }


### PR DESCRIPTION
Closes #340

## Contract

- Centralizes SCIM origin release, session settlement, and lockout-retention attention entry in one transaction.
- Keeps unconditional session advancement for deprovision and user deletion; other triggers advance only when authority changes.
- Preserves release-before-attention audit ordering and merges mapping deletion/narrowing onto one filtered release path.

## Migration and generated outputs

- No schema, API, domain, migration, wire, or generated artifact changes.

## Validation

- Focused internal/service suite passed.
- Six-trigger lockout coverage and zero-delta narrowing coverage passed on SQLite and PostgreSQL.
- go test -count=1 ./... passed.
- go vet ./... passed.
- Three review rounds ended Standards CLEAN and Spec CLEAN.