### PR TITLE
Centralize schema-revision budget ownership #361

### DIFF
--- a/docs/handoff/361-schema-revision-budget.md
+++ b/docs/handoff/361-schema-revision-budget.md
@@ -1,0 +1,38 @@
+# Issue #361 — single-owner schema-revision budget
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/361 (parent #326; audit
+finding `F-S06-2`). Draft source: https://github.com/Hikyo-Org/Hikyo/pull/385.
+
+**State: implemented.** Every production `BumpSchemaRevision` call now passes
+through the service budget helper that charges the § 151 project rate first.
+
+## Contract
+
+- `bumpSchemaRevision` owns the inseparable charge-then-bump sequence.
+- The helper runs inside each caller's write transaction after its no-op return.
+- `chargeOnce` remains idempotent across transaction retries.
+- A rate refusal returns before the revision bump and rolls back the transaction.
+- An AST guard refuses production calls outside the helper.
+
+Contract or migration decisions: none. Generated outputs: none.
+
+## Coverage
+
+- `TestBumpSchemaRevisionOnlyThroughBudget` pins the single production call site.
+- Existing schema-revision rate-limit and no-op scenarios preserve behavior.
+- Existing bound-registry coverage preserves budget classification totality.
+
+## Validation
+
+- Draft PR #385 passed build, test, race, fuzz, web, generated, analysis, and
+  CodeQL jobs at `c468f9e2`; only DCO failed because its bot commit lacked a
+  sign-off.
+- Focused guard, schema-rate, no-op, totality, bound-pin, service, and
+  conformance checks passed (330 tests across the two changed packages).
+- `go test -count=1 ./...` passed 3,592 tests in 61 packages.
+- `go build ./...`, `go vet ./internal/service`, and `git diff --check` passed.
+- Local PostgreSQL conformance was not run because `HIKYO_TEST_POSTGRES_DSN`
+  was unset; trusted CI owns the mandatory SQLite + PostgreSQL leg.
+- Three-round review finished Standards `CLEAN` and Spec `SOUND` after the AST
+  guard was hardened to distinguish receiver-less functions, methods, and
+  package declarations.

--- a/internal/service/budget.go
+++ b/internal/service/budget.go
@@ -427,6 +427,24 @@ func (b *Budget) chargeOnce(charged *bool, cat budgetCategory, keys budgetKeys) 
 	return nil
 }
 
+// bumpSchemaRevision charges the § 151 schema-revision rate and then advances the
+// project's revision, as one inseparable step. Every schema-mutating service
+// method calls it from INSIDE its tx.Write closure, past its own no-op early
+// return, so an unchanged request still consumes no budget. The charge runs
+// first: a rate refusal wraps admission.ErrOverloaded, rolls the transaction
+// back, and never reaches the bump — so a bump can never bypass the 60/h
+// per-project bound. charged, owned by the caller outside the closure, keeps the
+// charge idempotent across the retry loop (see chargeOnce). Direct
+// r.Catalogue().BumpSchemaRevision calls are banned outside this helper by
+// TestBumpSchemaRevisionOnlyThroughBudget, so a future call site cannot forget
+// the paired charge.
+func bumpSchemaRevision(ctx context.Context, r store.Repos, p authz.Proof, b *Budget, charged *bool, project domain.ProjectID) error {
+	if err := b.chargeOnce(charged, budgetSchemaRevision, budgetKeys{Project: project}); err != nil {
+		return err
+	}
+	return r.Catalogue().BumpSchemaRevision(ctx, p)
+}
+
 // evictStaleRate drops rate buckets whose windows have entirely elapsed, using
 // each bucket's OWN window rather than the widest one in play. A 1-minute
 // machine-fetch bucket is reclaimed a minute after its last hit, so a burst of

--- a/internal/service/budget_seam_test.go
+++ b/internal/service/budget_seam_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestBumpSchemaRevisionOnlyThroughBudget pins the § 151 invariant structurally:
+// r.Catalogue().BumpSchemaRevision is called in exactly ONE place in this
+// package's production code — the body of bumpSchemaRevision, the single helper
+// that charges the 60/h per-project schema-revision rate before it advances the
+// revision. A future schema-mutating method that bumps the revision directly
+// skips the paired charge and quietly bypasses the bound. The budget totality
+// test only catches an unclassified operation, not an unpaired bump, so no
+// behavioral test can catch this class; this one can, before it ships.
+func TestBumpSchemaRevisionOnlyThroughBudget(t *testing.T) {
+	fset := token.NewFileSet()
+	pkg, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sites []string
+	var owners []string
+	for _, p := range pkg {
+		for name, file := range p.Files {
+			for _, decl := range file.Decls {
+				owner := "<package>"
+				if fn, ok := decl.(*ast.FuncDecl); ok {
+					if fn.Recv == nil {
+						owner = fn.Name.Name
+					} else {
+						owner = "method " + fn.Name.Name
+					}
+				}
+				ast.Inspect(decl, func(n ast.Node) bool {
+					sel, ok := n.(*ast.SelectorExpr)
+					if !ok || sel.Sel.Name != "BumpSchemaRevision" {
+						return true
+					}
+					sites = append(sites, owner+" ("+name+":"+
+						fset.Position(sel.Pos()).String()+")")
+					owners = append(owners, owner)
+					return true
+				})
+			}
+		}
+	}
+	if len(sites) != 1 || owners[0] != "bumpSchemaRevision" {
+		t.Fatalf("BumpSchemaRevision called in %d site(s), want exactly 1 in bumpSchemaRevision: %v", len(sites), sites)
+	}
+}

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -126,10 +126,7 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 		// § 151 schema-revision rate: charged only for a non-empty plan (the
 		// empty-plan no-op returned above), once across the retry loop — see
 		// Keys.UpdateMetadata.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		newRevision, err := r.Catalogue().SchemaRevision(ctx, p)

