### PR TITLE
Centralize SAML provider update ownership #347

### DIFF
--- a/docs/handoff/347-saml-provider-update-owner.md
+++ b/docs/handoff/347-saml-provider-update-owner.md
@@ -1,0 +1,44 @@
+# Handoff: #347 SAML provider update owner
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/347 (parent #326; audit finding
+`F-S09-1`). Implementation base:
+`b891007b0d8a6ec8f318af506172cc217640089e`.
+
+## Contract
+
+- `applyProviderUpdate` owns the complete provider compare-and-swap, persisted
+  row reload, and security-sensitive session invalidation for PUT, PATCH, and
+  metadata refresh mutations.
+- `samlSessionsInvalidated` is the single directional predicate. Disabling a
+  provider invalidates sessions; enabling one does not. Assurance policy,
+  pinned signing certificates, SSO URL, and email NameID policy changes also
+  invalidate sessions.
+- Every successful create or update response is projected from the persisted
+  row. Storage-owned row versions and timestamps can no longer diverge from
+  the returned provider.
+- Wire shapes, audit payloads, database schema, and generated artifacts are
+  unchanged. Generated outputs: none.
+
+## Coverage
+
+- The predicate table covers disable/enable direction, assurance-policy and
+  NameID policy changes, rotated/identical certificates, SSO URL changes, and
+  display-only changes.
+- The SQLite SAML flow proves display-only and identical-certificate updates
+  preserve live sessions; disabling, policy changes, and certificate rotation
+  sweep them. It also compares PATCH and refresh responses with persisted
+  timestamps.
+- PostgreSQL coverage uses the same isolation fixture in CI; local execution
+  skips when `HIKYO_TEST_POSTGRES_DSN` is unset.
+
+## Validation
+
+```text
+go test -count=1 ./internal/service                          251 passed
+go test -count=1 -run 'SAML' ./internal/isolation             6 passed
+go test -count=1 -run 'SAML' ./internal/server                4 passed
+go test -count=1 ./...                          3,539 passed / 61 packages
+go vet ./internal/service ./internal/isolation ./internal/server      passed
+gofmt -w <changed Go files>                                   clean
+git diff --check                                               clean
+```

