### PR TITLE
Centralize Surface-2 scan refusal handling #350

### DIFF
--- a/docs/handoff/350-scan-refusal-owner.md
+++ b/docs/handoff/350-scan-refusal-owner.md
@@ -1,0 +1,52 @@
+# Handoff: #350 Surface-2 scan refusal owner
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/350 (parent #326; audit
+finding `F-S12-2`). Implementation PR:
+https://github.com/Hikyo-Org/Hikyo/pull/405. Integrated base:
+`b891007b0d8a6ec8f318af506172cc217640089e`.
+
+## Contract
+
+- `captureScanRefusal` now owns the Surface-2 refuse, audit-capture, and typed
+  return sequence used by declaration writes, preflight scans, and definitions
+  apply-skew scans.
+- The helper returns `nil` when a result does not refuse. On refusal, it
+  captures one `finding_blocked` event per blocked finding and returns the
+  pointer-form `*scanRefusalErr` carrying blocked findings and rejected tokens.
+- Callers still choose and pass their audit scope explicitly. Definitions apply
+  receives the project-only scope produced by `projectScope`; passing it
+  verbatim preserves current audit bytes while removing the drifting local
+  reconstruction.
+- Audit event order, trail, payload, object identity, error behavior, and wire
+  values are unchanged. Database migrations: none. Generated outputs: none.
+
+## Regression evidence
+
+- `TestCaptureScanRefusalNil` pins the accepted path: no error and no captured
+  audit events.
+- `TestCaptureScanRefusalRejectionsOnly` pins the typed refusal with zero
+  captured events when no blocked finding exists.
+- `TestCaptureScanRefusalOneEventPerBlockedFinding` pins event cardinality,
+  tenant trail, full caller scope, object locator, and ingress from
+  `Finding.Surface`.
+
+## Validation
+
+```text
+rtk go test -count=1 ./internal/service -run '^(TestCaptureScanRefusal|TestScanRejectionsNamedByClass)'
+                                                               9 passed
+rtk go test -count=1 ./internal/isolation -run 'Scanning'      2 passed
+rtk go test -count=1 ./internal/conformance -run 'Scanning'    no matching tests
+rtk go vet ./internal/service/...                              passed
+rtk go build ./...                                             passed
+rtk go test -count=1 ./...                     3533 passed / 61 packages
+rtk gofmt -w <changed-go-files>                                clean
+rtk git diff --check                                           clean
+```
+
+## Review
+
+- Standards round 1: `CLEAN`.
+- Spec round 1 questioned the apply scope. Production call-chain evidence
+  showed the only server caller supplies `projectScope`, whose `Env` is empty;
+  passing it verbatim preserves behavior. Spec round 2: `CLEAN`.

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -235,15 +235,8 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 		if err != nil {
 			return err
 		}
