### PR TITLE
Centralize adapter credential AAD ownership #354

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
 )
 
 const SentinelName = "MANAGED_BY_HIKYO"
@@ -72,6 +74,15 @@ type Target struct {
 
 type Access struct {
 	Credential string
+}
+
+// CredentialAAD binds an adapter credential ciphertext to its adapter row.
+// All seal and open sites share this owner so their byte contract cannot drift.
+func CredentialAAD(orgID, projectID, adapterID string) crypto.ProjectFieldAAD {
+	return crypto.ProjectFieldAAD{
+		OrgID: orgID, ProjectID: projectID,
+		OwnerTable: "adapters", OwnerRowID: adapterID, FieldTag: "credential",
+	}
 }
 
 type ConnectionRequest struct {

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -6,7 +6,19 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
 )
+
+func TestCredentialAADPreservesAdapterCredentialContract(t *testing.T) {
+	want := crypto.ProjectFieldAAD{
+		OrgID: "org_1", ProjectID: "prj_1",
+		OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential",
+	}
+	if got := CredentialAAD("org_1", "prj_1", "adp_1"); got != want {
+		t.Fatalf("CredentialAAD() = %#v, want %#v", got, want)
+	}
+}
 
 func TestValidateManifestRefusesLossyForgejoNamesAndValues(t *testing.T) {
 	tests := []struct {

--- a/internal/app/adapter_loader.go
+++ b/internal/app/adapter_loader.go
@@ -52,10 +52,7 @@ func (l *adapterLoader) LoadActivation(ctx context.Context, job adapter.Job, jou
 	if err := journal.Gate(ctx, adapter.Effect{Surface: adapter.Secret, EffectiveName: "credential", Disposition: adapter.Update}); err != nil {
 		return adapter.LoadedActivation{}, err
 	}
-	credential, err := openField(crypto.ProjectFieldAAD{
-		OrgID: job.OrgID, ProjectID: job.ProjectID,
-		OwnerTable: "adapters", OwnerRowID: material.CredentialOwnerID, FieldTag: "credential",
-	}, material.CredentialCiphertext)
+	credential, err := openField(adapter.CredentialAAD(job.OrgID, job.ProjectID, material.CredentialOwnerID), material.CredentialCiphertext)
 	if err != nil {
 		return adapter.LoadedActivation{}, err
 	}
@@ -117,10 +114,7 @@ func (l *adapterLoader) Load(ctx context.Context, job adapter.Job, journal adapt
 	if len(material.CredentialCiphertext) == 0 {
 		return adapter.LoadedSync{}, adapter.ErrProviderAuth
 	}
-	credential, err := openField(crypto.ProjectFieldAAD{
-		OrgID: job.OrgID, ProjectID: job.ProjectID,
-		OwnerTable: "adapters", OwnerRowID: material.CredentialOwnerID, FieldTag: "credential",
-	}, material.CredentialCiphertext)
+	credential, err := openField(adapter.CredentialAAD(job.OrgID, job.ProjectID, material.CredentialOwnerID), material.CredentialCiphertext)
 	if err != nil {
 		return adapter.LoadedSync{}, err
 	}

--- a/internal/isolation/reencrypt_e2e_test.go
+++ b/internal/isolation/reencrypt_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -413,7 +414,7 @@ func reencryptProjectCycle(t *testing.T, open func(*testing.T) *store.DB) {
 
 	// adapter + adapter_route_move credential, sealed under v1 (project_field,
 	// AAD owner_row = the adapter id for BOTH).
-	adpAAD := crypto.ProjectFieldAAD{OrgID: org, ProjectID: prj, OwnerTable: "adapters", OwnerRowID: "adp_reenc", FieldTag: "credential"}
+	adpAAD := adapter.CredentialAAD(org, prj, "adp_reenc")
 	adpCT := reencSealField(t, sealer, adpAAD, "adapter-secret")
 	reencExec(t, db, ctx,
 		`INSERT INTO adapters (id, org_id, project_id, provider, origin, credential_ciphertext, credential_set_at, authority_principal_id, state, created_at) VALUES ('adp_reenc','org_a','prj_a1','forgejo','https://reenc-origin',?, '2026-01-01T00:00:00Z','usr_root','active','2026-01-01T00:00:00Z')`,

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -321,7 +321,7 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	plain := append([]byte(nil), request.Credential...)
 	defer crypto.Zero(plain)
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: adapterID, FieldTag: "credential"}, plain)
+	sealed, err := sealer.SealField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), adapterID), plain)
 	if err != nil {
 		return AdapterView{}, err
 	}
@@ -508,7 +508,7 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	if len(ciphertext) == 0 {
 		return store.AdapterTarget{}, adapter.ErrProviderAuth
 	}
-	plain, err := sealer.OpenField(crypto.ProjectFieldAAD{OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: adapterID, FieldTag: "credential"}, ciphertext)
+	plain, err := sealer.OpenField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), adapterID), ciphertext)
 	if err != nil {
 		return store.AdapterTarget{}, err
 	}
