### PR TITLE
refactor(scim): centralize administration transactions #359

### DIFF
--- a/docs/handoff/359-scim-admin-transaction.md
+++ b/docs/handoff/359-scim-admin-transaction.md
@@ -32,6 +32,6 @@ authorization.
 - All `TestSCIM*` isolation tests: 66 passed.
 - `internal/service`: 242 passed.
 - Full repository suite: 3,545 passed across 61 packages.
-- Standards review: CLEAN. Spec review requested the red-test disposition
-  recorded above; round-2 verification is pending.
+- Standards review: CLEAN. Spec review: CLEAN in round 2/3 after the
+  characterization-test disposition was recorded.
 - Exact-head CI and merge: pending.

--- a/docs/handoff/359-scim-admin-transaction.md
+++ b/docs/handoff/359-scim-admin-transaction.md
@@ -1,0 +1,28 @@
+# Issue 359 — SCIM administration transaction owner
+
+## Outcome
+
+Binding-scoped SCIM administration now uses one `adminTx` owner for actor
+resolution, authorization, optional per-binding serialization, binding load,
+and audit insertion. `MintCredential` remains hand-rolled because its verified
+reauthentication evidence must be consumed after caller resolution and before
+authorization.
+
+## Contract
+
+- Mutations take the binding-row lock and emit the existing
+  `wire-enter:<binding>` / `wire-exit:<binding>` observer pair.
+- Reads share authorization, binding-load, and audit behavior without taking
+  the reconciliation lock.
+- Empty event sets are valid, preserving idempotent credential revocation
+  without inventing an audit transition.
+- No wire, audit, storage, migration, generated, or API contract changed.
+
+## Validation
+
+- `TestSCIMAdminMutationsMarkSerializedPhaseSQLite`: passed.
+- Named phase, serialization, and credential set: 3 passed; PostgreSQL variants
+  skipped locally because `HIKYO_TEST_POSTGRES_DSN` was unset.
+- All `TestSCIM*` isolation tests: 66 passed.
+- `internal/service`: 242 passed.
+- Full repository suite, review, exact-head CI, and merge: pending.

--- a/docs/handoff/359-scim-admin-transaction.md
+++ b/docs/handoff/359-scim-admin-transaction.md
@@ -20,9 +20,18 @@ authorization.
 
 ## Validation
 
+- The generic red-before-green acceptance line does not apply to this
+  representation-only simplification: `origin/main` already emitted the same
+  six phase pairs from duplicated preambles. The new phase test is therefore a
+  characterization test that passes on the base and after extraction. A
+  source-shape assertion for `adminTx` would couple the test to an internal
+  implementation detail instead of the ticket's public phase-observer seam.
 - `TestSCIMAdminMutationsMarkSerializedPhaseSQLite`: passed.
 - Named phase, serialization, and credential set: 3 passed; PostgreSQL variants
   skipped locally because `HIKYO_TEST_POSTGRES_DSN` was unset.
 - All `TestSCIM*` isolation tests: 66 passed.
 - `internal/service`: 242 passed.
-- Full repository suite, review, exact-head CI, and merge: pending.
+- Full repository suite: 3,545 passed across 61 packages.
+- Standards review: CLEAN. Spec review requested the red-test disposition
+  recorded above; round-2 verification is pending.
+- Exact-head CI and merge: pending.

