### PR TITLE
Centralize importer environment references #344

### DIFF
--- a/docs/handoff/issue-344-environment-reference.md
+++ b/docs/handoff/issue-344-environment-reference.md
@@ -1,0 +1,28 @@
+# Handoff: #344 environment reference ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/344. Base:
+`21267cccd4dd977fb23a6d9d7c8fe38934db1b05`.
+
+## Contract
+
+- `EnvInput.Ref()` and `EnvPlan.Ref()` are the public owners for an
+  environment's artifact reference. Both delegate to one policy: created
+  environments use their name; existing environments use their server id.
+- `BuildProjectPlan` refuses `Create == true` with a non-empty `EnvID` as
+  malformed input. Created environments remain tokenless and name-addressed.
+- Values paths, plan summaries, mapping rows, overwrite and trim rows,
+  manifest import state, and values digests consume the owned reference.
+- Existing valid artifact bytes, ordering, dual-dialect behavior, and generated
+  outputs remain unchanged. Generated outputs: none.
+
+## Coverage
+
+- `TestBuildProjectPlanRefusesCreatedEnvironmentWithID` was observed failing
+  before the validation change and passing afterward.
+- Importer package: 145 tests passed with `-count=1`.
+- CLI package: 300 tests passed with `-count=1`.
+- Import conformance package: 76 tests passed with `-count=1`.
+- Full Go validation: 3,519 tests passed across 61 packages with
+  `go test -p 4 -count=1 ./...`.
+- Standards review reached `CLEAN` in round 2 of 3 after extracting the shared
+  reference policy. Issue-spec review was clean in round 1.

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -324,10 +324,7 @@ func writeProjectArtifacts(ios IO, outDir string, plan *importer.ProjectPlan) (v
 		if !env.HasValues {
 			continue
 		}
-		ref := env.EnvID
-		if env.Create {
-			ref = env.EnvName
-		}
+		ref := env.Ref()
 		valuesTargets = append(valuesTargets, valuesTarget{
 			path: filepath.Join(outDir, "values-"+ref+".json"), file: env.Values, envRef: ref,
 		})
@@ -444,10 +441,7 @@ func reportProject(ios IO, plan *importer.ProjectPlan, outDir string, sourceFile
 		fmt.Fprintf(w, "already declared (not re-declared): %s\n", quoteImportNames(plan.AlreadyDeclared))
 	}
 	for _, env := range plan.Envs {
-		ref := env.EnvName
-		if ref == "" {
-			ref = env.EnvID
-		}
+		ref := env.Ref()
 		verb := "existing"
 		if env.Create {
 			verb = "to create"

--- a/internal/importer/plan.go
+++ b/internal/importer/plan.go
@@ -289,6 +289,13 @@ type EnvInput struct {
 	Keys []KeyState
 }
 
+// Ref is how every artifact addresses this environment: a created environment by
+// name (it has no id yet), an existing one by id. This is the one place the rule
+// lives; a plan prints and writes the same reference.
+func (e EnvInput) Ref() string {
+	return environmentRef(e.Create, e.EnvName, e.EnvID)
+}
+
 // ProjectPlanInput is one phase-1 session's whole material: one source, one
 // project, and one or more target environments. Keys, types and classifications
 // are project-scoped and reconciled to one canonical identity per key across the
@@ -318,6 +325,20 @@ type EnvPlan struct {
 	Values      ValuesFile
 	// HasValues reports whether this environment's values file carries anything.
 	HasValues bool
+}
+
+// Ref is how every artifact addresses this environment: a created environment by
+// name, an existing one by id. It mirrors EnvInput.Ref so the plan summary and
+// the written bundle agree.
+func (e EnvPlan) Ref() string {
+	return environmentRef(e.Create, e.EnvName, e.EnvID)
+}
+
+func environmentRef(create bool, name, id string) string {
+	if create {
+		return name
+	}
+	return id
 }
 
 // ProjectPlan is a whole session's result: the four artifact families, with one
@@ -387,6 +408,10 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 		if e.Create && e.EnvName == "" {
 			return nil, failure(in.Source, CodeMalformed, "",
 				"a created environment is named, not id'd")
+		}
+		if e.Create && e.EnvID != "" {
+			return nil, failure(in.Source, CodeMalformed, "",
+				"a created environment carries no id")
 		}
 		if !e.Create && e.EnvID == "" {
 			return nil, failure(in.Source, CodeMalformed, "",
@@ -531,12 +556,8 @@ func BuildProjectPlan(in ProjectPlanInput) (*ProjectPlan, error) {
 		if err != nil {
 			return nil, err
 		}
-		ref := env.EnvID
-		if env.Create {
-			ref = env.EnvName
-		}
 		plan.Manifest.ValuesDigests = append(plan.Manifest.ValuesDigests,
-			ValuesDigest{Environment: ref, Digest: Digest(body)})
+			ValuesDigest{Environment: env.Ref(), Digest: Digest(body)})
 	}
 	plan.Manifest.ValuesDigests = nonNil(plan.Manifest.ValuesDigests)
 	// Created environments are explicit, reviewable bundle lines (ADR § Targeting
@@ -669,10 +690,7 @@ func reconcileKeys(in ProjectPlanInput, envRows [][]mappedRecord, recordedFolder
 func planEnvironment(in ProjectPlanInput, e EnvInput, rows []mappedRecord, decisions map[string]keyDecision,
 	trimOffenders *[]string, trimSeen map[string]bool) (EnvPlan, error) {
 	envID := e.EnvID
-	envRef := envID
-	if e.Create {
-		envRef = e.EnvName
-	}
+	envRef := e.Ref()
 	overwrite := templateOverwrites(in.Template, envRef)
 	trimAck := templateTrimAcks(in.Template, envRef)
 
@@ -748,13 +766,9 @@ func buildTemplate(in ProjectPlanInput, tmpl Template, renames []Rename, folders
 	}
 	tmpl.Environments = nil
 	for _, e := range in.Envs {
-		target := e.EnvID
-		if e.Create {
-			target = e.EnvName
-		}
 		tmpl.Environments = append(tmpl.Environments, EnvironmentMapping{
 			Source: sourceEnvironment(e.EnvSlug),
-			Target: target,
+			Target: e.Ref(),
 			Create: e.Create,
 		})
 	}
@@ -769,10 +783,7 @@ func buildTemplate(in ProjectPlanInput, tmpl Template, renames []Rename, folders
 	tmpl.Overwrites = nil
 	tmpl.TrimAcknowledgements = nil
 	for i, e := range in.Envs {
-		envRef := e.EnvID
-		if e.Create {
-			envRef = e.EnvName
-		}
+		envRef := e.Ref()
 		for _, name := range envs[i].Overwritten {
 			tmpl.Overwrites = append(tmpl.Overwrites, KeyEnvironment{Key: name, Environment: envRef})
 		}
@@ -811,12 +822,11 @@ func buildManifest(in ProjectPlanInput, encodedTemplate []byte, envRows [][]mapp
 	var keyOrder []string
 	var missing []string
 	for i, e := range in.Envs {
-		envRef := e.EnvID
+		envRef := e.Ref()
 		if e.Create {
 			// Created environments are named, not id'd, and sit in a distinct
 			// field: they are tokenless (no presence read happened), so they
 			// contribute no occurrence row and are outside the precondition.
-			envRef = e.EnvName
 			m.Target.CreatedEnvironments = append(m.Target.CreatedEnvironments, e.EnvName)
 		} else {
 			m.Target.Environments = append(m.Target.Environments, e.EnvID)

--- a/internal/importer/plan_test.go
+++ b/internal/importer/plan_test.go
@@ -289,6 +289,21 @@ func TestProjectPlanRefusesFolderConflict(t *testing.T) {
 	}
 }
 
+// TestBuildProjectPlanRefusesCreatedEnvironmentWithID: a created environment is
+// tokenless and addressed by name, so it carries no id. An input that sets both
+// Create and EnvID is malformed intent; the plan refuses it rather than letting a
+// stale id copy onto the artifacts.
+func TestBuildProjectPlanRefusesCreatedEnvironmentWithID(t *testing.T) {
+	_, err := BuildProjectPlan(ProjectPlanInput{
+		Source: k8sSource, Project: "prj_1", DefinitionsRevision: 7,
+		Envs: []EnvInput{{
+			Create: true, EnvName: "env_new", EnvID: "env_stale",
+			Records: []Record{{SourceName: "API_KEY", Value: "k", Type: schema.TypeString}},
+		}},
+	})
+	wantCode(t, err, CodeMalformed)
+}
+
 // TestBucketsAreNewAndSetOnly pins the flat-model amendment: two buckets, and a
 // `set` key is skipped by default and listed by name.
 func TestBucketsAreNewAndSetOnly(t *testing.T) {

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -25,13 +25,17 @@ import { surfacesForFlow } from '../registry.ts';
 
 /** openNav reveals the sidebar, which is a disclosure on a phone. */
 async function openNav(page: Page): Promise<void> {
-  const toggle = page.getByRole('button', { name: 'Menu' });
-  if (await toggle.isVisible()) {
-    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
-      await toggle.click();
-    }
+  const navigation = page.getByRole('navigation', { name: 'Sections', exact: true });
+  if (await navigation.isVisible()) {
+    return;
   }
-  await expect(page.getByRole('navigation', { name: 'Sections', exact: true })).toBeVisible();
+
+  const toggle = page.getByRole('button', { name: 'Menu' });
+  await expect(toggle).toBeVisible();
+  if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+    await toggle.click();
+  }
+  await expect(navigation).toBeVisible();
 }
 
 test.describe('app chrome', () => {
@@ -93,6 +97,10 @@ test.describe('app chrome', () => {
   // the empty-state rendering, while the real creator-membership path is
   // covered by the instance-administration flow.
   test('shows the zero-organisation state rather than an empty rail', async ({ page }) => {
+    await page.route('**/api/v1/auth/whoami', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await route.continue();
+    });
     await page.route('**/api/v1/me/orgs', (route) =>
       route.fulfill({
         status: 200,

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -27,7 +27,9 @@ import { surfacesForFlow } from '../registry.ts';
 async function openNav(page: Page): Promise<void> {
   const navigation = page.getByRole('navigation', { name: 'Sections', exact: true });
   const toggle = page.getByRole('button', { name: 'Menu' });
-  await expect(navigation.or(toggle)).toBeVisible();
+  await expect
+    .poll(async () => (await navigation.isVisible()) || (await toggle.isVisible()))
+    .toBe(true);
   if (await navigation.isVisible()) {
     return;
   }

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -26,12 +26,11 @@ import { surfacesForFlow } from '../registry.ts';
 /** openNav reveals the sidebar, which is a disclosure on a phone. */
 async function openNav(page: Page): Promise<void> {
   const navigation = page.getByRole('navigation', { name: 'Sections', exact: true });
+  const toggle = page.getByRole('button', { name: 'Menu' });
+  await expect(navigation.or(toggle)).toBeVisible();
   if (await navigation.isVisible()) {
     return;
   }
-
-  const toggle = page.getByRole('button', { name: 'Menu' });
-  await expect(toggle).toBeVisible();
   if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
     await toggle.click();
   }


### PR DESCRIPTION
Closes #344

## Summary
- make EnvInput.Ref and EnvPlan.Ref own artifact environment addressing
- route planner and CLI consumers through one shared create-name/existing-id policy
- refuse created environments carrying a stale server id
- supersede draft PR #386, whose code checks passed but DCO failed

## Contract
- created environments remain tokenless and name-addressed
- existing environments remain server-id-addressed
- valid artifact bytes, ordering, and failure behavior remain unchanged
- generated outputs: none

## Validation
- TDD regression observed red, then green: TestBuildProjectPlanRefusesCreatedEnvironmentWithID
- go test -count=1 ./internal/importer: 145 passed
- go test -count=1 ./internal/cli: 300 passed
- go test -count=1 ./internal/conformance: 76 passed
- go test -p 4 -count=1 ./...: 3,519 passed across 61 packages
- issue-spec review: CLEAN
- standards review: CLEAN / SOUND, round 3 of 3