### PR TITLE
Centralize adapter ledger representation #342

### DIFF
--- a/docs/handoff/issue-342-shared-adapter-ledger.md
+++ b/docs/handoff/issue-342-shared-adapter-ledger.md
@@ -1,0 +1,36 @@
+# Handoff: #342 shared adapter ledger representation
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/342. Base:
+`052cc9b23ec325473eae48753102ad04a04b506a`.
+
+## Contract
+
+- `adapter.LedgerKey` and `IndexLedger` are the single normalized ledger index.
+  Indexing preserves `LedgerEntry.Missing` and refuses missing rows outside
+  owned or dispatched custody.
+- `DesiredRows`, `PlanChanges`, `Undesired`, and their ordering helpers own the
+  provider-neutral desired/plan/prune invariants. Both providers consume them;
+  no provider builds and reparses opaque ledger keys.
+- Durable missing remains an accessor-validated state-plus-flag representation,
+  as permitted by the issue. No persisted enum or schema migration is needed.
+  `Finish` refuses a missing completion for a concurrently released row, so
+  `released+missing` cannot be written.
+- Forgejo now treats an owned-missing variable as a create and honors the same
+  completed-name resume cursor as GitHub Actions.
+- Existing change ordering, sentinels-first writes, sentinels-last pruning,
+  audit payloads including `owned_missing`, and module/journal interfaces remain
+  unchanged.
+
+## Coverage
+
+- Shared adapter regressions pin missing preservation, invalid missing custody,
+  and sentinel-first desired ordering.
+- Forgejo regressions pin completed-name skipping and owned-missing create-only
+  replay.
+- Store regressions pin both valid owned-missing audit persistence and refusal
+  of a late owned-missing completion after release.
+- Scoped adapter, store, and service package suites pass with `-count=1`.
+- Full Go validation passes with `go test -p 4 -count=1 ./...`.
+- Standards and issue-spec review reached `CLEAN` in round 2 of 3 after fixing
+  missing-custody retention and all bulk-release writers.
+- Generated outputs: none.

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -82,6 +82,48 @@ func TestGitHubManifestRefusesUnrepresentableNonUTF8ByName(t *testing.T) {
 	}
 }
 