--- a/internal/service/hierarchy.go
+++ b/internal/service/hierarchy.go
@@ -839,15 +839,12 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 		// schema revision, so it charges the same per-project budget (see
 		// Keys.UpdateMetadata) — a delete/recreate loop must not mint revisions
 		// past the bound.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
 		// The environment list is definitions-bundle desired state, so its change
 		// advances the definitions revision (#70). Bumped BEFORE the new
 		// environment's initial materialization so that snapshot pins the fresh
 		// revision. Existing environments are not re-materialized: adding an
 		// environment changes no key, declaration or presence rule they deliver.
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventEnvCreated, caller.Principal,
@@ -971,13 +968,10 @@ func (s *Environments) Rename(ctx context.Context, actor Actor, scope domain.Sco
 		}
 		// § 151 schema-revision rate: a rename advances the project's schema
 		// revision (see Environments.create).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
 		// The environment name is definitions-bundle desired state, so a rename
 		// advances the definitions revision (#70). It materializes nothing — a
 		// rename moves a label nothing is delivered under.
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		out = before
@@ -1152,13 +1146,10 @@ func (s *Environments) Delete(ctx context.Context, actor Actor, scope domain.Sco
 		// § 151 schema-revision rate: a delete advances the project's schema
 		// revision (see Environments.create) — the other half of the
 		// delete/recreate loop that would otherwise mint revisions unbounded.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
 		// The environment list is definitions-bundle desired state, so its
 		// deletion advances the definitions revision unconditionally (#70) — even
 		// when the environment carried no presence rows for the cascade to rewrite.
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventEnvDeleted, caller.Principal,

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -617,10 +617,7 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 		}
 		// § 151 schema-revision rate (60/h per project), charged immediately
 		// before the bump so only a real revision counts — see Keys.UpdateMetadata.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventKeyCreated, caller.Principal,
@@ -786,10 +783,7 @@ func (s *Keys) Rename(ctx context.Context, actor Actor, scope domain.Scope, id, 
 			return err
 		}
 		// § 151 schema-revision rate (see Keys.UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		after := before
@@ -886,10 +880,7 @@ func (s *Keys) UpdateMetadata(ctx context.Context, actor Actor, scope domain.Sco
 		// alternates metadata to mint revisions past the bound. Charged only on
 		// the mutating path (the no-op above returned already) and once across
 		// the retry loop, keyed by project.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		after := before
@@ -1086,10 +1077,7 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 		}
 		// § 151 schema-revision rate (see Keys.UpdateMetadata). Placed past this
 		// method's no-op early return, so an unchanged declaration charges nothing.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		after := before
@@ -1227,10 +1215,7 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 		// by it, where — so it is a semantic schema change and advances the
 		// revision like any other.
 		// § 151 schema-revision rate (see Keys.UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		after := before
@@ -1399,10 +1384,7 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 		}
 		// § 151 schema-revision rate (see Keys.UpdateMetadata). Past this method's
 		// no-op early return, so a no-change SetGroup charges nothing.
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		after := before
@@ -1497,10 +1479,7 @@ func (s *Keys) Delete(ctx context.Context, actor Actor, scope domain.Scope, id s
 			return err
 		}
 		// § 151 schema-revision rate (see Keys.UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventKeyDeleted, caller.Principal,
@@ -1572,10 +1551,7 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 		}
 		// § 151 schema-revision rate: a group create bumps the revision, so it
 		// charges the per-project budget too (see UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventKeyGroupCreated, caller.Principal,
@@ -1705,10 +1681,7 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 		}
 		// § 151 schema-revision rate: a group rename bumps the revision (see
 		// UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		keys, err := r.Catalogue().List(ctx, p)
@@ -1779,10 +1752,7 @@ func (s *KeyGroups) Delete(ctx context.Context, actor Actor, scope domain.Scope,
 			return err
 		}
 		// § 151 schema-revision rate (see Keys.UpdateMetadata).
-		if err := s.Budget.chargeOnce(&rateCharged, budgetSchemaRevision, budgetKeys{Project: scope.Project}); err != nil {
-			return err
-		}
-		if err := r.Catalogue().BumpSchemaRevision(ctx, p); err != nil {
+		if err := bumpSchemaRevision(ctx, r, p, s.Budget, &rateCharged, scope.Project); err != nil {
 			return err
 		}
 		ev, err := domainEvent(ctx, audit.EventKeyGroupDeleted, caller.Principal,


### PR DESCRIPTION
## Outcome

- Own the §151 schema-revision charge and revision bump in one helper.
- Migrate all 14 service call sites without moving no-op or ordering boundaries.
- Add an AST guard that refuses direct production calls, including same-named methods and package initializers.
- Record the implementation contract and verification in the issue handoff.

## Validation

- go test -count=1 ./internal/service ./internal/conformance (330 tests)
- go test -count=1 ./... (3,592 tests across 61 packages)
- go build ./...
- go vet ./internal/service
- git diff --check
- Review round 3: Standards CLEAN; Spec SOUND

Generated outputs: none. Database migrations: none. Local PostgreSQL conformance was skipped because HIKYO_TEST_POSTGRES_DSN is unset; trusted CI runs the mandatory PostgreSQL leg.

Supersedes draft PR #385.

Closes #361