### PR TITLE
Centralize matrix query readiness #362

### DIFF
--- a/docs/handoff/362-matrix-query-state.md
+++ b/docs/handoff/362-matrix-query-state.md
@@ -1,0 +1,25 @@
+# Handoff: #362 matrix query state
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/362 (parent #326; audit finding
+`F-S28-2`). Implementation base: `428dd6a50c26512a634ece820794562241724e2f`.
+
+## Contract
+
+- Each environment query is mapped once at the API boundary to exactly one of
+  `pending`, `error`, `stale` with data, or `ready` with data.
+- Each matrix row owns one worst-family readiness. Loading retains precedence
+  over a simultaneous initial error; otherwise error precedes stale data.
+- A stale pending-drafts query now contributes to the background-refresh
+  warning, preserving its loaded data while making the refresh failure visible.
+- A signal exposes pending work as one optional `{ versionId, operation }`
+  value. The wire boundary still refuses either field without the other.
+
+## Coverage
+
+- `matrix.test.ts` covers all four query mappings, row readiness precedence,
+  stale pending drafts, signal parsing, and pending-preview lookup.
+- `matrix-hook.test.tsx` preserves keyed query ownership through environment
+  reorder and removal.
+- Generated outputs: none. Wire schemas and generated clients are unchanged.
+- Local validation: web typecheck passed; focused matrix tests passed 22/22;
+  full web Vitest passed 312/312 after review fixes.

--- a/web/src/api/matrix.test.ts
+++ b/web/src/api/matrix.test.ts
@@ -4,6 +4,7 @@ import { ApiError } from './client.ts';
 import {
   assembleMatrixEnvironmentRows,
   bindMatrixEnvironmentQueries,
+  type MatrixEnvironmentQuery,
   matrixPublishValidation,
   matrixMutationError,
   forgetRestorePreviews,
@@ -38,12 +39,27 @@ const environmentProd = {
   display_order: 1,
 };
 
-function query<T>(data: T | undefined, isPending = false) {
-  return { data, isPending, isError: false };
+function query<T>(data: T | undefined, isPending = false, isError = false) {
+  return { data, isPending, isError };
 }
 
-function environmentQuery<T>(environmentId: string, data: T | undefined, isPending = false) {
-  return { environmentId, query: query(data, isPending) };
+function environmentQuery<T>(
+  environmentId: string,
+  data: T | undefined,
+  isPending = false,
+  isError = false,
+): MatrixEnvironmentQuery<T> {
+  if (isPending) {
+    return { environmentId, query: { status: 'pending' } };
+  }
+  if (isError) {
+    return data === undefined
+      ? { environmentId, query: { status: 'error' } }
+      : { environmentId, query: { status: 'stale', data } };
+  }
+  return data === undefined
+    ? { environmentId, query: { status: 'error' } }
+    : { environmentId, query: { status: 'ready', data } };
 }
 
 beforeEach(() => {
@@ -128,7 +144,21 @@ describe('matrix signal boundary', () => {
           },
         ],
       }).cells,
-    ).toHaveLength(2);
+    ).toEqual([
+      {
+        key_id: keyLog,
+        name: 'LOG_LEVEL',
+        classification: 'config',
+        pending: { versionId: version, operation: 'set' },
+        pending_by_others: false,
+      },
+      {
+        key_id: keyOther,
+        name: 'OTHER',
+        classification: 'config',
+        pending_by_others: false,
+      },
+    ]);
   });
 });
 
