### PR TITLE
Resolve CLI auth rules at parse time #360

### DIFF
--- a/docs/handoff/360-cli-leaf-auth-operation.md
+++ b/docs/handoff/360-cli-leaf-auth-operation.md
@@ -1,0 +1,34 @@
+# Issue #360 — resolve CLI leaf authentication rules at parse time
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/360 (parent #326; audit
+finding `F-S19-1`). Pull request: https://github.com/Hikyo-Org/Hikyo/pull/412.
+Implementation base: `21254750377527a7291eaf2c99a84fc07277bf66`.
+
+## Contract
+
+- `parseCommon` resolves the closed authentication-kind rule before flag
+  parsing or client-state access and carries both operation and eligible kinds
+  in `commonFlags`.
+- Authenticated human/machine and compose-machine target resolution consume the
+  carried kinds; neither can repeat or defer the registry lookup.
+- The phase-one `import` parser, which intentionally cannot use the shared
+  `--env` grammar, resolves and carries the same rule before its custom flags.
+- Missing rules remain fail-closed. Existing authentication eligibility,
+  command output, wire/audit bytes, ordering, and dialect behavior are
+  unchanged.
+- Contract or migration decisions: none. Generated outputs: none.
+
+## Coverage
+
+- `TestEveryAuthOperationReachesItsRule` drives every authentication-table leaf
+  through `Run`; authenticated leaves must reach an exact missing-rule sentinel
+  before state or command validation, while local/refusal-only leaves must reach
+  their declared dispatcher spelling.
+- `TestParseCommonRefusesUnknownOperationBeforeStateRead` proves an unknown leaf
+  returns `ExitInternal` without reading the state environment.
+- Focused leaf/rule regression set: 163 passed.
+- Scoped `go test -count=1 ./internal/cli`: 463 passed.
+- Full `go test -count=1 ./...`: 3,707 passed in 61 packages.
+- Standards/spec review: CLEAN in round 2/3 after leaf inventory and helper
+  ownership findings were fixed.
+- Exact-head CI results are recorded on PR #412.