--- a/internal/isolation/scim_concurrency_test.go
+++ b/internal/isolation/scim_concurrency_test.go
@@ -3,6 +3,7 @@ package isolation
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -609,6 +610,80 @@ func runSCIMPerBindingSerializationOrder(t *testing.T, db *store.DB) {
 	if entries < 2 {
 		t.Fatalf("only %d serialized sections observed in the admin-versus-wire leg: %v", entries, mixed)
 	}
+}
+
+// TestSCIMAdminMutationsMarkSerializedPhase pins the common administration
+// transaction contract: every binding-scoped mutation enters and exits the
+// same serialized phase as the wire surface. The operations are exercised one
+// at a time so a missing pair names the exact caller that escaped the common
+// preamble.
+func TestSCIMAdminMutationsMarkSerializedPhaseSQLite(t *testing.T) {
+	runSCIMAdminMutationsMarkSerializedPhase(t, seededDB(t, openSQLite))
+}
+func TestSCIMAdminMutationsMarkSerializedPhasePostgres(t *testing.T) {
+	runSCIMAdminMutationsMarkSerializedPhase(t, seededDB(t, openPostgres))
+}
+
+func runSCIMAdminMutationsMarkSerializedPhase(t *testing.T, db *store.DB) {
+	t.Helper()
+	s := scimSvc(db)
+	ctx := t.Context()
+	bindingID, token := newSCIMBinding(t, db, "okta-admin-phase")
+	wire := service.SCIMCredentialActor(token, bindingID)
+	group, err := s.CreateGroup(ctx, wire, orgA, bindingID, service.DesiredGroup{
+		DisplayName: "Admin phase",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertPhase := func(name string, act func() error) {
+		t.Helper()
+		var phases []string
+		restore := service.SetSCIMPhaseObserver(func(phase string, _ map[string]int) {
+			if phase == "wire-enter:"+bindingID || phase == "wire-exit:"+bindingID {
+				phases = append(phases, phase)
+			}
+		})
+		err := act()
+		restore()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		want := []string{"wire-enter:" + bindingID, "wire-exit:" + bindingID}
+		if !slices.Equal(phases, want) {
+			t.Fatalf("%s phases = %v, want %v", name, phases, want)
+		}
+	}
+
+	var credentialID string
+	assertPhase("mint credential", func() error {
+		minted, err := s.MintCredential(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, false, "")
+		credentialID = minted.Credential.ID
+		return err
+	})
+	mapping := service.SCIMMappingSpec{
+		GroupID: group.ID, Template: domain.TemplateViewer, ProjectID: string(prjA1),
+	}
+	assertPhase("create mapping", func() error {
+		_, err := s.CreateMapping(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, mapping)
+		return err
+	})
+	assertPhase("update mapping", func() error {
+		mapping.Template = domain.TemplatePublisher
+		_, err := s.UpdateMapping(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, mapping)
+		return err
+	})
+	assertPhase("revoke credential", func() error {
+		return s.RevokeCredential(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, credentialID)
+	})
+	assertPhase("delete mapping", func() error {
+		_, err := s.DeleteMapping(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID, mapping)
+		return err
+	})
+	assertPhase("delete binding", func() error {
+		return s.DeleteBinding(ctx, service.LocalPrincipal(orgAdmin), orgA, bindingID)
+	})
 }
 
 // TestSCIMSyncInvalidatesSessions is SC4.d: "being granted anything logs you

--- a/internal/service/scim.go
+++ b/internal/service/scim.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/samlsp"
 	"github.com/Hikyo-Org/hikyo/internal/scimproto"
 	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
 // SCIM provisioning (#73, scim-provisioning ADR). This file is the engine the
@@ -799,6 +800,58 @@ func SetSCIMPhaseObserver(fn func(phase string, state map[string]int)) func() {
 		}
 		scimPhaseObserver.Store(prev)
 	}
+}
+
+// adminTx is the binding-scoped administration transaction preamble. Every
+// caller resolves and authorizes the actor inside the transaction, loads the
+// addressed binding under the resulting proof, and writes any returned audit
+// events before commit. Mutations additionally take §9's binding-row lock;
+// reads deliberately do not serialize with reconciliation.
+type scimAdminContext struct {
+	repos      store.Repos
+	authorizer *authz.TxAuthorizer
+	caller     authz.Identity
+	events     []grantEventInput
+	scimContext
+}
+
+func (a *scimAdminContext) addEvents(events ...grantEventInput) {
+	a.events = append(a.events, events...)
+}
+
+func (s *SCIM) adminTx(
+	ctx context.Context, actor Actor, org domain.OrgID, bindingID string,
+	op authz.Operation, lock bool,
+	body func(context.Context, *scimAdminContext) error,
+) error {
+	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+		caller, err := actor.resolve(ctx, az, s.now())
+		if err != nil {
+			return err
+		}
+		p, err := az.Authorize(ctx, caller, op, domain.Scope{Org: org})
+		if err != nil {
+			return err
+		}
+		if lock {
+			unlock, err := lockBindingRow(ctx, r, p, bindingID)
+			if err != nil {
+				return err
+			}
+			defer unlock()
+		}
+		c, err := s.loadBinding(ctx, r, az, p, bindingID, false)
+		if err != nil {
+			return err
+		}
+		a := &scimAdminContext{
+			repos: r, authorizer: az, caller: caller, scimContext: c,
+		}
+		if err := body(ctx, a); err != nil {
+			return err
+		}
+		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, a.events...)
+	})
 }
 
 // lockBindingRow takes §9's per-binding row lock for an ADMINISTRATION mutation

