### PR TITLE
Store snapshot collection as one state #358

### DIFF
--- a/docs/handoff/358-snapshot-collection-triple.md
+++ b/docs/handoff/358-snapshot-collection-triple.md
@@ -1,0 +1,26 @@
+# Handoff: #358 snapshot collection triple
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/358 (parent #326; audit finding
+`F-S03-1`). Implementation base:
+`d88cd224bdf18f7949519239164a7b2cfc4af01c`.
+
+## Contract
+
+- `store.Snapshot.Collected` owns collection time and policy together; `nil`
+  means the payload remains live.
+- SQLite and PostgreSQL mappers refuse every disagreement among
+  `payload_present`, `collected_at`, and `collected_policy`.
+- `PayloadPresent` and `CollectionPolicy` centralize collection-state reads for
+  store and service consumers.
+- API, audit, database, migration, ordering, and generated wire shapes remain
+  unchanged.
+
+## Coverage
+
+- `TestRevisionSnapshotMappersEnforceCollectionTriple` covers live, collected,
+  and four contradictory triples for both generated database row shapes.
+- `revision_list_detail_collection_state_agrees` covers public service parity
+  with real storage and keyring behavior on both conformance engines.
+- Retention GC, server revision tests, and focused store/service packages pass.
+- Final local validation passed 3,559 tests across 61 packages with
+  `go test -count=1 ./...`; standards and spec review both returned clean.

