### PR TITLE
Unify SCIM positional parsing #343

### DIFF
--- a/docs/handoff/343-scim-positional-grammar.md
+++ b/docs/handoff/343-scim-positional-grammar.md
@@ -1,0 +1,54 @@
+# Handoff: #343 SCIM positional grammar
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/343 (parent #326; audit
+finding `F-S20-2`). Pull request:
+https://github.com/Hikyo-Org/Hikyo/pull/399. Implementation base:
+`21267cccd4dd977fb23a6d9d7c8fe38934db1b05`.
+
+## Contract
+
+- SCIM binding, mapping, credential, user, and group commands parse all flags
+  and positional arguments through `parseCommon` and its canonical
+  interspersed grammar.
+- `scimPositionals` owns SCIM positional arity. Missing identifiers retain the
+  existing command-specific usage text; trailing identifiers retain the
+  existing `takes no positional arguments` diagnostic.
+- A literal `-` is a positional identifier. Flags may appear before, between,
+  or after required identifiers.
+- `account reset-credential` uses the same canonical parser and requires
+  exactly one principal. Syntax failures occur before disclosure preparation,
+  target resolution, or HTTP work.
+- Wire, audit, output-format, ordering, database, and generated contracts are
+  unchanged. Generated outputs: none.
+
+## Regression evidence
+
+- `TestSCIMPositionalGrammar` covers all four migrated SCIM command shapes,
+  including the two-identifier credential path, literal `-`, missing and extra
+  arguments, preserved diagnostics, and zero HTTP requests.
+- `TestResetCredentialPositionalGrammar` covers a principal after flags and a
+  refused trailing positional, with zero HTTP requests.
+- The named SCIM regression failed against the branch-point implementation:
+  `hikyo scim binding show -o json scb_1` returned `ExitUsage` before target
+  resolution. It passes on the pull-request implementation.
+
+## Validation
+
+```text
+go test -count=1 ./internal/cli -run
+  'Test(SCIMPositionalGrammar|ResetCredentialPositionalGrammar|DisclosurePreparationFailureMakesNoRequest)$'
+                                                         22 passed / 1 package
+go test -count=1 ./...                              3,532 passed / 61 packages
+gofmt -w internal/cli/scim.go internal/cli/verbs.go
+  internal/cli/identities_test.go                             clean
+git diff --check                                             clean
+```
+
+## Review
+
+- Standards round 1 found missing positive coverage for the two-identifier
+  credential path and repeated exact-arity logic. Both were fixed; round 2:
+  `CLEAN`.
+- Spec round 1 found missing/extra diagnostic drift and one remaining
+  zero-arity callsite. Both were fixed and pinned by message assertions; round
+  2: `CLEAN`.

--- a/internal/cli/identities_test.go
+++ b/internal/cli/identities_test.go
@@ -131,6 +131,99 @@ func TestDisclosurePreparationFailureMakesNoRequest(t *testing.T) {
 	}
 }
 
+func TestSCIMPositionalGrammar(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "binding accepts an interspersed output flag",
+			args: []string{"scim", "binding", "show", "-o", "json", "scb_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
+			name: "mapping accepts an interspersed output flag",
+			args: []string{"scim", "mapping", "list", "-o", "json", "scb_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
+			name: "directory accepts an interspersed output flag",
+			args: []string{"scim", "user", "list", "-o", "json", "scb_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
+			name: "literal dash is a binding id",
+			args: []string{"scim", "binding", "show", "-", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
+			name: "trailing positional is refused",
+			args: []string{"scim", "binding", "show", "scb_1", "stray", "--instance", server.URL},
+			want: cli.ExitUsage,
+		},
+		{
+			name: "missing credential id is refused",
+			args: []string{"scim", "credential", "show", "scb_1", "-o", "json", "--instance", server.URL},
+			want: cli.ExitUsage,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests.Store(0)
+			ios, _, stderr := testIO(t, nil)
+			if got := cli.Run(t.Context(), ios, tc.args); got != tc.want {
+				t.Fatalf("exit %d, want %d; stderr: %s", got, tc.want, stderr)
+			}
+			if requests.Load() != 0 {
+				t.Fatalf("positional parsing made %d HTTP request(s), want none", requests.Load())
+			}
+		})
+	}
+}
+
+func TestResetCredentialPositionalGrammar(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "reset-authority")
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "principal may follow flags",
+			args: []string{"account", "reset-credential", "--output-file", output, "usr_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
+			name: "trailing positional is refused",
+			args: []string{"account", "reset-credential", "--output-file", output, "usr_1", "stray", "--instance", server.URL},
+			want: cli.ExitUsage,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests.Store(0)
+			ios, _, stderr := testIO(t, nil)
+			if got := cli.Run(t.Context(), ios, tc.args); got != tc.want {
+				t.Fatalf("exit %d, want %d; stderr: %s", got, tc.want, stderr)
+			}
+			if requests.Load() != 0 {
+				t.Fatalf("positional parsing made %d HTTP request(s), want none", requests.Load())
+			}
+		})
+	}
+}
+
 // TestMintDeliveryAcceptedChannels is the positive side: each permitted
 // destination gets past preparation and fails later, on the network, which
 // is how we know the channel itself was accepted. `--dangerously-print` and