--- a/internal/service/scim_admin.go
+++ b/internal/service/scim_admin.go
@@ -518,146 +518,124 @@ func (s *SCIM) reconcileLockoutAttention(
 //     be had the user been invited; unlinking remains the account-security
 //     mutation it always was, and nothing here touches it.
 func (s *SCIM) DeleteBinding(ctx context.Context, actor Actor, org domain.OrgID, id string) error {
-	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMBindingDelete, scope)
-		if err != nil {
-			return err
-		}
-		// §9: per-binding writes SERIALIZE. The wire takes this lock through
-		// its contact UPDATE; an ADMINISTRATION mutation has no such update,
-		// so it takes the row lock explicitly and holds it to commit. Mapping
-		// authoring reconciles origins in its own transaction, which is the
-		// same origin arithmetic a push performs and needs the same
-		// serialization — so both legs mark the SAME phase pair, and a fixture
-		// asserting strict alternation covers admin-versus-wire races too.
-		unlock, err := lockBindingRow(ctx, r, p, id)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-		c, err := s.loadBinding(ctx, r, az, p, id, false)
-		if err != nil {
-			return err
-		}
-		now := s.now()
+	return s.adminTx(ctx, actor, org, id, authz.OpSCIMBindingDelete, true,
+		func(ctx context.Context, a *scimAdminContext) error {
+			r, az, p, caller, c := a.repos, a.authorizer, a.proof, a.caller, a.scimContext
+			var events []grantEventInput
+			now := s.now()
 
-		connection := domain.PrincipalID(c.binding.ConnectionPrincipalID)
+			connection := domain.PrincipalID(c.binding.ConnectionPrincipalID)
 
-		// (1) credentials first. The count is not in the payload: §10's field
-		// list for this event is "org, provider ref, actor", and how many
-		// credentials died is already one `scim.credential_revoked` per
-		// credential — recorded once, where the ADR puts it.
-		//
-		// Each phase is marked AFTER its work, carrying WHAT IT DID. A label
-		// emitted before the mutation proves only that the code reached a line,
-		// which a wrong implementation satisfies just as well as a right one;
-		// a label emitted after, carrying the count, is a statement about state.
-		revoked, err := r.SCIM().RevokeCredentialsForBinding(ctx, p, id, now)
-		if err != nil {
-			return err
-		}
-		s.markTeardown(ctx, r, az, p, c, connection, "credentials-revoked", int(revoked))
-
-		// (2) every origin the binding holds, for every user it provisioned.
-		users, err := r.SCIM().Users(ctx, p, id)
-		if err != nil {
-			return err
-		}
-		var events []grantEventInput
-		releasedOrigins := 0
-		for _, u := range users {
-			principal, err := principalForAccount(ctx, az, u.AccountID)
+			// (1) credentials first. The count is not in the payload: §10's field
+			// list for this event is "org, provider ref, actor", and how many
+			// credentials died is already one `scim.credential_revoked` per
+			// credential — recorded once, where the ADR puts it.
+			//
+			// Each phase is marked AFTER its work, carrying WHAT IT DID. A label
+			// emitted before the mutation proves only that the code reached a line,
+			// which a wrong implementation satisfies just as well as a right one;
+			// a label emitted after, carrying the count, is a statement about state.
+			revoked, err := r.SCIM().RevokeCredentialsForBinding(ctx, p, id, now)
 			if err != nil {
 				return err
 			}
-			outcome, evs, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
-				binding: id, org: org,
-				match: matchBinding(id), cause: domain.CauseBindingDelete,
-			}, advanceIfAuthorityChanged, now)
+			s.markTeardown(ctx, r, az, p, c, connection, "credentials-revoked", int(revoked))
+
+			// (2) every origin the binding holds, for every user it provisioned.
+			users, err := r.SCIM().Users(ctx, p, id)
 			if err != nil {
 				return err
 			}
-			events = append(events, evs...)
-			releasedOrigins += outcome.Released
-		}
+			releasedOrigins := 0
+			for _, u := range users {
+				principal, err := principalForAccount(ctx, az, u.AccountID)
+				if err != nil {
+					return err
+				}
+				outcome, evs, err := s.releaseAndSettle(ctx, r, az, c, principal, releaseArgs{
+					binding: id, org: org,
+					match: matchBinding(id), cause: domain.CauseBindingDelete,
+				}, advanceIfAuthorityChanged, now)
+				if err != nil {
+					return err
+				}
+				events = append(events, evs...)
+				releasedOrigins += outcome.Released
+			}
 
-		s.markTeardown(ctx, r, az, p, c, connection, "origins-released", releasedOrigins)
+			s.markTeardown(ctx, r, az, p, c, connection, "origins-released", releasedOrigins)
 
-		// (3) the connection's structural origin, then the principal, then the
-		// binding's own rows. The RESTRICT foreign key on grant_origins is what
-		// makes the ordering a database fact rather than a comment.
-		structural, err := releaseStructural(ctx, az, connection, id)
-		if err != nil {
-			return err
-		}
-		events = append(events, structural...)
-		s.markTeardown(ctx, r, az, p, c, connection, "connection-retired", len(structural))
-
-		directory := len(users)
-		if err := r.SCIM().DeleteGroupMembersForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		if err := r.SCIM().DeleteGroupsForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		if err := r.SCIM().DeleteUsersForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		if err := r.SCIM().DeleteMappingsForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		// Every raised state is cleared through the audited exit path BEFORE the
-		// rows go. A bulk delete erases states that were entered in this very
-		// transaction (a lockout conversion, say) leaving an entry event with
-		// no exit — and §9 requires the pair.
-		raised, err := r.SCIM().Attention(ctx, p, id)
-		if err != nil {
-			return err
-		}
-		for _, a := range raised {
-			ev, err := s.clearAttention(ctx, r, c,
-				domain.SCIMAttention(a.State), a.SubjectRef, domain.CauseBindingDelete)
+			// (3) the connection's structural origin, then the principal, then the
+			// binding's own rows. The RESTRICT foreign key on grant_origins is what
+			// makes the ordering a database fact rather than a comment.
+			structural, err := releaseStructural(ctx, az, connection, id)
 			if err != nil {
 				return err
 			}
-			events = append(events, ev...)
-		}
-		if err := r.SCIM().DeleteAttentionForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		if err := r.SCIM().DeleteCredentialsForBinding(ctx, p, id); err != nil {
-			return err
-		}
-		s.markTeardown(ctx, r, az, p, c, connection, "directory-deleted", directory)
-		if err := r.SCIM().DeleteBinding(ctx, p, id); err != nil {
-			return err
-		}
-		s.markTeardown(ctx, r, az, p, c, connection, "binding-deleted", 1)
-		// The connection is retired under the same PROOF, after its binding row
-		// is gone (that row references it). `connection` was read from the
-		// binding under this proof, and the statement can only remove a
-		// provisioning connection no binding still owns — so neither half is a
-		// caller-controlled delete-any-principal-by-id.
-		if _, err := r.SCIM().RetireConnectionPrincipal(ctx, p, connection); err != nil {
-			return err
-		}
+			events = append(events, structural...)
+			s.markTeardown(ctx, r, az, p, c, connection, "connection-retired", len(structural))
 
-		events = append(events, grantEventInput{
-			typ:    audit.EventSCIMBindingDeleted,
-			object: audit.Object{Type: "scim-binding", ID: id},
-			payload: audit.Payload{
-				"org":          string(org),
-				"provider_ref": c.providerID,
-				"actor":        string(caller.Principal),
-			},
+			directory := len(users)
+			if err := r.SCIM().DeleteGroupMembersForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			if err := r.SCIM().DeleteGroupsForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			if err := r.SCIM().DeleteUsersForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			if err := r.SCIM().DeleteMappingsForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			// Every raised state is cleared through the audited exit path BEFORE the
+			// rows go. A bulk delete erases states that were entered in this very
+			// transaction (a lockout conversion, say) leaving an entry event with
+			// no exit — and §9 requires the pair.
+			raised, err := r.SCIM().Attention(ctx, p, id)
+			if err != nil {
+				return err
+			}
+			for _, a := range raised {
+				ev, err := s.clearAttention(ctx, r, c,
+					domain.SCIMAttention(a.State), a.SubjectRef, domain.CauseBindingDelete)
+				if err != nil {
+					return err
+				}
+				events = append(events, ev...)
+			}
+			if err := r.SCIM().DeleteAttentionForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			if err := r.SCIM().DeleteCredentialsForBinding(ctx, p, id); err != nil {
+				return err
+			}
+			s.markTeardown(ctx, r, az, p, c, connection, "directory-deleted", directory)
+			if err := r.SCIM().DeleteBinding(ctx, p, id); err != nil {
+				return err
+			}
+			s.markTeardown(ctx, r, az, p, c, connection, "binding-deleted", 1)
+			// The connection is retired under the same PROOF, after its binding row
+			// is gone (that row references it). `connection` was read from the
+			// binding under this proof, and the statement can only remove a
+			// provisioning connection no binding still owns — so neither half is a
+			// caller-controlled delete-any-principal-by-id.
+			if _, err := r.SCIM().RetireConnectionPrincipal(ctx, p, connection); err != nil {
+				return err
+			}
+
+			events = append(events, grantEventInput{
+				typ:    audit.EventSCIMBindingDeleted,
+				object: audit.Object{Type: "scim-binding", ID: id},
+				payload: audit.Payload{
+					"org":          string(org),
+					"provider_ref": c.providerID,
+					"actor":        string(caller.Principal),
+				},
+			})
+			a.addEvents(events...)
+			return nil
 		})
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, events...)
-	})
 }
 
 // releaseStructural releases the `structural(binding)` origin and revokes the

