### PR TITLE
Test release fixtures through canonical manifest producer #346

### DIFF
--- a/docs/handoff/346-release-manifest-fixture.md
+++ b/docs/handoff/346-release-manifest-fixture.md
@@ -20,11 +20,15 @@ finding `F-S36-2`). Fixed point before this work:
 ## Validation
 
 - `git diff --check`: passed before the initial push.
-- Focused and full local checks are deferred until host memory pressure drops.
-- PR #400 exact-head CI started at commit `1b186e3`.
+- `scripts/release/create-manifest_test.sh`: passed; producer output completed
+  verifier checks with only cosign cryptography stubbed.
+- `scripts/release/test-fixtures.sh`: local start blocked because `cosign` is
+  not installed; CI installs its pinned cosign version before this fixture.
+- PR #400 exact-head CI is the full release-fixture gate.
 
 ## Review
 
 - Spec round 1: `CLEAN`.
 - Standards round 1 found this missing handoff and a duplicated SHA helper;
   both were added or replaced with the release library owner.
+- Standards and spec round 2: `CLEAN`.

--- a/docs/handoff/346-release-manifest-fixture.md
+++ b/docs/handoff/346-release-manifest-fixture.md
@@ -1,0 +1,30 @@
+# Handoff: #346 canonical release-manifest fixture
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/346 (parent #326; audit
+finding `F-S36-2`). Fixed point before this work:
+`b891007b0d8a6ec8f318af506172cc217640089e`.
+
+## Contract
+
+- `scripts/release/create-manifest.sh` now owns the v1 fixture manifest shape,
+  artifact classification, artifact hashes, image tag, and chart app version.
+- `scripts/release/test-fixtures.sh` supplies only classifiable release
+  artifacts and canonical candidate inputs before invoking that producer.
+- Intentional v2 and negative-fixture mutations remain local `jq` patches;
+  they model contradictory or historical bundles rather than a second valid
+  manifest producer.
+- `scripts/release/create-manifest_test.sh` passes producer output through the
+  complete `verify-bundle.sh` contract with only cosign cryptography stubbed.
+- Runtime release bytes, schema, ordering, and generated outputs are unchanged.
+
+## Validation
+
+- `git diff --check`: passed before the initial push.
+- Focused and full local checks are deferred until host memory pressure drops.
+- PR #400 exact-head CI started at commit `1b186e3`.
+
+## Review
+
+- Spec round 1: `CLEAN`.
+- Standards round 1 found this missing handoff and a duplicated SHA helper;
+  both were added or replaced with the release library owner.

--- a/scripts/release/create-manifest_test.sh
+++ b/scripts/release/create-manifest_test.sh
@@ -33,11 +33,17 @@ jq -n '{
 printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-source.spdx.json"
 printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-image.spdx.json"
 printf 'installer\n' >"$dist/install.sh"
-printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"},"type":"cosign container image signature"},"optional":null}\n' 1 >"$dist/image-index.oci-payload.json"
-printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"},"type":"cosign container image signature"},"optional":null}\n' 2 >"$dist/chart-index.oci-payload.json"
+image_digest=sha256:1111111111111111111111111111111111111111111111111111111111111111
+chart_digest=sha256:2222222222222222222222222222222222222222222222222222222222222222
+jq -nc --arg digest "$image_digest" \
+	'{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \
+	>"$dist/image-index.oci-payload.json"
+jq -nc --arg digest "$chart_digest" \
+	'{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \
+	>"$dist/chart-index.oci-payload.json"
 mkdir -p "$fixture_dir/hikyo"
 printf 'name: hikyo\nversion: 0.1.0\nappVersion: 0.1.0\n' >"$fixture_dir/hikyo/Chart.yaml"
-printf 'image:\n  repository: ghcr.io/hikyo-org/hikyo\n  digest: sha256:%064d\n' 1 \
+printf 'image:\n  repository: ghcr.io/hikyo-org/hikyo\n  digest: %s\n' "$image_digest" \
 	>"$fixture_dir/hikyo/values.yaml"
 tar -czf "$dist/hikyo-0.1.0.tgz" -C "$fixture_dir" hikyo
 printf '{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","key_id":"primary-1","public_key":"primary-1.pub","sequence":7,"version":"0.1.0"}\n' \
