### PR TITLE
Derive compose publish recovery state from phase #356

### DIFF
--- a/docs/handoff/356-compose-publish-recovery.md
+++ b/docs/handoff/356-compose-publish-recovery.md
@@ -1,0 +1,40 @@
+# Handoff: #356 phase-derived Compose publish recovery
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/356 (parent #326; audit
+finding `F-S21-2`). Pull request: https://github.com/Hikyo-Org/Hikyo/pull/407.
+Implementation base: `9a60a39055b4cb6f3b2c5460f70369d346acc130`.
+
+## Contract
+
+- `PublishResult.Stamps` is the sole candidate-stamp source; the duplicate
+  `CandidateStamps` map is removed.
+- `PublishResult.ActiveStamps` directly reports the stamp-file selection. A nil
+  map means the selection could not be inspected after an uncertain switch
+  failure; the contradictory `ActiveKnown` flag is removed.
+- `NeedsCleanup()` derives entirely from `Phase != PublishPhaseComplete`.
+  `CandidateActive()` remains phase-derived, and the redundant `GCComplete()`
+  method is removed.
+- Materialization, atomic stamp switching, post-commit recovery, and bounded GC
+  retain their existing ordering and failure behavior. Production CLI consumers
+  continue using only candidate stamps, materialization facts, and
+  `CandidateActive()`.
+
+Generated outputs: none. Database migrations: none. Wire/audit bytes: unchanged.
+
+## Regression evidence
+
+- The all-phase cleanup table was red before implementation because
+  `PublishResult.NeedsCleanup()` did not exist; it now covers materializing,
+  switching, collecting, and complete.
+- Existing publish success, materialization-failure, stamp-switch-failure,
+  post-commit-failure, GC-failure, partial-GC, and torn-generation tests use the
+  canonical `Phase`, `Stamps`, and `ActiveStamps` facts.
+- Focused `go test -count=1 ./internal/compose` passed 139 tests.
+- Full `go test -count=1 ./...` passed 3,547 tests in 61 packages.
+
+## Review
+
+- Standards round 1 found redundant direct complete-phase checks beside
+  `NeedsCleanup()`. Crash-seam tests now assert their exact phase separately
+  from derived behavior; round 2 returned `CLEAN`.
+- Spec round 1 returned `CLEAN`; round 2 returned `SOUND` after the test cleanup.

--- a/internal/compose/generation.go
+++ b/internal/compose/generation.go
@@ -140,18 +140,6 @@ type PublishPlan struct {
 	Targets    map[string][]byte
 }
 
-// PublishRecovery names the durable facts a caller can use after Publish
-// returns, including on error. ActiveStamps are the generations selected by the
-// stamp file. CandidateStamps are the deterministic generations the plan was
-// attempting to publish. NeedsCleanup means the next lock holder must run the
-// normal Recover/GC path before relying on unreferenced candidates being gone.
-type PublishRecovery struct {
-	ActiveStamps    map[string]string
-	CandidateStamps map[string]string
-	ActiveKnown     bool
-	NeedsCleanup    bool
-}
-
 // PublishPhase is the latest durable stage reached by a publication.
 type PublishPhase string
 
@@ -163,13 +151,15 @@ const (
 )
 
 // PublishResult records how far one recoverable filesystem publication got.
-// Stamps are the plan's candidate stamps and Materialized reports whether each
-// immutable generation was newly written.
+// Stamps are the plan's candidate stamps, Materialized reports whether each
+// immutable generation was newly written, and ActiveStamps are the generations
+// selected by the stamp file. A nil ActiveStamps means the active selection
+// could not be inspected after an uncertain stamp-switch failure.
 type PublishResult struct {
 	Stamps       map[string]string
 	Materialized map[string]bool
 	Phase        PublishPhase
-	Recover      PublishRecovery
+	ActiveStamps map[string]string
 }
 
 // CandidateActive reports whether the candidate stamp selection is active.
@@ -177,9 +167,10 @@ func (r PublishResult) CandidateActive() bool {
 	return r.Phase == PublishPhaseCollecting || r.Phase == PublishPhaseComplete
 }
 
