### PR TITLE
Own isolation probe keyring registrations #351

### DIFF
--- a/docs/handoff/351-keyring-root-registry.md
+++ b/docs/handoff/351-keyring-root-registry.md
@@ -1,0 +1,41 @@
+# Issue #351 — isolate probe keyring registrations
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/351 (parent #326; audit
+finding `F-S33-2`).
+
+**State: implemented.** Isolation-test keyrings and retained roots now share one
+registration lifecycle and fail closed when no registration exists.
+
+## Contract
+
+- One registry entry owns a datastore's probe keyring and retained root as an
+  atomic pair; half-registration is no longer representable.
+- `registerKeyring` is the only write path. It clones the retained root and
+  evicts the complete entry through `testing.T.Cleanup` before datastore
+  cleanup runs.
+- `probeRootSource.Current` refuses an unregistered or already-cleaned-up
+  datastore instead of returning a nil root with a nil error.
+- Probe-created and Compose-server keyrings use the same registration path.
+  Existing key material, rotation ordering, audit bytes, and dialect behavior
+  are unchanged.
+- Contract or migration decisions: none. Generated outputs: none.
+
+## Coverage
+
+- `TestProbeRootSourceRejectsUnregisteredDB` pins the fail-closed lookup.
+- `TestProbeKeyringRegistrationEvictsOnCleanup` proves paired visibility and
+  cleanup eviction.
+- `TestProbeKeyringRegistrationRejectsIncompleteState` proves nil datastore,
+  nil keyring, and invalid-length roots cannot form registrations.
+- Existing audit-root-rotation, reencrypt, and Compose CLI SQLite tests pass.
+  PostgreSQL variants remain covered by CI because no local
+  `HIKYO_TEST_POSTGRES_DSN` is configured.
+
+## Validation
+
+- Initial regression tests: 3 passed in `internal/isolation` (including
+  subtest); the strict-registration regression was added during review.
+- Named reencrypt and Compose CLI SQLite set: 34 passed.
+- `TestAuditCoreSQLite`: 15 passed.
+- Pre-review `go test -count=1 ./...`: 3,545 passed in 61 packages.
+- `gofmt` and `git diff --check`: passed.

--- a/internal/isolation/compose_cli_e2e_test.go
+++ b/internal/isolation/compose_cli_e2e_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
 	"github.com/Hikyo-Org/hikyo/internal/store"
-	"github.com/Hikyo-Org/hikyo/internal/store/keyring"
 )
 
 // In-process e2e for the Compose delivery verbs (#63): a real app.Boot server,