@@ -45,9 +51,9 @@ printf '{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","key_id":"primary-1
 
 "$(dirname "$0")/create-manifest.sh" \
 	"$dist/release-candidate.json" ghcr.io/hikyo-org/hikyo \
-	sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+	"$image_digest" \
 	ghcr.io/hikyo-org/charts/hikyo \
-	sha256:2222222222222222222222222222222222222222222222222222222222222222 \
+	"$chart_digest" \
 	"$dist" >/dev/null
 
 jq -e '
@@ -119,9 +125,9 @@ jq '.source_commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
 cp "$fixture_dir/wrong-commit.json" "$dist/binary-provenance.json"
 if "$(dirname "$0")/create-manifest.sh" \
 	"$dist/release-candidate.json" ghcr.io/hikyo-org/hikyo \
-	sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+	"$image_digest" \
 	ghcr.io/hikyo-org/charts/hikyo \
-	sha256:2222222222222222222222222222222222222222222222222222222222222222 \
+	"$chart_digest" \
 	"$dist" >"$fixture_dir/wrong-commit.out" 2>"$fixture_dir/wrong-commit.err"
 then
 	printf 'manifest fixture: mismatched binary candidate unexpectedly accepted\n' >&2

--- a/scripts/release/create-manifest_test.sh
+++ b/scripts/release/create-manifest_test.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -eu
 
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$script_dir/../lib/release.sh"
+
 fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/hikyo-manifest-fixture.XXXXXX")
 trap 'rm -rf "$fixture_dir"' EXIT HUP INT TERM
 dist="$fixture_dir/dist"
@@ -71,15 +75,9 @@ trust_dir="$fixture_dir/trust"
 mkdir -p "$trust_dir"
 printf 'fixture recovery key\n' >"$trust_dir/recovery.pub"
 printf 'fixture primary key\n' >"$trust_dir/primary-1.pub"
-if command -v sha256sum >/dev/null 2>&1; then
-	recovery_sha=$(sha256sum "$trust_dir/recovery.pub" | awk '{print $1}')
-	primary_sha=$(sha256sum "$trust_dir/primary-1.pub" | awk '{print $1}')
-	manifest_sha=$(sha256sum "$dist/release-manifest.json" | awk '{print $1}')
-else
-	recovery_sha=$(shasum -a 256 "$trust_dir/recovery.pub" | awk '{print $1}')
-	primary_sha=$(shasum -a 256 "$trust_dir/primary-1.pub" | awk '{print $1}')
-	manifest_sha=$(shasum -a 256 "$dist/release-manifest.json" | awk '{print $1}')
-fi
+recovery_sha=$(sha256_file "$trust_dir/recovery.pub")
+primary_sha=$(sha256_file "$trust_dir/primary-1.pub")
+manifest_sha=$(sha256_file "$dist/release-manifest.json")
 jq -n --arg recovery_sha "$recovery_sha" --arg primary_sha "$primary_sha" '{
 	schema: "hikyo.dev/trust-root/v1",
 	recovery: {id: "recovery-1", public_key: "recovery.pub", sha256: $recovery_sha},

--- a/scripts/release/create-manifest_test.sh
+++ b/scripts/release/create-manifest_test.sh
@@ -29,11 +29,12 @@ jq -n '{
 printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-source.spdx.json"
 printf '{"spdxVersion":"SPDX-2.3"}\n' >"$dist/hikyo-image.spdx.json"
 printf 'installer\n' >"$dist/install.sh"
-printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"}}}\n' 1 >"$dist/image-index.oci-payload.json"
-printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"}}}\n' 2 >"$dist/chart-index.oci-payload.json"
+printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"},"type":"cosign container image signature"},"optional":null}\n' 1 >"$dist/image-index.oci-payload.json"
+printf '{"critical":{"identity":{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},"image":{"docker-manifest-digest":"sha256:%064d"},"type":"cosign container image signature"},"optional":null}\n' 2 >"$dist/chart-index.oci-payload.json"
 mkdir -p "$fixture_dir/hikyo"
 printf 'name: hikyo\nversion: 0.1.0\nappVersion: 0.1.0\n' >"$fixture_dir/hikyo/Chart.yaml"