@@ -794,7 +794,7 @@ func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scop
 	if err != nil {
 		return err
 	}
-	plain, err := sealer.OpenField(crypto.ProjectFieldAAD{OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: current.AdapterID, FieldTag: "credential"}, ciphertext)
+	plain, err := sealer.OpenField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), current.AdapterID), ciphertext)
 	if err != nil {
 		return err
 	}
@@ -905,9 +905,7 @@ func (s *Adapters) MoveOrigin(ctx context.Context, actor Actor, scope domain.Sco
 	if err != nil {
 		return store.AdapterRouteMoveBatch{}, err
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{
-		OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: adapterID, FieldTag: "credential",
-	}, plain)
+	sealed, err := sealer.SealField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), adapterID), plain)
 	if err != nil {
 		return store.AdapterRouteMoveBatch{}, err
 	}
@@ -1157,7 +1155,7 @@ func (s *Adapters) ResumeOriginMove(ctx context.Context, actor Actor, scope doma
 		if err != nil {
 			return err
 		}
-		sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: move.AdapterID, FieldTag: "credential"}, plain)
+		sealed, err := sealer.SealField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), move.AdapterID), plain)
 		if err != nil {
 			return err
 		}
@@ -1282,9 +1280,7 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 	if len(material.CredentialCiphertext) == 0 {
 		return adapter.Connection{}, adapter.ErrProviderAuth
 	}
-	credential, err := sealer.OpenField(crypto.ProjectFieldAAD{
-		OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: material.Target.AdapterID, FieldTag: "credential",
-	}, material.CredentialCiphertext)
+	credential, err := sealer.OpenField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), material.Target.AdapterID), material.CredentialCiphertext)
 	if err != nil {
 		return adapter.Connection{}, err
 	}
@@ -1360,9 +1356,7 @@ func (s *Adapters) ReplaceCredential(ctx context.Context, actor Actor, scope dom
 	}
 	plain := append([]byte(nil), credential...)
 	defer crypto.Zero(plain)
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{
-		OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: adapterID, FieldTag: "credential",
-	}, plain)
+	sealed, err := sealer.SealField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), adapterID), plain)
 	if err != nil {
 		return store.AdapterCredentialResult{}, err
 	}
@@ -1542,7 +1536,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 	if len(material.CredentialCiphertext) == 0 {
 		return AdapterPlanResult{}, adapter.ErrProviderAuth
 	}