--- a/internal/conformance/revisions_test.go
+++ b/internal/conformance/revisions_test.go
@@ -39,6 +39,7 @@ func init() {
 	corpus = append(corpus,
 		scenario{"publish_is_serialized_per_project", scenarioPublishSerialization},
 		scenario{"selective_publish_closes_over_key_groups", scenarioSelectivePublish},
+		scenario{"revision_list_detail_collection_state_agrees", scenarioRevisionListDetailCollectionParity},
 		scenario{"rotate_token_key_moves_only_the_token", scenarioRotateTokenKey},
 		scenario{"publish_recomputes_signals_for_touched_environments", scenarioPublishSignals},
 		scenario{"pending_draft_preview_is_owner_filtered_and_classification_safe", scenarioPendingDraftPreview},
@@ -57,6 +58,33 @@ func init() {
 		scenario{"pin_lifecycle_quota_and_expiry_refusals_by_name", scenarioPinLifecycle},
 		scenario{"delivery_retry_clears_rolled_back_pin_metadata", scenarioDeliveryRetryClearsPinMetadata},
 	)
+}
+
+func scenarioRevisionListDetailCollectionParity(t *testing.T, db *store.DB) {
+	who, scope, values, envs, keys := valueFixture(t, db, "revisionparity")
+	actor := service.LocalPrincipal(who)
+	dev := mustEnv(t, envs, actor, scope, "dev")
+	mustKey(t, keys, actor, scope, "PARITY", string(schema.Config), schema.DefaultPresenceRules())
+	publishValue(t, db, values, actor, dev, "PARITY", "value")
+
+	revisions := revisionSvc(t, db)
+	history, err := revisions.History(t.Context(), actor, dev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) == 0 {
+		t.Fatal("history is empty after publish")
+	}
+	detail, err := revisions.Show(t.Context(), actor, dev, history[0].Revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.PayloadPresent != history[0].PayloadPresent || detail.CollectedPolicy != history[0].CollectedPolicy {
+		t.Fatalf("list/detail collection state disagrees: list=%+v detail=%+v", history[0], detail.RevisionView)
+	}
+	if !detail.PayloadPresent || detail.CollectedPolicy != "" {
+		t.Fatalf("live revision collection state = present %t policy %q, want true and empty", detail.PayloadPresent, detail.CollectedPolicy)
+	}
 }
 
 func scenarioAdapterCrashReservationRelease(t *testing.T, db *store.DB) {

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -342,7 +342,7 @@ func (s *Delivery) FetchAs(ctx context.Context, actor Actor, scope domain.Scope,
 					return invalidDetail("pinned delivery of revision %d is refused because the recorded authority no longer holds reveal-history", pin.Revision)
 				}
 			}
-			if !snapshot.PayloadPresent {
+			if !snapshot.PayloadPresent() {
 				return collectedRevisionError(snapshot)
 			}
 			selected = &snapshot

--- a/internal/service/pins.go
+++ b/internal/service/pins.go
@@ -130,7 +130,7 @@ func (s pinRetentionState) consequence(snapshotID, releasingPinID string, now ti
 	if target == nil {
 		return "", store.ErrNotFound
 	}
-	if !target.PayloadPresent {
+	if !target.PayloadPresent() {
 		return RetentionAlreadyCollected, nil
 	}
 	if s.policy.Unlimited || !target.PublishedAt.Before(now.Add(-s.policy.MaxAge)) {
@@ -230,7 +230,7 @@ func (s *Pins) Set(ctx context.Context, actor Actor, scope domain.Scope, request
 		if err != nil {
 			return err
 		}
-		if !target.PayloadPresent {
+		if !target.PayloadPresent() {
 			return collectedRevisionError(target)
 		}
 		renewing := existingErr == nil && existing.Revision == target.Revision

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -135,7 +135,7 @@ func (s *Revisions) History(ctx context.Context, actor Actor, scope domain.Scope
 				Revision: snapshot.Revision, SchemaRevision: snapshot.SchemaRevision,
 				PublishedBy: snapshot.PublishedBy, PublishedAt: snapshot.PublishedAt,
 				ChangedKeys:    changedKeys(changes),
-				PayloadPresent: snapshot.PayloadPresent, CollectedPolicy: collectedPolicy(snapshot),
+				PayloadPresent: snapshot.PayloadPresent(), CollectedPolicy: snapshot.CollectionPolicy(),
 			})
 		}
 		return nil
@@ -212,8 +212,8 @@ func (s *Revisions) Show(ctx context.Context, actor Actor, scope domain.Scope, r
 				Revision: snapshot.Revision, SchemaRevision: snapshot.SchemaRevision,
 				PublishedBy: snapshot.PublishedBy, PublishedAt: snapshot.PublishedAt,
 				ChangedKeys:     changedKeys(changes),
-				PayloadPresent:  snapshot.PayloadPresent,
-				CollectedPolicy: snapshot.CollectedPolicy,
+				PayloadPresent:  snapshot.PayloadPresent(),
+				CollectedPolicy: snapshot.CollectionPolicy(),
 			},
 			ChangeToken: token,
 			Keys:        keys,
@@ -235,20 +235,10 @@ func readSnapshot(ctx context.Context, snapshots store.SnapshotReader, p authz.P
 	return snapshots.AtRevision(ctx, p, revision)
 }
 
-// collectedPolicy reports the stamped policy only for a collected payload. A
-// live snapshot carries whatever the column defaulted to, and reporting that as
-// "the policy that collected this" would be a fact about nothing.
-func collectedPolicy(snapshot store.Snapshot) string {
-	if snapshot.PayloadPresent {
-		return ""
-	}
-	return snapshot.CollectedPolicy
-}
-
 func collectedRevisionError(snapshot store.Snapshot) error {
 	return &domain.CollectedRevisionError{
 		Revision: snapshot.Revision,
-		Policy:   snapshot.CollectedPolicy,
+		Policy:   snapshot.CollectionPolicy(),
 	}
 }
 

--- a/internal/service/rollback.go
+++ b/internal/service/rollback.go
@@ -68,7 +68,7 @@ func (s *Revisions) Restore(ctx context.Context, actor Actor, scope domain.Scope
 		if err != nil {
 			return err
 		}
-		if !target.PayloadPresent {
+		if !target.PayloadPresent() {
 			return collectedRevisionError(target)
 		}
 		keys, err := r.Catalogue().List(ctx, p)

--- a/internal/store/repos_revisions.go
+++ b/internal/store/repos_revisions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -696,27 +697,43 @@ func revisionSnapshotFromSQLite(row sqlitegen.Snapshot) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
+	var collectedAt time.Time
+	if row.CollectedAt.Valid {
+		collectedAt, err = parseTime("snapshot collection", row.ID, row.CollectedAt.String)
+		if err != nil {
+			return Snapshot{}, err
+		}
+	}
+	collected, err := snapshotCollection(row.ID, row.PayloadPresent == 1, row.CollectedAt.Valid, collectedAt, row.CollectedPolicy)
+	if err != nil {
+		return Snapshot{}, err
+	}
 	snapshot := Snapshot{
 		ID: row.ID, OrgID: row.OrgID, ProjectID: row.ProjectID,
 		EnvironmentID: row.EnvironmentID, Revision: row.Revision,
 		SchemaRevision: row.SchemaRevision, PublishedBy: row.PublishedBy,
-		PublishedAt: published, CollectedPolicy: row.CollectedPolicy,
-		PayloadPresent: row.PayloadPresent == 1,
-	}
-	if row.CollectedAt.Valid {
-		collected, err := parseTime("snapshot collection", row.ID, row.CollectedAt.String)
-		if err != nil {
-			return Snapshot{}, err
-		}
-		snapshot.CollectedAt = &collected
+		PublishedAt: published, Collected: collected,
 	}
 	return snapshot, nil
 }
 
+func snapshotCollection(id string, payloadPresent, hasCollectedAt bool, collectedAt time.Time, policy string) (*SnapshotCollection, error) {
+	if payloadPresent && !hasCollectedAt && policy == "" {
+		return nil, nil
+	}
+	if !payloadPresent && hasCollectedAt && policy != "" {
+		return &SnapshotCollection{At: collectedAt, Policy: policy}, nil
+	}
+	return nil, fmt.Errorf(
+		"store: snapshot %s carries inconsistent collection state (payload_present=%t, collected_at=%t, collected_policy=%t)",
+		id, payloadPresent, hasCollectedAt, policy != "",
+	)
+}
+
 func liveSnapshot(snapshot Snapshot) (Snapshot, error) {
-	if !snapshot.PayloadPresent {
+	if !snapshot.PayloadPresent() {
 		return Snapshot{}, &domain.CollectedRevisionError{
-			Revision: snapshot.Revision, Policy: snapshot.CollectedPolicy,
+			Revision: snapshot.Revision, Policy: snapshot.CollectionPolicy(),
 		}
 	}
 	return snapshot, nil
@@ -1140,7 +1157,7 @@ func (r pgSnapshots) Latest(ctx context.Context, p authz.Proof) (Snapshot, error
 	if err != nil {
 		return Snapshot{}, err
 	}
-	return revisionSnapshotFromPG(row), nil
+	return revisionSnapshotFromPG(row)
 }
 
 func (r pgSnapshots) ProjectRevisions(ctx context.Context, p authz.Proof) (map[string]int64, error) {
@@ -1211,7 +1228,7 @@ func (r pgSnapshots) atRevision(ctx context.Context, orgID, projectID, envID str
 	if err != nil {
 		return Snapshot{}, err
 	}
-	return revisionSnapshotFromPG(row), nil
+	return revisionSnapshotFromPG(row)
 }
 
 func (r pgSnapshots) List(ctx context.Context, p authz.Proof) ([]Snapshot, error) {
@@ -1233,7 +1250,11 @@ func (r pgSnapshots) List(ctx context.Context, p authz.Proof) ([]Snapshot, error
 	}
 	out := make([]Snapshot, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, revisionSnapshotFromPG(row))
+		snapshot, err := revisionSnapshotFromPG(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snapshot)
 	}
 	return out, nil
 }
@@ -1471,19 +1492,19 @@ func (r pgSnapshots) DeleteEnvironment(ctx context.Context, p authz.Proof) error
 	return constraint(err)
 }
 
-func revisionSnapshotFromPG(row pggen.Snapshot) Snapshot {
-	snapshot := Snapshot{
+func revisionSnapshotFromPG(row pggen.Snapshot) (Snapshot, error) {
+	collected, err := snapshotCollection(
+		row.ID, row.PayloadPresent, row.CollectedAt.Valid, row.CollectedAt.Time.UTC(), row.CollectedPolicy,
+	)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{
 		ID: row.ID, OrgID: row.OrgID, ProjectID: row.ProjectID,
 		EnvironmentID: row.EnvironmentID, Revision: row.Revision,
 		SchemaRevision: row.SchemaRevision, PublishedBy: row.PublishedBy,
-		PublishedAt: row.PublishedAt.Time.UTC(), CollectedPolicy: row.CollectedPolicy,
-		PayloadPresent: row.PayloadPresent,
-	}
-	if row.CollectedAt.Valid {
-		collected := row.CollectedAt.Time.UTC()
-		snapshot.CollectedAt = &collected
-	}
-	return snapshot
+		PublishedAt: row.PublishedAt.Time.UTC(), Collected: collected,
+	}, nil
 }
 
 type pgPins struct {

--- a/internal/store/repos_revisions_test.go
+++ b/internal/store/repos_revisions_test.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/Hikyo-Org/hikyo/internal/store/pggen"
+	"github.com/Hikyo-Org/hikyo/internal/store/sqlitegen"
+)
+
+func TestRevisionSnapshotMappersEnforceCollectionTriple(t *testing.T) {
+	stamp := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	policy := "keep-if-either(max_age=720h0m0s,last_revisions=2)"
+
+	tests := []struct {
+		name           string
+		payloadPresent bool
+		collectedAt    bool
+		policy         string
+		wantCollected  bool
+		wantErr        bool
+	}{
+		{name: "live", payloadPresent: true},
+		{name: "collected", collectedAt: true, policy: policy, wantCollected: true},
+		{name: "present with collection stamp", payloadPresent: true, collectedAt: true, policy: policy, wantErr: true},
+		{name: "present with collection policy", payloadPresent: true, policy: policy, wantErr: true},
+		{name: "collected without stamp", policy: policy, wantErr: true},
+		{name: "collected without policy", collectedAt: true, wantErr: true},
+	}
+
+	for _, engine := range []struct {
+		name   string
+		mapRow func(bool, bool, string) (Snapshot, error)
+	}{
+		{
+			name: "sqlite",
+			mapRow: func(payloadPresent, collectedAt bool, policy string) (Snapshot, error) {
+				row := sqlitegen.Snapshot{
+					ID: "snp_mapper", PublishedAt: stamp.Format(timeFormat),
+					PayloadPresent: boolInt(payloadPresent), CollectedPolicy: policy,
+				}
+				if collectedAt {
+					row.CollectedAt = sql.NullString{String: stamp.Format(timeFormat), Valid: true}
+				}
+				return revisionSnapshotFromSQLite(row)
+			},
+		},
+		{
+			name: "postgres",
+			mapRow: func(payloadPresent, collectedAt bool, policy string) (Snapshot, error) {
+				row := pggen.Snapshot{
+					ID:             "snp_mapper",
+					PublishedAt:    pgtype.Timestamptz{Time: stamp, Valid: true},
+					PayloadPresent: payloadPresent, CollectedPolicy: policy,
+				}
+				if collectedAt {
+					row.CollectedAt = pgtype.Timestamptz{Time: stamp, Valid: true}
+				}
+				return revisionSnapshotFromPG(row)
+			},
+		},
+	} {
+		t.Run(engine.name, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					got, err := engine.mapRow(test.payloadPresent, test.collectedAt, test.policy)
+					if test.wantErr {
+						if err == nil || !strings.Contains(err.Error(), "snp_mapper") {
+							t.Fatalf("mapper error = %v, want snapshot-specific collection-triple refusal", err)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if (got.Collected != nil) != test.wantCollected {
+						t.Fatalf("collected = %+v, want present %t", got.Collected, test.wantCollected)
+					}
+					if got.PayloadPresent() == test.wantCollected || got.CollectionPolicy() != test.policy {
+						t.Fatalf("collection behavior = present %t policy %q, want present %t policy %q",
+							got.PayloadPresent(), got.CollectionPolicy(), !test.wantCollected, test.policy)
+					}
+					if test.wantCollected && (got.Collected.At != stamp || got.Collected.Policy != policy) {
+						t.Fatalf("collection = %+v, want at %s with policy %q", got.Collected, stamp, policy)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/store/revisions.go
+++ b/internal/store/revisions.go
@@ -92,17 +92,36 @@ type NewPendingChange struct {
 // header. It carries the pinned schema revision; it deliberately carries no
 // change token, which is derived from the current root token key at read.
 type Snapshot struct {
-	ID              string
-	OrgID           string
-	ProjectID       string
-	EnvironmentID   string
-	Revision        int64
-	SchemaRevision  int64
-	PublishedBy     string
-	PublishedAt     time.Time
-	PayloadPresent  bool
-	CollectedAt     *time.Time
-	CollectedPolicy string
+	ID             string
+	OrgID          string
+	ProjectID      string
+	EnvironmentID  string
+	Revision       int64
+	SchemaRevision int64
+	PublishedBy    string
+	PublishedAt    time.Time
+	// Collected is nil while the snapshot payload is live. Collection time and
+	// policy travel together so callers cannot observe or construct only one
+	// part of the durable collection state.
+	Collected *SnapshotCollection
+}
+
+// SnapshotCollection is the indivisible marker stamped when retention removes
+// a snapshot's payload.
+type SnapshotCollection struct {
+	At     time.Time
+	Policy string
+}
+
+// PayloadPresent reports whether retention has not collected the payload.
+func (s Snapshot) PayloadPresent() bool { return s.Collected == nil }
+
+// CollectionPolicy reports the stamped policy only for a collected payload.
+func (s Snapshot) CollectionPolicy() string {
+	if s.Collected == nil {
+		return ""
+	}
+	return s.Collected.Policy
 }
 
 // NewSnapshot carries the caller-suppliable fields of a snapshot insert.


### PR DESCRIPTION
## Summary

- represent snapshot collection as one optional `SnapshotCollection{At, Policy}` value
- reject contradictory `payload_present`, `collected_at`, and `collected_policy` rows in both database mappers
- route delivery, pin, revision, and rollback consumers through centralized snapshot behavior
- add dual-dialect mapper regression coverage and list/detail service parity coverage

## Contract and migration decisions

- `Collected == nil` means live; a non-nil value always carries both collection time and policy
- database schema, stored rows, API/audit bytes, ordering, and named refusal behavior remain unchanged
- no migration is required

## Generated outputs

- None

## Validation

- `go test -count=1 ./internal/store -run ^TestRevisionSnapshotMappersEnforceCollectionTriple$`
- `go test -count=1 ./internal/isolation -run ^TestRetentionGCC6SQLite$`
- `go test -count=1 ./internal/conformance -run ^TestConformanceSQLite/revision_list_detail_collection_state_agrees$`
- `go test -count=1 ./internal/server`
- `go test -count=1 ./internal/service`
- `go test -count=1 ./internal/store`
- `go test -count=1 ./...` — 3,559 tests across 61 packages
- standards review CLEAN; spec review CLEAN

Closes #358