+func TestIndexLedgerPreservesMissing(t *testing.T) {
+	rows := []LedgerEntry{{Surface: Variable, EffectiveName: "MODE", State: Owned, Missing: true}}
+
+	indexed, err := IndexLedger(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := indexed[NewLedgerKey(Variable, "mode")]
+	if !ok || !got.Missing || got.State != Owned || got.EffectiveName != "MODE" {
+		t.Fatalf("IndexLedger() = %+v, want owned-missing MODE", indexed)
+	}
+}
+
+func TestLedgerMissingRequiresProviderCustody(t *testing.T) {
+	for _, state := range []LedgerState{Reserved, Released} {
+		t.Run(string(state), func(t *testing.T) {
+			if _, err := IndexLedger([]LedgerEntry{{Surface: Variable, EffectiveName: "MODE", State: state, Missing: true}}); err == nil {
+				t.Fatalf("IndexLedger() accepted %s+missing", state)
+			}
+			if err := ValidateCompletion(Completion{State: state, Missing: true}); err == nil {
+				t.Fatalf("ValidateCompletion() accepted %s+missing", state)
+			}
+		})
+	}
+}
+
+func TestDesiredRowsOrderSentinelsFirst(t *testing.T) {
+	rows := DesiredRows("PROD_", []ManifestEntry{
+		{KeyID: "key_variable", CanonicalName: "MODE", Classification: ConfigClassification},
+		{KeyID: "key_secret", CanonicalName: "TOKEN", Classification: SecretClassification},
+	}, true)
+	want := []DesiredRow{
+		{ManifestEntry: ManifestEntry{Classification: SecretClassification, Value: SentinelName}, Surface: Secret, EffectiveName: "PROD_" + SentinelName},
+		{ManifestEntry: ManifestEntry{Classification: ConfigClassification, Value: SentinelName}, Surface: Variable, EffectiveName: "PROD_" + SentinelName},
+		{ManifestEntry: ManifestEntry{KeyID: "key_secret", CanonicalName: "TOKEN", Classification: SecretClassification}, Surface: Secret, EffectiveName: "PROD_TOKEN"},
+		{ManifestEntry: ManifestEntry{KeyID: "key_variable", CanonicalName: "MODE", Classification: ConfigClassification}, Surface: Variable, EffectiveName: "PROD_MODE"},
+	}
+	if !slices.Equal(rows, want) {
+		t.Fatalf("DesiredRows() = %+v, want %+v", rows, want)
+	}
+}
+
 func TestProviderKindsAreClosedAndRejectUnknownValues(t *testing.T) {
 	want := []Provider{ForgejoProvider, GitHubActionsProvider}
 	if got := SupportedProviders(); !slices.Equal(got, want) {

--- a/internal/adapter/forgejo/module.go
+++ b/internal/adapter/forgejo/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -83,75 +82,12 @@ func (m *Module) Plan(ctx context.Context, req adapter.PlanRequest) (adapter.Pla
 	if err != nil {
 		return adapter.Plan{}, err
 	}
-	providerSecrets := set(secretNames)
-	ledger := ledgerMap(req.Ledger)
-	desired := desiredEntries(req.Target.NamePrefix, req.Manifest, true)
-	changes := make([]adapter.Change, 0, len(desired)+len(ledger))
-	for _, row := range desired {
-		key := ledgerKey(row.Surface, row.EffectiveName)
-		state, claimed := ledger[key]
-		disposition := adapter.Create
-		switch {
-		case claimed && (state == adapter.Owned || state == adapter.Dispatched):
-			disposition = adapter.Update
-		case row.Surface == adapter.Secret && providerSecrets[row.EffectiveName]:
-			disposition = adapter.Conflict
-		case row.Surface == adapter.Variable && !claimed:
-			disposition = adapter.Unknown
-		}
-		changes = append(changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: disposition})
+	ledger, err := adapter.IndexLedger(req.Ledger)
+	if err != nil {
+		return adapter.Plan{}, err
 	}
-	desiredSet := make(map[string]bool, len(desired))
-	for _, row := range desired {
-		desiredSet[ledgerKey(row.Surface, row.EffectiveName)] = true
-	}
-	for key, state := range ledger {
-		if desiredSet[key] || state == adapter.Reserved {
-			continue
-		}
-		surface, name := splitLedgerKey(key)
-		changes = append(changes, adapter.Change{Surface: surface, EffectiveName: name, Disposition: adapter.Delete})
-	}
-	sortChanges(changes)
-	return adapter.Plan{Changes: changes}, nil
-}
-
-type desired struct {
-	adapter.ManifestEntry
-	Surface       adapter.Surface
-	EffectiveName string
-}
-
-func desiredEntries(prefix string, manifest []adapter.ManifestEntry, sentinel bool) []desired {
-	rows := make([]desired, 0, len(manifest)+2)
-	if sentinel {
-		for _, surface := range []adapter.Surface{adapter.Secret, adapter.Variable} {
-			classification := adapter.SecretClassification
-			if surface == adapter.Variable {
-				classification = adapter.ConfigClassification
-			}
-			rows = append(rows, desired{ManifestEntry: adapter.ManifestEntry{Classification: classification, Value: adapter.SentinelName}, Surface: surface, EffectiveName: prefix + adapter.SentinelName})
-		}
-	}
-	for _, entry := range manifest {
-		rows = append(rows, desired{ManifestEntry: entry, Surface: entry.Surface(), EffectiveName: prefix + entry.CanonicalName})
-	}
-	slices.SortStableFunc(rows, func(a, b desired) int {
-		// Sentinels first. Remaining rows have deterministic surface/name order.
-		aSentinel := a.KeyID == ""
-		bSentinel := b.KeyID == ""
-		if aSentinel != bSentinel {
-			if aSentinel {
-				return -1
-			}
-			return 1
-		}
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
-	return rows
+	desired := adapter.DesiredRows(req.Target.NamePrefix, req.Manifest, true)
+	return adapter.Plan{Changes: adapter.PlanChanges(desired, ledger, adapter.NameSet(secretNames))}, nil
 }
 
 func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adapter.Journal) (adapter.SyncResult, error) {
@@ -175,15 +111,23 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 	if err != nil {
 		return adapter.SyncResult{}, err
 	}
-	providerSecrets := set(secretNames)
-	ledger := ledgerMap(req.Ledger)
-	desiredRows := desiredEntries(req.Target.NamePrefix, req.Manifest, !req.Teardown)
+	providerSecrets := adapter.NameSet(secretNames)
+	ledger, err := adapter.IndexLedger(req.Ledger)
+	if err != nil {
+		return adapter.SyncResult{}, err
+	}
+	desiredRows := adapter.DesiredRows(req.Target.NamePrefix, req.Manifest, !req.Teardown)
+	completed := adapter.CompletedNames(req.Completed)
 	result := adapter.SyncResult{}
 	for _, row := range desiredRows {
+		if completed[adapter.NewLedgerKey(row.Surface, row.EffectiveName)] {
+			continue
+		}
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Create, KeyID: row.KeyID}
-		key := ledgerKey(row.Surface, row.EffectiveName)
-		state, claimed := ledger[key]
-		if claimed && (state == adapter.Owned || state == adapter.Dispatched) {
+		key := adapter.NewLedgerKey(row.Surface, row.EffectiveName)
+		record, claimed := ledger[key]
+		state := record.State
+		if claimed && (state == adapter.Owned || state == adapter.Dispatched) && !record.Missing {
 			effect.Disposition = adapter.Update
 		}
 		if !claimed {
@@ -191,7 +135,8 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			if err != nil {
 				return result, err
 			}
-			ledger[key] = state
+			record = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: state}
+			ledger[key] = record
 		}
 		if state == adapter.Reserved && row.Surface == adapter.Secret && providerSecrets[row.EffectiveName] {
 			if err := journal.Refuse(ctx, effect); err != nil {
@@ -214,16 +159,27 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			return result, err
 		}
 		if gateErr := journal.Gate(ctx, effect); gateErr != nil {
-			if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: state}); finishErr != nil {
+			completion := adapter.Completion{Outcome: "failure", State: state}
+			if record.Missing {
+				completion.Missing = true
+				completion.Finding = "owned_missing"
+			}
+			if finishErr := journal.Finish(ctx, effect, completion); finishErr != nil {
 				return result, finishErr
 			}
 			return result, gateErr
 		}
-		err := m.write(ctx, req.Target.Destination, row, state)
-		absenceProven := row.Surface == adapter.Variable && (state == adapter.Owned || state == adapter.Dispatched) && IsNotFound(err)
+		err := m.write(ctx, req.Target.Destination, row, state, record.Missing)
+		absenceProven := row.Surface == adapter.Variable && !record.Missing && (state == adapter.Owned || state == adapter.Dispatched) && IsNotFound(err)
 		if err != nil {
-			if row.Surface == adapter.Variable && (state == adapter.Reserved || !claimed) && IsConflict(err) {
-				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", Conflict: true}); finishErr != nil {
+			if row.Surface == adapter.Variable && (state == adapter.Reserved || !claimed || record.Missing) && IsConflict(err) {
+				completion := adapter.Completion{Outcome: "failure", Conflict: true}
+				if record.Missing {
+					completion.State = state
+					completion.Missing = true
+					completion.Finding = "owned_missing"
+				}
+				if finishErr := journal.Finish(ctx, effect, completion); finishErr != nil {
 					return result, finishErr
 				}
 				conflict := adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Conflict}
@@ -243,7 +199,12 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 					finalState = state
 				}
 			}
-			if completeErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: outcome, State: finalState}); completeErr != nil {
+			completion := adapter.Completion{Outcome: outcome, State: finalState}
+			if record.Missing {
+				completion.Missing = true
+				completion.Finding = "owned_missing"
+			}
+			if completeErr := journal.Finish(ctx, effect, completion); completeErr != nil {
 				return result, completeErr
 			}
 			result.Failed = append(result.Failed, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: effect.Disposition})
@@ -255,33 +216,11 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
 			return result, err
 		}
-		ledger[key] = adapter.Owned
+		ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned}
 		result.Changes = append(result.Changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: effect.Disposition})
 	}
 
-	desiredSet := make(map[string]bool, len(desiredRows))
-	for _, row := range desiredRows {
-		desiredSet[ledgerKey(row.Surface, row.EffectiveName)] = true
-	}
-	var reservations, prunes []adapter.LedgerEntry
-	for key, state := range ledger {
-		if desiredSet[key] {
-			continue
-		}
-		surface, name := splitLedgerKey(key)
-		row := adapter.LedgerEntry{Surface: surface, EffectiveName: name, State: state}
-		if state == adapter.Reserved {
-			reservations = append(reservations, row)
-			continue
-		}
-		prunes = append(prunes, row)
-	}
-	slices.SortFunc(reservations, func(a, b adapter.LedgerEntry) int {
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
+	reservations, prunes := adapter.Undesired(desiredRows, ledger)
 	for _, row := range reservations {
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete}
 		if err := journal.Gate(ctx, effect); err != nil {
@@ -292,20 +231,6 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 		}
 		result.Changes = append(result.Changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete})
 	}