--- a/internal/isolation/saml_e2e_test.go
+++ b/internal/isolation/saml_e2e_test.go
@@ -130,6 +130,19 @@ func runSAMLLoginReplay(t *testing.T, db *store.DB) {
 	if got := queryInt(t, db, "SELECT COUNT(*) FROM audit_instance_events WHERE type = 'auth.saml_login' AND outcome = 'success'"); got == 0 {
 		t.Fatal("valid SAML login emitted no success audit event")
 	}
+	loginWith := func(label string, loginIDP *samltest.IdP) string {
+		t.Helper()
+		start, err := auth.SAMLStart(ctx, "saml-idp", "login", "", "", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		response := samlResponseForStart(t, loginIDP, start, "_response_"+label, "_assertion_"+label)
+		result, err := auth.SAMLACS(ctx, "saml-idp", response, samlAuditRelayState(t, start.RedirectURL), start.InitiatorCookie)
+		if err != nil {
+			t.Fatalf("%s login callback: %v", label, err)
+		}
+		return result.SessionToken
+	}
 
 	concurrent, err := auth.SAMLStart(ctx, "saml-idp", "login", "", "", "")
 	if err != nil {
@@ -185,19 +198,108 @@ func runSAMLLoginReplay(t *testing.T, db *store.DB) {
 		t.Fatalf("durable replay rows = %d, want 1", got)
 	}
 
+	providerNow := time.Now().UTC()
+	providers.Now = func() time.Time {
+		providerNow = providerNow.Add(time.Second)
+		return providerNow
+	}
 	displayName := "Renamed SAML test IdP"
-	if _, err := providers.Patch(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLProviderPatch{DisplayName: &displayName}); err != nil {
+	patched, err := providers.Patch(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLProviderPatch{DisplayName: &displayName})
+	if err != nil {
 		t.Fatal(err)
+	}
+	persisted, err := providers.Get(ctx, service.LocalPrincipal(admin), "saml-idp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !patched.UpdatedAt.Equal(persisted.UpdatedAt) {
+		t.Fatalf("Patch returned UpdatedAt %s, persisted %s", patched.UpdatedAt, persisted.UpdatedAt)
 	}
 	if _, err := auth.Identity(ctx, login.SessionToken); err != nil {
 		t.Fatalf("display-only provider change swept a SAML session: %v", err)
 	}
+	currentMetadata, err := idp.SignedMetadata(time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	unchanged, err := providers.RefreshMetadata(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLMetadataRefreshInput{
+		MetadataDocument: currentMetadata,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unchanged.Applied {
+		t.Fatalf("identical certificate refresh requires confirmation: %#v", unchanged)
+	}
+	persisted, err = providers.Get(ctx, service.LocalPrincipal(admin), "saml-idp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.Provider == nil || !unchanged.Provider.UpdatedAt.Equal(persisted.UpdatedAt) {
+		t.Fatalf("RefreshMetadata returned provider = %#v, persisted UpdatedAt %s", unchanged.Provider, persisted.UpdatedAt)
+	}
+	if _, err := auth.Identity(ctx, login.SessionToken); err != nil {
+		t.Fatalf("identical certificate refresh swept a SAML session: %v", err)
+	}
+	disabled := false
+	if _, err := providers.Patch(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLProviderPatch{Enabled: &disabled}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.Identity(ctx, login.SessionToken); !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("provider disable left SAML session live: %v", err)
+	}
+	enabled := true
+	if _, err := providers.Patch(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLProviderPatch{Enabled: &enabled}); err != nil {
+		t.Fatal(err)
+	}
+	policySession := loginWith("policy", idp)
 	policy := []string{"urn:example:mfa"}
 	if _, err := providers.Patch(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLProviderPatch{AssurancePolicy: &policy}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := auth.Identity(ctx, login.SessionToken); !errors.Is(err, domain.ErrUnauthenticated) {
+	if _, err := auth.Identity(ctx, policySession); !errors.Is(err, domain.ErrUnauthenticated) {
 		t.Fatalf("assurance-policy change left SAML session live: %v", err)
+	}
+	certificateSession := loginWith("certificate", idp)
+	rotatedIDP, err := samltest.New(time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotatedMetadata, err := rotatedIDP.SignedMetadata(time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotation, err := providers.RefreshMetadata(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLMetadataRefreshInput{
+		MetadataDocument: rotatedMetadata,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotation.Applied || len(rotation.RequiredFingerprints) != 1 {
+		t.Fatalf("rotated certificate preview = %#v", rotation)
+	}
+	rotation, err = providers.RefreshMetadata(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLMetadataRefreshInput{
+		MetadataDocument:      rotatedMetadata,
+		ConfirmedFingerprints: rotation.RequiredFingerprints,
+		ConfirmedEndpoints:    rotation.RequiredEndpoints,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rotation.Applied {
+		t.Fatalf("confirmed certificate rotation was not applied: %#v", rotation)
+	}
+	if _, err := auth.Identity(ctx, certificateSession); !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("rotated certificate left SAML session live: %v", err)
+	}
+	identicalSession := loginWith("identical", rotatedIDP)
+	if _, err := providers.RefreshMetadata(ctx, service.LocalPrincipal(admin), "saml-idp", service.SAMLMetadataRefreshInput{
+		MetadataDocument: rotatedMetadata,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.Identity(ctx, identicalSession); err != nil {
+		t.Fatalf("identical refreshed certificate swept a SAML session: %v", err)
 	}
 }
 

--- a/internal/service/saml_providers.go
+++ b/internal/service/saml_providers.go
@@ -251,17 +251,11 @@ func (s *SAMLProviders) Put(ctx context.Context, actor Actor, slug string, input
 			if err := s.ensureSPKey(ctx, repos, az, proof, caller.Principal, generatedKey); err != nil {
 				return err
 			}
-			output, err = samlProviderView(authz.SAMLProvider{
-				ID: provider.ID, Slug: provider.Slug, DisplayName: provider.DisplayName, Kind: SAMLKind,
-				EntityID: provider.EntityID, ACSURL: provider.ACSURL, SSORedirectURL: provider.SSORedirectURL,
-				SigningCertificates: provider.SigningCertificates, AssurancePolicy: provider.AssurancePolicy,
-				AllowEmailNameID: provider.AllowEmailNameID, ForceSignRequests: provider.ForceSignRequests,
-				MetadataWantAuthnRequestsSigned: provider.MetadataWantAuthnRequestsSigned,
-				MetadataSource:                  provider.MetadataSource, MetadataURL: provider.MetadataURL,
-				MetadataSigned: provider.MetadataSigned, MetadataSigningFingerprint: provider.MetadataSigningFingerprint,
-				MetadataValidUntil: provider.MetadataValidUntil, Enabled: provider.Enabled, RowVersion: 1,
-				CreatedAt: now, UpdatedAt: now,
-			}, s.now())
+			created, err := az.SAMLProviderBySlug(ctx, slug)
+			if err != nil {
+				return err
+			}
+			output, err = samlProviderView(created, s.now())
 			if err != nil {
 				return err
 			}
@@ -286,13 +280,21 @@ func (s *SAMLProviders) Put(ctx context.Context, actor Actor, slug string, input
 		if existing.MetadataSigned && !metadata.Signed {
 			return ErrSAMLMetadataSignatureDowngrade
 		}
-		swept, err := s.updateProvider(ctx, az, existing, input.DisplayName, assessment.CertificatesJSON, policy,
-			input.AllowEmailNameID, input.ForceSignRequests, metadata.WantAuthnRequestsSigned,
-			input.MetadataSource, input.MetadataURL, metadata, input.Enabled)
-		if err != nil {
-			return err
-		}
-		updated, err := az.SAMLProviderBySlug(ctx, slug)
+		next := existing
+		next.DisplayName = input.DisplayName
+		next.SSORedirectURL = metadata.SSOURL
+		next.SigningCertificates = assessment.CertificatesJSON
+		next.AssurancePolicy = policy
+		next.AllowEmailNameID = input.AllowEmailNameID
+		next.ForceSignRequests = input.ForceSignRequests
+		next.MetadataWantAuthnRequestsSigned = metadata.WantAuthnRequestsSigned
+		next.MetadataSource = input.MetadataSource
+		next.MetadataURL = input.MetadataURL
+		next.MetadataSigned = metadata.Signed
+		next.MetadataSigningFingerprint = assessment.MetadataFingerprint
+		next.MetadataValidUntil = metadata.ValidUntil
+		next.Enabled = input.Enabled
+		updated, err := s.applyProviderUpdate(ctx, az, existing, next)
 		if err != nil {
 			return err
 		}
@@ -307,7 +309,6 @@ func (s *SAMLProviders) Put(ctx context.Context, actor Actor, slug string, input
 				emailState = "set"
 			}
 		}
-		_ = swept
 		return s.recordProviderMutationEvents(ctx, repos, proof, caller.Principal,
 			audit.EventSAMLProviderConfigure, output, assessment.Diff, input.ConfirmedFingerprints, emailState)
 	})
@@ -370,34 +371,17 @@ func (s *SAMLProviders) Patch(ctx context.Context, actor Actor, slug string, pat
 		if patch.Enabled != nil {
 			enabled = *patch.Enabled
 		}
-		updated, err := az.UpdateSAMLProvider(ctx, authz.SAMLProviderUpdate{
-			ID: provider.ID, DisplayName: displayName, ACSURL: provider.ACSURL,
-			SSORedirectURL: provider.SSORedirectURL, SigningCertificates: provider.SigningCertificates,
-			AssurancePolicy: policy, AllowEmailNameID: allowEmail, ForceSignRequests: forceSign,
-			MetadataWantAuthnRequestsSigned: provider.MetadataWantAuthnRequestsSigned,
-			MetadataSource:                  provider.MetadataSource, MetadataURL: provider.MetadataURL,
-			MetadataSigned: provider.MetadataSigned, MetadataSigningFingerprint: provider.MetadataSigningFingerprint,
-			MetadataValidUntil: provider.MetadataValidUntil, Enabled: enabled,
-			RowVersion: provider.RowVersion, UpdatedAt: s.now(),
-		})
+		next := provider
+		next.DisplayName = displayName
+		next.AssurancePolicy = policy
+		next.AllowEmailNameID = allowEmail
+		next.ForceSignRequests = forceSign
+		next.Enabled = enabled
+		updated, err := s.applyProviderUpdate(ctx, az, provider, next)
 		if err != nil {
 			return err
 		}
-		if !updated {
-			return ErrSAMLProviderRace
-		}
-		swept := int64(0)
-		if provider.Enabled && !enabled || !equalOptionalString(provider.AssurancePolicy, policy) || provider.AllowEmailNameID != allowEmail {
-			swept, err = az.SweepSessionsForSAMLProvider(ctx, provider.ID)
-			if err != nil {
-				return err
-			}
-		}
-		provider.DisplayName, provider.AssurancePolicy = displayName, policy
-		provider.AllowEmailNameID, provider.ForceSignRequests, provider.Enabled = allowEmail, forceSign, enabled
-		provider.RowVersion++
-		provider.UpdatedAt = s.now()
-		output, err = samlProviderView(provider, s.now())
+		output, err = samlProviderView(updated, s.now())
 		if err != nil {
 			return err
 		}
@@ -416,7 +400,6 @@ func (s *SAMLProviders) Patch(ctx context.Context, actor Actor, slug string, pat
 				return eventErr
 			}
 		}
-		_ = swept
 		return s.recordProviderEvent(ctx, repos, proof, caller.Principal, audit.EventSAMLProviderConfigure, output, nil, nil)
 	})
 	return output, err
@@ -503,8 +486,7 @@ func (s *SAMLProviders) Delete(ctx context.Context, actor Actor, slug string) er
 		if err := az.LockSAMLProviderForDelete(ctx, provider.ID); err != nil {
 			return err
 		}
-		swept, err := az.SweepSessionsForSAMLProvider(ctx, provider.ID)
-		if err != nil {
+		if _, err := az.SweepSessionsForSAMLProvider(ctx, provider.ID); err != nil {
 			return err
 		}
 		if err := az.DeleteSAMLProvider(ctx, provider.ID); err != nil {
@@ -514,7 +496,6 @@ func (s *SAMLProviders) Delete(ctx context.Context, actor Actor, slug string) er
 		if err != nil {
 			return err
 		}
-		_ = swept
 		return s.recordProviderEvent(ctx, repos, proof, caller.Principal, audit.EventSAMLProviderRemove, view, nil, nil)
 	})
 }
@@ -580,26 +561,21 @@ func (s *SAMLProviders) RefreshMetadata(ctx context.Context, actor Actor, slug s
 		if fresh.MetadataSigned && !metadata.Signed {
 			return ErrSAMLMetadataSignatureDowngrade
 		}
-		swept, err := s.updateProvider(ctx, az, fresh, fresh.DisplayName, assessment.CertificatesJSON,
-			fresh.AssurancePolicy, fresh.AllowEmailNameID,
-			fresh.ForceSignRequests, metadata.WantAuthnRequestsSigned,
-			fresh.MetadataSource, fresh.MetadataURL, metadata, fresh.Enabled)
+		next := fresh
+		next.SSORedirectURL = metadata.SSOURL
+		next.SigningCertificates = assessment.CertificatesJSON
+		next.MetadataWantAuthnRequestsSigned = metadata.WantAuthnRequestsSigned
+		next.MetadataSigned = metadata.Signed
+		next.MetadataSigningFingerprint = assessment.MetadataFingerprint
+		next.MetadataValidUntil = metadata.ValidUntil
+		updated, err := s.applyProviderUpdate(ctx, az, fresh, next)
 		if err != nil {
 			return err
 		}
-		fresh.SigningCertificates = assessment.CertificatesJSON
-		fresh.SSORedirectURL = metadata.SSOURL
-		fresh.MetadataWantAuthnRequestsSigned = metadata.WantAuthnRequestsSigned
-		fresh.MetadataSigned = metadata.Signed
-		fresh.MetadataSigningFingerprint = assessment.MetadataFingerprint
-		fresh.MetadataValidUntil = metadata.ValidUntil
-		fresh.RowVersion++
-		fresh.UpdatedAt = s.now()
-		output, err = samlProviderView(fresh, s.now())
+		output, err = samlProviderView(updated, s.now())
 		if err != nil {
 			return err
 		}
-		_ = swept
 		return s.recordProviderMutationEvents(ctx, repos, proof, caller.Principal,
 			audit.EventSAMLProviderRefresh, output, assessment.Diff, input.ConfirmedFingerprints, "")
 	})
@@ -849,32 +825,44 @@ func samlProviderWarnings(provider authz.SAMLProvider, now time.Time) ([]SAMLPro
 	return warnings, nil
 }
 
-func (s *SAMLProviders) updateProvider(ctx context.Context, az *authz.TxAuthorizer, provider authz.SAMLProvider,
-	displayName string, certificates []byte, policy *string, allowEmail, forceSign, metadataWantSign bool,
-	metadataSource string, metadataURL *string, metadata samlsp.Metadata, enabled bool,
-) (int64, error) {
+func (s *SAMLProviders) applyProviderUpdate(ctx context.Context, az *authz.TxAuthorizer, before, next authz.SAMLProvider) (authz.SAMLProvider, error) {
 	updated, err := az.UpdateSAMLProvider(ctx, authz.SAMLProviderUpdate{
-		ID: provider.ID, DisplayName: displayName, ACSURL: provider.ACSURL,
-		SSORedirectURL: metadata.SSOURL, SigningCertificates: certificates,
-		AssurancePolicy: policy, AllowEmailNameID: allowEmail, ForceSignRequests: forceSign,
-		MetadataWantAuthnRequestsSigned: metadataWantSign,
-		MetadataSource:                  metadataSource, MetadataURL: metadataURL,
-		MetadataSigned: metadata.Signed, MetadataValidUntil: metadata.ValidUntil,
-		MetadataSigningFingerprint: metadataFingerprint(metadata), Enabled: enabled,
-		RowVersion: provider.RowVersion, UpdatedAt: s.now(),
+		ID: before.ID, DisplayName: next.DisplayName, ACSURL: next.ACSURL,
+		SSORedirectURL: next.SSORedirectURL, SigningCertificates: next.SigningCertificates,
+		AssurancePolicy: next.AssurancePolicy, AllowEmailNameID: next.AllowEmailNameID,
+		ForceSignRequests:               next.ForceSignRequests,
+		MetadataWantAuthnRequestsSigned: next.MetadataWantAuthnRequestsSigned,
+		MetadataSource:                  next.MetadataSource, MetadataURL: next.MetadataURL,
+		MetadataSigned: next.MetadataSigned, MetadataValidUntil: next.MetadataValidUntil,
+		MetadataSigningFingerprint: next.MetadataSigningFingerprint, Enabled: next.Enabled,
+		RowVersion: before.RowVersion, UpdatedAt: s.now(),
 	})
 	if err != nil {
-		return 0, err
+		return authz.SAMLProvider{}, err
 	}
 	if !updated {
-		return 0, ErrSAMLProviderRace
+		return authz.SAMLProvider{}, ErrSAMLProviderRace
 	}
-	if provider.Enabled && !enabled || !equalOptionalString(provider.AssurancePolicy, policy) ||
-		!bytes.Equal(provider.SigningCertificates, certificates) || provider.SSORedirectURL != metadata.SSOURL ||
-		provider.AllowEmailNameID != allowEmail {
-		return az.SweepSessionsForSAMLProvider(ctx, provider.ID)
+	stored, err := az.SAMLProviderBySlug(ctx, before.Slug)
+	if err != nil {
+		return authz.SAMLProvider{}, err
 	}
-	return 0, nil
+	if samlSessionsInvalidated(before, stored) {
+		if _, err := az.SweepSessionsForSAMLProvider(ctx, before.ID); err != nil {
+			return authz.SAMLProvider{}, err
+		}
+	}
+	return stored, nil
+}
+
+// samlSessionsInvalidated owns the provider-bound session deletion required by
+// the saml-sp ADR § Assurance and the human-auth ADR § Invalidation.
+func samlSessionsInvalidated(before, after authz.SAMLProvider) bool {
+	return before.Enabled && !after.Enabled ||
+		!equalOptionalString(before.AssurancePolicy, after.AssurancePolicy) ||
+		!bytes.Equal(before.SigningCertificates, after.SigningCertificates) ||
+		before.SSORedirectURL != after.SSORedirectURL ||
+		before.AllowEmailNameID != after.AllowEmailNameID
 }
 
 func equalOptionalString(left, right *string) bool {
@@ -882,17 +870,6 @@ func equalOptionalString(left, right *string) bool {
 		return left == nil && right == nil
 	}
 	return *left == *right
-}
-
-func metadataFingerprint(metadata samlsp.Metadata) *string {
-	if !metadata.Signed {
-		return nil
-	}
-	fingerprint, err := certificateFingerprint(metadata.SignatureCertificate)
-	if err != nil {
-		return nil
-	}
-	return &fingerprint
 }
 
 func (s *SAMLProviders) metadataBytes(ctx context.Context, source string, document []byte, metadataURL *string) ([]byte, error) {

--- a/internal/service/saml_test.go
+++ b/internal/service/saml_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -642,6 +643,79 @@ func TestSAMLProviderViewRefusesCorruptStoredTrustState(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if _, err := samlProviderView(provider, now); err == nil {
 				t.Fatal("samlProviderView accepted corrupt stored trust state")
+			}
+		})
+	}
+}
+
+func TestSAMLSessionsInvalidatedOnlyBySecurityRelevantProviderChanges(t *testing.T) {
+	policy := `["urn:example:mfa"]`
+	changedPolicy := `["urn:example:phishing-resistant"]`
+	base := authz.SAMLProvider{
+		DisplayName:         "Test IdP",
+		SSORedirectURL:      "https://idp.example/sso",
+		SigningCertificates: []byte(`["certificate-a"]`),
+		AssurancePolicy:     &policy,
+		Enabled:             true,
+	}
+
+	for name, test := range map[string]struct {
+		before authz.SAMLProvider
+		mutate func(*authz.SAMLProvider)
+		want   bool
+	}{
+		"Patch disable sweeps": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.Enabled = false },
+			want:   true,
+		},
+		"Patch enable does not sweep": {
+			before: func() authz.SAMLProvider {
+				provider := base
+				provider.Enabled = false
+				return provider
+			}(),
+			mutate: func(provider *authz.SAMLProvider) { provider.Enabled = true },
+			want:   false,
+		},
+		"Patch policy change sweeps": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.AssurancePolicy = &changedPolicy },
+			want:   true,
+		},
+		"Refresh rotated certificate sweeps": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.SigningCertificates = []byte(`["certificate-b"]`) },
+			want:   true,
+		},
+		"Refresh identical certificate does not sweep": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) {
+				provider.SigningCertificates = bytes.Clone(provider.SigningCertificates)
+			},
+			want: false,
+		},
+		"Refresh SSO URL change sweeps": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.SSORedirectURL = "https://idp.example/new-sso" },
+			want:   true,
+		},
+		"Patch NameID policy change sweeps": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.AllowEmailNameID = true },
+			want:   true,
+		},
+		"Patch display change does not sweep": {
+			before: base,
+			mutate: func(provider *authz.SAMLProvider) { provider.DisplayName = "Renamed IdP" },
+			want:   false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			after := test.before
+			test.mutate(&after)
+			if got := samlSessionsInvalidated(test.before, after); got != test.want {
+				t.Fatalf("samlSessionsInvalidated() = %t, want %t", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #347

## Contract

- Make applyProviderUpdate the single owner of provider CAS, persisted-row reload, and provider-bound session invalidation.
- Preserve directional invalidation: disable sweeps, enable does not; policy, certificate, SSO URL, and email NameID policy changes sweep.
- Return persisted rows after provider creates and updates so storage-owned versions and timestamps cannot diverge.
- Wire, audit, schema, and generated artifacts are unchanged. Generated outputs: none.

## Validation

- go test -count=1 ./internal/service — 251 passed
- go test -count=1 -run SAML ./internal/isolation — 6 passed
- go test -count=1 -run SAML ./internal/server — 4 passed
- go test -count=1 ./... — 3,539 passed / 61 packages
- go vet ./internal/service ./internal/isolation ./internal/server — passed
- gofmt and git diff --check — clean
- Local PostgreSQL leg skipped because HIKYO_TEST_POSTGRES_DSN is unset; CI owns the configured PostgreSQL leg.

## Review

Standards and spec review: CLEAN after adding the required saml-sp and human-auth ADR citation.