-printf 'image:\n  digest: sha256:%064d\n' 1 >"$fixture_dir/hikyo/values.yaml"
+printf 'image:\n  repository: ghcr.io/hikyo-org/hikyo\n  digest: sha256:%064d\n' 1 \
+	>"$fixture_dir/hikyo/values.yaml"
 tar -czf "$dist/hikyo-0.1.0.tgz" -C "$fixture_dir" hikyo
 printf '{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","key_id":"primary-1","public_key":"primary-1.pub","sequence":7,"version":"0.1.0"}\n' \
 	>"$dist/release-candidate.json"
@@ -66,6 +67,55 @@ jq -e '
 		.image_digest == "sha256:1111111111111111111111111111111111111111111111111111111111111111")
 ' "$dist/release-manifest.json" >/dev/null
 
+trust_dir="$fixture_dir/trust"
+mkdir -p "$trust_dir"
+printf 'fixture recovery key\n' >"$trust_dir/recovery.pub"
+printf 'fixture primary key\n' >"$trust_dir/primary-1.pub"
+if command -v sha256sum >/dev/null 2>&1; then
+	recovery_sha=$(sha256sum "$trust_dir/recovery.pub" | awk '{print $1}')
+	primary_sha=$(sha256sum "$trust_dir/primary-1.pub" | awk '{print $1}')
+	manifest_sha=$(sha256sum "$dist/release-manifest.json" | awk '{print $1}')
+else
+	recovery_sha=$(shasum -a 256 "$trust_dir/recovery.pub" | awk '{print $1}')
+	primary_sha=$(shasum -a 256 "$trust_dir/primary-1.pub" | awk '{print $1}')
+	manifest_sha=$(shasum -a 256 "$dist/release-manifest.json" | awk '{print $1}')
+fi
+jq -n --arg recovery_sha "$recovery_sha" --arg primary_sha "$primary_sha" '{
+	schema: "hikyo.dev/trust-root/v1",
+	recovery: {id: "recovery-1", public_key: "recovery.pub", sha256: $recovery_sha},
+	bootstrap_primary: {id: "primary-1", public_key: "primary-1.pub", sha256: $primary_sha}
+}' >"$trust_dir/root.json"
+jq -n \
+	--arg recovery_sha "$recovery_sha" \
+	--arg primary_sha "$primary_sha" \
+	--arg manifest_sha "$manifest_sha" '{
+	schema: "hikyo.dev/trust-metadata/v1",
+	sequence: 1,
+	highest_release: "0.1.0",
+	highest_release_sequence: 7,
+	recovery: {id: "recovery-1", sha256: $recovery_sha},
+	event: {type: "release", signed_by: "recovery-1"},
+	primary_keys: [{
+		id: "primary-1", public_key: "primary-1.pub", sha256: $primary_sha,
+		valid_from_release_sequence: 1, valid_through_release_sequence: null,
+		revoked: false
+	}],
+	releases: [{version: "0.1.0", sequence: 7, manifest_sha256: $manifest_sha}],
+	pending_release: null
+}' >"$trust_dir/metadata.json"
+: >"$trust_dir/metadata.sigstore.json"
+: >"$dist/release-manifest.sigstore.json"
+jq -r '.artifacts[].name' "$dist/release-manifest.json" | while IFS= read -r name; do
+	: >"$dist/$name.sigstore.json"
+done
+printf '#!/bin/sh\nexit 0\n' >"$fixture_dir/cosign"
+chmod +x "$fixture_dir/cosign"
+COSIGN_BIN="$fixture_dir/cosign" "$(dirname "$0")/verify-bundle.sh" \
+	--root "$trust_dir/root.json" \
+	--metadata "$trust_dir/metadata.json" \
+	--metadata-signature "$trust_dir/metadata.sigstore.json" \
+	--bundle "$dist" --state "$fixture_dir/verification-state.json" --latest >/dev/null
+
 jq '.source_commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
 	"$dist/binary-provenance.json" >"$fixture_dir/wrong-commit.json"
 cp "$fixture_dir/wrong-commit.json" "$dist/binary-provenance.json"