--- a/internal/service/scim_credential.go
+++ b/internal/service/scim_credential.go
@@ -160,59 +160,39 @@ func (s *SCIM) verifyMintReauth(ctx context.Context, actor Actor, proof string) 
 // ListCredentials returns the binding's credentials — ids and metadata only.
 func (s *SCIM) ListCredentials(ctx context.Context, actor Actor, org domain.OrgID, bindingID string) ([]SCIMCredentialView, error) {
 	var out []SCIMCredentialView
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMCredentialList, scope)
-		if err != nil {
-			return err
-		}
-		if _, err := s.loadBinding(ctx, r, az, p, bindingID, false); err != nil {
-			return err
-		}
-		rows, err := r.SCIM().Credentials(ctx, p, bindingID)
-		if err != nil {
-			return err
-		}
-		now := s.now()
-		for _, row := range rows {
-			out = append(out, credentialView(row, now))
-		}
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, adminReadEvent(string(org), bindingID, "credential", len(out)))
-	})
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMCredentialList, false,
+		func(ctx context.Context, a *scimAdminContext) error {
+			rows, err := a.repos.SCIM().Credentials(ctx, a.proof, bindingID)
+			if err != nil {
+				return err
+			}
+			now := s.now()
+			for _, row := range rows {
+				out = append(out, credentialView(row, now))
+			}
+			a.addEvents(adminReadEvent(string(org), bindingID, "credential", len(out)))
+			return nil
+		})
 	return out, err
 }
 
 // GetCredential returns one credential by id.
 func (s *SCIM) GetCredential(ctx context.Context, actor Actor, org domain.OrgID, bindingID, id string) (SCIMCredentialView, error) {
 	var out SCIMCredentialView
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMCredentialGet, scope)
-		if err != nil {
-			return err
-		}
-		if _, err := s.loadBinding(ctx, r, az, p, bindingID, false); err != nil {
-			return err
-		}
-		// The store predicates on (org from the proof, binding from the path),
-		// so a credential belonging to another org or another binding matches
-		// no row — the uniform nonexistent outcome, decided in SQL rather than
-		// by a Go check beside a caller-controlled id.
-		row, err := r.SCIM().Credential(ctx, p, bindingID, id)
-		if err != nil {
-			return err
-		}
-		out = credentialView(row, s.now())
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, adminReadEvent(string(org), bindingID, "credential", 1))
-	})
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMCredentialGet, false,
+		func(ctx context.Context, a *scimAdminContext) error {
+			// The store predicates on (org from the proof, binding from the path),
+			// so a credential belonging to another org or another binding matches
+			// no row — the uniform nonexistent outcome, decided in SQL rather than
+			// by a Go check beside a caller-controlled id.
+			row, err := a.repos.SCIM().Credential(ctx, a.proof, bindingID, id)
+			if err != nil {
+				return err
+			}
+			out = credentialView(row, s.now())
+			a.addEvents(adminReadEvent(string(org), bindingID, "credential", 1))
+			return nil
+		})
 	return out, err
 }
 
@@ -220,56 +200,34 @@ func (s *SCIM) GetCredential(ctx context.Context, actor Actor, org domain.OrgID,
 // the row is marked rather than deleted, so the verifier stays occupied and the
 // id keeps naming a real thing on this surface.
 func (s *SCIM) RevokeCredential(ctx context.Context, actor Actor, org domain.OrgID, bindingID, id string) error {
-	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMCredentialRevoke, scope)
-		if err != nil {
-			return err
-		}
-		// §9: per-binding writes SERIALIZE. The wire takes this lock through
-		// its contact UPDATE; an ADMINISTRATION mutation has no such update,
-		// so it takes the row lock explicitly and holds it to commit. Mapping
-		// authoring reconciles origins in its own transaction, which is the
-		// same origin arithmetic a push performs and needs the same
-		// serialization — so both legs mark the SAME phase pair, and a fixture
-		// asserting strict alternation covers admin-versus-wire races too.
-		unlock, err := lockBindingRow(ctx, r, p, bindingID)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-		if _, err := s.loadBinding(ctx, r, az, p, bindingID, false); err != nil {
-			return err
-		}
-		// The read proves the credential is this org's and this binding's before
-		// the revoke, which is a predicate the UPDATE repeats anyway; keeping it
-		// makes a credential from another binding the uniform not-found rather
-		// than a silent zero-row revoke.
-		if _, err := r.SCIM().Credential(ctx, p, bindingID, id); err != nil {
-			return err
-		}
-		revoked, err := r.SCIM().RevokeCredential(ctx, p, bindingID, id, s.now())
-		if err != nil {
-			return err
-		}
-		if !revoked {
-			// Already dead. The trail must not record a transition that did not
-			// happen — an investigator counting revocations would count polls.
+	return s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMCredentialRevoke, true,
+		func(ctx context.Context, a *scimAdminContext) error {
+			// The read proves the credential is this org's and this binding's before
+			// the revoke, which is a predicate the UPDATE repeats anyway; keeping it
+			// makes a credential from another binding the uniform not-found rather
+			// than a silent zero-row revoke.
+			if _, err := a.repos.SCIM().Credential(ctx, a.proof, bindingID, id); err != nil {
+				return err
+			}
+			revoked, err := a.repos.SCIM().RevokeCredential(ctx, a.proof, bindingID, id, s.now())
+			if err != nil {
+				return err
+			}
+			if !revoked {
+				// Already dead. The trail must not record a transition that did not
+				// happen — an investigator counting revocations would count polls.
+				return nil
+			}
+			a.addEvents(grantEventInput{
+				typ:    audit.EventSCIMCredentialRevoked,
+				object: audit.Object{Type: "scim-credential", ID: id},
+				payload: audit.Payload{
+					"binding": bindingID, "credential_id": id,
+					"actor": string(a.caller.Principal),
+				},
+			})
 			return nil
-		}
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, grantEventInput{
-			typ:    audit.EventSCIMCredentialRevoked,
-			object: audit.Object{Type: "scim-credential", ID: id},
-			payload: audit.Payload{
-				"binding": bindingID, "credential_id": id,
-				"actor": string(caller.Principal),
-			},
 		})
-	})
 }
 
 // ---------------------------------------------------------------------------