--- a/internal/cli/identities_test.go
+++ b/internal/cli/identities_test.go
@@ -139,9 +139,10 @@ func TestSCIMPositionalGrammar(t *testing.T) {
 	defer server.Close()
 
 	for _, tc := range []struct {
-		name string
-		args []string
-		want int
+		name        string
+		args        []string
+		want        int
+		wantMessage string
 	}{
 		{
 			name: "binding accepts an interspersed output flag",
@@ -159,6 +160,11 @@ func TestSCIMPositionalGrammar(t *testing.T) {
 			want: cli.ExitRefused,
 		},
 		{
+			name: "two-id credential accepts an interspersed output flag",
+			args: []string{"scim", "credential", "show", "scb_1", "-o", "json", "scc_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
 			name: "directory accepts an interspersed output flag",
 			args: []string{"scim", "user", "list", "-o", "json", "scb_1", "--instance", server.URL},
 			want: cli.ExitRefused,
@@ -169,14 +175,28 @@ func TestSCIMPositionalGrammar(t *testing.T) {
 			want: cli.ExitRefused,
 		},
 		{
-			name: "trailing positional is refused",
-			args: []string{"scim", "binding", "show", "scb_1", "stray", "--instance", server.URL},
-			want: cli.ExitUsage,
+			name:        "trailing positional is refused",
+			args:        []string{"scim", "binding", "show", "scb_1", "stray", "--instance", server.URL},
+			want:        cli.ExitUsage,
+			wantMessage: "usage: hikyo scim binding show takes no positional arguments, got: stray",
 		},
 		{
-			name: "missing credential id is refused",
-			args: []string{"scim", "credential", "show", "scb_1", "-o", "json", "--instance", server.URL},
-			want: cli.ExitUsage,
+			name:        "missing credential id is refused",
+			args:        []string{"scim", "credential", "show", "scb_1", "-o", "json", "--instance", server.URL},
+			want:        cli.ExitUsage,
+			wantMessage: "usage: hikyo scim credential show <binding> <credential-id>",
+		},
+		{
+			name:        "missing binding keeps its usage",
+			args:        []string{"scim", "credential", "show", "-o", "json", "--instance", server.URL},
+			want:        cli.ExitUsage,
+			wantMessage: "usage: hikyo scim credential show <binding> ...",
+		},
+		{
+			name:        "zero-arity binding rejects a positional",
+			args:        []string{"scim", "binding", "list", "stray", "--instance", server.URL},
+			want:        cli.ExitUsage,
+			wantMessage: "usage: hikyo scim binding list takes no positional arguments, got: stray",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -184,6 +204,9 @@ func TestSCIMPositionalGrammar(t *testing.T) {
 			ios, _, stderr := testIO(t, nil)
 			if got := cli.Run(t.Context(), ios, tc.args); got != tc.want {
 				t.Fatalf("exit %d, want %d; stderr: %s", got, tc.want, stderr)
+			}
+			if tc.wantMessage != "" && !strings.Contains(stderr.String(), tc.wantMessage) {
+				t.Fatalf("stderr %q does not contain %q", stderr, tc.wantMessage)
 			}
 			if requests.Load() != 0 {
 				t.Fatalf("positional parsing made %d HTTP request(s), want none", requests.Load())

--- a/internal/cli/identities_test.go
+++ b/internal/cli/identities_test.go
@@ -154,6 +154,11 @@ func TestSCIMPositionalGrammar(t *testing.T) {
 			want: cli.ExitRefused,
 		},
 		{
+			name: "credential accepts an interspersed output flag",
+			args: []string{"scim", "credential", "list", "-o", "json", "scb_1", "--instance", server.URL},
+			want: cli.ExitRefused,
+		},
+		{
 			name: "directory accepts an interspersed output flag",
 			args: []string{"scim", "user", "list", "-o", "json", "scb_1", "--instance", server.URL},
 			want: cli.ExitRefused,

--- a/internal/cli/scim.go
+++ b/internal/cli/scim.go
@@ -68,6 +68,18 @@ func scimBindingsPath(resolved Resolved) (string, error) {
 	return api.PathPrefix + "/orgs/" + url.PathEscape(org) + "/scim-bindings", nil
 }
 
+func scimPositionals(flags commonFlags, want int, usage, verb string) ([]string, error) {
+	if len(flags.positionals) < want {
+		return nil, failf(ExitUsage, "usage: hikyo %s", usage)
+	}
+	if len(flags.positionals) > want {
+		extras := flags
+		extras.positionals = flags.positionals[want:]
+		return nil, extras.checkNoPositionals(verb)
+	}
+	return flags.positionals, nil
+}
+
 // ---------------------------------------------------------------------------
 // binding
 // ---------------------------------------------------------------------------
@@ -113,12 +125,15 @@ func runSCIMBinding(ctx context.Context, ios IO, args []string) error {
 	// `show` and `delete` take the binding id positionally, per the spellings.
 	binding := ""
 	if sub == "show" || sub == "delete" {
-		if len(flags.positionals) != 1 {
-			return failf(ExitUsage, "usage: hikyo scim binding %s <binding>", sub)
+		positionals, err := scimPositionals(flags, 1, "scim binding "+sub+" <binding>", "scim binding "+sub)
+		if err != nil {
+			return err
 		}
-		binding = flags.positionals[0]
-	} else if err := flags.checkNoPositionals("scim binding " + sub); err != nil {
-		return err
+		binding = positionals[0]
+	} else {
+		if _, err := scimPositionals(flags, 0, "", "scim binding "+sub); err != nil {
+			return err
+		}
 	}
 	if sub == "create" {
 		if provider == "" {
@@ -225,10 +240,11 @@ func runSCIMMapping(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(flags.positionals) != 1 {
-		return failf(ExitUsage, "usage: hikyo scim mapping %s <binding> ...", sub)
+	positionals, err := scimPositionals(flags, 1, "scim mapping "+sub+" <binding> ...", "scim mapping "+sub)
+	if err != nil {
+		return err
 	}
-	binding := flags.positionals[0]
+	binding := positionals[0]
 	switch {
 	case sub != "list" && group == "":
 		return failf(ExitUsage, "usage: hikyo scim mapping %s <binding> --group <idp-group-id> ...", sub)
@@ -344,16 +360,21 @@ func runSCIMCredential(ctx context.Context, ios IO, args []string) (returnErr er
 	if sub == "show" || sub == "revoke" {
 		wantPositionals = 2
 	}
-	if len(flags.positionals) != wantPositionals {
-		if wantPositionals == 2 {
-			return failf(ExitUsage, "usage: hikyo scim credential %s <binding> <credential-id>", sub)
-		}
+	if len(flags.positionals) == 0 {
 		return failf(ExitUsage, "usage: hikyo scim credential %s <binding> ...", sub)
 	}
-	binding := flags.positionals[0]
+	usage := "scim credential " + sub + " <binding> ..."
+	if wantPositionals == 2 {
+		usage = "scim credential " + sub + " <binding> <credential-id>"
+	}
+	positionals, err := scimPositionals(flags, wantPositionals, usage, "scim credential "+sub)
+	if err != nil {
+		return err
+	}
+	binding := positionals[0]
 	credential := ""
 	if wantPositionals == 2 {
-		credential = flags.positionals[1]
+		credential = positionals[1]
 	}
 
 	// Reserve the print-triad destination BEFORE the mint, so a credential is
@@ -460,10 +481,11 @@ func runSCIMDirectory(ctx context.Context, ios IO, args []string, kind string) e
 	if err != nil {
 		return err
 	}
-	if len(flags.positionals) != 1 {
-		return failf(ExitUsage, "usage: hikyo scim %s list <binding>", kind)
+	positionals, err := scimPositionals(flags, 1, "scim "+kind+" list <binding>", "scim "+kind+" list")
+	if err != nil {
+		return err
 	}
-	binding := flags.positionals[0]
+	binding := positionals[0]
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
 	if err != nil {
 		return err

--- a/internal/cli/scim.go
+++ b/internal/cli/scim.go
@@ -77,14 +77,6 @@ func runSCIMBinding(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	// `show` and `delete` take the binding id positionally, per the spellings.
-	binding := ""
-	if sub == "show" || sub == "delete" {
-		if len(rest) == 0 || strings.HasPrefix(rest[0], "-") {
-			return failf(ExitUsage, "usage: hikyo scim binding %s <binding>", sub)
-		}
-		binding, rest = rest[0], rest[1:]
-	}
 
 	var format, provider, kind, subjectSource string
 	var nameIDFormat, nameIDQualifier, nameIDSPQualifier string
@@ -118,7 +110,14 @@ func runSCIMBinding(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := flags.checkNoPositionals("scim binding " + sub); err != nil {
+	// `show` and `delete` take the binding id positionally, per the spellings.
+	binding := ""
+	if sub == "show" || sub == "delete" {
+		if len(flags.positionals) != 1 {
+			return failf(ExitUsage, "usage: hikyo scim binding %s <binding>", sub)
+		}
+		binding = flags.positionals[0]
+	} else if err := flags.checkNoPositionals("scim binding " + sub); err != nil {
 		return err
 	}
 	if sub == "create" {
@@ -205,11 +204,6 @@ func runSCIMMapping(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(rest) == 0 || strings.HasPrefix(rest[0], "-") {
-		return failf(ExitUsage, "usage: hikyo scim mapping %s <binding> ...", sub)
-	}
-	binding := rest[0]
-	rest = rest[1:]
 
 	var format, group, template string
 	var orgScope bool
@@ -231,9 +225,10 @@ func runSCIMMapping(ctx context.Context, ios IO, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := flags.checkNoPositionals("scim mapping " + sub); err != nil {
-		return err
+	if len(flags.positionals) != 1 {
+		return failf(ExitUsage, "usage: hikyo scim mapping %s <binding> ...", sub)
 	}
+	binding := flags.positionals[0]
 	switch {
 	case sub != "list" && group == "":
 		return failf(ExitUsage, "usage: hikyo scim mapping %s <binding> --group <idp-group-id> ...", sub)
@@ -326,19 +321,6 @@ func runSCIMCredential(ctx context.Context, ios IO, args []string) (returnErr er
 	if err != nil {
 		return err
 	}
-	if len(rest) == 0 || strings.HasPrefix(rest[0], "-") {
-		return failf(ExitUsage, "usage: hikyo scim credential %s <binding> ...", sub)
-	}
-	binding := rest[0]
-	rest = rest[1:]
-
-	credential := ""
-	if sub == "show" || sub == "revoke" {
-		if len(rest) == 0 || strings.HasPrefix(rest[0], "-") {
-			return failf(ExitUsage, "usage: hikyo scim credential %s <binding> <credential-id>", sub)
-		}
-		credential, rest = rest[0], rest[1:]
-	}
 
 	var format, outputFile string
 	var dangerous, indefinite bool
@@ -358,8 +340,20 @@ func runSCIMCredential(ctx context.Context, ios IO, args []string) (returnErr er
 	if err != nil {
 		return err
 	}
-	if err := flags.checkNoPositionals("scim credential " + sub); err != nil {
-		return err
+	wantPositionals := 1
+	if sub == "show" || sub == "revoke" {
+		wantPositionals = 2
+	}
+	if len(flags.positionals) != wantPositionals {
+		if wantPositionals == 2 {
+			return failf(ExitUsage, "usage: hikyo scim credential %s <binding> <credential-id>", sub)
+		}
+		return failf(ExitUsage, "usage: hikyo scim credential %s <binding> ...", sub)
+	}
+	binding := flags.positionals[0]
+	credential := ""
+	if wantPositionals == 2 {
+		credential = flags.positionals[1]
 	}
 
 	// Reserve the print-triad destination BEFORE the mint, so a credential is
@@ -455,13 +449,8 @@ func runSCIMDirectory(ctx context.Context, ios IO, args []string, kind string) e
 	} else {
 		args = rest
 	}
-	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return failf(ExitUsage, "usage: hikyo scim %s list <binding>", kind)
-	}
-	binding := args[0]
-
 	var format string
-	st, flags, err := parseCommon("scim "+kind+" list", ios, args[1:], func(fs *flag.FlagSet) {
+	st, flags, err := parseCommon("scim "+kind+" list", ios, args, func(fs *flag.FlagSet) {
 		fs.StringVar(&format, "o", "table", "output format: table or json")
 	})
 	if err != nil {
@@ -471,9 +460,10 @@ func runSCIMDirectory(ctx context.Context, ios IO, args []string, kind string) e
 	if err != nil {
 		return err
 	}
-	if err := flags.checkNoPositionals("scim " + kind + " list"); err != nil {
-		return err
+	if len(flags.positionals) != 1 {
+		return failf(ExitUsage, "usage: hikyo scim %s list <binding>", kind)
 	}
+	binding := flags.positionals[0]
 	client, _, resolved, err := authenticatedTarget(st, ios, flags)
 	if err != nil {
 		return err

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -753,19 +753,19 @@ func runAccount(ctx context.Context, ios IO, args []string) error {
 // and is refused uniformly (like a nonexistent target, B2) - break-glass only,
 // via `hikyo admin reset-credential` on the host.
 func runResetCredential(ctx context.Context, ios IO, args []string) (returnErr error) {
-	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return failf(ExitUsage, "usage: hikyo account reset-credential <principal> [--output-file PATH | --dangerously-print]")
-	}
-	principal := args[0]
 	var outputFile string
 	var dangerous bool
-	st, flags, err := parseCommon("account reset-credential", ios, args[1:], func(fs *flag.FlagSet) {
+	st, flags, err := parseCommon("account reset-credential", ios, args, func(fs *flag.FlagSet) {
 		fs.StringVar(&outputFile, "output-file", "", "write the authority to a file this command creates (0600)")
 		fs.BoolVar(&dangerous, "dangerously-print", false, "print the authority to stdout")
 	})
 	if err != nil {
 		return err
 	}
+	if len(flags.positionals) != 1 {
+		return failf(ExitUsage, "usage: hikyo account reset-credential <principal> [--output-file PATH | --dangerously-print]")
+	}
+	principal := flags.positionals[0]
 	deliver := disclose.Options{OutputFile: outputFile, DangerouslyPrint: dangerous, Stdout: ios.Stdout}
 	sink, err := ios.prepareDisclosure(deliver)
 	if err != nil {


### PR DESCRIPTION
Closes #343

## Contract
- Parse SCIM and account reset positionals through the canonical interspersed flag grammar.
- Enforce exact positional counts before target resolution or HTTP work.
- Preserve existing missing/extra usage diagnostics, command behavior, and output formats.

## Coverage
- `TestSCIMPositionalGrammar`: all four SCIM shapes, two-ID credential path, literal dash, trailing extra, missing IDs, preserved diagnostics, and no HTTP.
- `TestResetCredentialPositionalGrammar`: flag-first principal, trailing extra, and no HTTP.
- Pre-fix proof at `21267ccc`: named SCIM regression fails because `-o` before the binding returns ExitUsage.

## Generated outputs
None.

## Validation
- Focused CLI gate: 22 passed.
- `go test -count=1 ./...`: 3,532 passed across 61 packages.
- `gofmt` and `git diff --check`: clean.
- Two-axis review round 2: Standards CLEAN; Spec CLEAN.
- Exact-head CI: running.

## Coordination
Branch refresh and merge wait until #399 is the lowest open non-draft PR.