### PR TITLE
Consume reauthentication evidence fail-closed #349

### DIFF
--- a/docs/handoff/349-reauth-evidence.md
+++ b/docs/handoff/349-reauth-evidence.md
@@ -1,0 +1,39 @@
+# Handoff: #349 reauthentication evidence model
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/349 (parent #326; audit finding
+`F-S07-2`, after merged prerequisite #335).
+
+## Contract
+
+- `ReauthEvidence` is a tagged three-state value: local-authority exemption,
+  TOTP evidence `(row id, row version, step)`, or password evidence `(row
+  version, credential epoch)`. Its zero value fails closed.
+- TOTP consumption retains the row-and-step CAS and the named
+  `ErrTOTPCodeAlreadyUsed` replay outcome.
+- Password consumption re-reads both the credential row and live instance
+  epoch inside the caller's write transaction. A password row replaced after
+  verification is refused with uniform `domain.ErrUnauthenticated`.
+- `GenerateRecoveryCodes` authenticates the bearer before the local-authority
+  exemption can apply, then uses the shared verification/consumption owner.
+  Missing or wrong proof remains a uniform unauthenticated refusal.
+- `proofSelection` and all wire/audit values are unchanged. Generated outputs:
+  none.
+
+## Coverage
+
+- A focused service test pins zero-value evidence refusal.
+- SQLite and PostgreSQL isolation fixtures pin password replacement between
+  verification and consumption.
+- SQLite and PostgreSQL recovery fixtures pin missing-proof mapping, recovery
+  code single use, and named TOTP-step replay during batch regeneration.
+
+## Validation
+
+```text
+gofmt -w <changed Go files>                                    clean
+go test -count=1 ./internal/service ./internal/server          490 passed
+go test -count=1 ./internal/isolation -run <issue-349 set>      6 passed
+go test -count=1 ./...                         3,533 passed / 61 packages
+go vet ./...                                                   passed
+git diff --check                                               clean
+```

--- a/internal/isolation/factors_e2e_test.go
+++ b/internal/isolation/factors_e2e_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/pquerna/otp/totp"
 
+	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
 // The A1 factor slice end to end on a real datastore (#54, human-auth ADR §
@@ -116,6 +118,96 @@ func TestRecoveryCompleteFlowSQLite(t *testing.T) { runRecoveryFlow(t, seededDB(
 
 func TestRecoveryCompleteFlowPostgres(t *testing.T) { runRecoveryFlow(t, seededDB(t, openPostgres)) }
 
+func TestPasswordReauthEvidenceRejectsReplacedCredentialSQLite(t *testing.T) {
+	runPasswordReauthEvidenceRejectsReplacedCredential(t, seededDB(t, openSQLite))
+}
+
+func TestPasswordReauthEvidenceRejectsReplacedCredentialPostgres(t *testing.T) {
+	runPasswordReauthEvidenceRejectsReplacedCredential(t, seededDB(t, openPostgres))
+}
+
+func TestRecoveryCodeRegenerationTOTPReplaySQLite(t *testing.T) {
+	runRecoveryCodeRegenerationTOTPReplay(t, seededDB(t, openSQLite))
+}
+
+func TestRecoveryCodeRegenerationTOTPReplayPostgres(t *testing.T) {
+	runRecoveryCodeRegenerationTOTPReplay(t, seededDB(t, openPostgres))
+}
+
+func runPasswordReauthEvidenceRejectsReplacedCredential(t *testing.T, db *store.DB) {
+	auth, boot, password := bootstrapFactorAdmin(t, db)
+	ctx := t.Context()
+	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := auth.VerifyReauthProof(ctx, login.SessionToken, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Move the verified password row exactly as a concurrent replacement does.
+	// Reusing the sealed bytes keeps this test focused on evidence liveness: the
+	// row version, not the replacement password's contents, is the CAS boundary.
+	err = tx.Write(ctx, db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+		account, err := az.AccountByPrincipal(ctx, boot.PrincipalID)
+		if err != nil {
+			return err
+		}
+		credential, err := az.PasswordCredentialFor(ctx, account.ID)
+		if err != nil {
+			return err
+		}
+		replaced, err := az.ReplacePasswordCredential(ctx, credential, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if !replaced {
+			t.Fatal("password credential replacement lost its CAS")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tx.Write(ctx, db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+		return auth.ConsumeReauthEvidence(ctx, az, evidence, boot.PrincipalID)
+	})
+	if !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("ConsumeReauthEvidence() after password replacement error = %v, want %v", err, domain.ErrUnauthenticated)
+	}
+}
+
+func runRecoveryCodeRegenerationTOTPReplay(t *testing.T, db *store.DB) {
+	auth, _, password := bootstrapFactorAdmin(t, db)
+	ctx := t.Context()
+	now := time.Now().UTC()
+	auth.Now = func() time.Time { return now }
+	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri, err := auth.EnrolTOTPStart(ctx, login.SessionToken, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	confirmed, err := auth.EnrolTOTPConfirm(ctx, login.SessionToken, totpCode(t, uri, now))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(60 * time.Second)
+	code := totpCode(t, uri, now)
+	_, reissued, err := auth.GenerateRecoveryCodes(ctx, confirmed.SessionToken, code)
+	if err != nil {
+		t.Fatalf("first regeneration: %v", err)
+	}
+	if _, _, err := auth.GenerateRecoveryCodes(ctx, reissued.SessionToken, code); !errors.Is(err, service.ErrTOTPCodeAlreadyUsed) {
+		t.Fatalf("replayed regeneration code error = %v, want %v", err, service.ErrTOTPCodeAlreadyUsed)
+	}
+}
+
 // runRecoveryFlow is the A1 recovery family: single-use, the complete
 // session-less flow (code -> authority -> establish -> login), and the mid-reset
 // invariant that the authority is not a session.
@@ -127,6 +219,9 @@ func runRecoveryFlow(t *testing.T, db *store.DB) {
 	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if _, _, err := auth.GenerateRecoveryCodes(ctx, login.SessionToken, ""); !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("missing recovery regeneration proof error = %v, want %v", err, domain.ErrUnauthenticated)
 	}
 	codes, _, err := auth.GenerateRecoveryCodes(ctx, login.SessionToken, password)
 	if err != nil {

--- a/internal/service/factors.go
+++ b/internal/service/factors.go
@@ -726,14 +726,12 @@ func stepUpFactors(existing []string, add string) []string {
 // recovery codes never authorize their own regeneration. The batch is a sealed
 // JSON array of the codes' verifiers; only the verifiers persist.
 func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof string) ([]string, LoginResult, error) {
-	// Phase 1 — read. Determine the proof class over the pre-existing set.
+	// Phase 1 — authenticate before VerifyReauthProof so an empty bearer cannot
+	// take that helper's local-authority exemption on this network-only path.
 	var (
-		account   authz.Account
-		cred      authz.PasswordCredential
-		confirmed authz.TOTPCredential
-		existing  authz.RecoveryBatch
-		hasTOTP   bool
-		hasBatch  bool
+		account  authz.Account
+		existing authz.RecoveryBatch
+		hasBatch bool
 	)
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
 		id, err := az.Authenticate(ctx, presented, s.now())
@@ -742,21 +740,6 @@ func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof strin
 		}
 		account, err = az.AccountByPrincipal(ctx, id.Principal)
 		if err != nil {
-			return err
-		}
-		confirmed, err = az.ConfirmedTOTP(ctx, account.ID)
-		switch {
-		case err == nil:
-			hasTOTP = true
-		case errors.Is(err, domain.ErrNotFound):
-			cred, err = az.PasswordCredentialFor(ctx, account.ID)
-			if errors.Is(err, domain.ErrNotFound) {
-				return ErrNoProofCredential
-			}
-			if err != nil {
-				return err
-			}
-		default:
 			return err
 		}
 		existing, err = az.RecoveryCodesFor(ctx, account.ID)
@@ -773,40 +756,25 @@ func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof strin
 		return nil, LoginResult{}, err
 	}
 
-	// Admission: whether the proof is a password (Argon2) or a TOTP code, a
-	// stolen session must not make regeneration an unthrottled oracle — a bad
-	// proof here yields a fresh recovery batch, so it is a takeover primitive.
-	release, err := s.enterFactorBudget(ctx, account.ID)
+	// Phase 2 — verify through the shared owner. Argon2/TOTP work and admission
+	// accounting happen outside the write transaction; consumption stays with
+	// the recovery-batch write below.
+	evidence, err := s.VerifyReauthProof(ctx, presented, proof)
 	if err != nil {
+		if err == ErrReauthProofRequired {
+			return nil, LoginResult{}, domain.ErrUnauthenticated
+		}
 		return nil, LoginResult{}, err
 	}
-	defer release()
-
-	// Phase 2 — verify the proof (Argon2 outside any tx for a password).
 	var proofClass string
-	var totpStep int64
-	if hasTOTP {
+	switch evidence.kind {
+	case reauthEvidenceTOTP:
 		proofClass = "totp"
-		seed, oerr := s.Keyring.ForInstance().OpenField(totpSeedAAD(confirmed.ID), confirmed.Seed)
-		if oerr != nil {
-			s.logFault(ctx, "opening a TOTP seed failed", oerr, account.ID)
-			return nil, LoginResult{}, domain.ErrUnauthenticated
-		}
-		var ok bool
-		totpStep, ok = crypto.ValidateTOTP(seed, proof, s.now(), crypto.TOTPSkewSteps)
-		crypto.Zero(seed)
-		if !ok {
-			s.recordFactorFailure(ctx, account.PrincipalID, account.ID)
-			return nil, LoginResult{}, domain.ErrUnauthenticated
-		}
-	} else {
+	case reauthEvidencePassword:
 		proofClass = "password"
-		if !s.verifyPassword(ctx, account.ID, cred, proof) {
-			s.recordFactorFailure(ctx, account.PrincipalID, account.ID)
-			return nil, LoginResult{}, domain.ErrUnauthenticated
-		}
+	default:
+		return nil, LoginResult{}, domain.ErrUnauthenticated
 	}
-	s.Admission.RecordSuccess(account.ID)
 
 	// Mint the batch and seal its verifiers.
 	codes, verifiers, err := crypto.GenerateRecoveryBatch(RecoveryBatchSize)
@@ -838,42 +806,12 @@ func (s *Auth) GenerateRecoveryCodes(ctx context.Context, presented, proof strin
 		if liveID.Principal != account.PrincipalID {
 			return domain.ErrUnauthenticated
 		}
+		if err := s.ConsumeReauthEvidence(ctx, az, evidence, liveID.Principal); err != nil {
+			return err
+		}
 		epoch, err := az.CredentialEpoch(ctx)
 		if err != nil {
 			return err
-		}
-		if hasTOTP {
-			if _, err := az.ConfirmedTOTP(ctx, account.ID); err != nil {
-				if errors.Is(err, domain.ErrNotFound) {
-					return domain.ErrUnauthenticated
-				}
-				return err
-			}
-			// CAS on the row VERIFIED in phase 1 (finding HIGH-5): a code proved
-			// against a since-replaced factor must not consume its successor.
-			consumed, err := az.AdvanceTOTPStep(ctx, confirmed.ID, confirmed.RowVersion, totpStep)
-			if err != nil {
-				return err
-			}
-			if !consumed {
-				// A step already spent on the same row is named; a moved row
-				// (a concurrent replace) stays the uniform refusal.
-				if s.totpStepConsumed(ctx, az, account.ID, confirmed.ID, totpStep) {
-					return totpStepAlreadyUsed()
-				}
-				return domain.ErrUnauthenticated
-			}
-		} else {
-			current, err := az.PasswordCredentialFor(ctx, account.ID)
-			if err != nil {
-				if errors.Is(err, domain.ErrNotFound) {
-					return domain.ErrUnauthenticated
-				}
-				return err
-			}
-			if current.RowVersion != cred.RowVersion || current.CredentialEpoch != epoch {
-				return domain.ErrUnauthenticated
-			}
 		}
 		batch := authz.RecoveryBatch{
 			AccountID: account.ID, Batch: sealed,

--- a/internal/service/reauth.go
+++ b/internal/service/reauth.go
@@ -628,41 +628,70 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 // principal the transaction actually authenticated — happens INSIDE the
 // operation's own transaction, so evidence and act commit together and a code
 // cannot be replayed against a second mint.
+type reauthEvidenceKind uint8
+
+const (
+	reauthEvidenceInvalid reauthEvidenceKind = iota
+	reauthEvidenceExempt
+	reauthEvidenceTOTP
+	reauthEvidencePassword
+)
+
 type ReauthEvidence struct {
 	// Principal is who the proof was verified FOR. The consuming transaction
 	// compares it against the principal IT authenticated, so a proof obtained
 	// on one session cannot be spent by another.
-	Principal domain.PrincipalID
-	// exempt marks local host authority: nothing to reauthenticate, nothing to
-	// consume.
-	exempt bool
-	// The TOTP row and step to CAS. A password proof has no step: a password is
-	// a long-lived secret and "single use" is not a property it can have — the
-	// factor is what carries replay resistance, and an account holding one must
-	// use it (VerifyReauthProof prefers TOTP whenever it is confirmed).
-	totpID     string
+	Principal  domain.PrincipalID
+	kind       reauthEvidenceKind
+	factorID   string
 	rowVersion int64
 	step       int64
-	hasTOTP    bool
+	epoch      int64
 }
 
 // ConsumeReauthEvidence spends the proof inside the caller's transaction. It
 // fails closed on a replayed TOTP step and on evidence belonging to a different
 // principal than the one this transaction authenticated.
 func (s *Auth) ConsumeReauthEvidence(ctx context.Context, az *authz.TxAuthorizer, ev ReauthEvidence, caller domain.PrincipalID) error {
-	if ev.exempt {
+	if ev.kind == reauthEvidenceExempt {
 		return nil
 	}
 	if ev.Principal != caller {
 		return domain.ErrUnauthenticated
 	}
-	if !ev.hasTOTP {
+	switch ev.kind {
+	case reauthEvidencePassword:
+		account, err := az.AccountByPrincipal(ctx, caller)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return domain.ErrUnauthenticated
+			}
+			return err
+		}
+		current, err := az.PasswordCredentialFor(ctx, account.ID)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return domain.ErrUnauthenticated
+			}
+			return err
+		}
+		epoch, err := az.CredentialEpoch(ctx)
+		if err != nil {
+			return err
+		}
+		if current.RowVersion != ev.rowVersion || current.CredentialEpoch != ev.epoch || ev.epoch != epoch {
+			return domain.ErrUnauthenticated
+		}
 		return nil
+	case reauthEvidenceTOTP:
+		// Continue below and atomically spend the verified step.
+	default:
+		return domain.ErrUnauthenticated
 	}
 	// CAS on the row whose seed was verified, so a code proved against a
 	// since-replaced factor cannot apply to its successor — and a code already
 	// spent cannot be spent again.
-	consumed, err := az.AdvanceTOTPStep(ctx, ev.totpID, ev.rowVersion, ev.step)
+	consumed, err := az.AdvanceTOTPStep(ctx, ev.factorID, ev.rowVersion, ev.step)
 	if err != nil {
 		return err
 	}
@@ -671,7 +700,7 @@ func (s *Auth) ConsumeReauthEvidence(ctx context.Context, az *authz.TxAuthorizer
 		// (the evidence carries no account id, so resolve it from the caller this
 		// transaction authenticated); a moved row stays the uniform refusal.
 		if account, aerr := az.AccountByPrincipal(ctx, caller); aerr == nil &&
-			s.totpStepConsumed(ctx, az, account.ID, ev.totpID, ev.step) {
+			s.totpStepConsumed(ctx, az, account.ID, ev.factorID, ev.step) {
 			return totpStepAlreadyUsed()
 		}
 		return domain.ErrUnauthenticated
@@ -694,7 +723,7 @@ func (s *Auth) ConsumeReauthEvidence(ctx context.Context, az *authz.TxAuthorizer
 // same exemption authorize() already makes for the MFA-mandatory rule.
 func (s *Auth) VerifyReauthProof(ctx context.Context, presented, proof string) (ReauthEvidence, error) {
 	if presented == "" {
-		return ReauthEvidence{exempt: true}, nil
+		return ReauthEvidence{kind: reauthEvidenceExempt}, nil
 	}
 	if proof == "" {
 		return ReauthEvidence{}, ErrReauthProofRequired
@@ -753,10 +782,12 @@ func (s *Auth) VerifyReauthProof(ctx context.Context, presented, proof string) (
 			s.recordFactorFailure(ctx, account.PrincipalID, account.ID)
 			return ReauthEvidence{}, domain.ErrUnauthenticated
 		}
-		out.hasTOTP, out.totpID, out.rowVersion, out.step = true, confirmed.ID, confirmed.RowVersion, step
+		out.kind, out.factorID, out.rowVersion, out.step = reauthEvidenceTOTP, confirmed.ID, confirmed.RowVersion, step
 	} else if !s.verifyPassword(ctx, account.ID, cred, proof) {
 		s.recordFactorFailure(ctx, account.PrincipalID, account.ID)
 		return ReauthEvidence{}, domain.ErrUnauthenticated
+	} else {
+		out.kind, out.rowVersion, out.epoch = reauthEvidencePassword, cred.RowVersion, cred.CredentialEpoch
 	}
 	s.Admission.RecordSuccess(account.ID)
 	return out, nil

--- a/internal/service/reauth_evidence_test.go
+++ b/internal/service/reauth_evidence_test.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+)
+
+func TestConsumeReauthEvidenceRefusesZeroValue(t *testing.T) {
+	auth := &Auth{}
+
+	err := auth.ConsumeReauthEvidence(context.Background(), nil, ReauthEvidence{}, "")
+
+	if !errors.Is(err, domain.ErrUnauthenticated) {
+		t.Fatalf("ConsumeReauthEvidence() error = %v, want %v", err, domain.ErrUnauthenticated)
+	}
+}

--- a/internal/service/scim_credential.go
+++ b/internal/service/scim_credential.go
@@ -147,7 +147,7 @@ func (s *SCIM) MintCredential(ctx context.Context, actor Actor, org domain.OrgID
 // fails closed rather than skipping the gate.
 func (s *SCIM) verifyMintReauth(ctx context.Context, actor Actor, proof string) (ReauthEvidence, error) {
 	if actor.bearer == "" {
-		return ReauthEvidence{exempt: true}, nil
+		return ReauthEvidence{kind: reauthEvidenceExempt}, nil
 	}
 	if s.Auth == nil {
 		return ReauthEvidence{}, fmt.Errorf(


### PR DESCRIPTION
Closes #349

## Contract and migration

- ReauthEvidence is a tagged exempt, TOTP, or password state; its zero value fails closed.
- Password evidence carries row version and credential epoch, both rechecked inside the consuming write transaction.
- GenerateRecoveryCodes now uses VerifyReauthProof and ConsumeReauthEvidence while preserving uniform missing-proof refusal and named TOTP replay.
- proofSelection, wire values, audit values, and ordering contracts are unchanged.

Generated outputs: none.

## Validation

- go test -count=1 ./internal/service ./internal/server — 490 passed
- issue #349 SQLite/PostgreSQL isolation set — 6 passed
- go test -count=1 ./... — 3,533 passed / 61 packages
- go vet ./... — passed
- git diff --check — clean
- Standards review — CLEAN
- Spec review — CLEAN