@@ -71,13 +70,7 @@ func bootComposeRig(t *testing.T, engine store.Engine) *composeRig {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, rootKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	probeKeyringMu.Lock()
-	probeKeyrings[db] = kr
-	probeKeyringMu.Unlock()
+	loadAndRegisterKeyring(t, db, rootKey)
 
 	seedComposeCatalogue(t, db)
 

--- a/internal/isolation/harness_test.go
+++ b/internal/isolation/harness_test.go
@@ -489,12 +489,59 @@ func keySvc(t *testing.T, db *store.DB) *service.Keys {
 // the hierarchy is minted ONCE per store under one root, so a second loader
 // with a fresh root is refused — correctly.
 var (
-	probeKeyringMu sync.Mutex
-	probeKeyrings  = map[*store.DB]*crypto.Keyring{}
-	// probeRoots retains a clone of each keyring's root so tests exercising
-	// master/root rotation can re-supply it (LoadKeyring zeroes the original).
-	probeRoots = map[*store.DB][]byte{}
+	probeKeyringInitMu   sync.Mutex
+	probeKeyringMu       sync.Mutex
+	probeKeyringRegistry = map[*store.DB]probeKeyringRegistration{}
 )
+
+type probeKeyringRegistration struct {
+	keyring *crypto.Keyring
+	// root retains a clone so tests exercising master/root rotation can
+	// re-supply it (LoadKeyring zeroes the original).
+	root []byte
+}
+
+func registerKeyring(t *testing.T, db *store.DB, kr *crypto.Keyring, root []byte) {
+	t.Helper()
+	if err := validateProbeKeyringRegistration(db, kr, root); err != nil {
+		t.Fatal(err)
+	}
+	probeKeyringMu.Lock()
+	defer probeKeyringMu.Unlock()
+	if _, exists := probeKeyringRegistry[db]; exists {
+		t.Fatal("register probe keyring: datastore already registered")
+	}
+	probeKeyringRegistry[db] = probeKeyringRegistration{keyring: kr, root: bytes.Clone(root)}
+	t.Cleanup(func() {
+		probeKeyringMu.Lock()
+		defer probeKeyringMu.Unlock()
+		delete(probeKeyringRegistry, db)
+	})
+}
+
+func validateProbeKeyringRegistration(db *store.DB, kr *crypto.Keyring, root []byte) error {
+	if db == nil {
+		return errors.New("probe keyring registration: datastore is nil")
+	}
+	if kr == nil {
+		return errors.New("probe keyring registration: keyring is nil")
+	}
+	if len(root) != crypto.KeySize {
+		return errors.New("probe keyring registration: root has invalid length")
+	}
+	return nil
+}
+
+func loadAndRegisterKeyring(t *testing.T, db *store.DB, root []byte) *crypto.Keyring {
+	t.Helper()
+	retainedRoot := bytes.Clone(root)
+	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registerKeyring(t, db, kr, retainedRoot)
+	return kr
+}
 
 // probeRootSource is a service.RootKeySource over a probe keyring's retained
 // root, for the rotations that re-read the root from its source. Next returns
@@ -507,7 +554,69 @@ type probeRootSource struct {
 func (s probeRootSource) Current(context.Context) ([]byte, error) {
 	probeKeyringMu.Lock()
 	defer probeKeyringMu.Unlock()
-	return bytes.Clone(probeRoots[s.db]), nil
+	registration, ok := probeKeyringRegistry[s.db]
+	if !ok {
+		return nil, errors.New("probe root source: datastore has no registered keyring")
+	}
+	if err := validateProbeKeyringRegistration(s.db, registration.keyring, registration.root); err != nil {
+		return nil, err
+	}
+	return bytes.Clone(registration.root), nil
+}
+
+func TestProbeRootSourceRejectsUnregisteredDB(t *testing.T) {
+	_, err := (probeRootSource{db: new(store.DB)}).Current(t.Context())
+	if err == nil {
+		t.Fatal("Current() error = nil, want unregistered datastore refusal")
+	}
+}
+
+func TestProbeKeyringRegistrationEvictsOnCleanup(t *testing.T) {
+	db := new(store.DB)
+	root := make([]byte, crypto.KeySize)
+	kr := new(crypto.Keyring)
+
+	t.Run("registered", func(t *testing.T) {
+		registerKeyring(t, db, kr, root)
+		if got := probeKeyring(t, db); got != kr {
+			t.Fatal("probeKeyring() did not return registered keyring")
+		}
+		gotRoot, err := (probeRootSource{db: db}).Current(t.Context())
+		if err != nil {
+			t.Fatalf("Current() error = %v", err)
+		}
+		if !bytes.Equal(gotRoot, root) {
+			t.Fatalf("Current() = %q, want %q", gotRoot, root)
+		}
+	})
+
+	_, err := (probeRootSource{db: db}).Current(t.Context())
+	if err == nil {
+		t.Fatal("Current() error = nil after cleanup, want unregistered datastore refusal")
+	}
+}
+
+func TestProbeKeyringRegistrationRejectsIncompleteState(t *testing.T) {
+	db := new(store.DB)
+	kr := new(crypto.Keyring)
+	root := make([]byte, crypto.KeySize)
+	for _, tc := range []struct {
+		name string
+		db   *store.DB
+		kr   *crypto.Keyring
+		root []byte
+	}{
+		{name: "nil datastore", kr: kr, root: root},
+		{name: "nil keyring", db: db, root: root},
+		{name: "nil root", db: db, kr: kr},
+		{name: "short root", db: db, kr: kr, root: root[:crypto.KeySize-1]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateProbeKeyringRegistration(tc.db, tc.kr, tc.root); err == nil {
+				t.Fatal("validation error = nil, want incomplete-state refusal")
+			}
+		})
+	}
 }
 
 func (s probeRootSource) Next(context.Context) ([]byte, error) {
@@ -562,22 +671,19 @@ func valueSvc(t *testing.T, db *store.DB) *service.Values {
 // the auth service) has to share this one.
 func probeKeyring(t *testing.T, db *store.DB) *crypto.Keyring {
 	t.Helper()
+	probeKeyringInitMu.Lock()
+	defer probeKeyringInitMu.Unlock()
 	probeKeyringMu.Lock()
-	defer probeKeyringMu.Unlock()
-	if kr, ok := probeKeyrings[db]; ok {
-		return kr
+	registration, ok := probeKeyringRegistry[db]
+	probeKeyringMu.Unlock()
+	if ok {
+		return registration.keyring
 	}
 	root, err := crypto.GenerateRootKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	probeRoots[db] = bytes.Clone(root)
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	probeKeyrings[db] = kr
-	return kr
+	return loadAndRegisterKeyring(t, db, root)
 }
 func keyGroupSvc(t *testing.T, db *store.DB) *service.KeyGroups {
 	return &service.KeyGroups{DB: db, Keyring: probeKeyring(t, db)}


### PR DESCRIPTION
Closes #351.

## Contract
- One registry entry atomically owns each datastore probe keyring and retained root.
- registerKeyring is the sole write path and evicts the complete entry with testing.T.Cleanup.
- Registration and probeRootSource.Current fail closed for nil, invalid-length, unregistered, or cleaned-up states.
- probeKeyring preserves one initializer across concurrent same-datastore consumers.
- Probe-created and Compose-server keyrings preserve existing key material and rotation behavior.

## Migration decisions
- None. Test-harness-only representation change.

## Generated outputs
- None.

## Validation
- TDD regression proved the pre-change nil-root/nil-error failure.
- Exact-head focused isolation set: 54 passed.
- Exact-head go test -count=1 ./...: 3,550 passed in 61 packages.
- gofmt and git diff --check: passed.
- PostgreSQL variants: CI-owned because HIKYO_TEST_POSTGRES_DSN is not configured locally.
- Two-axis review round 2/3: Standards CLEAN; Spec CLEAN.