-	credential, err := sealer.OpenField(crypto.ProjectFieldAAD{OrgID: string(scope.Org), ProjectID: string(scope.Project), OwnerTable: "adapters", OwnerRowID: material.Target.AdapterID, FieldTag: "credential"}, material.CredentialCiphertext)
+	credential, err := sealer.OpenField(adapter.CredentialAAD(string(scope.Org), string(scope.Project), material.Target.AdapterID), material.CredentialCiphertext)
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -431,7 +431,7 @@ func TestOrganizationSelectedRepositoryIDsAreVerifiedBeforeRoutingCommit(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("github_pat_fine"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("github_pat_fine"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -711,7 +711,7 @@ func TestApplyTargetMutationConcurrentChangesUseLockedGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("github_pat_fine"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("github_pat_fine"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,7 +779,7 @@ func TestAdapterTargetAddAuditsTransactionAuthorityTransition(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("provider-token"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestAdapterTargetAddRefusesDestinationEffectiveNameCollisionAtomically(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("provider-token"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -940,7 +940,7 @@ func TestAdapterTargetAddRequiresRevealAcrossEveryAdapterEnvironmentBeforeCreden
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("provider-token"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1391,7 +1391,7 @@ func TestAdapterOriginMoveKeepsOldRouteAndCredentialThroughScrubBarrier(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldCredential, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("old-token"))
+	oldCredential, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("old-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1940,7 +1940,7 @@ func TestAdapterCredentialReplaceAndRevokeFenceWithoutAutoConverge(t *testing.T)
 	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT credential_ciphertext FROM adapters WHERE id='adp_1'`).Scan(&sealed); err != nil {
 		t.Fatal(err)
 	}
-	plain, err := sealer.OpenField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, sealed)
+	plain, err := sealer.OpenField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), sealed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2040,7 +2040,7 @@ func TestAdapterTargetConnectionReauthorizesEveryProviderRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("provider-token"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2116,7 +2116,7 @@ func TestAdapterPlanPersistsProviderConflictArtifactAndInspectReturnsIt(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(crypto.ProjectFieldAAD{OrgID: "org_adapter", ProjectID: "prj_adapter", OwnerTable: "adapters", OwnerRowID: "adp_1", FieldTag: "credential"}, []byte("provider-token"))
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/service/reencrypt.go
+++ b/internal/service/reencrypt.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
@@ -168,7 +169,7 @@ func (s *Reencrypt) ReencryptProject(ctx context.Context, actor Actor, orgID, pr
 	// Adapter credential ciphertext (live row + any pending route-move credential)
 	// binds the ADAPTER's id (row.owner) in its AAD, not the row id.
 	adapterAAD := func(row projectFieldRow) crypto.AAD {
-		return crypto.ProjectFieldAAD{OrgID: orgID, ProjectID: projectID, OwnerTable: "adapters", OwnerRowID: row.owner, FieldTag: "credential"}
+		return adapter.CredentialAAD(orgID, projectID, row.owner)
 	}
 	// The five project ciphertext tables, defined once and shared by the walk and
 	// the retire's dryness gate — a DEK version is retired only when zero


### PR DESCRIPTION
## Summary

- add `adapter.CredentialAAD` as the sole owner of adapter credential AAD construction
- route all 11 production seal/open sites and credential fixtures through it
- retain one independent golden test for the exact legacy byte contract

## Contract and migration decisions

- `OwnerTable: "adapters"`, `FieldTag: "credential"`, org/project scope, and adapter row ownership are unchanged
- stored ciphertext needs no migration because canonical AAD bytes are unchanged
- valid behavior, ordering, audit/wire bytes, and dialect behavior are unchanged

## Generated outputs

None affected.

## Validation

- red: `go test -count=1 ./internal/adapter -run ^TestCredentialAADPreservesAdapterCredentialContract$` failed with `undefined: CredentialAAD`
- green: same focused test passed
- named adapter round trips: 3 passed
- reencrypt adapter cycle: passed
- scoped packages: `go test -count=1 ./internal/adapter ./internal/app ./internal/service` — 326 passed
- full local gate: `go test -count=1 -p=1 ./...` — 3,543 passed across 61 packages
- hosted exact-head `validation / test`: passed
- two-axis code review: Standards CLEAN; Spec CLEAN

Closes #354

Supersedes draft #390 with a DCO-compliant commit on current main.