@@ -304,89 +262,69 @@ type SCIMDirectoryGroup struct {
 // DirectoryUsers is `hikyo scim user list <binding>`.
 func (s *SCIM) DirectoryUsers(ctx context.Context, actor Actor, org domain.OrgID, bindingID string) ([]SCIMDirectoryUser, error) {
 	var out []SCIMDirectoryUser
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMDirectoryUsers, scope)
-		if err != nil {
-			return err
-		}
-		if _, err := s.loadBinding(ctx, r, az, p, bindingID, false); err != nil {
-			return err
-		}
-		users, err := r.SCIM().Users(ctx, p, bindingID)
-		if err != nil {
-			return err
-		}
-		attention, err := r.SCIM().Attention(ctx, p, bindingID)
-		if err != nil {
-			return err
-		}
-		for _, u := range users {
-			memberships, err := r.SCIM().MembershipsForUser(ctx, p, bindingID, u.ID)
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMDirectoryUsers, false,
+		func(ctx context.Context, a *scimAdminContext) error {
+			users, err := a.repos.SCIM().Users(ctx, a.proof, bindingID)
 			if err != nil {
 				return err
 			}
-			view := SCIMDirectoryUser{
-				ID: u.ID, UserName: u.UserName, ExternalID: u.ExternalID,
-				AccountID: u.AccountID, Active: u.Active,
-				CreatedAt: u.CreatedAt, UpdatedAt: u.UpdatedAt,
+			attention, err := a.repos.SCIM().Attention(ctx, a.proof, bindingID)
+			if err != nil {
+				return err
 			}
-			for _, m := range memberships {
-				view.Groups = append(view.Groups, m.GroupID)
-			}
-			for _, a := range attention {
-				if a.SubjectRef != u.ID {
-					continue
+			for _, u := range users {
+				memberships, err := a.repos.SCIM().MembershipsForUser(ctx, a.proof, bindingID, u.ID)
+				if err != nil {
+					return err
 				}
-				view.Attention = append(view.Attention, SCIMAttentionView{
-					State: a.State, SubjectRef: a.SubjectRef, Cause: a.Cause,
-					EnteredAt:   a.EnteredAt,
-					Remediation: attentionRemediation(domain.SCIMAttention(a.State)),
-				})
+				view := SCIMDirectoryUser{
+					ID: u.ID, UserName: u.UserName, ExternalID: u.ExternalID,
+					AccountID: u.AccountID, Active: u.Active,
+					CreatedAt: u.CreatedAt, UpdatedAt: u.UpdatedAt,
+				}
+				for _, m := range memberships {
+					view.Groups = append(view.Groups, m.GroupID)
+				}
+				for _, a := range attention {
+					if a.SubjectRef != u.ID {
+						continue
+					}
+					view.Attention = append(view.Attention, SCIMAttentionView{
+						State: a.State, SubjectRef: a.SubjectRef, Cause: a.Cause,
+						EnteredAt:   a.EnteredAt,
+						Remediation: attentionRemediation(domain.SCIMAttention(a.State)),
+					})
+				}
+				out = append(out, view)
 			}
-			out = append(out, view)
-		}
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, adminReadEvent(string(org), bindingID, "directory", len(out)))
-	})
+			a.addEvents(adminReadEvent(string(org), bindingID, "directory", len(out)))
+			return nil
+		})
 	return out, err
 }
 
 // DirectoryGroups is `hikyo scim group list <binding>`.
 func (s *SCIM) DirectoryGroups(ctx context.Context, actor Actor, org domain.OrgID, bindingID string) ([]SCIMDirectoryGroup, error) {
 	var out []SCIMDirectoryGroup
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMDirectoryGroups, scope)
-		if err != nil {
-			return err
-		}
-		if _, err := s.loadBinding(ctx, r, az, p, bindingID, false); err != nil {
-			return err
-		}
-		groups, err := r.SCIM().Groups(ctx, p, bindingID)
-		if err != nil {
-			return err
-		}
-		for _, g := range groups {
-			members, err := r.SCIM().GroupMembers(ctx, p, bindingID, g.ID)
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMDirectoryGroups, false,
+		func(ctx context.Context, a *scimAdminContext) error {
+			groups, err := a.repos.SCIM().Groups(ctx, a.proof, bindingID)
 			if err != nil {
 				return err
 			}
-			out = append(out, SCIMDirectoryGroup{
-				ID: g.ID, DisplayName: g.DisplayName, ExternalID: g.ExternalID,
-				MemberCount: len(members), CreatedAt: g.CreatedAt, UpdatedAt: g.UpdatedAt,
-			})
-		}
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, adminReadEvent(string(org), bindingID, "directory", len(out)))
-	})
+			for _, g := range groups {
+				members, err := a.repos.SCIM().GroupMembers(ctx, a.proof, bindingID, g.ID)
+				if err != nil {
+					return err
+				}
+				out = append(out, SCIMDirectoryGroup{
+					ID: g.ID, DisplayName: g.DisplayName, ExternalID: g.ExternalID,
+					MemberCount: len(members), CreatedAt: g.CreatedAt, UpdatedAt: g.UpdatedAt,
+				})
+			}
+			a.addEvents(adminReadEvent(string(org), bindingID, "directory", len(out)))
+			return nil
+		})
 	return out, err
 }
 