@@ -81,4 +131,4 @@ then
 fi
 grep -F 'manifest: invalid binary provenance' "$fixture_dir/wrong-commit.err" >/dev/null
 
-printf 'manifest fixture: complete artifact set recorded\n'
+printf 'manifest fixture: producer output accepted by verifier\n'

--- a/scripts/release/test-fixtures.sh
+++ b/scripts/release/test-fixtures.sh
@@ -185,8 +185,6 @@ jq -n --arg commit "$candidate_commit" '{
 	})
 }' >"$bundle_dir/binary-provenance.json"
 printf '{"spdxVersion":"SPDX-2.3"}\n' >"$bundle_dir/hikyo-source.spdx.json"
-printf 'sha256:%064d\n' 1 >"$bundle_dir/image-index.digest"
-printf 'sha256:%064d\n' 2 >"$bundle_dir/chart-index.digest"
 printf '#!/bin/sh\nprintf "fixture installer\\n"\n' >"$bundle_dir/install.sh"
 printf '{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","key_id":"primary-1","public_key":"primary-1.pub","sequence":1,"version":"0.1.0"}\n' \
 	>"$bundle_dir/release-candidate.json"
@@ -196,56 +194,15 @@ printf 'image:\n  repository: ghcr.io/hikyo-org/hikyo\n  digest: sha256:%064d\n'
 	>"$fixture_dir/chart/hikyo/values.yaml"
 tar -czf "$bundle_dir/hikyo-0.1.0.tgz" -C "$fixture_dir/chart" hikyo
 
-binary_sha=$(sha256_file "$bundle_dir/hikyo_Linux_arm64.tar.gz")
-binary_provenance_sha=$(sha256_file "$bundle_dir/binary-provenance.json")
-sbom_sha=$(sha256_file "$bundle_dir/hikyo-source.spdx.json")
-image_file_sha=$(sha256_file "$bundle_dir/image-index.digest")
-image_digest=$(tr -d '\n' <"$bundle_dir/image-index.digest")
-chart_file_sha=$(sha256_file "$bundle_dir/hikyo-0.1.0.tgz")
-chart_digest_file_sha=$(sha256_file "$bundle_dir/chart-index.digest")
-chart_digest=$(tr -d '\n' <"$bundle_dir/chart-index.digest")
-installer_sha=$(sha256_file "$bundle_dir/install.sh")
-candidate_sha=$(sha256_file "$bundle_dir/release-candidate.json")
+image_digest=sha256:1111111111111111111111111111111111111111111111111111111111111111
+chart_digest=sha256:2222222222222222222222222222222222222222222222222222222222222222
 jq -n --arg digest "$image_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \
 	>"$bundle_dir/image-index.oci-payload.json"
 jq -n --arg digest "$chart_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \
 	>"$bundle_dir/chart-index.oci-payload.json"
