### PR TITLE
Consolidate key rotation invariants #348

### DIFF
--- a/docs/handoff/348-key-rotation-invariants.md
+++ b/docs/handoff/348-key-rotation-invariants.md
@@ -34,7 +34,9 @@ finding `F-S05-1`). Implementation base:
 rtk go test -count=1 ./internal/store -run '^TestKeyRotationInvariantsSQLite$'
                                                         11 passed
 rtk go test -count=1 ./internal/store                   58 passed
-rtk go vet ./internal/store                             passed
+rtk go test -count=1 ./...                 3,541 passed / 61 packages
+rtk go vet ./...                                        passed
+rtk gofmt -l <changed-go-files>                         clean
 rtk git diff --check                                    clean
 ```
 

--- a/docs/handoff/348-key-rotation-invariants.md
+++ b/docs/handoff/348-key-rotation-invariants.md
@@ -1,0 +1,48 @@
+# Handoff: #348 key-rotation invariant ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/348 (parent #326; audit
+finding `F-S05-1`). Implementation base:
+`b891007b0d8a6ec8f318af506172cc217640089e`.
+
+## Contract
+
+- `keyMutationAdapter` is the private two-dialect seam. SQLite and PostgreSQL
+  adapters own generated-query parameter shapes, timestamp encoding, driver
+  no-row translation, and exact unique-violation mapping.
+- Hierarchy/scope fence ordering, predecessor compare-and-swap counts,
+  exactly-one-master checks, root/master rotation exclusion, stranded tier-3
+  refusal, and root-finalize epoch ordering now have one implementation.
+- Token and scanning-key rotation share `rotateRootScopedTier3`; the operation
+  proof and fixed purpose remain explicit inputs.
+- SQLite retains `BEGIN IMMEDIATE` serialization; PostgreSQL retains
+  `SELECT ... FOR UPDATE`. Wire/audit bytes, schema, and generated outputs are
+  unchanged. Database migrations: none. Generated outputs: none.
+
+## Regression evidence
+
+- One public `store.KeyRepo` corpus runs against SQLite and PostgreSQL.
+- It covers stale token, scanning, and DEK predecessors; dual-wrapped master
+  refusal; root-prepare master mismatch; finalize without dual wrapping;
+  newest-epoch finalize; stranded tier-3 refusal; and master/tier-3 unique
+  conflict mapping.
+- PostgreSQL uses a dedicated scratch database and fails loudly in CI if
+  `HIKYO_TEST_POSTGRES_DSN` is absent.
+
+## Validation
+
+```text
+rtk go test -count=1 ./internal/store -run '^TestKeyRotationInvariantsSQLite$'
+                                                        11 passed
+rtk go test -count=1 ./internal/store                   58 passed
+rtk go vet ./internal/store                             passed
+rtk git diff --check                                    clean
+```
+
+Local PostgreSQL execution was unavailable because `HIKYO_TEST_POSTGRES_DSN`
+was unset; required CI supplies it. Full-suite and exact-head CI results are
+recorded in the pull request.
+
+## Review
+
+- Standards round 1: `CLEAN` (0 violations, 0 smells).
+- Spec round 1 found lost dialect fence comments; fixed. Round 2: `CLEAN`.

--- a/internal/store/keys.go
+++ b/internal/store/keys.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgtype"
 	sqlite "modernc.org/sqlite"
 	sqlitelib "modernc.org/sqlite/lib"
 
@@ -252,89 +251,19 @@ func tier3FromSQLite(row sqlitegen.Tier3Key) (crypto.WrappedKey, error) {
 }
 
 func (k sqliteKeys) AcquireHierarchyGeneration(ctx context.Context, pf authz.Proof) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysAcquireHierarchyGeneration, k.tok); err != nil {
-		return err
-	}
-	// sqlite: the single write connection plus BEGIN IMMEDIATE already
-	// serializes writers globally; reading the row keeps the call shape (and
-	// proves the row exists) until rotation gives it teeth.
-	_, err := k.q.AcquireHierarchyGeneration(ctx)
-	return err
+	return acquireHierarchyGeneration(ctx, pf, k)
 }
 
 func (k sqliteKeys) InsertMaster(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertMaster, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertMasterKey(ctx, sqlitegen.InsertMasterKeyParams{
-		Version:      int64(key.Version),
-		RootKeyEpoch: int64(key.RootKeyEpoch),
-		Blob:         key.Blob,
-		CreatedAt:    CanonTime(key.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertMaster(ctx, pf, key, k)
 }
 
 func (k sqliteKeys) InsertTier3(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertTier3, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertTier3Key(ctx, sqlitegen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        CanonTime(key.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertTier3(ctx, pf, key, k)
 }
 
 func (k sqliteKeys) RotateTokenKey(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateTokenKey, k.tok); err != nil {
-		return err
-	}
-	// The fence first, for the reason every other tier-3 write takes it: a
-	// master rotation must not slip between the retire and the insert.
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	// Compare-and-swap on the predecessor: the successor row was minted
-	// against version-1, and if the active key is no longer that version a
-	// concurrent rotation already won. Refusing here is what keeps the
-	// in-memory adopt and the datastore agreeing on which key is live.
-	retired, err := k.q.RetireTier3KeyAtVersion(ctx, sqlitegen.RetireTier3KeyAtVersionParams{
-		Purpose: string(crypto.PurposeToken), OrgID: "", ProjectID: "",
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, sqlitegen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        CanonTime(key.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateRootScopedTier3(ctx, pf, key, k, authz.StoreKeysRotateTokenKey, crypto.PurposeToken)
 }
 
 func (k sqliteKeys) AllOpenableTier3(ctx context.Context, pf authz.Proof) ([]crypto.WrappedKey, error) {
@@ -357,277 +286,35 @@ func (k sqliteKeys) AllOpenableTier3(ctx context.Context, pf authz.Proof) ([]cry
 }
 
 func (k sqliteKeys) RotateMasterKey(ctx context.Context, pf authz.Proof, newMaster crypto.WrappedKey, rewrapped []crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateMasterKey, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	// Exactly one active master, or the root is dual-wrapped (two) / the
-	// hierarchy is missing (zero): the two rotations are mutually exclusive.
-	if len(masters) != 1 {
-		return crypto.ErrMasterRotationBlocked
-	}
-	// The successor must be minted against the master that is still active — a
-	// master rotation that slipped in before this fence moved the predecessor.
-	if int64(newMaster.Version) != masters[0].Version+1 {
-		return ErrRotationSuperseded
-	}
-	retired, err := k.q.RetireMasterAtVersion(ctx, masters[0].Version)
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertMasterKey(ctx, sqlitegen.InsertMasterKeyParams{
-		Version:      int64(newMaster.Version),
-		RootKeyEpoch: int64(newMaster.RootKeyEpoch),
-		Blob:         newMaster.Blob,
-		CreatedAt:    CanonTime(newMaster.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	if err != nil {
-		return err
-	}
-	for _, row := range rewrapped {
-		n, err := k.q.UpdateTier3Wrapping(ctx, sqlitegen.UpdateTier3WrappingParams{
-			Blob:             row.Blob,
-			MasterKeyVersion: int64(row.MasterKeyVersion),
-			ID:               row.ID,
-			Version:          int64(row.Version),
-		})
-		if err != nil {
-			return err
-		}
-		if n != 1 {
-			return fmt.Errorf("store: tier-3 key %s v%d vanished during master rotation", row.ID, row.Version)
-		}
-	}
-	// Zero-reference check INSIDE the fence: a tier-3 key created or
-	// version-appended in the window before this transaction (under the old
-	// master) is not in `rewrapped`, so it still references the retired master.
-	// Refuse and let the caller retry against the now-complete set rather than
-	// strand it — the ADR's "verified by query inside the fence, never assumed".
-	stranded, err := k.q.CountOpenableTier3NotAtMaster(ctx, int64(newMaster.Version))
-	if err != nil {
-		return err
-	}
-	if stranded != 0 {
-		return ErrRotationSuperseded
-	}
-	return nil
-}
-
-// assertActiveMaster is the fence's teeth for a tier-3 rotation, mirroring the
-// boot mint site's check: with the hierarchy generation held, the successor's
-// wrapping master must still be the active one. A master rotation that slipped
-// in between the mint and this insert would otherwise wrap a fresh DEK version
-// under a retired master — CI invariant 9's writer race, structurally refused.
-func (k sqliteKeys) assertActiveMaster(ctx context.Context, masterVersion uint32) error {
-	wrappers, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	if len(wrappers) == 0 {
-		return errors.New("store: no active master key — hierarchy missing")
-	}
-	for _, w := range wrappers {
-		if w.Version != int64(masterVersion) {
-			return crypto.ErrStaleMaster
-		}
-	}
-	return nil
+	return rotateMasterKey(ctx, pf, newMaster, rewrapped, k)
 }
 
 func (k sqliteKeys) AssertActiveDEKVersion(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string, version uint32) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysAssertActiveDEKVersion, k.tok); err != nil {
-		return err
-	}
-	state, err := k.q.AssertActiveTier3Version(ctx, sqlitegen.AssertActiveTier3VersionParams{
-		Purpose: string(p), OrgID: orgID, ProjectID: projectID, Version: int64(version),
-	})
-	if errors.Is(err, sql.ErrNoRows) {
-		return ErrStaleDEK
-	}
-	if err != nil {
-		return err
-	}
-	if state != "active" {
-		return ErrStaleDEK
-	}
-	return nil
+	return assertActiveDEKVersion(ctx, pf, p, orgID, projectID, version, k)
 }
 
 func (k sqliteKeys) RotateScanningKey(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateScanningKey, k.tok); err != nil {
-		return err
-	}
-	// The fence first, then a compare-and-swap on the predecessor version — the
-	// exact shape RotateTokenKey uses, purpose scanning.
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	retired, err := k.q.RetireTier3KeyAtVersion(ctx, sqlitegen.RetireTier3KeyAtVersionParams{
-		Purpose: string(crypto.PurposeScanning), OrgID: "", ProjectID: "",
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, sqlitegen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        CanonTime(key.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateRootScopedTier3(ctx, pf, key, k, authz.StoreKeysRotateScanningKey, crypto.PurposeScanning)
 }
 
 func (k sqliteKeys) RotateDEK(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateDEK, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireScopeGeneration(ctx, scopeGenerationKey(key.Purpose, key.OrgID, key.ProjectID)); err != nil {
-		return err
-	}
-	if err := k.assertActiveMaster(ctx, key.MasterKeyVersion); err != nil {
-		return err
-	}
-	demoted, err := k.q.DemoteActiveTier3ToRetiring(ctx, sqlitegen.DemoteActiveTier3ToRetiringParams{
-		Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID,
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if demoted != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, sqlitegen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        CanonTime(key.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateDEK(ctx, pf, key, k)
 }
 
 func (k sqliteKeys) RetireRetiringTier3(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string) (int64, error) {
-	if _, err := authz.Verify(pf, authz.StoreKeysRetireRetiringTier3, k.tok); err != nil {
-		return 0, err
-	}
-	if _, err := k.q.AcquireScopeGeneration(ctx, scopeGenerationKey(p, orgID, projectID)); err != nil {
-		return 0, err
-	}
-	return k.q.RetireRetiringTier3ForScope(ctx, sqlitegen.RetireRetiringTier3ForScopeParams{
-		Purpose: string(p), OrgID: orgID, ProjectID: projectID,
-	})
+	return retireRetiringTier3(ctx, pf, p, orgID, projectID, k)
 }
 
 func (k sqliteKeys) RootKeyRotatePrepare(ctx context.Context, pf authz.Proof, newWrapper crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRootRotatePrepare, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	if len(masters) != 1 {
-		return crypto.ErrRootRotationBlocked
-	}
-	// Pin the master version INSIDE the fence: the wrapper was sealed over the
-	// master version that was active when prepare read it. A master rotation that
-	// completed in the gap moved that version, and inserting a wrapper for the old
-	// version alongside the new master's wrapper is the two-different-versions
-	// state the ADR refuses — it bricks boot under the new root. Refuse and retry.
-	if masters[0].Version != int64(newWrapper.Version) {
-		return crypto.ErrRootRotationBlocked
-	}
-	err = k.q.InsertMasterKey(ctx, sqlitegen.InsertMasterKeyParams{
-		Version:      int64(newWrapper.Version),
-		RootKeyEpoch: int64(newWrapper.RootKeyEpoch),
-		Blob:         newWrapper.Blob,
-		CreatedAt:    CanonTime(newWrapper.CreatedAt).Format(timeFormat),
-	})
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rootKeyRotatePrepare(ctx, pf, newWrapper, k)
 }
 
 func (k sqliteKeys) RootKeyRotateFinalize(ctx context.Context, pf authz.Proof) (uint32, error) {
-	if _, err := authz.Verify(pf, authz.StoreKeysRootRotateFinalize, k.tok); err != nil {
-		return 0, err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return 0, err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return 0, err
-	}
-	if len(masters) != 2 {
-		return 0, crypto.ErrNotDualWrapped
-	}
-	// GetActiveMasterKeys orders by root_key_epoch DESC: [new, old].
-	newEpoch := masters[0].RootKeyEpoch
-	old := masters[len(masters)-1]
-	retired, err := k.q.RetireMasterWrapperAtEpoch(ctx, sqlitegen.RetireMasterWrapperAtEpochParams{
-		Version:      old.Version,
-		RootKeyEpoch: old.RootKeyEpoch,
-	})
-	if err != nil {
-		return 0, err
-	}
-	if retired != 1 {
-		return 0, ErrRotationSuperseded
-	}
-	epoch, err := dbVersion("root key epoch", newEpoch)
-	if err != nil {
-		return 0, err
-	}
-	return epoch, nil
+	return rootKeyRotateFinalize(ctx, pf, k)
 }
 
 func (k sqliteKeys) InsertScopeGeneration(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertScopeGeneration, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertKeyGeneration(ctx, scopeGenerationKey(p, orgID, projectID))
-	if sqliteUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertScopeGeneration(ctx, pf, p, orgID, projectID, k)
 }
 
 // --- postgres ---
@@ -741,83 +428,19 @@ func tier3FromPG(row pggen.Tier3Key) (crypto.WrappedKey, error) {
 }
 
 func (k pgKeys) AcquireHierarchyGeneration(ctx context.Context, pf authz.Proof) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysAcquireHierarchyGeneration, k.tok); err != nil {
-		return err
-	}
-	// SELECT ... FOR UPDATE: the row lock serializes tier-3 key creation
-	// against future master/root rotation in the same fence.
-	_, err := k.q.AcquireHierarchyGeneration(ctx)
-	return err
+	return acquireHierarchyGeneration(ctx, pf, k)
 }
 
 func (k pgKeys) InsertMaster(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertMaster, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertMasterKey(ctx, pggen.InsertMasterKeyParams{
-		Version:      int64(key.Version),
-		RootKeyEpoch: int64(key.RootKeyEpoch),
-		Blob:         key.Blob,
-		CreatedAt:    pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertMaster(ctx, pf, key, k)
 }
 
 func (k pgKeys) InsertTier3(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertTier3, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertTier3Key(ctx, pggen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertTier3(ctx, pf, key, k)
 }
 
 func (k pgKeys) RotateTokenKey(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateTokenKey, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	// Compare-and-swap on the predecessor: see the sqlite twin.
-	retired, err := k.q.RetireTier3KeyAtVersion(ctx, pggen.RetireTier3KeyAtVersionParams{
-		Purpose: string(crypto.PurposeToken), OrgID: "", ProjectID: "",
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, pggen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateRootScopedTier3(ctx, pf, key, k, authz.StoreKeysRotateTokenKey, crypto.PurposeToken)
 }
 
 func (k pgKeys) AllOpenableTier3(ctx context.Context, pf authz.Proof) ([]crypto.WrappedKey, error) {
@@ -840,255 +463,33 @@ func (k pgKeys) AllOpenableTier3(ctx context.Context, pf authz.Proof) ([]crypto.
 }
 
 func (k pgKeys) RotateMasterKey(ctx context.Context, pf authz.Proof, newMaster crypto.WrappedKey, rewrapped []crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateMasterKey, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	if len(masters) != 1 {
-		return crypto.ErrMasterRotationBlocked
-	}
-	if int64(newMaster.Version) != masters[0].Version+1 {
-		return ErrRotationSuperseded
-	}
-	retired, err := k.q.RetireMasterAtVersion(ctx, masters[0].Version)
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertMasterKey(ctx, pggen.InsertMasterKeyParams{
-		Version:      int64(newMaster.Version),
-		RootKeyEpoch: int64(newMaster.RootKeyEpoch),
-		Blob:         newMaster.Blob,
-		CreatedAt:    pgtype.Timestamptz{Time: CanonTime(newMaster.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	if err != nil {
-		return err
-	}
-	for _, row := range rewrapped {
-		n, err := k.q.UpdateTier3Wrapping(ctx, pggen.UpdateTier3WrappingParams{
-			Blob:             row.Blob,
-			MasterKeyVersion: int64(row.MasterKeyVersion),
-			ID:               row.ID,
-			Version:          int64(row.Version),
-		})
-		if err != nil {
-			return err
-		}
-		if n != 1 {
-			return fmt.Errorf("store: tier-3 key %s v%d vanished during master rotation", row.ID, row.Version)
-		}
-	}
-	stranded, err := k.q.CountOpenableTier3NotAtMaster(ctx, int64(newMaster.Version))
-	if err != nil {
-		return err
-	}
-	if stranded != 0 {
-		return ErrRotationSuperseded
-	}
-	return nil
-}
-
-func (k pgKeys) assertActiveMaster(ctx context.Context, masterVersion uint32) error {
-	wrappers, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	if len(wrappers) == 0 {
-		return errors.New("store: no active master key — hierarchy missing")
-	}
-	for _, w := range wrappers {
-		if w.Version != int64(masterVersion) {
-			return crypto.ErrStaleMaster
-		}
-	}
-	return nil
+	return rotateMasterKey(ctx, pf, newMaster, rewrapped, k)
 }
 
 func (k pgKeys) AssertActiveDEKVersion(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string, version uint32) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysAssertActiveDEKVersion, k.tok); err != nil {
-		return err
-	}
-	state, err := k.q.AssertActiveTier3Version(ctx, pggen.AssertActiveTier3VersionParams{
-		Purpose: string(p), OrgID: orgID, ProjectID: projectID, Version: int64(version),
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ErrStaleDEK
-	}
-	if err != nil {
-		return err
-	}
-	if state != "active" {
-		return ErrStaleDEK
-	}
-	return nil
+	return assertActiveDEKVersion(ctx, pf, p, orgID, projectID, version, k)
 }
 
 func (k pgKeys) RotateScanningKey(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateScanningKey, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	// Compare-and-swap on the predecessor: see the sqlite twin and RotateTokenKey.
-	retired, err := k.q.RetireTier3KeyAtVersion(ctx, pggen.RetireTier3KeyAtVersionParams{
-		Purpose: string(crypto.PurposeScanning), OrgID: "", ProjectID: "",
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if retired != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, pggen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateRootScopedTier3(ctx, pf, key, k, authz.StoreKeysRotateScanningKey, crypto.PurposeScanning)
 }
 
 func (k pgKeys) RotateDEK(ctx context.Context, pf authz.Proof, key crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRotateDEK, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireScopeGeneration(ctx, scopeGenerationKey(key.Purpose, key.OrgID, key.ProjectID)); err != nil {
-		return err
-	}
-	if err := k.assertActiveMaster(ctx, key.MasterKeyVersion); err != nil {
-		return err
-	}
-	demoted, err := k.q.DemoteActiveTier3ToRetiring(ctx, pggen.DemoteActiveTier3ToRetiringParams{
-		Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID,
-		Version: int64(key.Version) - 1,
-	})
-	if err != nil {
-		return err
-	}
-	if demoted != 1 {
-		return ErrRotationSuperseded
-	}
-	err = k.q.InsertTier3Key(ctx, pggen.InsertTier3KeyParams{
-		ID:               key.ID,
-		Purpose:          string(key.Purpose),
-		OrgID:            key.OrgID,
-		ProjectID:        key.ProjectID,
-		Version:          int64(key.Version),
-		MasterKeyVersion: int64(key.MasterKeyVersion),
-		Blob:             key.Blob,
-		CreatedAt:        pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rotateDEK(ctx, pf, key, k)
 }
 
 func (k pgKeys) RetireRetiringTier3(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string) (int64, error) {
-	if _, err := authz.Verify(pf, authz.StoreKeysRetireRetiringTier3, k.tok); err != nil {
-		return 0, err
-	}
-	if _, err := k.q.AcquireScopeGeneration(ctx, scopeGenerationKey(p, orgID, projectID)); err != nil {
-		return 0, err
-	}
-	return k.q.RetireRetiringTier3ForScope(ctx, pggen.RetireRetiringTier3ForScopeParams{
-		Purpose: string(p), OrgID: orgID, ProjectID: projectID,
-	})
+	return retireRetiringTier3(ctx, pf, p, orgID, projectID, k)
 }
 
 func (k pgKeys) RootKeyRotatePrepare(ctx context.Context, pf authz.Proof, newWrapper crypto.WrappedKey) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysRootRotatePrepare, k.tok); err != nil {
-		return err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return err
-	}
-	if len(masters) != 1 {
-		return crypto.ErrRootRotationBlocked
-	}
-	// Pin the master version inside the fence — see the sqlite twin.
-	if masters[0].Version != int64(newWrapper.Version) {
-		return crypto.ErrRootRotationBlocked
-	}
-	err = k.q.InsertMasterKey(ctx, pggen.InsertMasterKeyParams{
-		Version:      int64(newWrapper.Version),
-		RootKeyEpoch: int64(newWrapper.RootKeyEpoch),
-		Blob:         newWrapper.Blob,
-		CreatedAt:    pgtype.Timestamptz{Time: CanonTime(newWrapper.CreatedAt), Valid: true},
-	})
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return rootKeyRotatePrepare(ctx, pf, newWrapper, k)
 }
 
 func (k pgKeys) RootKeyRotateFinalize(ctx context.Context, pf authz.Proof) (uint32, error) {
-	if _, err := authz.Verify(pf, authz.StoreKeysRootRotateFinalize, k.tok); err != nil {
-		return 0, err
-	}
-	if _, err := k.q.AcquireHierarchyGeneration(ctx); err != nil {
-		return 0, err
-	}
-	masters, err := k.q.GetActiveMasterKeys(ctx)
-	if err != nil {
-		return 0, err
-	}
-	if len(masters) != 2 {
-		return 0, crypto.ErrNotDualWrapped
-	}
-	newEpoch := masters[0].RootKeyEpoch
-	old := masters[len(masters)-1]
-	retired, err := k.q.RetireMasterWrapperAtEpoch(ctx, pggen.RetireMasterWrapperAtEpochParams{
-		Version:      old.Version,
-		RootKeyEpoch: old.RootKeyEpoch,
-	})
-	if err != nil {
-		return 0, err
-	}
-	if retired != 1 {
-		return 0, ErrRotationSuperseded
-	}
-	epoch, err := dbVersion("root key epoch", newEpoch)
-	if err != nil {
-		return 0, err
-	}
-	return epoch, nil
+	return rootKeyRotateFinalize(ctx, pf, k)
 }
 
 func (k pgKeys) InsertScopeGeneration(ctx context.Context, pf authz.Proof, p crypto.Purpose, orgID, projectID string) error {
-	if _, err := authz.Verify(pf, authz.StoreKeysInsertScopeGeneration, k.tok); err != nil {
-		return err
-	}
-	err := k.q.InsertKeyGeneration(ctx, scopeGenerationKey(p, orgID, projectID))
-	if pgUniqueViolation(err) {
-		return crypto.ErrKeyExists
-	}
-	return err
+	return insertScopeGeneration(ctx, pf, p, orgID, projectID, k)
 }

--- a/internal/store/keys_mutations.go
+++ b/internal/store/keys_mutations.go
@@ -1,0 +1,463 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/store/pggen"
+	"github.com/Hikyo-Org/hikyo/internal/store/sqlitegen"
+)
+
+// keyMutationAdapter is the internal seam between key-rotation policy and the
+// two SQL dialects. The adapter owns only generated-query shape and driver
+// error translation; every security invariant and operation ordering rule is
+// owned once by the functions below.
+type keyMutationAdapter interface {
+	txToken() *authz.TxToken
+	acquireHierarchy(context.Context) error
+	acquireScope(context.Context, string) error
+	activeMasters(context.Context) ([]activeMasterRow, error)
+	insertMasterRow(context.Context, crypto.WrappedKey) error
+	insertTier3Row(context.Context, crypto.WrappedKey) error
+	retireTier3AtVersion(context.Context, crypto.Purpose, string, string, int64) (int64, error)
+	demoteTier3AtVersion(context.Context, crypto.WrappedKey, int64) (int64, error)
+	retireMasterAtVersion(context.Context, int64) (int64, error)
+	retireMasterWrapper(context.Context, activeMasterRow) (int64, error)
+	updateTier3Wrapping(context.Context, crypto.WrappedKey) (int64, error)
+	countOpenableTier3NotAtMaster(context.Context, int64) (int64, error)
+	activeTier3State(context.Context, crypto.Purpose, string, string, int64) (string, error)
+	retireRetiringTier3ForScope(context.Context, crypto.Purpose, string, string) (int64, error)
+	insertScopeGenerationRow(context.Context, string) error
+}
+
+type activeMasterRow struct {
+	version      int64
+	rootKeyEpoch int64
+}
+
+func verifyKeyMutation(proof authz.Proof, op authz.StoreOp, adapter keyMutationAdapter) error {
+	_, err := authz.Verify(proof, op, adapter.txToken())
+	return err
+}
+
+func acquireHierarchyGeneration(ctx context.Context, proof authz.Proof, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysAcquireHierarchyGeneration, adapter); err != nil {
+		return err
+	}
+	return adapter.acquireHierarchy(ctx)
+}
+
+func insertMaster(ctx context.Context, proof authz.Proof, key crypto.WrappedKey, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysInsertMaster, adapter); err != nil {
+		return err
+	}
+	return adapter.insertMasterRow(ctx, key)
+}
+
+func insertTier3(ctx context.Context, proof authz.Proof, key crypto.WrappedKey, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysInsertTier3, adapter); err != nil {
+		return err
+	}
+	return adapter.insertTier3Row(ctx, key)
+}
+
+func rotateRootScopedTier3(ctx context.Context, proof authz.Proof, key crypto.WrappedKey, adapter keyMutationAdapter, op authz.StoreOp, purpose crypto.Purpose) error {
+	if err := verifyKeyMutation(proof, op, adapter); err != nil {
+		return err
+	}
+	// Hierarchy fence first: master rotation cannot slip between retire and
+	// insert. CAS on predecessor keeps process memory and datastore aligned.
+	if err := adapter.acquireHierarchy(ctx); err != nil {
+		return err
+	}
+	retired, err := adapter.retireTier3AtVersion(ctx, purpose, "", "", int64(key.Version)-1)
+	if err != nil {
+		return err
+	}
+	if retired != 1 {
+		return ErrRotationSuperseded
+	}
+	return adapter.insertTier3Row(ctx, key)
+}
+
+func rotateDEK(ctx context.Context, proof authz.Proof, key crypto.WrappedKey, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysRotateDEK, adapter); err != nil {
+		return err
+	}
+	if err := adapter.acquireHierarchy(ctx); err != nil {
+		return err
+	}
+	if err := adapter.acquireScope(ctx, scopeGenerationKey(key.Purpose, key.OrgID, key.ProjectID)); err != nil {
+		return err
+	}
+	if err := assertActiveMaster(ctx, key.MasterKeyVersion, adapter); err != nil {
+		return err
+	}
+	demoted, err := adapter.demoteTier3AtVersion(ctx, key, int64(key.Version)-1)
+	if err != nil {
+		return err
+	}
+	if demoted != 1 {
+		return ErrRotationSuperseded
+	}
+	return adapter.insertTier3Row(ctx, key)
+}
+
+// assertActiveMaster gives the hierarchy fence teeth for tier-3 rotation. A
+// successor wrapped under a master that retired after minting is refused.
+func assertActiveMaster(ctx context.Context, masterVersion uint32, adapter keyMutationAdapter) error {
+	masters, err := adapter.activeMasters(ctx)
+	if err != nil {
+		return err
+	}
+	if len(masters) == 0 {
+		return errors.New("store: no active master key — hierarchy missing")
+	}
+	for _, master := range masters {
+		if master.version != int64(masterVersion) {
+			return crypto.ErrStaleMaster
+		}
+	}
+	return nil
+}
+
+func assertActiveDEKVersion(ctx context.Context, proof authz.Proof, purpose crypto.Purpose, orgID, projectID string, version uint32, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysAssertActiveDEKVersion, adapter); err != nil {
+		return err
+	}
+	state, err := adapter.activeTier3State(ctx, purpose, orgID, projectID, int64(version))
+	if err != nil {
+		return err
+	}
+	if state != "active" {
+		return ErrStaleDEK
+	}
+	return nil
+}
+
+func rotateMasterKey(ctx context.Context, proof authz.Proof, newMaster crypto.WrappedKey, rewrapped []crypto.WrappedKey, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysRotateMasterKey, adapter); err != nil {
+		return err
+	}
+	if err := adapter.acquireHierarchy(ctx); err != nil {
+		return err
+	}
+	masters, err := adapter.activeMasters(ctx)
+	if err != nil {
+		return err
+	}
+	// Exactly one active wrapper: zero means missing hierarchy; two means root
+	// rotation is dual-wrapped. Master and root rotation are mutually exclusive.
+	if len(masters) != 1 {
+		return crypto.ErrMasterRotationBlocked
+	}
+	if int64(newMaster.Version) != masters[0].version+1 {
+		return ErrRotationSuperseded
+	}
+	retired, err := adapter.retireMasterAtVersion(ctx, masters[0].version)
+	if err != nil {
+		return err
+	}
+	if retired != 1 {
+		return ErrRotationSuperseded
+	}
+	if err := adapter.insertMasterRow(ctx, newMaster); err != nil {
+		return err
+	}
+	for _, row := range rewrapped {
+		updated, err := adapter.updateTier3Wrapping(ctx, row)
+		if err != nil {
+			return err
+		}
+		if updated != 1 {
+			return fmt.Errorf("store: tier-3 key %s v%d vanished during master rotation", row.ID, row.Version)
+		}
+	}
+	// Checked inside the fence: no openable key may remain under old master.
+	stranded, err := adapter.countOpenableTier3NotAtMaster(ctx, int64(newMaster.Version))
+	if err != nil {
+		return err
+	}
+	if stranded != 0 {
+		return ErrRotationSuperseded
+	}
+	return nil
+}
+
+func retireRetiringTier3(ctx context.Context, proof authz.Proof, purpose crypto.Purpose, orgID, projectID string, adapter keyMutationAdapter) (int64, error) {
+	if err := verifyKeyMutation(proof, authz.StoreKeysRetireRetiringTier3, adapter); err != nil {
+		return 0, err
+	}
+	if err := adapter.acquireScope(ctx, scopeGenerationKey(purpose, orgID, projectID)); err != nil {
+		return 0, err
+	}
+	return adapter.retireRetiringTier3ForScope(ctx, purpose, orgID, projectID)
+}
+
+func rootKeyRotatePrepare(ctx context.Context, proof authz.Proof, newWrapper crypto.WrappedKey, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysRootRotatePrepare, adapter); err != nil {
+		return err
+	}
+	if err := adapter.acquireHierarchy(ctx); err != nil {
+		return err
+	}
+	masters, err := adapter.activeMasters(ctx)
+	if err != nil {
+		return err
+	}
+	if len(masters) != 1 || masters[0].version != int64(newWrapper.Version) {
+		return crypto.ErrRootRotationBlocked
+	}
+	return adapter.insertMasterRow(ctx, newWrapper)
+}
+
+func rootKeyRotateFinalize(ctx context.Context, proof authz.Proof, adapter keyMutationAdapter) (uint32, error) {
+	if err := verifyKeyMutation(proof, authz.StoreKeysRootRotateFinalize, adapter); err != nil {
+		return 0, err
+	}
+	if err := adapter.acquireHierarchy(ctx); err != nil {
+		return 0, err
+	}
+	masters, err := adapter.activeMasters(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if len(masters) != 2 {
+		return 0, crypto.ErrNotDualWrapped
+	}
+	// activeMasters is ordered by root epoch descending: [new, old].
+	newEpoch := masters[0].rootKeyEpoch
+	retired, err := adapter.retireMasterWrapper(ctx, masters[len(masters)-1])
+	if err != nil {
+		return 0, err
+	}
+	if retired != 1 {
+		return 0, ErrRotationSuperseded
+	}
+	return dbVersion("root key epoch", newEpoch)
+}
+
+func insertScopeGeneration(ctx context.Context, proof authz.Proof, purpose crypto.Purpose, orgID, projectID string, adapter keyMutationAdapter) error {
+	if err := verifyKeyMutation(proof, authz.StoreKeysInsertScopeGeneration, adapter); err != nil {
+		return err
+	}
+	return adapter.insertScopeGenerationRow(ctx, scopeGenerationKey(purpose, orgID, projectID))
+}
+
+func (k sqliteKeys) txToken() *authz.TxToken { return k.tok }
+
+func (k sqliteKeys) acquireHierarchy(ctx context.Context) error {
+	// SQLite's single write connection plus BEGIN IMMEDIATE serializes writers
+	// globally; reading the row keeps the dialect-neutral call shape and proves
+	// the hierarchy generation exists.
+	_, err := k.q.AcquireHierarchyGeneration(ctx)
+	return err
+}
+
+func (k sqliteKeys) acquireScope(ctx context.Context, scope string) error {
+	_, err := k.q.AcquireScopeGeneration(ctx, scope)
+	return err
+}
+
+func (k sqliteKeys) activeMasters(ctx context.Context) ([]activeMasterRow, error) {
+	rows, err := k.q.GetActiveMasterKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]activeMasterRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, activeMasterRow{version: row.Version, rootKeyEpoch: row.RootKeyEpoch})
+	}
+	return out, nil
+}
+
+func (k sqliteKeys) insertMasterRow(ctx context.Context, key crypto.WrappedKey) error {
+	err := k.q.InsertMasterKey(ctx, sqlitegen.InsertMasterKeyParams{
+		Version: int64(key.Version), RootKeyEpoch: int64(key.RootKeyEpoch), Blob: key.Blob,
+		CreatedAt: CanonTime(key.CreatedAt).Format(timeFormat),
+	})
+	if sqliteUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}
+
+func (k sqliteKeys) insertTier3Row(ctx context.Context, key crypto.WrappedKey) error {
+	err := k.q.InsertTier3Key(ctx, sqlitegen.InsertTier3KeyParams{
+		ID: key.ID, Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID,
+		Version: int64(key.Version), MasterKeyVersion: int64(key.MasterKeyVersion), Blob: key.Blob,
+		CreatedAt: CanonTime(key.CreatedAt).Format(timeFormat),
+	})
+	if sqliteUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}
+
+func (k sqliteKeys) retireTier3AtVersion(ctx context.Context, purpose crypto.Purpose, orgID, projectID string, version int64) (int64, error) {
+	return k.q.RetireTier3KeyAtVersion(ctx, sqlitegen.RetireTier3KeyAtVersionParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID, Version: version,
+	})
+}
+
+func (k sqliteKeys) demoteTier3AtVersion(ctx context.Context, key crypto.WrappedKey, version int64) (int64, error) {
+	return k.q.DemoteActiveTier3ToRetiring(ctx, sqlitegen.DemoteActiveTier3ToRetiringParams{
+		Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID, Version: version,
+	})
+}
+
+func (k sqliteKeys) retireMasterAtVersion(ctx context.Context, version int64) (int64, error) {
+	return k.q.RetireMasterAtVersion(ctx, version)
+}
+
+func (k sqliteKeys) retireMasterWrapper(ctx context.Context, master activeMasterRow) (int64, error) {
+	return k.q.RetireMasterWrapperAtEpoch(ctx, sqlitegen.RetireMasterWrapperAtEpochParams{
+		Version: master.version, RootKeyEpoch: master.rootKeyEpoch,
+	})
+}
+
+func (k sqliteKeys) updateTier3Wrapping(ctx context.Context, key crypto.WrappedKey) (int64, error) {
+	return k.q.UpdateTier3Wrapping(ctx, sqlitegen.UpdateTier3WrappingParams{
+		Blob: key.Blob, MasterKeyVersion: int64(key.MasterKeyVersion), ID: key.ID, Version: int64(key.Version),
+	})
+}
+
+func (k sqliteKeys) countOpenableTier3NotAtMaster(ctx context.Context, version int64) (int64, error) {
+	return k.q.CountOpenableTier3NotAtMaster(ctx, version)
+}
+
+func (k sqliteKeys) activeTier3State(ctx context.Context, purpose crypto.Purpose, orgID, projectID string, version int64) (string, error) {
+	state, err := k.q.AssertActiveTier3Version(ctx, sqlitegen.AssertActiveTier3VersionParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID, Version: version,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrStaleDEK
+	}
+	return state, err
+}
+
+func (k sqliteKeys) retireRetiringTier3ForScope(ctx context.Context, purpose crypto.Purpose, orgID, projectID string) (int64, error) {
+	return k.q.RetireRetiringTier3ForScope(ctx, sqlitegen.RetireRetiringTier3ForScopeParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID,
+	})
+}
+
+func (k sqliteKeys) insertScopeGenerationRow(ctx context.Context, scope string) error {
+	err := k.q.InsertKeyGeneration(ctx, scope)
+	if sqliteUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}
+
+func (k pgKeys) txToken() *authz.TxToken { return k.tok }
+
+func (k pgKeys) acquireHierarchy(ctx context.Context) error {
+	// SELECT ... FOR UPDATE locks the hierarchy generation, serializing tier-3
+	// key creation against master and root rotation in this transaction.
+	_, err := k.q.AcquireHierarchyGeneration(ctx)
+	return err
+}
+
+func (k pgKeys) acquireScope(ctx context.Context, scope string) error {
+	_, err := k.q.AcquireScopeGeneration(ctx, scope)
+	return err
+}
+
+func (k pgKeys) activeMasters(ctx context.Context) ([]activeMasterRow, error) {
+	rows, err := k.q.GetActiveMasterKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]activeMasterRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, activeMasterRow{version: row.Version, rootKeyEpoch: row.RootKeyEpoch})
+	}
+	return out, nil
+}
+
+func (k pgKeys) insertMasterRow(ctx context.Context, key crypto.WrappedKey) error {
+	err := k.q.InsertMasterKey(ctx, pggen.InsertMasterKeyParams{
+		Version: int64(key.Version), RootKeyEpoch: int64(key.RootKeyEpoch), Blob: key.Blob,
+		CreatedAt: pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
+	})
+	if pgUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}
+
+func (k pgKeys) insertTier3Row(ctx context.Context, key crypto.WrappedKey) error {
+	err := k.q.InsertTier3Key(ctx, pggen.InsertTier3KeyParams{
+		ID: key.ID, Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID,
+		Version: int64(key.Version), MasterKeyVersion: int64(key.MasterKeyVersion), Blob: key.Blob,
+		CreatedAt: pgtype.Timestamptz{Time: CanonTime(key.CreatedAt), Valid: true},
+	})
+	if pgUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}
+
+func (k pgKeys) retireTier3AtVersion(ctx context.Context, purpose crypto.Purpose, orgID, projectID string, version int64) (int64, error) {
+	return k.q.RetireTier3KeyAtVersion(ctx, pggen.RetireTier3KeyAtVersionParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID, Version: version,
+	})
+}
+
+func (k pgKeys) demoteTier3AtVersion(ctx context.Context, key crypto.WrappedKey, version int64) (int64, error) {
+	return k.q.DemoteActiveTier3ToRetiring(ctx, pggen.DemoteActiveTier3ToRetiringParams{
+		Purpose: string(key.Purpose), OrgID: key.OrgID, ProjectID: key.ProjectID, Version: version,
+	})
+}
+
+func (k pgKeys) retireMasterAtVersion(ctx context.Context, version int64) (int64, error) {
+	return k.q.RetireMasterAtVersion(ctx, version)
+}
+
+func (k pgKeys) retireMasterWrapper(ctx context.Context, master activeMasterRow) (int64, error) {
+	return k.q.RetireMasterWrapperAtEpoch(ctx, pggen.RetireMasterWrapperAtEpochParams{
+		Version: master.version, RootKeyEpoch: master.rootKeyEpoch,
+	})
+}
+
+func (k pgKeys) updateTier3Wrapping(ctx context.Context, key crypto.WrappedKey) (int64, error) {
+	return k.q.UpdateTier3Wrapping(ctx, pggen.UpdateTier3WrappingParams{
+		Blob: key.Blob, MasterKeyVersion: int64(key.MasterKeyVersion), ID: key.ID, Version: int64(key.Version),
+	})
+}
+
+func (k pgKeys) countOpenableTier3NotAtMaster(ctx context.Context, version int64) (int64, error) {
+	return k.q.CountOpenableTier3NotAtMaster(ctx, version)
+}
+
+func (k pgKeys) activeTier3State(ctx context.Context, purpose crypto.Purpose, orgID, projectID string, version int64) (string, error) {
+	state, err := k.q.AssertActiveTier3Version(ctx, pggen.AssertActiveTier3VersionParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID, Version: version,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrStaleDEK
+	}
+	return state, err
+}
+
+func (k pgKeys) retireRetiringTier3ForScope(ctx context.Context, purpose crypto.Purpose, orgID, projectID string) (int64, error) {
+	return k.q.RetireRetiringTier3ForScope(ctx, pggen.RetireRetiringTier3ForScopeParams{
+		Purpose: string(purpose), OrgID: orgID, ProjectID: projectID,
+	})
+}
+
+func (k pgKeys) insertScopeGenerationRow(ctx context.Context, scope string) error {
+	err := k.q.InsertKeyGeneration(ctx, scope)
+	if pgUniqueViolation(err) {
+		return crypto.ErrKeyExists
+	}
+	return err
+}

--- a/internal/store/keys_test.go
+++ b/internal/store/keys_test.go
@@ -1,0 +1,324 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
+	storetx "github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+var errRollbackKeyTest = errors.New("rollback key-store test fixture")
+
+func TestKeyRotationInvariantsSQLite(t *testing.T) {
+	cfg := store.Config{
+		Engine: store.EngineSQLite,
+		Path:   filepath.Join(t.TempDir(), "keys.db"),
+	}
+	runKeyRotationInvariants(t, openKeyTestDB(t, cfg))
+}
+
+func TestKeyRotationInvariantsPostgres(t *testing.T) {
+	dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres key-store leg must not silently skip")
+		}
+		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
+	}
+
+	admin, cfg := postgresKeyTestConfig(t, dsn)
+	t.Cleanup(func() {
+		_, _ = admin.PG().Exec(context.Background(), `DROP DATABASE IF EXISTS "`+
+			strings.ReplaceAll(strings.TrimPrefix(mustParseURL(t, cfg.DSN).Path, "/"), `"`, ``)+`" WITH (FORCE)`)
+		admin.Close()
+	})
+	runKeyRotationInvariants(t, openKeyTestDB(t, cfg))
+}
+
+func runKeyRotationInvariants(t *testing.T, db *store.DB) {
+	t.Helper()
+	seedKeyTestOperator(t, db)
+
+	for _, purpose := range []crypto.Purpose{crypto.PurposeToken, crypto.PurposeScanning} {
+		purpose := purpose
+		t.Run("stale_"+string(purpose)+"_predecessor", func(t *testing.T) {
+			withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+				mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, []crypto.WrappedKey{tier3Key(purpose, 1, 1)})
+				stale := tier3Key(purpose, 3, 1)
+				var err error
+				if purpose == crypto.PurposeToken {
+					err = keys.RotateTokenKey(ctx, proofs.token, stale)
+				} else {
+					err = keys.RotateScanningKey(ctx, proofs.scanning, stale)
+				}
+				if !errors.Is(err, store.ErrRotationSuperseded) {
+					t.Fatalf("stale %s rotation error = %v, want ErrRotationSuperseded", purpose, err)
+				}
+			})
+		})
+	}
+
+	t.Run("stale_dek_predecessor", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, []crypto.WrappedKey{projectKey(1, 1)})
+			if err := keys.RotateDEK(ctx, proofs.dek, projectKey(3, 1)); !errors.Is(err, store.ErrRotationSuperseded) {
+				t.Fatalf("stale DEK rotation error = %v, want ErrRotationSuperseded", err)
+			}
+		})
+	})
+
+	t.Run("master_rotation_refuses_dual_wrap", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1), masterKey(1, 2)}, nil)
+			if err := keys.RotateMasterKey(ctx, proofs.master, masterKey(2, 2), nil); !errors.Is(err, crypto.ErrMasterRotationBlocked) {
+				t.Fatalf("dual-wrapped master rotation error = %v, want ErrMasterRotationBlocked", err)
+			}
+		})
+	})
+
+	t.Run("root_prepare_refuses_master_version_mismatch", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, nil)
+			if err := keys.RootKeyRotatePrepare(ctx, proofs.root, masterKey(2, 2)); !errors.Is(err, crypto.ErrRootRotationBlocked) {
+				t.Fatalf("mismatched root prepare error = %v, want ErrRootRotationBlocked", err)
+			}
+		})
+	})
+
+	t.Run("root_finalize_requires_dual_wrap", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, nil)
+			if _, err := keys.RootKeyRotateFinalize(ctx, proofs.root); !errors.Is(err, crypto.ErrNotDualWrapped) {
+				t.Fatalf("single-wrapper finalize error = %v, want ErrNotDualWrapped", err)
+			}
+		})
+	})
+
+	t.Run("root_finalize_keeps_newest_epoch", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1), masterKey(1, 2)}, nil)
+			epoch, err := keys.RootKeyRotateFinalize(ctx, proofs.root)
+			if err != nil {
+				t.Fatalf("finalize dual-wrapped root: %v", err)
+			}
+			if epoch != 2 {
+				t.Fatalf("finalized root epoch = %d, want 2", epoch)
+			}
+			wrappers, err := keys.ActiveMasterWrappers(ctx, proofs.boot)
+			if err != nil {
+				t.Fatalf("read finalized master wrappers: %v", err)
+			}
+			if len(wrappers) != 1 || wrappers[0].RootKeyEpoch != 2 {
+				t.Fatalf("active wrappers after finalize = %+v, want only epoch 2", wrappers)
+			}
+		})
+	})
+
+	t.Run("master_rotation_refuses_stranded_tier3", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, []crypto.WrappedKey{projectKey(1, 1)})
+			if err := keys.RotateMasterKey(ctx, proofs.master, masterKey(2, 1), nil); !errors.Is(err, store.ErrRotationSuperseded) {
+				t.Fatalf("stranded tier-3 rotation error = %v, want ErrRotationSuperseded", err)
+			}
+		})
+	})
+
+	t.Run("duplicate_master_maps_to_key_exists", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			key := masterKey(1, 1)
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{key}, nil)
+			if err := keys.InsertMaster(ctx, proofs.boot, key); !errors.Is(err, crypto.ErrKeyExists) {
+				t.Fatalf("duplicate master error = %v, want ErrKeyExists", err)
+			}
+		})
+	})
+
+	t.Run("duplicate_tier3_maps_to_key_exists", func(t *testing.T) {
+		withKeyRepo(t, db, func(ctx context.Context, keys store.KeyRepo, proofs keyTestProofs) {
+			key := tier3Key(crypto.PurposeToken, 1, 1)
+			mustInsertKeyFixture(t, ctx, keys, proofs.boot, []crypto.WrappedKey{masterKey(1, 1)}, []crypto.WrappedKey{key})
+			if err := keys.InsertTier3(ctx, proofs.boot, key); !errors.Is(err, crypto.ErrKeyExists) {
+				t.Fatalf("duplicate tier-3 error = %v, want ErrKeyExists", err)
+			}
+		})
+	})
+}
+
+type keyTestProofs struct {
+	boot     authz.Proof
+	token    authz.Proof
+	scanning authz.Proof
+	dek      authz.Proof
+	master   authz.Proof
+	root     authz.Proof
+}
+
+func withKeyRepo(t *testing.T, db *store.DB, test func(context.Context, store.KeyRepo, keyTestProofs)) {
+	t.Helper()
+	err := storetx.Write(t.Context(), db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
+		proofs, err := mintKeyTestProofs(ctx, az)
+		if err != nil {
+			return err
+		}
+		test(ctx, repos.Keys(), proofs)
+		return errRollbackKeyTest
+	})
+	if !errors.Is(err, errRollbackKeyTest) {
+		t.Fatalf("key-store test transaction: %v", err)
+	}
+}
+
+func mintKeyTestProofs(ctx context.Context, az *authz.TxAuthorizer) (keyTestProofs, error) {
+	boot, err := authz.SystemAuthority(authz.SiteBoot, az.Token())
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	authorize := func(op authz.Operation) (authz.Proof, error) {
+		return az.Authorize(ctx, authz.Identity{Principal: "usr_keys"}, op, domain.Scope{})
+	}
+	token, err := authorize(authz.OpRotateTokenKey)
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	scanning, err := authorize(authz.OpRotateScanningKey)
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	dek, err := authorize(authz.OpRotateDEK)
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	master, err := authorize(authz.OpRotateMasterKey)
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	root, err := authorize(authz.OpRotateRootKey)
+	if err != nil {
+		return keyTestProofs{}, err
+	}
+	return keyTestProofs{boot: boot, token: token, scanning: scanning, dek: dek, master: master, root: root}, nil
+}
+
+func seedKeyTestOperator(t *testing.T, db *store.DB) {
+	t.Helper()
+	statements := []string{
+		`INSERT INTO principals (id, kind, created_at) VALUES ('usr_keys', 'human', '2026-08-23T12:00:00Z')`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at)
+		 VALUES ('grt_keys_dek', 'usr_keys', 'rotate-dek', NULL, NULL, NULL, '2026-08-23T12:00:00Z')`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at)
+		 VALUES ('grt_keys_master', 'usr_keys', 'rotate-master-key', NULL, NULL, NULL, '2026-08-23T12:00:00Z')`,
+		`INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at)
+		 VALUES ('grt_keys_root', 'usr_keys', 'rotate-root-key', NULL, NULL, NULL, '2026-08-23T12:00:00Z')`,
+	}
+	for _, statement := range statements {
+		var err error
+		if db.Engine() == store.EnginePostgres {
+			_, err = db.PG().Exec(t.Context(), statement)
+		} else {
+			_, err = db.SQLiteWrite().ExecContext(t.Context(), statement)
+		}
+		if err != nil {
+			t.Fatalf("seed key-store operator: %v", err)
+		}
+	}
+}
+
+func mustInsertKeyFixture(t *testing.T, ctx context.Context, keys store.KeyRepo, proof authz.Proof, masters, tier3 []crypto.WrappedKey) {
+	t.Helper()
+	if err := keys.AcquireHierarchyGeneration(ctx, proof); err != nil {
+		t.Fatalf("acquire hierarchy fixture fence: %v", err)
+	}
+	for _, key := range masters {
+		if err := keys.InsertMaster(ctx, proof, key); err != nil {
+			t.Fatalf("insert master fixture: %v", err)
+		}
+	}
+	for _, key := range tier3 {
+		if err := keys.InsertTier3(ctx, proof, key); err != nil {
+			t.Fatalf("insert tier-3 fixture: %v", err)
+		}
+		if err := keys.InsertScopeGeneration(ctx, proof, key.Purpose, key.OrgID, key.ProjectID); err != nil {
+			t.Fatalf("insert scope-generation fixture: %v", err)
+		}
+	}
+}
+
+func masterKey(version, epoch uint32) crypto.WrappedKey {
+	return crypto.WrappedKey{
+		Version: version, RootKeyEpoch: epoch,
+		Blob: []byte(fmt.Sprintf("master-v%d-e%d", version, epoch)), CreatedAt: keyTestTime(),
+	}
+}
+
+func tier3Key(purpose crypto.Purpose, version, masterVersion uint32) crypto.WrappedKey {
+	return crypto.WrappedKey{
+		ID: fmt.Sprintf("key-%s-v%d", purpose, version), Purpose: purpose,
+		Version: version, MasterKeyVersion: masterVersion,
+		Blob: []byte(fmt.Sprintf("%s-v%d", purpose, version)), CreatedAt: keyTestTime(),
+	}
+}
+
+func projectKey(version, masterVersion uint32) crypto.WrappedKey {
+	key := tier3Key(crypto.PurposeProject, version, masterVersion)
+	key.OrgID = "org_keys"
+	key.ProjectID = "prj_keys"
+	return key
+}
+
+func keyTestTime() time.Time {
+	return time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+}
+
+func openKeyTestDB(t *testing.T, cfg store.Config) *store.DB {
+	t.Helper()
+	if err := migrate.Run(t.Context(), cfg); err != nil {
+		t.Fatalf("migrate key-store database: %v", err)
+	}
+	db, err := store.Open(t.Context(), cfg)
+	if err != nil {
+		t.Fatalf("open key-store database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func postgresKeyTestConfig(t *testing.T, dsn string) (*store.DB, store.Config) {
+	t.Helper()
+	parsed := mustParseURL(t, dsn)
+	base := strings.TrimPrefix(parsed.Path, "/")
+	if base == "" {
+		t.Fatal("postgres test DSN has no database name")
+	}
+	database := fmt.Sprintf("%s_store_keys_%d", base, time.Now().UnixNano())
+	admin, err := store.Open(t.Context(), store.Config{Engine: store.EnginePostgres, DSN: dsn})
+	if err != nil {
+		t.Fatalf("open postgres admin database: %v", err)
+	}
+	if _, err := admin.PG().Exec(t.Context(), `CREATE DATABASE "`+strings.ReplaceAll(database, `"`, ``)+`"`); err != nil {
+		admin.Close()
+		t.Fatalf("create postgres key-store database: %v", err)
+	}
+	parsed.Path = "/" + database
+	return admin, store.Config{Engine: store.EnginePostgres, DSN: parsed.String()}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse postgres DSN: %v", err)
+	}
+	return parsed
+}


### PR DESCRIPTION
Closes #348

## Contract

- One private two-dialect seam owns generated-query shapes and driver error translation.
- One shared implementation owns hierarchy and scope fence order, predecessor CAS, master/root exclusion, stranded tier-3 refusal, and finalize epoch order.
- Token and scanning rotations share the same root-scoped tier-3 path with explicit operation proof and purpose.
- SQLite BEGIN IMMEDIATE and PostgreSQL SELECT ... FOR UPDATE semantics are preserved.

## Migration and generated outputs

- Database migrations: none.
- Contract changes: none.
- Generated outputs: none.

## Validation

- go test -count=1 ./internal/store -run ^TestKeyRotationInvariantsSQLite$: 11 passed
- go test -count=1 ./internal/store: 58 passed
- go test -count=1 ./...: 3,541 passed across 61 packages
- go vet ./...: passed
- gofmt -l changed Go files: clean
- git diff --check: clean
- Local PostgreSQL unavailable because HIKYO_TEST_POSTGRES_DSN is unset; required CI runs both engines.

## Review

- Standards round 1: CLEAN.
- Spec round 1: restored dialect fence comments; round 2: CLEAN.