-	slices.SortFunc(prunes, func(a, b adapter.LedgerEntry) int {
-		aSentinel := strings.HasSuffix(a.EffectiveName, adapter.SentinelName)
-		bSentinel := strings.HasSuffix(b.EffectiveName, adapter.SentinelName)
-		if aSentinel != bSentinel {
-			if aSentinel {
-				return 1
-			}
-			return -1
-		}
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
 	for _, row := range prunes {
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete}
 		if err := journal.Gate(ctx, effect); err != nil {
@@ -358,11 +283,11 @@ func (m *Module) verifyDestination(ctx context.Context, target adapter.Target) e
 	return nil
 }
 
-func (m *Module) write(ctx context.Context, destination adapter.Destination, row desired, prior adapter.LedgerState) error {
+func (m *Module) write(ctx context.Context, destination adapter.Destination, row adapter.DesiredRow, prior adapter.LedgerState, forceCreate bool) error {
 	if row.Surface == adapter.Secret {
 		return m.API.PutSecret(ctx, destination, row.EffectiveName, row.Value)
 	}
-	if prior == adapter.Dispatched || prior == adapter.Owned {
+	if !forceCreate && (prior == adapter.Dispatched || prior == adapter.Owned) {
 		return m.API.UpdateVariable(ctx, destination, row.EffectiveName, row.Value)
 	}
 	return m.API.CreateVariable(ctx, destination, row.EffectiveName, row.Value)
@@ -373,34 +298,4 @@ func (m *Module) delete(ctx context.Context, destination adapter.Destination, su
 		return m.API.DeleteSecret(ctx, destination, name)
 	}
 	return m.API.DeleteVariable(ctx, destination, name)
-}
-
-func set(values []string) map[string]bool {
-	out := make(map[string]bool, len(values))
-	for _, value := range values {
-		out[strings.ToUpper(value)] = true
-	}
-	return out
-}
-func ledgerKey(surface adapter.Surface, name string) string {
-	return string(surface) + "\x00" + strings.ToUpper(name)
-}
-func splitLedgerKey(key string) (adapter.Surface, string) {
-	parts := strings.SplitN(key, "\x00", 2)
-	return adapter.Surface(parts[0]), parts[1]
-}
-func ledgerMap(rows []adapter.LedgerEntry) map[string]adapter.LedgerState {
-	out := make(map[string]adapter.LedgerState, len(rows))
-	for _, row := range rows {
-		out[ledgerKey(row.Surface, row.EffectiveName)] = row.State
-	}
-	return out
-}
-func sortChanges(changes []adapter.Change) {
-	slices.SortFunc(changes, func(a, b adapter.Change) int {
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
 }

--- a/internal/adapter/forgejo/module_test.go
+++ b/internal/adapter/forgejo/module_test.go
@@ -134,6 +134,72 @@ func TestDispatchWindowVariableReplayUsesUpdateNotCreate(t *testing.T) {
 	}
 }
 
+func TestSyncSkipsCompletedNames(t *testing.T) {
+	api := &fakeAPI{id: 42, version: "1.21.0", secrets: map[string]bool{}}
+	journal := newFakeJournal()
+	journal.states["secret:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:LOG_LEVEL"] = adapter.Owned
+
+	_, err := (&Module{API: api}).Sync(t.Context(), adapter.SyncRequest{
+		Target:    testTargetNoPrefix(),
+		Manifest:  []adapter.ManifestEntry{{KeyID: "key_1", CanonicalName: "LOG_LEVEL", Classification: adapter.ConfigClassification, Value: "debug"}},
+		Ledger:    journal.ledger(),
+		Completed: []adapter.Change{{Surface: adapter.Variable, EffectiveName: "LOG_LEVEL", Disposition: adapter.Update}},
+	}, journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(api.writes, "update-variable:LOG_LEVEL") || journal.prepares["variable:LOG_LEVEL"] != 0 {
+		t.Fatalf("completed LOG_LEVEL replayed: writes=%v prepares=%d", api.writes, journal.prepares["variable:LOG_LEVEL"])
+	}
+}
+
+func TestOwnedMissingVariableRetriesCreateOnly(t *testing.T) {
+	api := &fakeAPI{id: 42, version: "1.21.0", secrets: map[string]bool{}}
+	journal := newFakeJournal()
+	journal.states["secret:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:LOG_LEVEL"] = adapter.Owned
+	journal.missing["variable:LOG_LEVEL"] = true
+	_, err := (&Module{API: api}).Sync(t.Context(), adapter.SyncRequest{
+		Target:   testTargetNoPrefix(),
+		Manifest: []adapter.ManifestEntry{{KeyID: "key_1", CanonicalName: "LOG_LEVEL", Classification: adapter.ConfigClassification, Value: "debug"}},
+		Ledger:   journal.ledger(),
+	}, journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(api.writes, "create-variable:LOG_LEVEL") || slices.Contains(api.writes, "update-variable:LOG_LEVEL") {
+		t.Fatalf("owned-missing retry writes=%v, want create without update", api.writes)
+	}
+}
+
+func TestOwnedMissingVariableConflictPreservesMissingCustody(t *testing.T) {
+	api := &fakeAPI{id: 42, version: "1.21.0", secrets: map[string]bool{}, conflict: map[string]bool{"LOG_LEVEL": true}}
+	journal := newFakeJournal()
+	journal.states["secret:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:"+adapter.SentinelName] = adapter.Owned
+	journal.states["variable:LOG_LEVEL"] = adapter.Owned
+	journal.missing["variable:LOG_LEVEL"] = true
+
+	_, err := (&Module{API: api}).Sync(t.Context(), adapter.SyncRequest{
+		Target:   testTargetNoPrefix(),
+		Manifest: []adapter.ManifestEntry{{KeyID: "key_1", CanonicalName: "LOG_LEVEL", Classification: adapter.ConfigClassification, Value: "debug"}},
+		Ledger:   journal.ledger(),
+	}, journal)
+	if !errors.Is(err, adapter.ErrConflict) {
+		t.Fatalf("Sync() error = %v, want ErrConflict", err)
+	}
+	completion := journal.completions["variable:LOG_LEVEL"]
+	if len(completion) != 1 || !completion[0].Conflict || completion[0].State != adapter.Owned || !completion[0].Missing || completion[0].Finding != "owned_missing" {
+		t.Fatalf("owned-missing conflict completion=%+v", completion)
+	}
+	if journal.states["variable:LOG_LEVEL"] != adapter.Owned || !journal.missing["variable:LOG_LEVEL"] {
+		t.Fatalf("owned-missing custody state=%q missing=%v", journal.states["variable:LOG_LEVEL"], journal.missing["variable:LOG_LEVEL"])
+	}
+}
+
 func TestOwnedVariableDeletedAtProviderRetriesCreateUnderFreshEffect(t *testing.T) {
 	api := &fakeAPI{id: 42, version: "1.21.0", secrets: map[string]bool{}, failures: map[string]error{"update-variable:LOG_LEVEL": &ResponseError{Status: 404}}}
 	journal := newFakeJournal()
@@ -475,6 +541,7 @@ func (f *fakeAPI) DeleteVariable(_ context.Context, _ adapter.Destination, name 
 
 type fakeJournal struct {
 	states       map[string]adapter.LedgerState
+	missing      map[string]bool
 	prepares     map[string]int
 	completions  map[string][]adapter.Completion
 	trace        *[]string
@@ -488,7 +555,7 @@ type fakeJournal struct {
 }
 
 func newFakeJournal() *fakeJournal {
-	return &fakeJournal{states: map[string]adapter.LedgerState{}, prepares: map[string]int{}, completions: map[string][]adapter.Completion{}, releases: map[string]int{}}
+	return &fakeJournal{states: map[string]adapter.LedgerState{}, missing: map[string]bool{}, prepares: map[string]int{}, completions: map[string][]adapter.Completion{}, releases: map[string]int{}}
 }
 func effectKey(e adapter.Effect) string { return string(e.Surface) + ":" + e.EffectiveName }
 func (j *fakeJournal) Gate(context.Context, adapter.Effect) error {
@@ -524,14 +591,17 @@ func (j *fakeJournal) Finish(_ context.Context, e adapter.Effect, completion ada
 	j.completions[effectKey(e)] = append(j.completions[effectKey(e)], completion)
 	if completion.State == "" {
 		delete(j.states, effectKey(e))
+		delete(j.missing, effectKey(e))
 	} else {
 		j.states[effectKey(e)] = completion.State
+		j.missing[effectKey(e)] = completion.Missing
 	}
 	return nil
 }
 func (j *fakeJournal) Refuse(_ context.Context, e adapter.Effect) error {
 	j.refusals++
 	delete(j.states, effectKey(e))
+	delete(j.missing, effectKey(e))
 	return nil
 }
 func (j *fakeJournal) ReleaseReservation(_ context.Context, e adapter.Effect) error {
@@ -541,13 +611,14 @@ func (j *fakeJournal) ReleaseReservation(_ context.Context, e adapter.Effect) er
 	}
 	j.releases[key]++
 	delete(j.states, key)
+	delete(j.missing, key)
 	return nil
 }
 func (j *fakeJournal) ledger() []adapter.LedgerEntry {
 	out := make([]adapter.LedgerEntry, 0, len(j.states))
 	for key, state := range j.states {
 		parts := strings.SplitN(key, ":", 2)
-		out = append(out, adapter.LedgerEntry{Surface: adapter.Surface(parts[0]), EffectiveName: parts[1], State: state})
+		out = append(out, adapter.LedgerEntry{Surface: adapter.Surface(parts[0]), EffectiveName: parts[1], State: state, Missing: j.missing[key]})
 	}
 	return out
 }

--- a/internal/adapter/githubactions/module.go
+++ b/internal/adapter/githubactions/module.go
@@ -176,69 +176,16 @@ func (m *Module) Plan(ctx context.Context, req adapter.PlanRequest) (adapter.Pla
 	if err != nil {
 		return adapter.Plan{}, err
 	}
-	providerSecrets := stringSet(names)
-	ledger := ledgerMap(req.Ledger)
-	desired := desiredEntries(req.Target.NamePrefix, req.Manifest, true)
-	changes := make([]adapter.Change, 0, len(desired)+len(ledger))
-	desiredSet := make(map[string]bool, len(desired))
-	for _, row := range desired {
-		key := ledgerKey(row.Surface, row.EffectiveName)
-		desiredSet[key] = true
-		record, claimed := ledger[key]
-		state := record.State
-		disposition := adapter.Create
-		switch {
-		case claimed && (state == adapter.Owned || state == adapter.Dispatched) && !record.Missing:
-			disposition = adapter.Update
-		case row.Surface == adapter.Secret && providerSecrets[row.EffectiveName]:
-			disposition = adapter.Conflict
-		case row.Surface == adapter.Variable && !claimed:
-			disposition = adapter.Unknown
-		}
-		changes = append(changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: disposition})
+	providerSecrets := adapter.NameSet(names)
+	ledger, err := adapter.IndexLedger(req.Ledger)
+	if err != nil {
+		return adapter.Plan{}, err
 	}
-	for key, record := range ledger {
-		if desiredSet[key] || record.State == adapter.Reserved {
-			continue
-		}
-		surface, name := splitLedgerKey(key)
-		changes = append(changes, adapter.Change{Surface: surface, EffectiveName: name, Disposition: adapter.Delete})
-	}
-	sortChanges(changes)
-	return adapter.Plan{Changes: changes, Warnings: capacityWarnings(req.Target.Destination, desired, req.Ledger, providerSecrets)}, nil
-}
-
-type desired struct {
-	adapter.ManifestEntry
-	Surface       adapter.Surface
-	EffectiveName string
-}
-
-func desiredEntries(prefix string, manifest []adapter.ManifestEntry, sentinel bool) []desired {
-	rows := make([]desired, 0, len(manifest)+2)
-	if sentinel {
-		rows = append(rows,
-			desired{ManifestEntry: adapter.ManifestEntry{Classification: adapter.SecretClassification, Value: adapter.SentinelName}, Surface: adapter.Secret, EffectiveName: prefix + adapter.SentinelName},
-			desired{ManifestEntry: adapter.ManifestEntry{Classification: adapter.ConfigClassification, Value: adapter.SentinelName}, Surface: adapter.Variable, EffectiveName: prefix + adapter.SentinelName},
-		)
-	}
-	for _, entry := range manifest {
-		rows = append(rows, desired{ManifestEntry: entry, Surface: entry.Surface(), EffectiveName: prefix + entry.CanonicalName})
-	}
-	slices.SortStableFunc(rows, func(a, b desired) int {
-		aSentinel, bSentinel := a.KeyID == "", b.KeyID == ""
-		if aSentinel != bSentinel {
-			if aSentinel {
-				return -1
-			}
-			return 1
-		}
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
-	return rows
+	desired := adapter.DesiredRows(req.Target.NamePrefix, req.Manifest, true)
+	return adapter.Plan{
+		Changes:  adapter.PlanChanges(desired, ledger, providerSecrets),
+		Warnings: capacityWarnings(req.Target.Destination, desired, req.Ledger, providerSecrets),
+	}, nil
 }
 
 func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adapter.Journal) (adapter.SyncResult, error) {
@@ -265,14 +212,11 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 	if err != nil {
 		return adapter.SyncResult{}, err
 	}
-	providerSecrets := stringSet(names)
-	desiredRows := desiredEntries(req.Target.NamePrefix, req.Manifest, !req.Teardown)
-	completed := make(map[string]bool, len(req.Completed))
-	for _, change := range req.Completed {
-		completed[ledgerKey(change.Surface, change.EffectiveName)] = true
-	}
+	providerSecrets := adapter.NameSet(names)
+	desiredRows := adapter.DesiredRows(req.Target.NamePrefix, req.Manifest, !req.Teardown)
+	completed := adapter.CompletedNames(req.Completed)
 	var publicKey PublicKey
-	if slices.ContainsFunc(desiredRows, func(row desired) bool { return row.Surface == adapter.Secret }) {
+	if slices.ContainsFunc(desiredRows, func(row adapter.DesiredRow) bool { return row.Surface == adapter.Secret }) {
 		if err := journal.Gate(ctx, inspect); err != nil {
 			return adapter.SyncResult{}, err
 		}
@@ -281,16 +225,19 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			return adapter.SyncResult{}, err
 		}
 	}
-	ledger := ledgerMap(req.Ledger)
+	ledger, err := adapter.IndexLedger(req.Ledger)
+	if err != nil {
+		return adapter.SyncResult{}, err
+	}
 	result := adapter.SyncResult{Warnings: capacityWarnings(req.Target.Destination, desiredRows, req.Ledger, providerSecrets)}
 	for _, row := range desiredRows {
-		if completed[ledgerKey(row.Surface, row.EffectiveName)] {
+		if completed[adapter.NewLedgerKey(row.Surface, row.EffectiveName)] {
 			continue
 		}
-		key := ledgerKey(row.Surface, row.EffectiveName)
+		key := adapter.NewLedgerKey(row.Surface, row.EffectiveName)
 		record, claimed := ledger[key]
 		state := record.State
-		ownedMissing := record.Missing && (state == adapter.Owned || state == adapter.Dispatched)
+		ownedMissing := record.Missing
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Create, KeyID: row.KeyID}
 		if claimed && (state == adapter.Owned || state == adapter.Dispatched) && !ownedMissing {
 			effect.Disposition = adapter.Update
@@ -300,7 +247,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			if err != nil {
 				return result, err
 			}
-			ledger[key] = ledgerRecord{State: state}
+			ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: state}
 		}
 		freshReservation := state == adapter.Reserved
 		if freshReservation && row.Surface == adapter.Secret && providerSecrets[row.EffectiveName] {
@@ -353,7 +300,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: adapter.Owned, Missing: true, ProviderStatus: http.StatusNotFound, Finding: "owned_missing"}); finishErr != nil {
 					return result, finishErr
 				}
-				ledger[key] = ledgerRecord{State: adapter.Owned, Missing: true}
+				ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned, Missing: true}
 				ownedMissing = true
 				effect.Disposition = adapter.Create
 				if err = m.prepare(ctx, journal, effect, adapter.Owned, req.Target); err != nil {
@@ -406,7 +353,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Owned, ProviderStatus: providerStatus}); err != nil {
 			return result, err
 		}
-		ledger[key] = ledgerRecord{State: adapter.Owned}
+		ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned}
 		result.Changes = append(result.Changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: effect.Disposition})
 	}
 	return m.prune(ctx, req, journal, desiredRows, ledger, result)
@@ -434,7 +381,7 @@ func (m *Module) prepare(ctx context.Context, journal adapter.Journal, effect ad
 	return nil
 }
 
-func (m *Module) writeSecret(ctx context.Context, journal adapter.Journal, effect adapter.Effect, destination adapter.Destination, row desired, key PublicKey) (WriteResult, error) {
+func (m *Module) writeSecret(ctx context.Context, journal adapter.Journal, effect adapter.Effect, destination adapter.Destination, row adapter.DesiredRow, key PublicKey) (WriteResult, error) {
 	sealed, err := m.sealer()([]byte(row.Value), key)
 	if err != nil {
 		return WriteResult{}, err
@@ -445,7 +392,7 @@ func (m *Module) writeSecret(ctx context.Context, journal adapter.Journal, effec
 	return m.API.PutSecret(ctx, destination, row.EffectiveName, sealed, key.ID)
 }
 
-func (m *Module) writeVariable(ctx context.Context, journal adapter.Journal, effect adapter.Effect, destination adapter.Destination, row desired, state adapter.LedgerState, forceCreate bool) (WriteResult, error) {
+func (m *Module) writeVariable(ctx context.Context, journal adapter.Journal, effect adapter.Effect, destination adapter.Destination, row adapter.DesiredRow, state adapter.LedgerState, forceCreate bool) (WriteResult, error) {
 	if err := journal.Gate(ctx, effect); err != nil {
 		return WriteResult{}, err
 	}
@@ -463,25 +410,8 @@ func (m *Module) writeVariable(ctx context.Context, journal adapter.Journal, eff
 	return result, err
 }
 
-func (m *Module) prune(ctx context.Context, req adapter.SyncRequest, journal adapter.Journal, desiredRows []desired, ledger map[string]ledgerRecord, result adapter.SyncResult) (adapter.SyncResult, error) {
-	desiredSet := make(map[string]bool, len(desiredRows))
-	for _, row := range desiredRows {
-		desiredSet[ledgerKey(row.Surface, row.EffectiveName)] = true
-	}
-	var reservations, prunes []adapter.LedgerEntry
-	for key, record := range ledger {
-		if desiredSet[key] {
-			continue
-		}
-		surface, name := splitLedgerKey(key)
-		row := adapter.LedgerEntry{Surface: surface, EffectiveName: name, State: record.State, Missing: record.Missing}
-		if record.State == adapter.Reserved {
-			reservations = append(reservations, row)
-		} else {
-			prunes = append(prunes, row)
-		}
-	}
-	sortLedger(reservations, false)
+func (m *Module) prune(ctx context.Context, req adapter.SyncRequest, journal adapter.Journal, desiredRows []adapter.DesiredRow, ledger map[adapter.LedgerKey]adapter.LedgerEntry, result adapter.SyncResult) (adapter.SyncResult, error) {
+	reservations, prunes := adapter.Undesired(desiredRows, ledger)
 	for _, row := range reservations {
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete}
 		if err := journal.Gate(ctx, effect); err != nil {
@@ -491,7 +421,6 @@ func (m *Module) prune(ctx context.Context, req adapter.SyncRequest, journal ada
 			return result, err
 		}
 	}
-	sortLedger(prunes, true)
 	for _, row := range prunes {
 		effect := adapter.Effect{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete}
 		if err := m.prepare(ctx, journal, effect, row.State, req.Target); err != nil {
@@ -535,7 +464,7 @@ func (m *Module) verifyDestination(ctx context.Context, target adapter.Target) e
 	return m.API.VerifySelectedRepositories(ctx, target.Destination)
 }
 
-func addConflict(result adapter.SyncResult, row desired) adapter.SyncResult {
+func addConflict(result adapter.SyncResult, row adapter.DesiredRow) adapter.SyncResult {
 	result.Conflicts = append(result.Conflicts, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Conflict})
 	return result
 }
@@ -565,60 +494,7 @@ func failureCompletion(prior adapter.LedgerState, err error) (string, adapter.Le
 	return "unknown", adapter.Dispatched
 }
 
-func stringSet(values []string) map[string]bool {
-	out := make(map[string]bool, len(values))
-	for _, value := range values {
-		out[strings.ToUpper(value)] = true
-	}
-	return out
-}
-func ledgerKey(surface adapter.Surface, name string) string {
-	return string(surface) + "\x00" + strings.ToUpper(name)
-}
-func splitLedgerKey(key string) (adapter.Surface, string) {
-	parts := strings.SplitN(key, "\x00", 2)
-	return adapter.Surface(parts[0]), parts[1]
-}
-
-type ledgerRecord struct {
-	State   adapter.LedgerState
-	Missing bool
-}
-
-func ledgerMap(rows []adapter.LedgerEntry) map[string]ledgerRecord {
-	out := make(map[string]ledgerRecord, len(rows))
-	for _, row := range rows {
-		out[ledgerKey(row.Surface, row.EffectiveName)] = ledgerRecord{State: row.State, Missing: row.Missing}
-	}
-	return out
-}
-func sortChanges(rows []adapter.Change) {
-	slices.SortFunc(rows, func(a, b adapter.Change) int {
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
-}
-func sortLedger(rows []adapter.LedgerEntry, sentinelsLast bool) {
-	slices.SortFunc(rows, func(a, b adapter.LedgerEntry) int {
-		if sentinelsLast {
-			aSentinel, bSentinel := strings.HasSuffix(a.EffectiveName, adapter.SentinelName), strings.HasSuffix(b.EffectiveName, adapter.SentinelName)
-			if aSentinel != bSentinel {
-				if aSentinel {
-					return 1
-				}
-				return -1
-			}
-		}
-		if a.Surface != b.Surface {
-			return strings.Compare(string(a.Surface), string(b.Surface))
-		}
-		return strings.Compare(a.EffectiveName, b.EffectiveName)
-	})
-}
-
-func capacityWarnings(destination adapter.Destination, desiredRows []desired, ledger []adapter.LedgerEntry, providerSecrets map[string]bool) []string {
+func capacityWarnings(destination adapter.Destination, desiredRows []adapter.DesiredRow, ledger []adapter.LedgerEntry, providerSecrets map[string]bool) []string {
 	secretCap, variableCap := 100, 500
 	scope := "repository"
 	switch destination.Kind {

--- a/internal/adapter/ledger.go
+++ b/internal/adapter/ledger.go
@@ -1,0 +1,163 @@
+package adapter
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type LedgerKey struct {
+	surface Surface
+	name    string
+}
+
+func NewLedgerKey(surface Surface, name string) LedgerKey {
+	return LedgerKey{surface: surface, name: strings.ToUpper(name)}
+}
+
+func IndexLedger(rows []LedgerEntry) (map[LedgerKey]LedgerEntry, error) {
+	out := make(map[LedgerKey]LedgerEntry, len(rows))
+	for _, row := range rows {
+		if err := validateMissingState(row.State, row.Missing); err != nil {
+			return nil, fmt.Errorf("adapter: ledger entry %s/%s: %w", row.Surface, row.EffectiveName, err)
+		}
+		out[NewLedgerKey(row.Surface, row.EffectiveName)] = row
+	}
+	return out, nil
+}
+
+func ValidateCompletion(completion Completion) error {
+	return validateMissingState(completion.State, completion.Missing)
+}
+
+func validateMissingState(state LedgerState, missing bool) error {
+	if missing && state != Owned && state != Dispatched {
+		return fmt.Errorf("missing requires owned or dispatched state, got %q", state)
+	}
+	return nil
+}
+
+type DesiredRow struct {
+	ManifestEntry
+	Surface       Surface
+	EffectiveName string
+}
+
+func DesiredRows(prefix string, manifest []ManifestEntry, sentinels bool) []DesiredRow {
+	rows := make([]DesiredRow, 0, len(manifest)+2)
+	if sentinels {
+		rows = append(rows,
+			DesiredRow{ManifestEntry: ManifestEntry{Classification: SecretClassification, Value: SentinelName}, Surface: Secret, EffectiveName: prefix + SentinelName},
+			DesiredRow{ManifestEntry: ManifestEntry{Classification: ConfigClassification, Value: SentinelName}, Surface: Variable, EffectiveName: prefix + SentinelName},
+		)
+	}
+	for _, entry := range manifest {
+		rows = append(rows, DesiredRow{ManifestEntry: entry, Surface: entry.Surface(), EffectiveName: prefix + entry.CanonicalName})
+	}
+	slices.SortStableFunc(rows, func(a, b DesiredRow) int {
+		aSentinel, bSentinel := a.KeyID == "", b.KeyID == ""
+		if aSentinel != bSentinel {
+			if aSentinel {
+				return -1
+			}
+			return 1
+		}
+		if a.Surface != b.Surface {
+			return strings.Compare(string(a.Surface), string(b.Surface))
+		}
+		return strings.Compare(a.EffectiveName, b.EffectiveName)
+	})
+	return rows
+}
+
+func NameSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		out[strings.ToUpper(value)] = true
+	}
+	return out
+}
+
+func CompletedNames(changes []Change) map[LedgerKey]bool {
+	out := make(map[LedgerKey]bool, len(changes))
+	for _, change := range changes {
+		out[NewLedgerKey(change.Surface, change.EffectiveName)] = true
+	}
+	return out
+}
+
+func PlanChanges(desired []DesiredRow, ledger map[LedgerKey]LedgerEntry, providerSecrets map[string]bool) []Change {
+	changes := make([]Change, 0, len(desired)+len(ledger))
+	desiredSet := make(map[LedgerKey]bool, len(desired))
+	for _, row := range desired {
+		key := NewLedgerKey(row.Surface, row.EffectiveName)
+		desiredSet[key] = true
+		record, claimed := ledger[key]
+		disposition := Create
+		switch {
+		case claimed && (record.State == Owned || record.State == Dispatched) && !record.Missing:
+			disposition = Update
+		case row.Surface == Secret && providerSecrets[row.EffectiveName]:
+			disposition = Conflict
+		case row.Surface == Variable && !claimed:
+			disposition = Unknown
+		}
+		changes = append(changes, Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: disposition})
+	}
+	for key, record := range ledger {
+		if desiredSet[key] || record.State == Reserved {
+			continue
+		}
+		changes = append(changes, Change{Surface: record.Surface, EffectiveName: record.EffectiveName, Disposition: Delete})
+	}
+	SortChanges(changes)
+	return changes
+}
+
+func Undesired(desired []DesiredRow, ledger map[LedgerKey]LedgerEntry) (reservations, prunes []LedgerEntry) {
+	desiredSet := make(map[LedgerKey]bool, len(desired))
+	for _, row := range desired {
+		desiredSet[NewLedgerKey(row.Surface, row.EffectiveName)] = true
+	}
+	for key, row := range ledger {
+		if desiredSet[key] {
+			continue
+		}
+		if row.State == Reserved {
+			reservations = append(reservations, row)
+		} else {
+			prunes = append(prunes, row)
+		}
+	}
+	sortLedger(reservations, false)
+	sortLedger(prunes, true)
+	return reservations, prunes
+}
+
+func SortChanges(rows []Change) {
+	slices.SortFunc(rows, func(a, b Change) int {
+		if a.Surface != b.Surface {
+			return strings.Compare(string(a.Surface), string(b.Surface))
+		}
+		return strings.Compare(a.EffectiveName, b.EffectiveName)
+	})
+}
+
+func sortLedger(rows []LedgerEntry, sentinelsLast bool) {
+	slices.SortFunc(rows, func(a, b LedgerEntry) int {
+		if sentinelsLast {
+			aSentinel := strings.HasSuffix(a.EffectiveName, SentinelName)
+			bSentinel := strings.HasSuffix(b.EffectiveName, SentinelName)
+			if aSentinel != bSentinel {
+				if aSentinel {
+					return 1
+				}
+				return -1
+			}
+		}
+		if a.Surface != b.Surface {
+			return strings.Compare(string(a.Surface), string(b.Surface))
+		}
+		return strings.Compare(a.EffectiveName, b.EffectiveName)
+	})
+}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -1028,7 +1028,7 @@ func TestAdapterTargetDestinationMoveKeepRemoteReleasesBeforeActivation(t *testi
 		`INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_keep_move_reveal_two','usr_adapter','reveal','org_adapter','prj_adapter','env_two','2026-08-17T00:00:00Z')`,
 		`INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_keep_move','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`,
 		`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) VALUES ('org_adapter','prj_adapter','env_one','tgt_one','adp_1','key_keep_move')`,
-		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_keep_move','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'secret','ONE_API_TOKEN','ONE_API_TOKEN','owned','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,missing,updated_at) VALUES ('led_keep_move','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'secret','ONE_API_TOKEN','ONE_API_TOKEN','owned',1,'2026-08-17T00:00:00Z')`,
 	} {
 		if _, err := db.SQLiteWrite().ExecContext(t.Context(), statement); err != nil {
 			t.Fatal(err)
@@ -1045,7 +1045,8 @@ func TestAdapterTargetDestinationMoveKeepRemoteReleasesBeforeActivation(t *testi
 		t.Fatalf("orphaned = %v", result.Orphaned)
 	}
 	var ledgerState, moveState, jobKind string
-	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state FROM adapter_ledger WHERE id='led_keep_move'`).Scan(&ledgerState); err != nil {
+	var ledgerMissing int
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state,missing FROM adapter_ledger WHERE id='led_keep_move'`).Scan(&ledgerState, &ledgerMissing); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state FROM adapter_route_moves WHERE id=?`, result.MoveID).Scan(&moveState); err != nil {
@@ -1054,8 +1055,8 @@ func TestAdapterTargetDestinationMoveKeepRemoteReleasesBeforeActivation(t *testi
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT kind FROM adapter_outbox WHERE id=?`, result.JobID).Scan(&jobKind); err != nil {
 		t.Fatal(err)
 	}
-	if ledgerState != "released" || moveState != "activating" || jobKind != "activate" {
-		t.Fatalf("keep-remote state ledger=%q move=%q job=%q", ledgerState, moveState, jobKind)
+	if ledgerState != "released" || ledgerMissing != 0 || moveState != "activating" || jobKind != "activate" {
+		t.Fatalf("keep-remote state ledger=%q missing=%d move=%q job=%q", ledgerState, ledgerMissing, moveState, jobKind)
 	}
 	var audited int
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM audit_tenant_events WHERE type='adapter.scrub' AND object_id='tgt_one' AND json_extract(payload,'$.orphaned[0]')='secret:ONE_API_TOKEN'`).Scan(&audited); err != nil {
@@ -1784,8 +1785,8 @@ func TestAdapterAdoptRequiresRevealAcrossEveryAdapterEnvironment(t *testing.T) {
 func TestAdapterTargetKeepRemoteReleasesAndEnumeratesCustodyWithoutReveal(t *testing.T) {
 	db := adapterServiceDB(t)
 	statements := []string{
-		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_keep_owned','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'secret','ONE_TOKEN','ONE_TOKEN','owned','2026-08-17T00:00:00Z')`,
-		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_keep_dispatched','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'variable','ONE_CONFIG','ONE_CONFIG','dispatched','2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,missing,updated_at) VALUES ('led_keep_owned','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'secret','ONE_TOKEN','ONE_TOKEN','owned',1,'2026-08-17T00:00:00Z')`,
+		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,missing,updated_at) VALUES ('led_keep_dispatched','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'variable','ONE_CONFIG','ONE_CONFIG','dispatched',1,'2026-08-17T00:00:00Z')`,
 		`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_keep_reserved','org_adapter','prj_adapter','env_one','tgt_one','https://git.example',42,'secret','ONE_PENDING','ONE_PENDING','reserved','2026-08-17T00:00:00Z')`,
 	}
 	for _, statement := range statements {
@@ -1809,18 +1810,21 @@ func TestAdapterTargetKeepRemoteReleasesAndEnumeratesCustodyWithoutReveal(t *tes
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT generation,state,sync_status FROM adapter_targets WHERE id='tgt_one'`).Scan(&generation, &targetState, &syncStatus); err != nil {
 		t.Fatal(err)
 	}
-	var activeLedger, releasedLedger, scrubAudits int
+	var activeLedger, releasedLedger, releasedMissing, scrubAudits int
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_ledger WHERE target_id='tgt_one' AND state<>'released'`).Scan(&activeLedger); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_ledger WHERE target_id='tgt_one' AND state='released'`).Scan(&releasedLedger); err != nil {
 		t.Fatal(err)
 	}
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_ledger WHERE target_id='tgt_one' AND state='released' AND missing=1`).Scan(&releasedMissing); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM audit_tenant_events WHERE type='adapter.scrub' AND object_id='tgt_one' AND outcome='success' AND json_extract(payload,'$.orphaned[0]')='secret:ONE_TOKEN' AND json_extract(payload,'$.orphaned[1]')='variable:ONE_CONFIG'`).Scan(&scrubAudits); err != nil {
 		t.Fatal(err)
 	}
-	if generation != 2 || targetState != "tombstoned" || syncStatus != "converged" || activeLedger != 0 || releasedLedger != 3 || scrubAudits != 1 {
-		t.Fatalf("target=%d/%s/%s ledger active=%d released=%d scrub audits=%d", generation, targetState, syncStatus, activeLedger, releasedLedger, scrubAudits)
+	if generation != 2 || targetState != "tombstoned" || syncStatus != "converged" || activeLedger != 0 || releasedLedger != 3 || releasedMissing != 0 || scrubAudits != 1 {
+		t.Fatalf("target=%d/%s/%s ledger active=%d released=%d released_missing=%d scrub audits=%d", generation, targetState, syncStatus, activeLedger, releasedLedger, releasedMissing, scrubAudits)
 	}
 	// A released global name is unowned. A different target can reserve the
 	// same provider identity, while the old row remains as custody history.

--- a/internal/store/adapter_runtime.go
+++ b/internal/store/adapter_runtime.go
@@ -677,6 +677,9 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 	if effectID == "" {
 		return errors.New("store: adapter effect has no durable INTENT")
 	}
+	if err := adapter.ValidateCompletion(completion); err != nil {
+		return err
+	}
 	outcomeID := newAdapterID("aud")
 	now := time.Now().UTC()
 	err := j.runtime.transaction(ctx, func(tx adapterDBTX) error {
@@ -713,9 +716,9 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 			rows, err = tx.Exec(ctx, remove, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
 		} else {
 			update := j.runtime.query(
-				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE ? END,missing=?,updated_at=? WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=?`,
-				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE $1 END,missing=$2,updated_at=$3 WHERE org_id=$4 AND project_id=$5 AND environment_id=$6 AND target_id=$7 AND surface=$8 AND normalized_name=$9`)
-			rows, err = tx.Exec(ctx, update, string(completion.State), completion.Missing, adapterTimestamp(j.runtime.db.Engine(), now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
+				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE ? END,missing=?,updated_at=? WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND NOT (state='released' AND ?)`,
+				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE $1 END,missing=$2,updated_at=$3 WHERE org_id=$4 AND project_id=$5 AND environment_id=$6 AND target_id=$7 AND surface=$8 AND normalized_name=$9 AND NOT (state='released' AND $10)`)
+			rows, err = tx.Exec(ctx, update, string(completion.State), completion.Missing, adapterTimestamp(j.runtime.db.Engine(), now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName), completion.Missing)
 		}
 		if err != nil {
 			return err
@@ -1426,8 +1429,8 @@ func (r *AdapterRuntime) finishDeadCredentialScrub(ctx context.Context, tx adapt
 		return err
 	}
 	releaseLedger := r.query(
-		`UPDATE adapter_ledger SET state='released',updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
-		`UPDATE adapter_ledger SET state='released',updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
+		`UPDATE adapter_ledger SET state='released',missing=0,updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
+		`UPDATE adapter_ledger SET state='released',missing=false,updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
 	if _, err := tx.Exec(ctx, releaseLedger, adapterTimestamp(r.db.Engine(), finished), job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID); err != nil {
 		return err
 	}

--- a/internal/store/adapter_runtime_test.go
+++ b/internal/store/adapter_runtime_test.go
@@ -155,6 +155,38 @@ func TestAdapterJournalPersistsOwnedMissingAndAuditFinding(t *testing.T) {
 	}
 }
 
+func TestAdapterJournalRefusesOwnedMissingCompletionAfterRelease(t *testing.T) {
+	db := adapterRuntimeDB(t)
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_released','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example','repository',0,42,'variable','MODE','MODE','released','2026-08-17T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	runtime := store.NewAdapterRuntime(db, func(context.Context, adapter.Job, adapter.Effect) error { return nil })
+	job, ok, err := runtime.ClaimDue(t.Context(), "worker_1", time.Now().UTC(), time.Now().UTC().Add(adapter.LeaseTime))
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue() = %+v, %v, %v", job, ok, err)
+	}
+	effect := adapter.Effect{Surface: adapter.Variable, EffectiveName: "MODE", Disposition: adapter.Update, KeyID: "key_1"}
+	journal := runtime.Journal(job)
+	if err := journal.Prepare(t.Context(), effect, adapter.Released); err != nil {
+		t.Fatal(err)
+	}
+	err = journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "failure", State: adapter.Owned, Missing: true, ProviderStatus: 404, Finding: "owned_missing"})
+	if !errors.Is(err, adapter.ErrSuperseded) {
+		t.Fatalf("Finish() error = %v, want ErrSuperseded", err)
+	}
+	var state string
+	var missing, outcomes int
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state,missing FROM adapter_ledger WHERE id='led_released'`).Scan(&state, &missing); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM audit_tenant_events WHERE correlation_id='job_1' AND type='adapter.push_outcome'`).Scan(&outcomes); err != nil {
+		t.Fatal(err)
+	}
+	if state != "released" || missing != 0 || outcomes != 0 {
+		t.Fatalf("released row changed: state=%q missing=%d outcomes=%d", state, missing, outcomes)
+	}
+}
+
 func TestAdapterJournalPUTNotFoundEndsEffectBeforeFreshCreateRetry(t *testing.T) {
 	db := adapterRuntimeDB(t)
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_variable','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example',42,'variable','LOG_LEVEL','LOG_LEVEL','owned','2026-08-17T00:00:00Z')`); err != nil {
@@ -675,7 +707,7 @@ func TestAdapterDeadCredentialScrubTerminatesAndEnumeratesOrphans(t *testing.T) 
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapter_outbox SET kind='scrub' WHERE id='job_1'`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_1','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example',42,'secret','TOKEN','TOKEN','owned','2026-08-17T00:00:00Z')`); err != nil {
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_id,surface,effective_name,normalized_name,state,missing,updated_at) VALUES ('led_1','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example',42,'secret','TOKEN','TOKEN','owned',1,'2026-08-17T00:00:00Z')`); err != nil {
 		t.Fatal(err)
 	}
 	runtime := store.NewAdapterRuntime(db, nil)
@@ -698,11 +730,12 @@ func TestAdapterDeadCredentialScrubTerminatesAndEnumeratesOrphans(t *testing.T) 
 		t.Fatal(err)
 	}
 	var ledgerState string
-	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state FROM adapter_ledger WHERE target_id='tgt_1'`).Scan(&ledgerState); err != nil {
+	var ledgerMissing int
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state,missing FROM adapter_ledger WHERE target_id='tgt_1'`).Scan(&ledgerState, &ledgerMissing); err != nil {
 		t.Fatal(err)
 	}
-	if targetState != "tombstoned" || syncStatus != "failed" || failureNames != `["secret:TOKEN"]` || outcome != "failure" || payload != `{"orphaned":["secret:TOKEN"]}` || ledgerState != "released" {
-		t.Fatalf("target=%q status=%q failures=%s audit=%q %s ledger=%q", targetState, syncStatus, failureNames, outcome, payload, ledgerState)
+	if targetState != "tombstoned" || syncStatus != "failed" || failureNames != `["secret:TOKEN"]` || outcome != "failure" || payload != `{"orphaned":["secret:TOKEN"]}` || ledgerState != "released" || ledgerMissing != 0 {
+		t.Fatalf("target=%q status=%q failures=%s audit=%q %s ledger=%q missing=%d", targetState, syncStatus, failureNames, outcome, payload, ledgerState, ledgerMissing)
 	}
 }
 

--- a/internal/store/repos_adapters.go
+++ b/internal/store/repos_adapters.go
@@ -1059,8 +1059,8 @@ func teardownAdapterTarget(ctx context.Context, db adoptDB, chain domain.Scope, 
 	}
 	if keepRemote {
 		release := db.SQL(
-			`UPDATE adapter_ledger SET state='released',updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
-			`UPDATE adapter_ledger SET state='released',updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
+			`UPDATE adapter_ledger SET state='released',missing=0,updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
+			`UPDATE adapter_ledger SET state='released',missing=false,updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
 		if _, err := db.Exec(ctx, release, stamp, target.targetID, chain.Org, chain.Project, target.environmentID); err != nil {
 			return AdapterTeardownResult{}, err
 		}

--- a/internal/store/repos_adapters_move.go
+++ b/internal/store/repos_adapters_move.go
@@ -587,8 +587,8 @@ func beginAdapterOriginMove(ctx context.Context, db adoptDB, chain domain.Scope,
 		}
 		if mutation.KeepRemote {
 			release := db.SQL(
-				`UPDATE adapter_ledger SET state='released',updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
-				`UPDATE adapter_ledger SET state='released',updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
+				`UPDATE adapter_ledger SET state='released',missing=0,updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
+				`UPDATE adapter_ledger SET state='released',missing=false,updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
 			if _, err := db.Exec(ctx, release, stamp, target.id, chain.Org, chain.Project, target.environmentID); err != nil {
 				return AdapterRouteMoveBatch{}, err
 			}
@@ -772,8 +772,8 @@ func beginAdapterTargetMove(ctx context.Context, db adoptDB, chain domain.Scope,
 	}
 	if mutation.KeepRemote {
 		release := db.SQL(
-			`UPDATE adapter_ledger SET state='released',updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
-			`UPDATE adapter_ledger SET state='released',updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
+			`UPDATE adapter_ledger SET state='released',missing=0,updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
+			`UPDATE adapter_ledger SET state='released',missing=false,updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
 		if _, err := db.Exec(ctx, release, stamp, mutation.Target.ID, chain.Org, chain.Project, current.environmentID); err != nil {
 			return AdapterRouteMoveResult{}, err
 		}


### PR DESCRIPTION
Closes #342

## Summary
- centralize typed ledger indexing, desired rows, plan classification, completed cursors, and prune ordering in internal/adapter
- make both providers preserve durable missing state and create owned-missing variables
- prevent released+missing across journal completion and every bulk-release path

## Contract and migration decisions
- keep the persisted state-plus-missing representation with shared fail-closed validation, as permitted by the issue
- retain existing owned_missing audit payloads and module/journal interfaces
- no database migration and no generated outputs

## Validation
- go test -count=1 ./internal/adapter/... ./internal/store ./internal/service
- go test -p 4 -count=1 ./...
- standards and issue-spec review: CLEAN in round 2 of 3