-// GCComplete reports whether bounded retention completed.
-func (r PublishResult) GCComplete() bool {
-	return r.Phase == PublishPhaseComplete
+// NeedsCleanup reports whether the next lock holder must run the normal
+// Recover/GC path before relying on unreferenced candidates being gone.
+func (r PublishResult) NeedsCleanup() bool {
+	return r.Phase != PublishPhaseComplete
 }
 
 // errLockReleased is returned by every RenderLock verb — including a second
@@ -225,10 +216,10 @@ func (rl *RenderLock) Close() error {
 // file once, then collect superseded generations. It does not claim atomicity
 // with snapshot, cursor, or offline-record persistence performed by callers.
 //
-// On error, result.Recover states which stamps remain active and which
-// deterministic candidates a retry will reuse. Before Committed, the previous
-// stamp selection remains active. After Committed, the candidate selection is
-// active even if GC fails.
+// On error, result states which stamps remain active and which deterministic
+// candidates a retry will reuse. Before Committed, the previous stamp selection
+// remains active. After Committed, the candidate selection is active even if GC
+// fails.
 func (rl *RenderLock) Publish(plan PublishPlan) (PublishResult, error) {
 	var result PublishResult
 	if rl.closed {
@@ -263,48 +254,39 @@ func (rl *RenderLock) Publish(plan PublishPlan) (PublishResult, error) {
 		Stamps:       maps.Clone(stamps),
 		Materialized: make(map[string]bool, len(stamps)),
 		Phase:        PublishPhaseMaterializing,
-		Recover: PublishRecovery{
-			ActiveStamps:    maps.Clone(active),
-			CandidateStamps: maps.Clone(stamps),
-			ActiveKnown:     true,
-		},
+		ActiveStamps: maps.Clone(active),
 	}
 
 	for _, target := range targets {
 		stamp, materialized, err := rl.WriteGeneration(plan.RuntimeDir, plan.Keys, target, plan.Targets[target])
 		if err != nil {
-			result.Recover.NeedsCleanup = true
 			return result, fmt.Errorf("compose: publish materialize %s: %w", target, err)
 		}
 		if stamp != stamps[target] {
-			result.Recover.NeedsCleanup = true
 			return result, fmt.Errorf("compose: publish target %s stamp changed between plan and materialization", target)
 		}
 		result.Materialized[target] = materialized
 		if rl.w.probe != nil {
 			if err := rl.w.probe.AfterGenerationMaterialized(target, stamp); err != nil {
-				result.Recover.NeedsCleanup = true
 				return result, fmt.Errorf("compose: publish after materialize %s: %w", target, err)
 			}
 		}
 	}
 	result.Phase = PublishPhaseSwitching
-	result.Recover.NeedsCleanup = true
 	if err := rl.CommitStamps(stamps); err != nil {
 		active, inspectErr := CurrentStamps(rl.projectDir)
 		if inspectErr != nil {
-			result.Recover.ActiveStamps = nil
-			result.Recover.ActiveKnown = false
+			result.ActiveStamps = nil
 			return result, errors.Join(fmt.Errorf("compose: publish commit stamps: %w", err), fmt.Errorf("compose: inspect active stamps after commit failure: %w", inspectErr))
 		}
-		result.Recover.ActiveStamps = maps.Clone(active)
+		result.ActiveStamps = maps.Clone(active)
 		if maps.Equal(active, stamps) {
 			result.Phase = PublishPhaseCollecting
 		}
 		return result, fmt.Errorf("compose: publish commit stamps: %w", err)
 	}
 	result.Phase = PublishPhaseCollecting
-	result.Recover.ActiveStamps = maps.Clone(stamps)
+	result.ActiveStamps = maps.Clone(stamps)
 	if rl.w.probe != nil {
 		if err := rl.w.probe.AfterStampCommit(); err != nil {
 			return result, fmt.Errorf("compose: publish after stamp commit: %w", err)
@@ -319,7 +301,6 @@ func (rl *RenderLock) Publish(plan PublishPlan) (PublishResult, error) {
 		return result, fmt.Errorf("compose: publish gc: %w", err)
 	}
 	result.Phase = PublishPhaseComplete
-	result.Recover.NeedsCleanup = false
 	return result, nil
 }
 

--- a/internal/compose/generation_test.go
+++ b/internal/compose/generation_test.go
@@ -117,11 +117,11 @@ func TestPublishMaterializesCommitsAndCollects(t *testing.T) {
 	if !reflect.DeepEqual(result.Materialized, map[string]bool{"api": true, "worker": true}) {
 		t.Fatalf("Publish materialized = %v, want both targets", result.Materialized)
 	}
-	if !result.CandidateActive() || !result.GCComplete() {
+	if !result.CandidateActive() || result.Phase != PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s, want complete", result.Phase)
 	}
-	if !result.Recover.ActiveKnown || result.Recover.NeedsCleanup || !reflect.DeepEqual(result.Recover.ActiveStamps, wantStamps) || !reflect.DeepEqual(result.Recover.CandidateStamps, wantStamps) {
-		t.Fatalf("Publish recovery = %+v, want active candidates and no cleanup", result.Recover)
+	if result.NeedsCleanup() || !reflect.DeepEqual(result.ActiveStamps, wantStamps) {
+		t.Fatalf("Publish result = %+v, want active candidates and no cleanup", result)
 	}
 	gotStamps, err := CurrentStamps(projectDir)
 	if err != nil {
@@ -135,6 +135,23 @@ func TestPublishMaterializesCommitsAndCollects(t *testing.T) {
 		if err != nil || string(got) != string(content[target]) {
 			t.Fatalf("%s generation = %q err=%v", target, got, err)
 		}
+	}
+}
+
+func TestPublishResultNeedsCleanupFollowsPhase(t *testing.T) {
+	for _, phase := range []PublishPhase{
+		PublishPhaseMaterializing,
+		PublishPhaseSwitching,
+		PublishPhaseCollecting,
+		PublishPhaseComplete,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			result := PublishResult{Phase: phase}
+			want := phase != PublishPhaseComplete
+			if got := result.NeedsCleanup(); got != want {
+				t.Fatalf("NeedsCleanup() = %t, want %t", got, want)
+			}
+		})
 	}
 }
 
@@ -243,14 +260,14 @@ func TestPublishMaterializeFailureKeepsPreviousActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected materialization failure")
 	}
-	if result.CandidateActive() || result.GCComplete() {
+	if result.CandidateActive() || result.Phase == PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s after materialization failure", result.Phase)
 	}
-	if !result.Materialized["api"] || !result.Recover.NeedsCleanup {
+	if !result.Materialized["api"] || !result.NeedsCleanup() {
 		t.Fatalf("Publish result = %+v, want materialized candidate needing cleanup", result)
 	}
-	if result.Recover.ActiveStamps["api"] != oldStamp || result.Recover.CandidateStamps["api"] != newStamp {
-		t.Fatalf("Publish recovery = %+v, want old active and new candidate", result.Recover)
+	if result.ActiveStamps["api"] != oldStamp || result.Stamps["api"] != newStamp {
+		t.Fatalf("Publish result = %+v, want old active and new candidate", result)
 	}
 	if present, complete := GenerationState(rt, newStamp); !present || !complete {
 		t.Fatalf("candidate present=%v complete=%v, want recoverable complete candidate", present, complete)
@@ -269,11 +286,11 @@ func TestPublishPostCommitFailureReportsCandidateActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected post-commit failure")
 	}
-	if !result.CandidateActive() || result.GCComplete() {
+	if !result.CandidateActive() || result.Phase == PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s after post-commit failure", result.Phase)
 	}
-	if !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != stamp {
-		t.Fatalf("Publish recovery = %+v, want committed candidate active and cleanup pending", result.Recover)
+	if !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
+		t.Fatalf("Publish result = %+v, want committed candidate active and cleanup pending", result)
 	}
 	got, err := CurrentStamps(projectDir)
 	if err != nil || got["api"] != stamp {
@@ -302,11 +319,11 @@ func TestPublishStampSwitchFailureKeepsPreviousActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected stamp-switch failure")
 	}
-	if result.CandidateActive() || result.GCComplete() {
+	if result.CandidateActive() || result.Phase == PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s after stamp-switch failure", result.Phase)
 	}
-	if !result.Recover.ActiveKnown || !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != oldStamp || result.Recover.CandidateStamps["api"] != newStamp {
-		t.Fatalf("Publish recovery = %+v, want old active and new recoverable candidate", result.Recover)
+	if !result.NeedsCleanup() || result.ActiveStamps["api"] != oldStamp || result.Stamps["api"] != newStamp {
+		t.Fatalf("Publish result = %+v, want old active and new recoverable candidate", result)
 	}
 	got, err := CurrentStamps(projectDir)
 	if err != nil || got["api"] != oldStamp {
@@ -326,11 +343,11 @@ func TestPublishGCFailureNeverRemovesActiveGeneration(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected GC failure")
 	}
-	if !result.CandidateActive() || result.GCComplete() {
+	if !result.CandidateActive() || result.Phase == PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s after GC failure", result.Phase)
 	}
-	if !result.Recover.NeedsCleanup || result.Recover.ActiveStamps["api"] != stamp {
-		t.Fatalf("Publish recovery = %+v, want active generation retained", result.Recover)
+	if !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
+		t.Fatalf("Publish result = %+v, want active generation retained", result)
 	}
 	if present, complete := GenerationState(rt, stamp); !present || !complete {
 		t.Fatalf("active generation present=%v complete=%v after GC failure", present, complete)
@@ -739,7 +756,7 @@ func TestPublishGCPartialFailureKeepsActiveAndReportsCleanup(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected partial GC failure")
 	}
-	if !result.CandidateActive() || result.GCComplete() || !result.Recover.NeedsCleanup {
+	if !result.CandidateActive() || result.Phase == PublishPhaseComplete || !result.NeedsCleanup() {
 		t.Fatalf("Publish result = %+v, want committed active state with cleanup pending", result)
 	}
 	if present, complete := GenerationState(rt, stamps[5]); !present || !complete {

--- a/internal/compose/generation_test.go
+++ b/internal/compose/generation_test.go
@@ -117,10 +117,10 @@ func TestPublishMaterializesCommitsAndCollects(t *testing.T) {
 	if !reflect.DeepEqual(result.Materialized, map[string]bool{"api": true, "worker": true}) {
 		t.Fatalf("Publish materialized = %v, want both targets", result.Materialized)
 	}
-	if !result.CandidateActive() || result.Phase != PublishPhaseComplete {
+	if result.Phase != PublishPhaseComplete {
 		t.Fatalf("Publish phase=%s, want complete", result.Phase)
 	}
-	if result.NeedsCleanup() || !reflect.DeepEqual(result.ActiveStamps, wantStamps) {
+	if !result.CandidateActive() || result.NeedsCleanup() || !reflect.DeepEqual(result.ActiveStamps, wantStamps) {
 		t.Fatalf("Publish result = %+v, want active candidates and no cleanup", result)
 	}
 	gotStamps, err := CurrentStamps(projectDir)
@@ -260,10 +260,10 @@ func TestPublishMaterializeFailureKeepsPreviousActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected materialization failure")
 	}
-	if result.CandidateActive() || result.Phase == PublishPhaseComplete {
-		t.Fatalf("Publish phase=%s after materialization failure", result.Phase)
+	if result.Phase != PublishPhaseMaterializing {
+		t.Fatalf("Publish phase=%s after materialization failure, want %s", result.Phase, PublishPhaseMaterializing)
 	}
-	if !result.Materialized["api"] || !result.NeedsCleanup() {
+	if result.CandidateActive() || !result.Materialized["api"] || !result.NeedsCleanup() {
 		t.Fatalf("Publish result = %+v, want materialized candidate needing cleanup", result)
 	}
 	if result.ActiveStamps["api"] != oldStamp || result.Stamps["api"] != newStamp {
@@ -286,10 +286,10 @@ func TestPublishPostCommitFailureReportsCandidateActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected post-commit failure")
 	}
-	if !result.CandidateActive() || result.Phase == PublishPhaseComplete {
-		t.Fatalf("Publish phase=%s after post-commit failure", result.Phase)
+	if result.Phase != PublishPhaseCollecting {
+		t.Fatalf("Publish phase=%s after post-commit failure, want %s", result.Phase, PublishPhaseCollecting)
 	}
-	if !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
+	if !result.CandidateActive() || !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
 		t.Fatalf("Publish result = %+v, want committed candidate active and cleanup pending", result)
 	}
 	got, err := CurrentStamps(projectDir)
@@ -319,10 +319,10 @@ func TestPublishStampSwitchFailureKeepsPreviousActive(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected stamp-switch failure")
 	}
-	if result.CandidateActive() || result.Phase == PublishPhaseComplete {
-		t.Fatalf("Publish phase=%s after stamp-switch failure", result.Phase)
+	if result.Phase != PublishPhaseSwitching {
+		t.Fatalf("Publish phase=%s after stamp-switch failure, want %s", result.Phase, PublishPhaseSwitching)
 	}
-	if !result.NeedsCleanup() || result.ActiveStamps["api"] != oldStamp || result.Stamps["api"] != newStamp {
+	if result.CandidateActive() || !result.NeedsCleanup() || result.ActiveStamps["api"] != oldStamp || result.Stamps["api"] != newStamp {
 		t.Fatalf("Publish result = %+v, want old active and new recoverable candidate", result)
 	}
 	got, err := CurrentStamps(projectDir)
@@ -343,10 +343,10 @@ func TestPublishGCFailureNeverRemovesActiveGeneration(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected GC failure")
 	}
-	if !result.CandidateActive() || result.Phase == PublishPhaseComplete {
-		t.Fatalf("Publish phase=%s after GC failure", result.Phase)
+	if result.Phase != PublishPhaseCollecting {
+		t.Fatalf("Publish phase=%s after GC failure, want %s", result.Phase, PublishPhaseCollecting)
 	}
-	if !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
+	if !result.CandidateActive() || !result.NeedsCleanup() || result.ActiveStamps["api"] != stamp {
 		t.Fatalf("Publish result = %+v, want active generation retained", result)
 	}
 	if present, complete := GenerationState(rt, stamp); !present || !complete {
@@ -756,7 +756,10 @@ func TestPublishGCPartialFailureKeepsActiveAndReportsCleanup(t *testing.T) {
 	if err == nil {
 		t.Fatal("Publish should surface the injected partial GC failure")
 	}
-	if !result.CandidateActive() || result.Phase == PublishPhaseComplete || !result.NeedsCleanup() {
+	if result.Phase != PublishPhaseCollecting {
+		t.Fatalf("Publish phase=%s after partial GC failure, want %s", result.Phase, PublishPhaseCollecting)
+	}
+	if !result.CandidateActive() || !result.NeedsCleanup() {
 		t.Fatalf("Publish result = %+v, want committed active state with cleanup pending", result)
 	}
 	if present, complete := GenerationState(rt, stamps[5]); !present || !complete {


### PR DESCRIPTION
Closes #356

## Contract

- `PublishResult.Stamps` is the sole candidate-stamp source.
- `PublishResult.ActiveStamps` directly reports the selected stamp set; `nil` means inspection was impossible after an uncertain switch failure.
- `NeedsCleanup()` is derived solely from `Phase != PublishPhaseComplete`.
- `CandidateActive()` remains phase-derived; the redundant `PublishRecovery`, `ActiveKnown`, `CandidateStamps`, and `GCComplete` state is removed.

## Migration

All compose publish producers and crash-seam tests now use `Phase`, `Stamps`, and `ActiveStamps` directly. Production CLI consumers remain limited to `Stamps`, `Materialized`, and `CandidateActive()`.

Generated outputs: none. Database migrations: none. Wire/audit bytes: unchanged.

## Validation

- Red: focused regression failed because `PublishResult.NeedsCleanup` did not exist.
- `go test -count=1 ./internal/compose` — 139 passed.
- `go vet ./...` — passed.
- `go test -count=1 ./...` — 3,547 passed in 61 packages.
- `./scripts/ci/verify-docs.sh` — passed, including Astro, PWA/offline, OSS policy, live docs, and fallback-channel gates.
- Standards review round 2: `CLEAN`.
- Spec review round 2: `SOUND`.

Delivery note: branch-update and merge preparation remain intentionally paused until #407 is the lowest-numbered open non-draft PR.