--- a/internal/cli/auth_artifact_internal_test.go
+++ b/internal/cli/auth_artifact_internal_test.go
@@ -57,7 +57,23 @@ func TestEveryAuthOperationReachesItsRule(t *testing.T) {
 	original := operationAuthKinds
 	t.Cleanup(func() { operationAuthKinds = original })
 
-	operations := slices.Sorted(maps.Keys(original))
+	operations := documentedLeafOperations(t)
+	operationSet := make(map[AuthOperation]bool, len(operations))
+	for _, operation := range operations {
+		operationSet[operation] = true
+		if _, ok := original[operation]; !ok {
+			t.Errorf("documented CLI leaf %q has no authentication-kind rule", operation)
+		}
+	}
+	for operation := range original {
+		if !operationSet[operation] {
+			t.Errorf("authentication-kind rule %q has no documented CLI leaf", operation)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
 	for _, operation := range operations {
 		t.Run(string(operation), func(t *testing.T) {
 			// These leaves are local or terminal refusals. They deliberately do not
@@ -65,16 +81,7 @@ func TestEveryAuthOperationReachesItsRule(t *testing.T) {
 			// that the auth table's spelling reaches the declared leaf.
 			if operationDoesNotParseCommon(operation) {
 				var stderr bytes.Buffer
-				stateDir := t.TempDir()
-				code := Run(t.Context(), IO{
-					Stdout: &bytes.Buffer{}, Stderr: &stderr,
-					Env: Env{Getenv: func(key string) string {
-						if key == "HIKYO_STATE_DIR" {
-							return stateDir
-						}
-						return ""
-					}}, Workdir: t.TempDir(),
-				}, strings.Fields(string(operation)))
+				code := Run(t.Context(), authOperationTestIO(t, &stderr), strings.Fields(string(operation)))
 				if strings.Contains(stderr.String(), "unknown ") {
 					t.Fatalf("%s did not reach its declared leaf: exit=%d stderr=%q", operation, code, stderr.String())
 				}
@@ -102,16 +109,7 @@ func TestEveryAuthOperationReachesItsRule(t *testing.T) {
 				args = append(args, "binding_1", "credential_1")
 			}
 			var stderr bytes.Buffer
-			stateDir := t.TempDir()
-			code := Run(t.Context(), IO{
-				Stdout: &bytes.Buffer{}, Stderr: &stderr,
-				Env: Env{Getenv: func(key string) string {
-					if key == "HIKYO_STATE_DIR" {
-						return stateDir
-					}
-					return ""
-				}}, Workdir: t.TempDir(),
-			}, args)
+			code := Run(t.Context(), authOperationTestIO(t, &stderr), args)
 			want := "hikyo " + string(operation) + " has no authentication-kind rule"
 			wantCode := ExitInternal
 			if operation == "definitions check" {
@@ -123,6 +121,58 @@ func TestEveryAuthOperationReachesItsRule(t *testing.T) {
 				t.Fatalf("%s reached exit=%d stderr=%q, want exit=%d containing %q", operation, code, stderr.String(), wantCode, want)
 			}
 		})
+	}
+}
+
+func documentedLeafOperations(t *testing.T) []AuthOperation {
+	t.Helper()
+	var usage bytes.Buffer
+	Usage(&usage)
+	operations := map[AuthOperation]bool{
+		// The scanning-key rotation is intentionally documented by its locked
+		// ADR rather than the already-frozen help snapshot.
+		"rotate-scanning-key": true,
+	}
+	for _, line := range strings.Split(usage.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "hikyo ") {
+			continue
+		}
+		command := strings.TrimPrefix(line, "hikyo ")
+		if description := strings.Index(command, "  "); description >= 0 {
+			command = command[:description]
+		}
+		fields := strings.Fields(command)
+		path := make([]string, 0, len(fields))
+		for _, field := range fields {
+			if strings.ContainsAny(field[:1], "-[(<") {
+				break
+			}
+			path = append(path, field)
+		}
+		if len(path) == 0 {
+			continue
+		}
+		choices := strings.Split(path[len(path)-1], "|")
+		for _, choice := range choices {
+			leaf := append(slices.Clone(path[:len(path)-1]), choice)
+			operations[AuthOperation(strings.Join(leaf, " "))] = true
+		}
+	}
+	return slices.Sorted(maps.Keys(operations))
+}
+
+func authOperationTestIO(t *testing.T, stderr *bytes.Buffer) IO {
+	t.Helper()
+	stateDir := t.TempDir()
+	return IO{
+		Stdout: &bytes.Buffer{}, Stderr: stderr,
+		Env: Env{Getenv: func(key string) string {
+			if key == "HIKYO_STATE_DIR" {
+				return stateDir
+			}
+			return ""
+		}}, Workdir: t.TempDir(),
 	}
 }
 

--- a/internal/cli/auth_artifact_internal_test.go
+++ b/internal/cli/auth_artifact_internal_test.go
@@ -53,6 +53,105 @@ func TestVerbAuthKindsCoverEveryVerb(t *testing.T) {
 	}
 }
 
+func TestEveryAuthOperationReachesItsRule(t *testing.T) {
+	original := operationAuthKinds
+	t.Cleanup(func() { operationAuthKinds = original })
+
+	operations := slices.Sorted(maps.Keys(original))
+	for _, operation := range operations {
+		t.Run(string(operation), func(t *testing.T) {
+			// These leaves are local or terminal refusals. They deliberately do not
+			// parse common authenticated flags, but still need a drive-through check
+			// that the auth table's spelling reaches the declared leaf.
+			if operationDoesNotParseCommon(operation) {
+				var stderr bytes.Buffer
+				stateDir := t.TempDir()
+				code := Run(t.Context(), IO{
+					Stdout: &bytes.Buffer{}, Stderr: &stderr,
+					Env: Env{Getenv: func(key string) string {
+						if key == "HIKYO_STATE_DIR" {
+							return stateDir
+						}
+						return ""
+					}}, Workdir: t.TempDir(),
+				}, strings.Fields(string(operation)))
+				if strings.Contains(stderr.String(), "unknown ") {
+					t.Fatalf("%s did not reach its declared leaf: exit=%d stderr=%q", operation, code, stderr.String())
+				}
+				return
+			}
+
+			// Emptying the registry turns its lookup into a sentinel. The invocation
+			// must reach parseCommon with this exact leaf spelling before state or
+			// command-specific validation can change the answer.
+			operationAuthKinds = map[AuthOperation]AuthKinds{}
+			defer func() { operationAuthKinds = original }()
+
+			args := strings.Fields(string(operation))
+			switch operation {
+			case "account reset-credential":
+				args = append(args, "principal_1")
+			case "run":
+				args = append(args, "--", "true")
+			case "scim binding show", "scim binding delete",
+				"scim mapping add", "scim mapping update", "scim mapping remove", "scim mapping list",
+				"scim credential mint", "scim credential list",
+				"scim user list", "scim group list":
+				args = append(args, "binding_1")
+			case "scim credential show", "scim credential revoke":
+				args = append(args, "binding_1", "credential_1")
+			}
+			var stderr bytes.Buffer
+			stateDir := t.TempDir()
+			code := Run(t.Context(), IO{
+				Stdout: &bytes.Buffer{}, Stderr: &stderr,
+				Env: Env{Getenv: func(key string) string {
+					if key == "HIKYO_STATE_DIR" {
+						return stateDir
+					}
+					return ""
+				}}, Workdir: t.TempDir(),
+			}, args)
+			want := "hikyo " + string(operation) + " has no authentication-kind rule"
+			wantCode := ExitInternal
+			if operation == "definitions check" {
+				// `definitions check` deliberately maps every command error to its
+				// separate 0/1/2 contract after the leaf has resolved its rule.
+				wantCode = ExitUsage
+			}
+			if code != wantCode || !strings.Contains(stderr.String(), want) {
+				t.Fatalf("%s reached exit=%d stderr=%q, want exit=%d containing %q", operation, code, stderr.String(), wantCode, want)
+			}
+		})
+	}
+}
+
+func operationDoesNotParseCommon(operation AuthOperation) bool {
+	switch operation {
+	case "login",
+		"context create", "context list", "context show", "context delete",
+		"account passkey enrol", "account passkey list", "account passkey remove",
+		"definitions scaffold":
+		return true
+	default:
+		return false
+	}
+}
+
+func TestParseCommonRefusesUnknownOperationBeforeStateRead(t *testing.T) {
+	stateReads := 0
+	_, _, err := parseCommon("unknown operation", IO{Env: Env{Getenv: func(string) string {
+		stateReads++
+		return t.TempDir()
+	}}}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "hikyo unknown operation has no authentication-kind rule") {
+		t.Fatalf("error = %v, want missing authentication-kind rule", err)
+	}
+	if stateReads != 0 {
+		t.Fatalf("state environment reads = %d, want 0", stateReads)
+	}
+}
+
 func TestAuthenticatedTargetReturnsExplicitMachineCredential(t *testing.T) {
 	stateDir := t.TempDir()
 	st := &State{dir: stateDir}
@@ -70,7 +169,7 @@ func TestAuthenticatedTargetReturnsExplicitMachineCredential(t *testing.T) {
 	}, Stderr: &bytes.Buffer{}}
 
 	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
-		Flags: Flags{Instance: "local"}, operation: "definitions apply",
+		Flags: Flags{Instance: "local"}, operation: "definitions apply", kinds: humanOrMachine,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +189,7 @@ func TestAuthenticatedTargetReturnsExplicitMachineCredential(t *testing.T) {
 func TestDualEligibleOperationRequiresExplicitAuthChoice(t *testing.T) {
 	st, ios := authTargetFixture(t)
 	_, _, _, err := authenticatedTarget(st, ios, commonFlags{
-		Flags: Flags{Instance: "local"}, operation: "values export",
+		Flags: Flags{Instance: "local"}, operation: "values export", kinds: humanOrMachine,
 	})
 	if err == nil || !strings.Contains(err.Error(), "both a stored human session and a machine credential") || !strings.Contains(err.Error(), "--auth=human") {
 		t.Fatalf("error = %v, want explicit artifact-choice refusal", err)
@@ -100,7 +199,7 @@ func TestDualEligibleOperationRequiresExplicitAuthChoice(t *testing.T) {
 func TestExplicitHumanChoiceDoesNotReadMachineCredential(t *testing.T) {
 	st, ios := authTargetFixture(t)
 	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
-		Flags: Flags{Instance: "local"}, operation: "values export", Auth: "human",
+		Flags: Flags{Instance: "local"}, operation: "values export", kinds: humanOrMachine, Auth: "human",
 		TokenFile: filepath.Join(t.TempDir(), "missing-token"),
 	})
 	if err != nil {
@@ -114,7 +213,7 @@ func TestExplicitHumanChoiceDoesNotReadMachineCredential(t *testing.T) {
 func TestHumanOnlyOperationIgnoresIneligibleAmbientMachineCredential(t *testing.T) {
 	st, ios := authTargetFixture(t)
 	_, artifact, _, err := authenticatedTarget(st, ios, commonFlags{
-		Flags: Flags{Instance: "local"}, operation: "whoami",
+		Flags: Flags{Instance: "local"}, operation: "whoami", kinds: humanOnly,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/compose.go
+++ b/internal/cli/compose.go
@@ -1173,11 +1173,7 @@ func resolveMachineTarget(st *State, ios IO, flags commonFlags, cfg *compose.Con
 	if _, err := NewTenantScope(resolved); err != nil {
 		return nil, TrustEntry{}, Resolved{}, "", err
 	}
-	kinds, err := authKindsFor(flags.operation)
-	if err != nil {
-		return nil, TrustEntry{}, Resolved{}, "", err
-	}
-	if !kinds.Allows(AuthKindMachineCredential) {
+	if !flags.kinds.Allows(AuthKindMachineCredential) {
 		return nil, TrustEntry{}, Resolved{}, "", failf(ExitRefused, "hikyo %s does not accept machine credentials", flags.operation)
 	}
 	if flags.Auth == "human" {

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -62,10 +62,13 @@ const (
 )
 
 func runImport(ctx context.Context, ios IO, args []string) error {
+	kinds, err := authKindsFor("import")
+	if err != nil {
+		return err
+	}
 	fs := flag.NewFlagSet("import", flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
-	var c commonFlags
-	c.operation = "import"
+	c := commonFlags{operation: "import", kinds: kinds}
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -62,13 +62,12 @@ const (
 )
 
 func runImport(ctx context.Context, ios IO, args []string) error {
-	kinds, err := authKindsFor("import")
+	c, err := commonFlagsForOperation("import")
 	if err != nil {
 		return err
 	}
 	fs := flag.NewFlagSet("import", flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
-	c := commonFlags{operation: "import", kinds: kinds}
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -1404,6 +1404,7 @@ func runOrg(ctx context.Context, ios IO, args []string) error {
 type commonFlags struct {
 	Flags
 	operation AuthOperation
+	kinds     AuthKinds
 	Auth      string
 	// TokenFile is the machine-credential channel (#61). There is
 	// deliberately no `--token` flag beside it: a secret in argv is visible
@@ -1462,10 +1463,14 @@ func (c commonFlags) checkNoPositionals(verb string) error {
 
 // parseCommon parses the per-dimension flags every server-mediated verb takes.
 func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) (*State, commonFlags, error) {
+	operation := AuthOperation(name)
+	kinds, err := authKindsFor(operation)
+	if err != nil {
+		return nil, commonFlags{}, err
+	}
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
-	var c commonFlags
-	c.operation = AuthOperation(name)
+	c := commonFlags{operation: operation, kinds: kinds}
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")
@@ -1547,13 +1552,9 @@ func authenticatedResolvedTarget(st *State, ios IO, flags commonFlags, resolved 
 	if err != nil {
 		return nil, nil, Resolved{}, err
 	}
-	kinds, err := authKindsFor(flags.operation)
-	if err != nil {
-		return nil, nil, Resolved{}, err
-	}
 	humanSession, humanPresent := sessions[instance]
 	machinePresent := flags.TokenFile != "" || ios.Env.Getenv("HIKYO_TOKEN") != ""
-	selected, err := selectAuthKind(flags.operation, kinds, flags.Auth, humanPresent, machinePresent)
+	selected, err := selectAuthKind(flags.operation, flags.kinds, flags.Auth, humanPresent, machinePresent)
 	if err != nil {
 		return nil, nil, Resolved{}, err
 	}

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -1463,14 +1463,12 @@ func (c commonFlags) checkNoPositionals(verb string) error {
 
 // parseCommon parses the per-dimension flags every server-mediated verb takes.
 func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) (*State, commonFlags, error) {
-	operation := AuthOperation(name)
-	kinds, err := authKindsFor(operation)
+	c, err := commonFlagsForOperation(name)
 	if err != nil {
 		return nil, commonFlags{}, err
 	}
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(ios.Stderr)
-	c := commonFlags{operation: operation, kinds: kinds}
 	fs.StringVar(&c.Context, "context", "", "named context to select for this invocation")
 	fs.StringVar(&c.Instance, "instance", "", "instance reference")
 	fs.StringVar(&c.Org, "org", "", "organisation")
@@ -1494,6 +1492,15 @@ func parseCommon(name string, ios IO, args []string, extra func(*flag.FlagSet)) 
 		return nil, commonFlags{}, err
 	}
 	return st, c, nil
+}
+
+func commonFlagsForOperation(name string) (commonFlags, error) {
+	operation := AuthOperation(name)
+	kinds, err := authKindsFor(operation)
+	if err != nil {
+		return commonFlags{}, err
+	}
+	return commonFlags{operation: operation, kinds: kinds}, nil
 }
 
 // authenticatedClient resolves the instance and its stored artifact.


### PR DESCRIPTION
Closes #360

## Contract

- `parseCommon` resolves the closed authentication-kind rule before flag parsing or state access and carries it in `commonFlags`.
- Authenticated target consumers use the resolved rule; no rule lookup remains after trust/session/config reads.
- The hand-parsed phase-one `import` command resolves the same rule before its own parsing path.
- Missing rules remain fail-closed. Existing auth eligibility, wire/audit bytes, ordering, and dual-dialect behavior are unchanged.

## Tests

- `TestEveryAuthOperationReachesItsRule` derives an independent leaf inventory from the frozen CLI help plus the locked-ADR scanning-key operation, checks both set differences, then drives every leaf through dispatch.
- `TestParseCommonRefusesUnknownOperationBeforeStateRead` proves unknown operations fail before state access.
- Focused leaf/rule regression set — 163 passed.
- `go test -count=1 ./internal/cli` — 463 passed.
- `go test -count=1 ./...` — 3,707 passed in 61 packages.
- Standards/spec review — CLEAN in round 2/3 after all findings were fixed.

## Generated outputs and migrations

- Generated outputs: none.
- Database or contract migrations: none.