-		if res.refuses() {
-			for _, f := range res.blocked {
-				ev, evErr := blockedEvent(ctx, caller.Principal, f)
-				if evErr != nil {
-					return evErr
-				}
-				az.CaptureAudit(audit.TrailTenant, domain.Scope{Org: scope.Org, Project: scope.Project}, ev)
-			}
-			return &scanRefusalErr{blocked: res.blocked, rejections: res.rejections}
+		if err := captureScanRefusal(ctx, az, caller.Principal, scope, res); err != nil {
+			return err
 		}
 		overrides = res.overridden
 		return nil

--- a/internal/service/scan.go
+++ b/internal/service/scan.go
@@ -900,6 +900,24 @@ func emitFindingOverridden(ctx context.Context, r store.Repos, p authz.Proof, pr
 	return r.Audit().InsertTenant(ctx, p, ev)
 }
 
+// captureScanRefusal owns the Surface-2 refuse -> capture -> return invariant
+// from the secret-scanning ADR section 7. Scope stays explicit because
+// CaptureAudit cannot derive the event chain from the authorization proof.
+func captureScanRefusal(ctx context.Context, az *authz.TxAuthorizer, principal domain.PrincipalID,
+	scope domain.Scope, res declScanResult) error {
+	if !res.refuses() {
+		return nil
+	}
+	for _, finding := range res.blocked {
+		event, err := blockedEvent(ctx, principal, finding)
+		if err != nil {
+			return err
+		}
+		az.CaptureAudit(audit.TrailTenant, scope, event)
+	}
+	return &scanRefusalErr{blocked: res.blocked, rejections: res.rejections}
+}
+
 // applyDeclarationScan runs a Surface-2 scan inside a declaration ingress and
 // shapes the §7 transaction. It runs post-authorize and BEFORE any declaration
 // state persists.
@@ -923,15 +941,8 @@ func applyDeclarationScan(ctx context.Context, r store.Repos, p authz.Proof, az 
 	if err != nil {
 		return err
 	}
-	if res.refuses() {
-		for _, f := range res.blocked {
-			ev, err := blockedEvent(ctx, principal, f)
-			if err != nil {
-				return err
-			}
-			az.CaptureAudit(audit.TrailTenant, scope, ev)
-		}
-		return &scanRefusalErr{blocked: res.blocked, rejections: res.rejections}
+	if err := captureScanRefusal(ctx, az, principal, scope, res); err != nil {
+		return err
 	}
 	for _, o := range res.overridden {
 		if err := emitFindingOverridden(ctx, r, p, principal, o); err != nil {
@@ -988,15 +999,8 @@ func scanSurface2Preflight(ctx context.Context, db *store.DB, kr *crypto.Keyring
 		if err != nil {
 			return err
 		}
-		if res.refuses() {
-			for _, f := range res.blocked {
-				ev, err := blockedEvent(ctx, caller.Principal, f)
-				if err != nil {
-					return err
-				}
-				az.CaptureAudit(audit.TrailTenant, scope, ev)
-			}
-			return &scanRefusalErr{blocked: res.blocked, rejections: res.rejections}
+		if err := captureScanRefusal(ctx, az, caller.Principal, scope, res); err != nil {
+			return err
 		}
 		overrides = res.overridden
 		return nil

--- a/internal/service/scan_refusal_test.go
+++ b/internal/service/scan_refusal_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/audit"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+)
+
+func TestCaptureScanRefusalNil(t *testing.T) {
+	az := authz.NewTxAuthorizer(nil, nil)
+	scope := domain.Scope{Org: "org_a", Project: "proj_b", Env: "env_c"}
+	err := captureScanRefusal(t.Context(), az, "prin_1", scope, declScanResult{
+		overridden: []overrideAck{{ruleID: "r1", locator: "a.b"}},
+	})
+	if err != nil {
+		t.Fatalf("no-refusal result: want nil error, got %v", err)
+	}
+	if got := len(az.PendingDenials()); got != 0 {
+		t.Fatalf("no-refusal result: want 0 captured events, got %d", got)
+	}
+}
+
+func TestCaptureScanRefusalRejectionsOnly(t *testing.T) {
+	az := authz.NewTxAuthorizer(nil, nil)
+	scope := domain.Scope{Org: "org_a", Project: "proj_b", Env: "env_c"}
+	res := declScanResult{rejections: []scanRejection{{Index: 0, Reason: rejectSurplus}}}
+	err := captureScanRefusal(t.Context(), az, "prin_1", scope, res)
+
+	var refusal *scanRefusalErr
+	if !errors.As(err, &refusal) {
+		t.Fatalf("rejections-only result: want *scanRefusalErr, got %v", err)
+	}
+	if len(refusal.rejections) != 1 || len(refusal.blocked) != 0 {
+		t.Fatalf("rejections-only result: want 1 rejection and 0 blocked, got %d and %d",
+			len(refusal.rejections), len(refusal.blocked))
+	}
+	if got := len(az.PendingDenials()); got != 0 {
+		t.Fatalf("rejections-only result: want 0 captured events, got %d", got)
+	}
+}
+
+func TestCaptureScanRefusalOneEventPerBlockedFinding(t *testing.T) {
+	az := authz.NewTxAuthorizer(nil, nil)
+	scope := domain.Scope{Org: "org_a", Project: "proj_b", Env: "env_c"}
+	res := declScanResult{blocked: []Finding{
+		{RuleID: "aws-key", Surface: "apply", Locator: "keys.db.value"},
+		{RuleID: "gh-token", Surface: "edit", Locator: "keys.ci.value"},
+	}}
+	err := captureScanRefusal(t.Context(), az, "prin_1", scope, res)
+
+	var refusal *scanRefusalErr
+	if !errors.As(err, &refusal) {
+		t.Fatalf("blocked result: want *scanRefusalErr, got %v", err)
+	}
+	denials := az.PendingDenials()
+	if len(denials) != len(res.blocked) {
+		t.Fatalf("blocked result: want %d captured events, got %d", len(res.blocked), len(denials))
+	}
+	for i, denial := range denials {
+		finding := res.blocked[i]
+		if denial.Trail != audit.TrailTenant {
+			t.Errorf("event %d: want trail %q, got %q", i, audit.TrailTenant, denial.Trail)
+		}
+		if denial.Scope != scope {
+			t.Errorf("event %d: want scope %+v, got %+v", i, scope, denial.Scope)
+		}
+		if denial.Event.Type != audit.EventScanningFindingBlocked {
+			t.Errorf("event %d: want type %q, got %q", i, audit.EventScanningFindingBlocked, denial.Event.Type)
+		}
+		if denial.Event.Object.ID != finding.Locator {
+			t.Errorf("event %d: want object id %q, got %q", i, finding.Locator, denial.Event.Object.ID)
+		}
+		if denial.Event.Payload["ingress"] != finding.Surface {
+			t.Errorf("event %d: want ingress %q, got %v", i, finding.Surface, denial.Event.Payload["ingress"])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The Surface-2 refuse, audit-capture, and typed-return invariant was copied across three ingress paths. One copy had already drifted by rebuilding the audit scope without `Env`.

## Changes

- Add `captureScanRefusal` as the single owner of the refusal invariant.
- Route declaration scan, preflight scan, and apply-skew scan through it.
- Preserve caller-owned scope selection and pass the full `domain.Scope` at every site.
- Keep `*scanRefusalErr` pointer semantics and existing event ordering/wire values.
- Add `docs/handoff/350-scan-refusal-owner.md` with contract and evidence.

## Tests

- `rtk go test -count=1 ./internal/service -run "^(TestCaptureScanRefusal|TestScanRejectionsNamedByClass)"` — 9 passed.
- `rtk go test -count=1 ./internal/isolation -run Scanning` — 2 passed.
- `rtk go vet ./internal/service/...` — passed.
- `rtk go build ./...` — passed.
- `rtk go test -count=1 ./...` — 3,533 passed across 61 packages.

## Review

- Standards round 1: CLEAN.
- Spec round 2: CLEAN after verifying definitions apply receives project-only `projectScope`.

## Contracts

- Database migrations: none.
- Generated outputs: none.
- API/wire changes: none.

Closes #350