--- a/internal/service/scim_mapping.go
+++ b/internal/service/scim_mapping.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/store"
-	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
 // Mapping-table administration (#73 §3, §4).
@@ -132,80 +131,58 @@ func blastWarnings(scope domain.Scope, caps []domain.Capability, members int) []
 // current members, in the authoring transaction (§3).
 func (s *SCIM) CreateMapping(ctx context.Context, actor Actor, org domain.OrgID, bindingID string, spec SCIMMappingSpec) (SCIMMappingResult, error) {
 	var out SCIMMappingResult
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMMappingCreate, scope)
-		if err != nil {
-			return err
-		}
-		// §9: per-binding writes SERIALIZE. The wire takes this lock through
-		// its contact UPDATE; an ADMINISTRATION mutation has no such update,
-		// so it takes the row lock explicitly and holds it to commit. Mapping
-		// authoring reconciles origins in its own transaction, which is the
-		// same origin arithmetic a push performs and needs the same
-		// serialization — so both legs mark the SAME phase pair, and a fixture
-		// asserting strict alternation covers admin-versus-wire races too.
-		unlock, err := lockBindingRow(ctx, r, p, bindingID)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-		c, err := s.loadBinding(ctx, r, az, p, bindingID, false)
-		if err != nil {
-			return err
-		}
-		if err := checkMappingScope(c.binding, spec.Template, spec.ProjectID, spec.EnvID); err != nil {
-			return err
-		}
-		if err := s.resolveMappingScope(ctx, r, az, p, c.binding, spec.ProjectID, spec.EnvID); err != nil {
-			return err
-		}
-		// The row references the binding's group resource BY ITS SERVER-MINTED
-		// ID (§3), so a row naming an id this server never minted is refused
-		// rather than stored as something that can never match.
-		if _, err := r.SCIM().Group(ctx, p, bindingID, spec.GroupID); err != nil {
-			return err
-		}
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMMappingCreate, true,
+		func(ctx context.Context, a *scimAdminContext) error {
+			r, az, p, caller, c := a.repos, a.authorizer, a.proof, a.caller, a.scimContext
+			if err := checkMappingScope(c.binding, spec.Template, spec.ProjectID, spec.EnvID); err != nil {
+				return err
+			}
+			if err := s.resolveMappingScope(ctx, r, az, p, c.binding, spec.ProjectID, spec.EnvID); err != nil {
+				return err
+			}
+			// The row references the binding's group resource BY ITS SERVER-MINTED
+			// ID (§3), so a row naming an id this server never minted is refused
+			// rather than stored as something that can never match.
+			if _, err := r.SCIM().Group(ctx, p, bindingID, spec.GroupID); err != nil {
+				return err
+			}
 
-		now := s.now()
-		id, err := newID("scm")
-		if err != nil {
-			return err
-		}
-		if err := r.SCIM().CreateMapping(ctx, p, store.NewSCIMMapping{
-			ID: id, BindingID: bindingID, GroupID: spec.GroupID,
-			Template:       string(spec.Template),
-			ScopeProjectID: spec.ProjectID, ScopeEnvID: spec.EnvID,
-			CreatedAt: now,
-		}); err != nil {
-			return err
-		}
-		row, err := r.SCIM().Mapping(ctx, p, id)
-		if err != nil {
-			return err
-		}
+			now := s.now()
+			id, err := newID("scm")
+			if err != nil {
+				return err
+			}
+			if err := r.SCIM().CreateMapping(ctx, p, store.NewSCIMMapping{
+				ID: id, BindingID: bindingID, GroupID: spec.GroupID,
+				Template:       string(spec.Template),
+				ScopeProjectID: spec.ProjectID, ScopeEnvID: spec.EnvID,
+				CreatedAt: now,
+			}); err != nil {
+				return err
+			}
+			row, err := r.SCIM().Mapping(ctx, p, id)
+			if err != nil {
+				return err
+			}
 
-		events, created, members, err := s.applyRowToMembers(ctx, r, az, c, row, now)
-		if err != nil {
-			return err
-		}
-		caps, err := domain.ExpandTemplate(spec.Template, mustLevel(mappingScope(c.binding, row)))
-		if err != nil {
-			return err
-		}
-		out = SCIMMappingResult{
-			Mapping:         mappingView(row, caps),
-			Warnings:        blastWarnings(mappingScope(c.binding, row), caps, members),
-			MembersAffected: members,
-			GrantsCreated:   created,
-		}
-		events = append(events, mappingEvent(audit.EventSCIMMappingCreated, c, row, caller.Principal))
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, events...)
-	})
+			events, created, members, err := s.applyRowToMembers(ctx, r, az, c, row, now)
+			if err != nil {
+				return err
+			}
+			caps, err := domain.ExpandTemplate(spec.Template, mustLevel(mappingScope(c.binding, row)))
+			if err != nil {
+				return err
+			}
+			out = SCIMMappingResult{
+				Mapping:         mappingView(row, caps),
+				Warnings:        blastWarnings(mappingScope(c.binding, row), caps, members),
+				MembersAffected: members,
+				GrantsCreated:   created,
+			}
+			events = append(events, mappingEvent(audit.EventSCIMMappingCreated, c, row, caller.Principal))
+			a.addEvents(events...)
+			return nil
+		})
 	return out, err
 }
 