-image_payload_sha=$(sha256_file "$bundle_dir/image-index.oci-payload.json")
-chart_payload_sha=$(sha256_file "$bundle_dir/chart-index.oci-payload.json")
-
-jq -n \
-	--arg binary_sha "$binary_sha" \
-	--arg binary_provenance_sha "$binary_provenance_sha" \
-	--arg sbom_sha "$sbom_sha" \
-	--arg image_file_sha "$image_file_sha" \
-	--arg image_digest "$image_digest" \
-	--arg chart_file_sha "$chart_file_sha" \
-	--arg chart_digest_file_sha "$chart_digest_file_sha" \
-	--arg chart_digest "$chart_digest" \
-	--arg installer_sha "$installer_sha" \
-	--arg candidate_sha "$candidate_sha" \
-	--arg image_payload_sha "$image_payload_sha" \
-	--arg chart_payload_sha "$chart_payload_sha" \
-	'{
-		schema: "hikyo.dev/release-manifest/v1",
-		version: "0.1.0",
-		tag: "v0.1.0",
-		source_commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		release_sequence: 1,
-		signing_key_id: "primary-1",
-		artifacts: [
-			{name: "release-candidate.json", kind: "release-candidate", sha256: $candidate_sha},
-			{name: "hikyo_Linux_arm64.tar.gz", kind: "binary", sha256: $binary_sha},
-			{name: "binary-provenance.json", kind: "binary-provenance", sha256: $binary_provenance_sha},
-			{name: "hikyo-source.spdx.json", kind: "sbom", sha256: $sbom_sha},
-			{name: "image-index.digest", kind: "image", sha256: $image_file_sha, digest: $image_digest, image: "ghcr.io/hikyo-org/hikyo", tag: "0.1.0"},
-			{name: "hikyo-0.1.0.tgz", kind: "chart", sha256: $chart_file_sha, chart_version: "0.1.0", app_version: "0.1.0", image_repository: "ghcr.io/hikyo-org/hikyo", image_digest: $image_digest},
-			{name: "chart-index.digest", kind: "chart-digest", sha256: $chart_digest_file_sha, digest: $chart_digest, chart: "ghcr.io/hikyo-org/charts/hikyo"},
-			{name: "install.sh", kind: "installer", sha256: $installer_sha},
-			{name: "image-index.oci-payload.json", kind: "oci-payload", sha256: $image_payload_sha, subject_kind: "image", subject: ("ghcr.io/hikyo-org/hikyo@" + $image_digest), digest: $image_digest},
-			{name: "chart-index.oci-payload.json", kind: "oci-payload", sha256: $chart_payload_sha, subject_kind: "chart", subject: ("ghcr.io/hikyo-org/charts/hikyo@" + $chart_digest), digest: $chart_digest}
-		]
-	}' >"$bundle_dir/release-manifest.json"
+"$(dirname "$0")/create-manifest.sh" \
+	"$bundle_dir/release-candidate.json" ghcr.io/hikyo-org/hikyo "$image_digest" \
+	ghcr.io/hikyo-org/charts/hikyo "$chart_digest" "$bundle_dir" >/dev/null
 
 manifest_sha=$(sha256_file "$bundle_dir/release-manifest.json")
 jq --arg manifest_sha "$manifest_sha" \

--- a/scripts/release/test-fixtures.sh
+++ b/scripts/release/test-fixtures.sh
@@ -194,8 +194,8 @@ printf 'image:\n  repository: ghcr.io/hikyo-org/hikyo\n  digest: sha256:%064d\n'
 	>"$fixture_dir/chart/hikyo/values.yaml"
 tar -czf "$bundle_dir/hikyo-0.1.0.tgz" -C "$fixture_dir/chart" hikyo
 
-image_digest=sha256:1111111111111111111111111111111111111111111111111111111111111111
-chart_digest=sha256:2222222222222222222222222222222222222222222222222222222222222222
+image_digest=$(printf 'sha256:%064d' 1)
+chart_digest=$(printf 'sha256:%064d' 2)
 jq -n --arg digest "$image_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \
 	>"$bundle_dir/image-index.oci-payload.json"
 jq -n --arg digest "$chart_digest" '{critical:{identity:{"docker-reference":"ghcr.io/hikyo-org/charts/hikyo"},image:{"docker-manifest-digest":$digest},type:"cosign container image signature"},optional:null}' \


### PR DESCRIPTION
Closes #346

## Contract
- Build the v1 fixture manifest with scripts/release/create-manifest.sh.
- Keep v2 and negative-fixture jq mutations intentional and local.
- Exercise create-manifest output through scripts/release/verify-bundle.sh; only cosign cryptography is stubbed in the focused producer test.

## Generated outputs
None.

## Validation
- git diff --check: pass
- Local test execution: deferred while host memory pressure remains high, per delivery instruction
- CI: started by this PR

## Merge coordination
Do not update this branch for merge until this is the lowest-numbered open non-draft PR.