@@ -196,14 +226,69 @@ describe('environment-keyed matrix rows', () => {
   it('keeps one pending query on its own row while other rows render ready data', () => {
     const rows = assembleMatrixEnvironmentRows([environmentDev, environmentProd], {
       ...inputs,
-      signals: [environmentQuery(envProd, undefined, true), environmentQuery(envDev, devSignals)],
+      signals: [
+        environmentQuery<typeof prodSignals>(envProd, undefined, true),
+        environmentQuery(envDev, devSignals),
+      ],
     });
 
     expect(rows[0]?.signals.data?.revision).toBe(2n);
-    expect(rows[0]?.signals.isPending).toBe(false);
+    expect(rows[0]?.signals.status).toBe('ready');
+    expect(rows[0]?.readiness).toBe('ready');
     expect(rows[1]?.environmentId).toBe(envProd);
     expect(rows[1]?.signals.data).toBeUndefined();
-    expect(rows[1]?.signals.isPending).toBe(true);
+    expect(rows[1]?.signals.status).toBe('pending');
+    expect(rows[1]?.readiness).toBe('pending');
+  });
+
+  it('maps query flags once into pending, error, stale, and ready states', () => {
+    const [pending, error, stale, ready] = bindMatrixEnvironmentQueries(
+      'values',
+      [
+        environmentDev,
+        environmentProd,
+        { ...environmentDev, id: 'env_stale' },
+        { ...environmentDev, id: 'env_ready' },
+      ],
+      [
+        query(undefined, true),
+        query(undefined, false, true),
+        query({ environmentId: 'env_stale', value: devValues }, false, true),
+        query({ environmentId: 'env_ready', value: prodValues }),
+      ],
+    ).map((entry) => entry.query);
+
+    expect(pending).toEqual({ status: 'pending' });
+    expect(error).toEqual({ status: 'error' });
+    expect(stale).toEqual({ status: 'stale', data: devValues });
+    expect(ready).toEqual({ status: 'ready', data: prodValues });
+  });
+
+  it('derives one row readiness with loading precedence and includes stale pending drafts', () => {
+    const [row] = assembleMatrixEnvironmentRows([environmentDev], {
+      values: [environmentQuery<typeof devValues>(envDev, undefined, true)],
+      signals: [{ environmentId: envDev, query: { status: 'error' } }],
+      settings: [{ environmentId: envDev, query: { status: 'stale', data: devSettings } }],
+      pendingDrafts: [{ environmentId: envDev, query: { status: 'stale', data: drafts } }],
+    });
+
+    expect(row?.readiness).toBe('pending');
+
+    const [errorRow] = assembleMatrixEnvironmentRows([environmentDev], {
+      values: [environmentQuery(envDev, devValues)],
+      signals: [{ environmentId: envDev, query: { status: 'error' } }],
+      settings: [environmentQuery(envDev, devSettings)],
+      pendingDrafts: [environmentQuery(envDev, drafts)],
+    });
+    expect(errorRow?.readiness).toBe('error');
+
+    const [staleRow] = assembleMatrixEnvironmentRows([environmentDev], {
+      values: [environmentQuery(envDev, devValues)],
+      signals: [environmentQuery(envDev, devSignals)],
+      settings: [environmentQuery(envDev, devSettings)],
+      pendingDrafts: [{ environmentId: envDev, query: { status: 'stale', data: drafts } }],
+    });
+    expect(staleRow?.readiness).toBe('stale');
   });
 
   it('rejects duplicate or missing query identities instead of guessing by position', () => {
@@ -280,11 +365,15 @@ describe('pending draft preview boundary', () => {
       name: 'LOG_LEVEL',
       classification: 'config',
       pending_by_others: false,
-      pending_version_id: version,
-      pending_operation: 'set',
+      pending: { versionId: version, operation: 'set' },
     };
     expect(pendingConfigPreview(signal, byVersion)).toBe('debug');
-    expect(pendingConfigPreview({ ...signal, pending_version_id: 'ver_other' }, byVersion)).toBeUndefined();
+    expect(
+      pendingConfigPreview(
+        { ...signal, pending: { versionId: 'ver_other', operation: 'set' } },
+        byVersion,
+      ),
+    ).toBeUndefined();
     expect(() => pendingConfigPreview({ ...signal, key_id: keyOther }, byVersion)).toThrow(
       'bound to the wrong key',
     );

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -62,15 +62,35 @@ export type MatrixKeyList = z.infer<typeof zKeyList>;
  * never carries the matched text, so the UI renders only what it holds.
  */
 export type ScanFinding = z.infer<typeof zScanFinding>;
-export type MatrixEnvironmentSignals = z.infer<typeof zEnvironmentSignals>;
-export type MatrixSignalCell = MatrixEnvironmentSignals['cells'][number];
+type MatrixEnvironmentSignalsWire = z.infer<typeof zEnvironmentSignals>;
+type MatrixSignalCellWire = MatrixEnvironmentSignalsWire['cells'][number];
+export type MatrixSignalCell = Omit<
+  MatrixSignalCellWire,
+  'pending_version_id' | 'pending_operation'
+> & {
+  readonly pending?: {
+    readonly versionId: string;
+    readonly operation: NonNullable<MatrixSignalCellWire['pending_operation']>;
+  };
+};
+export type MatrixEnvironmentSignals = Omit<MatrixEnvironmentSignalsWire, 'cells'> & {
+  readonly cells: readonly MatrixSignalCell[];
+};
 
 type MatrixEnvironment = z.infer<typeof zEnvironmentList>['items'][number];
 type MatrixEnvironmentSettings = z.infer<typeof zEnvironmentSettings>;
 type MatrixValueList = z.infer<typeof zValueList>;
 type MatrixPendingDraftList = z.infer<typeof zPendingDraftList>;
 
-export type MatrixQueryState<T> = {
+export type MatrixQueryStatus = 'pending' | 'error' | 'stale' | 'ready';
+
+export type MatrixQueryState<T> =
+  | { readonly status: 'pending'; readonly data?: undefined }
+  | { readonly status: 'error'; readonly data?: undefined }
+  | { readonly status: 'stale'; readonly data: T }
+  | { readonly status: 'ready'; readonly data: T };
+
+type MatrixQueryResult<T> = {
   readonly data: T | undefined;
   readonly isPending: boolean;
   readonly isError: boolean;
@@ -90,6 +110,7 @@ type EnvironmentQueryData<T> = {
 export type MatrixEnvironmentRow = {
   readonly environmentId: string;
   readonly environment: MatrixEnvironment;
+  readonly readiness: MatrixQueryStatus;
   readonly values: MatrixQueryState<MatrixValueList>;
   readonly signals: MatrixQueryState<MatrixEnvironmentSignals>;
   readonly settings: MatrixQueryState<MatrixEnvironmentSettings>;
@@ -143,20 +164,65 @@ export function assembleMatrixEnvironmentRows(
   const signals = matrixQueryIndex('signals', input.signals);
   const settings = matrixQueryIndex('settings', input.settings);
   const pendingDrafts = matrixQueryIndex('pending drafts', input.pendingDrafts);
-  return environments.map((environment) => ({
-    environmentId: environment.id,
-    environment,
-    values: requiredMatrixQuery('values', environment.id, values),
-    signals: requiredMatrixQuery('signals', environment.id, signals),
-    settings: requiredMatrixQuery('settings', environment.id, settings),
-    pendingDrafts: requiredMatrixQuery('pending drafts', environment.id, pendingDrafts),
-  }));
+  return environments.map((environment) => {
+    const rowValues = requiredMatrixQuery('values', environment.id, values);
+    const rowSignals = requiredMatrixQuery('signals', environment.id, signals);
+    const rowSettings = requiredMatrixQuery('settings', environment.id, settings);
+    const rowPendingDrafts = requiredMatrixQuery(
+      'pending drafts',
+      environment.id,
+      pendingDrafts,
+    );
+    return {
+      environmentId: environment.id,
+      environment,
+      readiness: matrixRowReadiness([
+        rowValues,
+        rowSignals,
+        rowSettings,
+        rowPendingDrafts,
+      ]),
+      values: rowValues,
+      signals: rowSignals,
+      settings: rowSettings,
+      pendingDrafts: rowPendingDrafts,
+    };
+  });
+}
+
+function matrixRowReadiness(
+  states: readonly { readonly status: MatrixQueryStatus }[],
+): MatrixQueryStatus {
+  if (states.some((state) => state.status === 'pending')) {
+    return 'pending';
+  }
+  if (states.some((state) => state.status === 'error')) {
+    return 'error';
+  }
+  if (states.some((state) => state.status === 'stale')) {
+    return 'stale';
+  }
+  return 'ready';
+}
+
+function matrixQueryState<T>(query: MatrixQueryResult<T>): MatrixQueryState<T> {
+  if (query.isPending) {
+    return { status: 'pending' };
+  }
+  if (query.isError) {
+    return query.data === undefined
+      ? { status: 'error' }
+      : { status: 'stale', data: query.data };
+  }
+  return query.data === undefined
+    ? { status: 'error' }
+    : { status: 'ready', data: query.data };
 }
 
 export function bindMatrixEnvironmentQueries<T>(
   label: string,
   environments: readonly MatrixEnvironment[],
-  queries: readonly MatrixQueryState<EnvironmentQueryData<T>>[],
+  queries: readonly MatrixQueryResult<EnvironmentQueryData<T>>[],
 ): readonly MatrixEnvironmentQuery<T>[] {
   if (environments.length !== queries.length) {
     throw new Error(
@@ -175,11 +241,11 @@ export function bindMatrixEnvironmentQueries<T>(
     }
     return {
       environmentId: environment.id,
-      query: {
+      query: matrixQueryState({
         data: query.data?.value,
         isPending: query.isPending,
         isError: query.isError,
-      },
+      }),
     };
   });
 }
@@ -255,17 +321,27 @@ export function restorePreviewWasAttached(error: Error): boolean {
   return previewAttachedErrors.has(error);
 }
 
-const zMatrixEnvironmentSignals = zEnvironmentSignals.superRefine((signals, context) => {
-  signals.cells.forEach((cell, index) => {
-    if ((cell.pending_version_id === undefined) !== (cell.pending_operation === undefined)) {
-      context.addIssue({
-        code: 'custom',
-        message: 'pending_version_id and pending_operation must be present together',
-        path: ['cells', index],
-      });
-    }
-  });
-});
+const zMatrixEnvironmentSignals = zEnvironmentSignals
+  .superRefine((signals, context) => {
+    signals.cells.forEach((cell, index) => {
+      if ((cell.pending_version_id === undefined) !== (cell.pending_operation === undefined)) {
+        context.addIssue({
+          code: 'custom',
+          message: 'pending_version_id and pending_operation must be present together',
+          path: ['cells', index],
+        });
+      }
+    });
+  })
+  .transform((signals) => ({
+    ...signals,
+    cells: signals.cells.map(({ pending_version_id, pending_operation, ...cell }) => ({
+      ...cell,
+      ...(pending_version_id === undefined || pending_operation === undefined
+        ? {}
+        : { pending: { versionId: pending_version_id, operation: pending_operation } }),
+    })),
+  }));
 
 export function parseMatrixEnvironmentSignals(input: unknown): MatrixEnvironmentSignals {
   return zMatrixEnvironmentSignals.parse(input);
@@ -331,10 +407,10 @@ export function pendingConfigPreview(
   signal: MatrixSignalCell | undefined,
   draftsByVersion: ReadonlyMap<string, MatrixPendingDraft>,
 ): string | undefined {
-  if (signal?.pending_version_id === undefined) {
+  if (signal?.pending === undefined) {
     return undefined;
   }
-  const draft = draftsByVersion.get(signal.pending_version_id);
+  const draft = draftsByVersion.get(signal.pending.versionId);
   if (draft === undefined) {
     return undefined;
   }

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -185,7 +185,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
             keyId: key.id,
             environmentId: environment.id,
             set: valuesByCell.get(cellID(key.id, environment.id))?.set === true,
-            pendingOperation: signalsByCell.get(cellID(key.id, environment.id))?.pending_operation,
+            pendingOperation: signalsByCell.get(cellID(key.id, environment.id))?.pending?.operation,
           })),
         ),
         validationErrors,
@@ -244,18 +244,13 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
     for (const row of environmentRows) {
       const rows: MatrixPendingEntry[] = [];
       for (const signal of row.signals.data?.cells ?? []) {
-        if (signal.pending_version_id !== undefined) {
-          if (signal.pending_operation === undefined) {
-            throw new Error(
-              `matrix signal ${signal.pending_version_id} has no pending_operation`,
-            );
-          }
+        if (signal.pending !== undefined) {
           rows.push({
-            versionId: signal.pending_version_id,
+            versionId: signal.pending.versionId,
             keyId: signal.key_id,
             name: signal.name,
             classification: signal.classification,
-            operation: signal.pending_operation,
+            operation: signal.pending.operation,
             configPreview: pendingConfigPreview(signal, draftsByVersion),
           });
         }
@@ -331,34 +326,17 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
     matrix.environments.isPending ||
     matrix.keys.isPending ||
     matrix.groups.isPending ||
-    environmentRows.some(
-      (row) =>
-        row.values.isPending ||
-        row.signals.isPending ||
-        row.settings.isPending ||
-        row.pendingDrafts.isPending,
-    );
+    environmentRows.some((row) => row.readiness === 'pending');
   const loadError =
     (matrix.environments.isError && matrix.environments.data === undefined) ||
     (matrix.keys.isError && matrix.keys.data === undefined) ||
     (matrix.groups.isError && matrix.groups.data === undefined) ||
-    environmentRows.some(
-      (row) =>
-        (row.values.isError && row.values.data === undefined) ||
-        (row.signals.isError && row.signals.data === undefined) ||
-        (row.settings.isError && row.settings.data === undefined) ||
-        (row.pendingDrafts.isError && row.pendingDrafts.data === undefined),
-    );
+    environmentRows.some((row) => row.readiness === 'error');
   const backgroundRefreshError =
     (matrix.environments.isError && matrix.environments.data !== undefined) ||
     (matrix.keys.isError && matrix.keys.data !== undefined) ||
     (matrix.groups.isError && matrix.groups.data !== undefined) ||
-    environmentRows.some(
-      (row) =>
-        (row.values.isError && row.values.data !== undefined) ||
-        (row.signals.isError && row.signals.data !== undefined) ||
-        (row.settings.isError && row.settings.data !== undefined),
-    );
+    environmentRows.some((row) => row.readiness === 'stale');
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualPaddingTop = virtualRows[0]?.start ?? 0;
   const virtualPaddingBottom =
@@ -954,9 +932,9 @@ function MatrixCell({
     state = cell.value ?? 'set';
     stateClass = 'matrix-cell--set';
   }
-  const pending = signal?.pending_operation === undefined
+  const pending = signal?.pending === undefined
     ? null
-    : `Δ draft ${signal.pending_operation === 'unset' ? 'clear' : 'set'}`;
+    : `Δ draft ${signal.pending.operation === 'unset' ? 'clear' : 'set'}`;
   const changed = signal?.changed_in_revision === undefined
     ? null
     : `Δ changed in r${String(signal.changed_in_revision)}`;

--- a/web/src/routes/MatrixRowEditor.tsx
+++ b/web/src/routes/MatrixRowEditor.tsx
@@ -71,7 +71,7 @@ export function MatrixRowEditor({
           draftValueForMatrixCell(
             keyRecord.classification,
             row.cell?.set === true ? row.cell.value : undefined,
-            row.signal?.pending_operation,
+            row.signal?.pending?.operation,
             row.draftPreview,
           ),
         ]),
@@ -229,8 +229,8 @@ export function MatrixRowEditor({
                     <h3 id={`matrix-row-${rowEnvironmentId}`}>{row.environment.name}</h3>
                     {row.protected ? <span>PROTECTED</span> : null}
                     <span>{publishedSet ? 'explicit set' : 'explicit absent'}</span>
-                    {row.signal?.pending_operation === undefined ? null : (
-                      <span>{`Δ ${row.signal.pending_operation} pending`}</span>
+                    {row.signal?.pending === undefined ? null : (
+                      <span>{`Δ ${row.signal.pending.operation} pending`}</span>
                     )}
                   </div>
                   {row.problems.map((problem) => (
@@ -295,7 +295,7 @@ export function MatrixRowEditor({
                   <button
                     type="button"
                     className="btn"
-                    disabled={busy || applying || (!clearing && !canClearMatrixCell(publishedSet, row.signal?.pending_operation))}
+                    disabled={busy || applying || (!clearing && !canClearMatrixCell(publishedSet, row.signal?.pending?.operation))}
                     onClick={() => {
                       setEdits((current) => {
                         if (clearing) {


### PR DESCRIPTION
Closes #362

## Contract

- Maps each per-environment query once to pending, error, stale-with-data, or ready-with-data.
- Derives one row readiness across values, signals, settings, and pending drafts.
- Includes stale pending-draft refreshes in the background warning.
- Represents signal pending identity and operation as one optional value while preserving fail-closed wire parsing.

## Generated outputs

None.

## Validation

- pnpm --dir web run typecheck
- pnpm --dir web exec vitest run src/api/matrix.test.ts src/api/matrix-hook.test.tsx (22 passed)
- pnpm --dir web run test (312 passed)