@@ -220,92 +197,70 @@ func (s *SCIM) CreateMapping(ctx context.Context, actor Actor, org domain.OrgID,
 // with no IdP round-trip (§4).
 func (s *SCIM) UpdateMapping(ctx context.Context, actor Actor, org domain.OrgID, bindingID string, spec SCIMMappingSpec) (SCIMMappingResult, error) {
 	var out SCIMMappingResult
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMMappingUpdate, scope)
-		if err != nil {
-			return err
-		}
-		// §9: per-binding writes SERIALIZE. The wire takes this lock through
-		// its contact UPDATE; an ADMINISTRATION mutation has no such update,
-		// so it takes the row lock explicitly and holds it to commit. Mapping
-		// authoring reconciles origins in its own transaction, which is the
-		// same origin arithmetic a push performs and needs the same
-		// serialization — so both legs mark the SAME phase pair, and a fixture
-		// asserting strict alternation covers admin-versus-wire races too.
-		unlock, err := lockBindingRow(ctx, r, p, bindingID)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-		c, err := s.loadBinding(ctx, r, az, p, bindingID, false)
-		if err != nil {
-			return err
-		}
-		if err := checkMappingScope(c.binding, spec.Template, spec.ProjectID, spec.EnvID); err != nil {
-			return err
-		}
-		if err := s.resolveMappingScope(ctx, r, az, p, c.binding, spec.ProjectID, spec.EnvID); err != nil {
-			return err
-		}
-		row, err := s.addressedMapping(ctx, r, p, bindingID, spec)
-		if err != nil {
-			return err
-		}
-		level := mustLevel(mappingScope(c.binding, row))
-		before, err := domain.ExpandTemplate(domain.Template(row.Template), level)
-		if err != nil {
-			return err
-		}
-		after, err := domain.ExpandTemplate(spec.Template, level)
-		if err != nil {
-			return err
-		}
-		now := s.now()
-		if err := r.SCIM().UpdateMappingTemplate(ctx, p, row.ID, string(spec.Template)); err != nil {
-			return err
-		}
-		row.Template = string(spec.Template)
-
-		var events []grantEventInput
-		released := 0
-		// Narrowing first: release what the row no longer covers, before the
-		// widening half re-reads the members' rows.
-		dropped := missing(before, after)
-		if len(dropped) > 0 {
-			drop := map[domain.Capability]bool{}
-			for _, capability := range dropped {
-				drop[capability] = true
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMMappingUpdate, true,
+		func(ctx context.Context, a *scimAdminContext) error {
+			r, az, p, caller, c := a.repos, a.authorizer, a.proof, a.caller, a.scimContext
+			if err := checkMappingScope(c.binding, spec.Template, spec.ProjectID, spec.EnvID); err != nil {
+				return err
 			}
-			evs, count, err := s.releaseRow(ctx, r, az, c, row,
-				func(g domain.Grant) bool { return drop[g.Capability] },
-				domain.CauseMappingDelete, now)
+			if err := s.resolveMappingScope(ctx, r, az, p, c.binding, spec.ProjectID, spec.EnvID); err != nil {
+				return err
+			}
+			row, err := s.addressedMapping(ctx, r, p, bindingID, spec)
 			if err != nil {
 				return err
 			}
-			events = append(events, evs...)
-			released = count
-		}
-		grantEvents, created, members, err := s.applyRowToMembers(ctx, r, az, c, row, now)
-		if err != nil {
-			return err
-		}
-		events = append(events, grantEvents...)
+			level := mustLevel(mappingScope(c.binding, row))
+			before, err := domain.ExpandTemplate(domain.Template(row.Template), level)
+			if err != nil {
+				return err
+			}
+			after, err := domain.ExpandTemplate(spec.Template, level)
+			if err != nil {
+				return err
+			}
+			now := s.now()
+			if err := r.SCIM().UpdateMappingTemplate(ctx, p, row.ID, string(spec.Template)); err != nil {
+				return err
+			}
+			row.Template = string(spec.Template)
 
-		out = SCIMMappingResult{
-			Mapping:         mappingView(row, after),
-			Warnings:        blastWarnings(mappingScope(c.binding, row), after, members),
-			MembersAffected: members,
-			GrantsCreated:   created,
-			OriginsReleased: released,
-		}
-		events = append(events, mappingEvent(audit.EventSCIMMappingUpdated, c, row, caller.Principal))
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, events...)
-	})
+			var events []grantEventInput
+			released := 0
+			// Narrowing first: release what the row no longer covers, before the
+			// widening half re-reads the members' rows.
+			dropped := missing(before, after)
+			if len(dropped) > 0 {
+				drop := map[domain.Capability]bool{}
+				for _, capability := range dropped {
+					drop[capability] = true
+				}
+				evs, count, err := s.releaseRow(ctx, r, az, c, row,
+					func(g domain.Grant) bool { return drop[g.Capability] },
+					domain.CauseMappingDelete, now)
+				if err != nil {
+					return err
+				}
+				events = append(events, evs...)
+				released = count
+			}
+			grantEvents, created, members, err := s.applyRowToMembers(ctx, r, az, c, row, now)
+			if err != nil {
+				return err
+			}
+			events = append(events, grantEvents...)
+
+			out = SCIMMappingResult{
+				Mapping:         mappingView(row, after),
+				Warnings:        blastWarnings(mappingScope(c.binding, row), after, members),
+				MembersAffected: members,
+				GrantsCreated:   created,
+				OriginsReleased: released,
+			}
+			events = append(events, mappingEvent(audit.EventSCIMMappingUpdated, c, row, caller.Principal))
+			a.addEvents(events...)
+			return nil
+		})
 	return out, err
 }
 
@@ -314,93 +269,59 @@ func (s *SCIM) UpdateMapping(ctx context.Context, actor Actor, org domain.OrgID,
 // an IdP they don't control".
 func (s *SCIM) DeleteMapping(ctx context.Context, actor Actor, org domain.OrgID, bindingID string, spec SCIMMappingSpec) (SCIMMappingResult, error) {
 	var out SCIMMappingResult
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMMappingDelete, scope)
-		if err != nil {
-			return err
-		}
-		// §9: per-binding writes SERIALIZE. The wire takes this lock through
-		// its contact UPDATE; an ADMINISTRATION mutation has no such update,
-		// so it takes the row lock explicitly and holds it to commit. Mapping
-		// authoring reconciles origins in its own transaction, which is the
-		// same origin arithmetic a push performs and needs the same
-		// serialization — so both legs mark the SAME phase pair, and a fixture
-		// asserting strict alternation covers admin-versus-wire races too.
-		unlock, err := lockBindingRow(ctx, r, p, bindingID)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-		c, err := s.loadBinding(ctx, r, az, p, bindingID, false)
-		if err != nil {
-			return err
-		}
-		row, err := s.addressedMapping(ctx, r, p, bindingID, spec)
-		if err != nil {
-			return err
-		}
-		now := s.now()
-		events, released, err := s.releaseRow(ctx, r, az, c, row, nil, domain.CauseMappingDelete, now)
-		if err != nil {
-			return err
-		}
-		if err := r.SCIM().DeleteMapping(ctx, p, row.ID); err != nil {
-			return err
-		}
-		// The row is gone, so any `inert_mapping` attention it raised is too.
-		// The exit cause is the ACT that cleared it — the mapping was deleted —
-		// not the older act that made it inert. Recording `group_deleted` here
-		// put a false explanation in the trail: the audited exit says why the
-		// state ended, and this state ended because an administrator deleted
-		// the row.
-		cleared, err := s.clearAttention(ctx, r, c, domain.AttentionInertMapping, row.ID, domain.CauseMappingDelete)
-		if err != nil {
-			return err
-		}
-		events = append(events, cleared...)
-		out = SCIMMappingResult{Mapping: mappingView(row, nil), OriginsReleased: released, Warnings: []SCIMBlastWarning{}}
-		events = append(events, mappingEvent(audit.EventSCIMMappingDeleted, c, row, caller.Principal))
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg, events...)
-	})
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMMappingDelete, true,
+		func(ctx context.Context, a *scimAdminContext) error {
+			r, az, p, caller, c := a.repos, a.authorizer, a.proof, a.caller, a.scimContext
+			row, err := s.addressedMapping(ctx, r, p, bindingID, spec)
+			if err != nil {
+				return err
+			}
+			now := s.now()
+			events, released, err := s.releaseRow(ctx, r, az, c, row, nil, domain.CauseMappingDelete, now)
+			if err != nil {
+				return err
+			}
+			if err := r.SCIM().DeleteMapping(ctx, p, row.ID); err != nil {
+				return err
+			}
+			// The row is gone, so any `inert_mapping` attention it raised is too.
+			// The exit cause is the ACT that cleared it — the mapping was deleted —
+			// not the older act that made it inert. Recording `group_deleted` here
+			// put a false explanation in the trail: the audited exit says why the
+			// state ended, and this state ended because an administrator deleted
+			// the row.
+			cleared, err := s.clearAttention(ctx, r, c, domain.AttentionInertMapping, row.ID, domain.CauseMappingDelete)
+			if err != nil {
+				return err
+			}
+			events = append(events, cleared...)
+			out = SCIMMappingResult{Mapping: mappingView(row, nil), OriginsReleased: released, Warnings: []SCIMBlastWarning{}}
+			events = append(events, mappingEvent(audit.EventSCIMMappingDeleted, c, row, caller.Principal))
+			a.addEvents(events...)
+			return nil
+		})
 	return out, err
 }
 
 // ListMappings returns the binding's mapping table.
 func (s *SCIM) ListMappings(ctx context.Context, actor Actor, org domain.OrgID, bindingID string) ([]SCIMMappingView, error) {
 	var out []SCIMMappingView
-	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMMappingList, scope)
-		if err != nil {
-			return err
-		}
-		c, err := s.loadBinding(ctx, r, az, p, bindingID, false)
-		if err != nil {
-			return err
-		}
-		rows, err := r.SCIM().Mappings(ctx, p, bindingID)
-		if err != nil {
-			return err
-		}
-		for _, row := range rows {
-			caps, err := domain.ExpandTemplate(domain.Template(row.Template), mustLevel(mappingScope(c.binding, row)))
+	err := s.adminTx(ctx, actor, org, bindingID, authz.OpSCIMMappingList, false,
+		func(ctx context.Context, a *scimAdminContext) error {
+			rows, err := a.repos.SCIM().Mappings(ctx, a.proof, bindingID)
 			if err != nil {
 				return err
 			}
-			out = append(out, mappingView(row, caps))
-		}
-		return insertGrantEvent(ctx, r, p, caller.Principal, domain.LevelOrg,
-			adminReadEvent(string(org), bindingID, "mapping", len(out)))
-	})
+			for _, row := range rows {
+				caps, err := domain.ExpandTemplate(domain.Template(row.Template), mustLevel(mappingScope(a.binding, row)))
+				if err != nil {
+					return err
+				}
+				out = append(out, mappingView(row, caps))
+			}
+			a.addEvents(adminReadEvent(string(org), bindingID, "mapping", len(out)))
+			return nil
+		})
 	return out, err
 }
 


### PR DESCRIPTION
Closes #359

## Outcome
- centralizes binding-scoped SCIM admin actor resolution, authorization, optional serialization, binding loading, and audit insertion in adminTx
- keeps MintCredential hand-rolled so reauthentication evidence is consumed after caller resolution and before authorization
- pins wire-enter/wire-exit phase pairs for all six admin mutations on SQLite and PostgreSQL fixtures

## Contracts and migration
- no wire, audit, storage, migration, generated, or API contract changes
- read transactions do not take the reconciliation lock
- empty event sets remain valid for idempotent credential revocation
- generated outputs: none

## Red-test disposition
- origin/main already emitted all six phase pairs from duplicated preambles, so this representation-only simplification has no public behavior that can fail before extraction
- the new phase test is a characterization test on the ticket-named public observer seam
- a source-shape assertion for adminTx was rejected as implementation-coupled

## Validation
- all TestSCIM isolation tests: 66 passed
- internal/service: 242 passed
- full repository suite: 3,545 passed across 61 packages
- named PostgreSQL legs skipped locally because HIKYO_TEST_POSTGRES_DSN is unset; trusted CI owns them
- standards review: CLEAN
- spec review: CLEAN in round 2/3