### PR TITLE
Make adapter completion outcome and ledger release explicit #374

### DIFF
--- a/docs/handoff/issue-374-explicit-adapter-completion.md
+++ b/docs/handoff/issue-374-explicit-adapter-completion.md
@@ -1,0 +1,33 @@
+# Handoff: #374 explicit adapter completion
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/374. Base:
+`84359a75e2cd457141a2967c16c982a19b1422a7`.
+
+## Contract
+
+- `adapter.Outcome` closes completion outcomes over the existing byte values
+  `success`, `failure`, and `unknown`. `unknown` is retained because both
+  providers already emit it for indeterminate writes and the audit registry
+  permits it.
+- `Completion.ReleaseLedger` is the only command that deletes a ledger row.
+  Empty `State` no longer carries deletion semantics.
+- Every completion must provide a valid outcome and exactly one ledger
+  disposition: a non-empty `State` or `ReleaseLedger: true`.
+- `State: Released` remains a retained history row. `Conflict`, `Missing`,
+  provider status, finding payloads, and success-only key-delivery audit
+  behavior remain independent and byte-identical.
+- Forgejo and GitHub Actions producers use the closed outcome constants and
+  mark each formerly empty-state release explicitly.
+
+## Coverage
+
+- Adapter validation regressions cover all valid outcomes, typo refusal,
+  zero-value refusal, and state/release exclusivity.
+- Store regressions prove `Completion{}` cannot change a ledger or audit row,
+  explicit release deletes the intended row, and `State: Released` retains it.
+- Provider fakes now model deletion from `ReleaseLedger`, so module coverage
+  fails if a producer falls back to an empty-state sentinel.
+- Local Go validation was deferred before the first push because host memory
+  pressure was high. Hosted CI and final local validation results will be
+  recorded before merge.
+- Generated outputs: none.

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -173,9 +173,18 @@ type Effect struct {
 	KeyID         string
 }
 
+type Outcome string
+
+const (
+	OutcomeSuccess Outcome = "success"
+	OutcomeFailure Outcome = "failure"
+	OutcomeUnknown Outcome = "unknown"
+)
+
 type Completion struct {
-	Outcome        string
-	State          LedgerState // empty releases the claim
+	Outcome        Outcome
+	State          LedgerState
+	ReleaseLedger  bool
 	Conflict       bool
 	Missing        bool
 	ProviderStatus int
@@ -191,7 +200,7 @@ type Journal interface {
 	Reserve(ctx context.Context, effect Effect) (LedgerState, error)
 	Prepare(ctx context.Context, effect Effect, prior LedgerState) error
 	// Finish atomically writes the terminal OUTCOME, applies the final ledger
-	// state (empty means release), records any conflict artifact, and releases
+	// state or explicitly releases the ledger row, records any conflict artifact, and releases
 	// the provider-write lease held since Prepare.
 	Finish(ctx context.Context, effect Effect, completion Completion) error
 	// Refuse atomically records a pre-dispatch conflict artifact and releases a

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -101,10 +101,37 @@ func TestLedgerMissingRequiresProviderCustody(t *testing.T) {
 			if _, err := IndexLedger([]LedgerEntry{{Surface: Variable, EffectiveName: "MODE", State: state, Missing: true}}); err == nil {
 				t.Fatalf("IndexLedger() accepted %s+missing", state)
 			}
-			if err := ValidateCompletion(Completion{State: state, Missing: true}); err == nil {
+			if err := ValidateCompletion(Completion{Outcome: OutcomeFailure, State: state, Missing: true}); err == nil {
 				t.Fatalf("ValidateCompletion() accepted %s+missing", state)
 			}
 		})
+	}
+}
+
+func TestCompletionRequiresClosedOutcomeAndExplicitLedgerDisposition(t *testing.T) {
+	valid := []Completion{
+		{Outcome: OutcomeSuccess, State: Owned},
+		{Outcome: OutcomeFailure, State: Dispatched},
+		{Outcome: OutcomeUnknown, State: Dispatched},
+		{Outcome: OutcomeFailure, ReleaseLedger: true},
+	}
+	for _, completion := range valid {
+		if err := ValidateCompletion(completion); err != nil {
+			t.Fatalf("ValidateCompletion(%+v) = %v", completion, err)
+		}
+	}
+
+	invalid := []Completion{
+		{},
+		{Outcome: Outcome("sucess"), State: Owned},
+		{Outcome: OutcomeSuccess},
+		{Outcome: OutcomeSuccess, State: Owned, ReleaseLedger: true},
+		{Outcome: OutcomeFailure, ReleaseLedger: true, Missing: true},
+	}
+	for _, completion := range invalid {
+		if err := ValidateCompletion(completion); err == nil {
+			t.Fatalf("ValidateCompletion(%+v) accepted invalid completion", completion)
+		}
 	}
 }
 

--- a/internal/adapter/forgejo/module.go
+++ b/internal/adapter/forgejo/module.go
@@ -159,7 +159,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			return result, err
 		}
 		if gateErr := journal.Gate(ctx, effect); gateErr != nil {
-			completion := adapter.Completion{Outcome: "failure", State: state}
+			completion := adapter.Completion{Outcome: adapter.OutcomeFailure, State: state}
 			if record.Missing {
 				completion.Missing = true
 				completion.Finding = "owned_missing"
@@ -173,9 +173,10 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 		absenceProven := row.Surface == adapter.Variable && !record.Missing && (state == adapter.Owned || state == adapter.Dispatched) && IsNotFound(err)
 		if err != nil {
 			if row.Surface == adapter.Variable && (state == adapter.Reserved || !claimed || record.Missing) && IsConflict(err) {
-				completion := adapter.Completion{Outcome: "failure", Conflict: true}
+				completion := adapter.Completion{Outcome: adapter.OutcomeFailure, ReleaseLedger: true, Conflict: true}
 				if record.Missing {
 					completion.State = state
+					completion.ReleaseLedger = false
 					completion.Missing = true
 					completion.Finding = "owned_missing"
 				}
@@ -186,13 +187,13 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 				result.Conflicts = append(result.Conflicts, conflict)
 				return result, fmt.Errorf("%w: variable %s", adapter.ErrConflict, row.EffectiveName)
 			}
-			outcome := "unknown"
+			outcome := adapter.OutcomeUnknown
 			var response *ResponseError
 			if errors.As(err, &response) && response.Status >= 400 && response.Status < 500 {
-				outcome = "failure"
+				outcome = adapter.OutcomeFailure
 			}
 			finalState := adapter.Dispatched
-			if outcome == "failure" {
+			if outcome == adapter.OutcomeFailure {
 				if state == adapter.Reserved || absenceProven {
 					finalState = ""
 				} else {
@@ -200,6 +201,9 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 				}
 			}
 			completion := adapter.Completion{Outcome: outcome, State: finalState}
+			if finalState == "" {
+				completion.ReleaseLedger = true
+			}
 			if record.Missing {
 				completion.Missing = true
 				completion.Finding = "owned_missing"
@@ -208,12 +212,12 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 				return result, completeErr
 			}
 			result.Failed = append(result.Failed, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: effect.Disposition})
-			if outcome == "unknown" {
+			if outcome == adapter.OutcomeUnknown {
 				return result, fmt.Errorf("%w: %s %s", adapter.ErrIndeterminate, row.Surface, row.EffectiveName)
 			}
 			return result, err
 		}
-		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
+		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned}); err != nil {
 			return result, err
 		}
 		ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned}
@@ -246,17 +250,17 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			return result, err
 		}
 		if gateErr := journal.Gate(ctx, effect); gateErr != nil {
-			if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: row.State}); finishErr != nil {
+			if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: row.State}); finishErr != nil {
 				return result, finishErr
 			}
 			return result, gateErr
 		}
 		err := m.delete(ctx, req.Target.Destination, row.Surface, row.EffectiveName)
 		if err != nil && !IsNotFound(err) {
-			outcome := "unknown"
+			outcome := adapter.OutcomeUnknown
 			var response *ResponseError
 			if errors.As(err, &response) && response.Status >= 400 && response.Status < 500 {
-				outcome = "failure"
+				outcome = adapter.OutcomeFailure
 			}
 			if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: outcome, State: row.State}); finishErr != nil {
 				return result, finishErr
@@ -264,7 +268,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			result.Failed = append(result.Failed, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete})
 			return result, err
 		}
-		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Released}); err != nil {
+		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Released}); err != nil {
 			return result, err
 		}
 		result.Changes = append(result.Changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete})

--- a/internal/adapter/forgejo/module_test.go
+++ b/internal/adapter/forgejo/module_test.go
@@ -224,7 +224,7 @@ func TestOwnedVariableDeletedAtProviderRetriesCreateUnderFreshEffect(t *testing.
 		t.Fatalf("absence-proven variable remained claimed as %q", journal.states["variable:LOG_LEVEL"])
 	}
 	completion := journal.completions["variable:LOG_LEVEL"]
-	if journal.prepares["variable:LOG_LEVEL"] != 1 || len(completion) != 1 || completion[0].Outcome != "failure" || completion[0].State != "" {
+	if journal.prepares["variable:LOG_LEVEL"] != 1 || len(completion) != 1 || completion[0].Outcome != adapter.OutcomeFailure || !completion[0].ReleaseLedger {
 		t.Fatalf("first effect prepare=%d completion=%+v", journal.prepares["variable:LOG_LEVEL"], completion)
 	}
 
@@ -237,7 +237,7 @@ func TestOwnedVariableDeletedAtProviderRetriesCreateUnderFreshEffect(t *testing.
 		t.Fatalf("replay writes=%v, want fresh create attempt %v", api.writes, want)
 	}
 	completion = journal.completions["variable:LOG_LEVEL"]
-	if journal.prepares["variable:LOG_LEVEL"] != 2 || len(completion) != 2 || completion[1].Outcome != "success" || completion[1].State != adapter.Owned {
+	if journal.prepares["variable:LOG_LEVEL"] != 2 || len(completion) != 2 || completion[1].Outcome != adapter.OutcomeSuccess || completion[1].State != adapter.Owned {
 		t.Fatalf("replay effects prepare=%d completion=%+v", journal.prepares["variable:LOG_LEVEL"], completion)
 	}
 }
@@ -265,7 +265,7 @@ func TestPostPrepareGateFailureFinishesWithoutProviderRequest(t *testing.T) {
 				t.Fatalf("provider writes after failed post-Prepare gate = %v", api.writes)
 			}
 			completion := journal.completions["secret:MANAGED_BY_HIKYO"]
-			if len(completion) != 1 || completion[0].Outcome != "failure" || completion[0].State != tt.state || journal.states["secret:MANAGED_BY_HIKYO"] != tt.state {
+			if len(completion) != 1 || completion[0].Outcome != adapter.OutcomeFailure || completion[0].State != tt.state || journal.states["secret:MANAGED_BY_HIKYO"] != tt.state {
 				t.Fatalf("completion=%+v state=%q, want preserved %q", completion, journal.states["secret:MANAGED_BY_HIKYO"], tt.state)
 			}
 		})
@@ -286,7 +286,7 @@ func TestPrunePostPrepareGateFailureFinishesAndReleasesFence(t *testing.T) {
 		t.Fatalf("provider deletes after failed post-Prepare gate = %v", api.writes)
 	}
 	completion := journal.completions["variable:OLD"]
-	if len(completion) != 1 || completion[0].Outcome != "failure" || completion[0].State != adapter.Owned {
+	if len(completion) != 1 || completion[0].Outcome != adapter.OutcomeFailure || completion[0].State != adapter.Owned {
 		t.Fatalf("completion = %+v", completion)
 	}
 }
@@ -589,7 +589,7 @@ func (j *fakeJournal) Finish(_ context.Context, e adapter.Effect, completion ada
 		return j.finishErr
 	}
 	j.completions[effectKey(e)] = append(j.completions[effectKey(e)], completion)
-	if completion.State == "" {
+	if completion.ReleaseLedger {
 		delete(j.states, effectKey(e))
 		delete(j.missing, effectKey(e))
 	} else {

--- a/internal/adapter/githubactions/module.go
+++ b/internal/adapter/githubactions/module.go
@@ -266,7 +266,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			write, err = m.writeSecret(ctx, journal, effect, req.Target.Destination, row, publicKey)
 			if err != nil && definiteNonRate4xx(err) {
 				firstState := stateAfterFailure(state, err)
-				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: firstState}); finishErr != nil {
+				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: firstState}); finishErr != nil {
 					return result, finishErr
 				}
 				if gateErr := journal.Gate(ctx, inspect); gateErr != nil {
@@ -287,7 +287,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			providerStatus = write.Status
 			primaryLanded = err == nil
 			if err == nil && freshReservation && write.Status == http.StatusNoContent {
-				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", Conflict: true, ProviderStatus: write.Status, Finding: "possible_capture"}); finishErr != nil {
+				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, ReleaseLedger: true, Conflict: true, ProviderStatus: write.Status, Finding: "possible_capture"}); finishErr != nil {
 					return result, finishErr
 				}
 				return addConflict(result, row), fmt.Errorf("%w: possible_capture secret %s", adapter.ErrConflict, row.EffectiveName)
@@ -297,7 +297,7 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 			write, err = m.writeVariable(ctx, journal, effect, req.Target.Destination, row, state, ownedMissing)
 			providerStatus = write.Status
 			if IsStatus(err, http.StatusNotFound) && (state == adapter.Owned || state == adapter.Dispatched) && !ownedMissing {
-				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: adapter.Owned, Missing: true, ProviderStatus: http.StatusNotFound, Finding: "owned_missing"}); finishErr != nil {
+				if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: adapter.Owned, Missing: true, ProviderStatus: http.StatusNotFound, Finding: "owned_missing"}); finishErr != nil {
 					return result, finishErr
 				}
 				ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned, Missing: true}
@@ -310,9 +310,10 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 				providerStatus = write.Status
 			}
 			if IsStatus(err, http.StatusConflict) {
-				completion := adapter.Completion{Outcome: "failure", Conflict: true, ProviderStatus: http.StatusConflict}
+				completion := adapter.Completion{Outcome: adapter.OutcomeFailure, ReleaseLedger: true, Conflict: true, ProviderStatus: http.StatusConflict}
 				if ownedMissing {
 					completion.State = adapter.Owned
+					completion.ReleaseLedger = false
 					completion.Missing = true
 					completion.Finding = "owned_missing"
 				}
@@ -333,24 +334,28 @@ func (m *Module) Sync(ctx context.Context, req adapter.SyncRequest, journal adap
 		if err != nil {
 			outcome, finalState := failureCompletion(state, err)
 			completion := adapter.Completion{Outcome: outcome, State: finalState, ProviderStatus: providerStatus}
+			if finalState == "" {
+				completion.ReleaseLedger = true
+			}
 			if ownedMissing {
 				completion.Missing = true
 				completion.Finding = "owned_missing"
 			}
 			if primaryLanded {
-				completion.Outcome = "unknown"
+				completion.Outcome = adapter.OutcomeUnknown
 				completion.State = adapter.Dispatched
+				completion.ReleaseLedger = false
 			}
 			if finishErr := journal.Finish(ctx, effect, completion); finishErr != nil {
 				return result, finishErr
 			}
 			result.Failed = append(result.Failed, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: effect.Disposition})
-			if outcome == "unknown" {
+			if outcome == adapter.OutcomeUnknown {
 				return result, fmt.Errorf("%w: %s %s", adapter.ErrIndeterminate, row.Surface, row.EffectiveName)
 			}
 			return result, err
 		}
-		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Owned, ProviderStatus: providerStatus}); err != nil {
+		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned, ProviderStatus: providerStatus}); err != nil {
 			return result, err
 		}
 		ledger[key] = adapter.LedgerEntry{Surface: row.Surface, EffectiveName: row.EffectiveName, State: adapter.Owned}
@@ -373,7 +378,7 @@ func (m *Module) prepare(ctx context.Context, journal adapter.Journal, effect ad
 		return err
 	}
 	if err := journal.Gate(ctx, effect); err != nil {
-		if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: state}); finishErr != nil {
+		if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: state}); finishErr != nil {
 			return finishErr
 		}
 		return err
@@ -437,12 +442,16 @@ func (m *Module) prune(ctx context.Context, req adapter.SyncRequest, journal ada
 		}
 		if err != nil && !IsStatus(err, http.StatusNotFound) {
 			outcome, state := failureCompletion(row.State, err)
-			if finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: outcome, State: state}); finishErr != nil {
+			completion := adapter.Completion{Outcome: outcome, State: state}
+			if state == "" {
+				completion.ReleaseLedger = true
+			}
+			if finishErr := journal.Finish(ctx, effect, completion); finishErr != nil {
 				return result, finishErr
 			}
 			return result, err
 		}
-		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Released}); err != nil {
+		if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Released}); err != nil {
 			return result, err
 		}
 		result.Changes = append(result.Changes, adapter.Change{Surface: row.Surface, EffectiveName: row.EffectiveName, Disposition: adapter.Delete})
@@ -484,14 +493,14 @@ func stateAfterFailure(prior adapter.LedgerState, err error) adapter.LedgerState
 	return adapter.Dispatched
 }
 
-func failureCompletion(prior adapter.LedgerState, err error) (string, adapter.LedgerState) {
+func failureCompletion(prior adapter.LedgerState, err error) (adapter.Outcome, adapter.LedgerState) {
 	if definiteNonRate4xx(err) || errors.Is(err, adapter.ErrRateLimited) {
 		if prior == adapter.Reserved {
-			return "failure", ""
+			return adapter.OutcomeFailure, ""
 		}
-		return "failure", prior
+		return adapter.OutcomeFailure, prior
 	}
-	return "unknown", adapter.Dispatched
+	return adapter.OutcomeUnknown, adapter.Dispatched
 }
 
 func capacityWarnings(destination adapter.Destination, desiredRows []adapter.DesiredRow, ledger []adapter.LedgerEntry, providerSecrets map[string]bool) []string {

--- a/internal/adapter/githubactions/module_test.go
+++ b/internal/adapter/githubactions/module_test.go
@@ -507,8 +507,13 @@ func (j *fakeJournal) Prepare(_ context.Context, effect adapter.Effect, _ adapte
 	return nil
 }
 func (j *fakeJournal) Finish(_ context.Context, effect adapter.Effect, completion adapter.Completion) error {
-	j.states[effectKey(effect)] = completion.State
-	j.missing[effectKey(effect)] = completion.Missing
+	if completion.ReleaseLedger {
+		delete(j.states, effectKey(effect))
+		delete(j.missing, effectKey(effect))
+	} else {
+		j.states[effectKey(effect)] = completion.State
+		j.missing[effectKey(effect)] = completion.Missing
+	}
 	j.completions[effectKey(effect)] = completion
 	return nil
 }

--- a/internal/adapter/ledger.go
+++ b/internal/adapter/ledger.go
@@ -27,6 +27,18 @@ func IndexLedger(rows []LedgerEntry) (map[LedgerKey]LedgerEntry, error) {
 }
 
 func ValidateCompletion(completion Completion) error {
+	switch completion.Outcome {
+	case OutcomeSuccess, OutcomeFailure, OutcomeUnknown:
+	default:
+		return fmt.Errorf("adapter: invalid completion outcome %q", completion.Outcome)
+	}
+	if completion.ReleaseLedger {
+		if completion.State != "" {
+			return fmt.Errorf("adapter: completion cannot set state %q and release ledger", completion.State)
+		}
+	} else if completion.State == "" {
+		return fmt.Errorf("adapter: completion requires ledger state or explicit release")
+	}
 	return validateMissingState(completion.State, completion.Missing)
 }
 

--- a/internal/isolation/adapter_audit_e2e_test.go
+++ b/internal/isolation/adapter_audit_e2e_test.go
@@ -55,13 +55,13 @@ func (auditAdapterModule) Sync(ctx context.Context, _ adapter.SyncRequest, journ
 		return adapter.SyncResult{}, err
 	}
 	if err := journal.Gate(ctx, effect); err != nil {
-		finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: "failure", State: prior})
+		finishErr := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: prior})
 		if finishErr != nil {
 			return adapter.SyncResult{}, finishErr
 		}
 		return adapter.SyncResult{}, err
 	}
-	if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
+	if err := journal.Finish(ctx, effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned}); err != nil {
 		return adapter.SyncResult{}, err
 	}
 	return adapter.SyncResult{Changes: []adapter.Change{{

--- a/internal/isolation/forgejo_e2e_test.go
+++ b/internal/isolation/forgejo_e2e_test.go
@@ -311,7 +311,7 @@ func (j *forgejoLifecycleJournal) Prepare(_ context.Context, effect adapter.Effe
 
 func (j *forgejoLifecycleJournal) Finish(_ context.Context, effect adapter.Effect, completion adapter.Completion) error {
 	key := forgejoLifecycleEffectKey(effect)
-	if completion.State == "" {
+	if completion.ReleaseLedger {
 		delete(j.states, key)
 	} else {
 		j.states[key] = completion.State

--- a/internal/store/adapter_runtime.go
+++ b/internal/store/adapter_runtime.go
@@ -694,13 +694,13 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 			payload["owned_missing"] = true
 		}
 		payloadJSON, _ := json.Marshal(payload)
-		if err := j.insertAudit(ctx, tx, outcomeID, "adapter.push_outcome", completion.Outcome, now, payloadJSON); err != nil {
+		if err := j.insertAudit(ctx, tx, outcomeID, "adapter.push_outcome", string(completion.Outcome), now, payloadJSON); err != nil {
 			return err
 		}
 		updateEffect := j.runtime.query(
 			`UPDATE adapter_effects SET outcome_audit_id=?,outcome=?,finished_at=? WHERE id=? AND outcome IS NULL`,
 			`UPDATE adapter_effects SET outcome_audit_id=$1,outcome=$2,finished_at=$3 WHERE id=$4 AND outcome IS NULL`)
-		rows, err := tx.Exec(ctx, updateEffect, outcomeID, completion.Outcome, adapterTimestamp(j.runtime.db.Engine(), now), effectID)
+		rows, err := tx.Exec(ctx, updateEffect, outcomeID, string(completion.Outcome), adapterTimestamp(j.runtime.db.Engine(), now), effectID)
 		if err != nil || rows != 1 {
 			return errors.New("store: adapter effect OUTCOME was not recorded exactly once")
 		}
@@ -709,7 +709,7 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 				return err
 			}
 		}
-		if completion.State == "" {
+		if completion.ReleaseLedger {
 			remove := j.runtime.query(
 				`DELETE FROM adapter_ledger WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=?`,
 				`DELETE FROM adapter_ledger WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND target_id=$4 AND surface=$5 AND normalized_name=$6`)
@@ -726,7 +726,7 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 		if rows != 1 {
 			return adapter.ErrSuperseded
 		}
-		if completion.Outcome == "success" && effect.KeyID != "" && effect.Disposition != adapter.Delete {
+		if completion.Outcome == adapter.OutcomeSuccess && effect.KeyID != "" && effect.Disposition != adapter.Delete {
 			payload, _ := json.Marshal(map[string]string{"key_id": effect.KeyID, "surface": string(effect.Surface), "effective_name": effect.EffectiveName})
 			if err := j.insertAudit(ctx, tx, newAdapterID("aud"), "adapter.key_delivered", "success", now, payload); err != nil {
 				return err

--- a/internal/store/adapter_runtime_test.go
+++ b/internal/store/adapter_runtime_test.go
@@ -91,7 +91,7 @@ func TestAdapterJournalCommitsIntentOutcomeAndLedgerAtomically(t *testing.T) {
 	if err := journal.Prepare(t.Context(), effect, state); err != nil {
 		t.Fatal(err)
 	}
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "success", State: adapter.Owned, ProviderStatus: 201}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned, ProviderStatus: 201}); err != nil {
 		t.Fatal(err)
 	}
 	var ledgerState, effectOutcome string
@@ -124,6 +124,67 @@ func TestAdapterJournalCommitsIntentOutcomeAndLedgerAtomically(t *testing.T) {
 	}
 }
 
+func TestAdapterJournalRejectsZeroCompletionWithoutDeletingLedger(t *testing.T) {
+	db := adapterRuntimeDB(t)
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_zero','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example','repository',0,42,'variable','MODE','MODE','owned','2026-08-17T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	runtime := store.NewAdapterRuntime(db, func(context.Context, adapter.Job, adapter.Effect) error { return nil })
+	job, ok, err := runtime.ClaimDue(t.Context(), "worker_1", time.Now().UTC(), time.Now().UTC().Add(adapter.LeaseTime))
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue() = %+v, %v, %v", job, ok, err)
+	}
+	effect := adapter.Effect{Surface: adapter.Variable, EffectiveName: "MODE", Disposition: adapter.Update}
+	journal := runtime.Journal(job)
+	if err := journal.Prepare(t.Context(), effect, adapter.Owned); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{}); err == nil {
+		t.Fatal("Finish() accepted zero completion")
+	}
+	var ledgerRows, outcomeRows int
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_ledger WHERE id='led_zero' AND state='owned'`).Scan(&ledgerRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_effects WHERE job_id='job_1' AND outcome IS NOT NULL`).Scan(&outcomeRows); err != nil {
+		t.Fatal(err)
+	}
+	if ledgerRows != 1 || outcomeRows != 0 {
+		t.Fatalf("zero completion changed persistence: ledger=%d outcomes=%d", ledgerRows, outcomeRows)
+	}
+}
+
+func TestAdapterJournalReleasedStateRetainsLedgerRow(t *testing.T) {
+	db := adapterRuntimeDB(t)
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_release_state','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example','repository',0,42,'variable','OLD','OLD','owned','2026-08-17T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	runtime := store.NewAdapterRuntime(db, func(context.Context, adapter.Job, adapter.Effect) error { return nil })
+	job, ok, err := runtime.ClaimDue(t.Context(), "worker_1", time.Now().UTC(), time.Now().UTC().Add(adapter.LeaseTime))
+	if err != nil || !ok {
+		t.Fatalf("ClaimDue() = %+v, %v, %v", job, ok, err)
+	}
+	effect := adapter.Effect{Surface: adapter.Variable, EffectiveName: "OLD", Disposition: adapter.Delete}
+	journal := runtime.Journal(job)
+	if err := journal.Prepare(t.Context(), effect, adapter.Owned); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Released}); err != nil {
+		t.Fatal(err)
+	}
+	var state string
+	var rows int
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT state FROM adapter_ledger WHERE id='led_release_state'`).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SQLiteRead().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM adapter_ledger WHERE id='led_release_state'`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if state != "released" || rows != 1 {
+		t.Fatalf("released state persistence: state=%q rows=%d", state, rows)
+	}
+}
+
 func TestAdapterJournalPersistsOwnedMissingAndAuditFinding(t *testing.T) {
 	db := adapterRuntimeDB(t)
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ('led_missing','org_adapter','prj_adapter','env_adapter','tgt_1','https://git.example','repository',0,42,'variable','MODE','MODE','owned','2026-08-17T00:00:00Z')`); err != nil {
@@ -139,7 +200,7 @@ func TestAdapterJournalPersistsOwnedMissingAndAuditFinding(t *testing.T) {
 	if err := journal.Prepare(t.Context(), effect, adapter.Owned); err != nil {
 		t.Fatal(err)
 	}
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "failure", State: adapter.Owned, Missing: true, ProviderStatus: 404, Finding: "owned_missing"}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: adapter.Owned, Missing: true, ProviderStatus: 404, Finding: "owned_missing"}); err != nil {
 		t.Fatal(err)
 	}
 	var state string
@@ -170,7 +231,7 @@ func TestAdapterJournalRefusesOwnedMissingCompletionAfterRelease(t *testing.T) {
 	if err := journal.Prepare(t.Context(), effect, adapter.Released); err != nil {
 		t.Fatal(err)
 	}
-	err = journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "failure", State: adapter.Owned, Missing: true, ProviderStatus: 404, Finding: "owned_missing"})
+	err = journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: adapter.Owned, Missing: true, ProviderStatus: 404, Finding: "owned_missing"})
 	if !errors.Is(err, adapter.ErrSuperseded) {
 		t.Fatalf("Finish() error = %v, want ErrSuperseded", err)
 	}
@@ -203,7 +264,7 @@ func TestAdapterJournalPUTNotFoundEndsEffectBeforeFreshCreateRetry(t *testing.T)
 	if err := first.Prepare(t.Context(), update, adapter.Owned); err != nil {
 		t.Fatal(err)
 	}
-	if err := first.Finish(t.Context(), update, adapter.Completion{Outcome: "failure", State: ""}); err != nil {
+	if err := first.Finish(t.Context(), update, adapter.Completion{Outcome: adapter.OutcomeFailure, ReleaseLedger: true}); err != nil {
 		t.Fatal(err)
 	}
 	var ledgerRows, firstEffects int
@@ -241,7 +302,7 @@ func TestAdapterJournalPUTNotFoundEndsEffectBeforeFreshCreateRetry(t *testing.T)
 	if err := second.Prepare(t.Context(), create, state); err != nil {
 		t.Fatal(err)
 	}
-	if err := second.Finish(t.Context(), create, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
+	if err := second.Finish(t.Context(), create, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned}); err != nil {
 		t.Fatal(err)
 	}
 	var effects, intents, outcomes int
@@ -283,7 +344,7 @@ func TestAdapterJournalFinishesUnsentIntentBeforeAuthorityAbort(t *testing.T) {
 	if err := journal.Gate(t.Context(), effect); !errors.Is(err, adapter.ErrUnauthorized) {
 		t.Fatalf("post-Prepare Gate() = %v", err)
 	}
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "failure", State: state}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: state}); err != nil {
 		t.Fatal(err)
 	}
 	if err := runtime.Fail(t.Context(), job, now.Add(time.Second), adapter.ErrUnauthorized); err != nil {
@@ -331,7 +392,7 @@ func TestAdapterJournalFinishesUnsentIntentBeforeGenerationAbort(t *testing.T) {
 	if err := journal.Gate(t.Context(), effect); !errors.Is(err, adapter.ErrSuperseded) {
 		t.Fatalf("post-Prepare Gate() = %v", err)
 	}
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "failure", State: state}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeFailure, State: state}); err != nil {
 		t.Fatal(err)
 	}
 	if err := runtime.Fail(t.Context(), job, now.Add(time.Second), adapter.ErrSuperseded); err != nil {
@@ -402,7 +463,7 @@ func TestPublishedGenerationSupersedesWithoutStealingLiveProviderFence(t *testin
 		t.Fatalf("publish stole live fence: generation=%d lease=%q/%q old=%q", generation, leaseJob, leaseEffect, oldState)
 	}
 
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned}); err != nil {
 		t.Fatalf("old in-flight effect could not finish after publish generation bump: %v", err)
 	}
 	if err := journal.Gate(t.Context(), adapter.Effect{}); !errors.Is(err, adapter.ErrSuperseded) {
@@ -567,7 +628,7 @@ func TestAdapterFinishPreservesConcurrentReleasedCustody(t *testing.T) {
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapter_ledger SET state='released' WHERE target_id='tgt_1' AND normalized_name='TOKEN'`); err != nil {
 		t.Fatal(err)
 	}
-	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "success", State: adapter.Owned}); err != nil {
+	if err := journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned}); err != nil {
 		t.Fatal(err)
 	}
 	var ledgerState, outcome string
@@ -637,7 +698,7 @@ func TestAdapterJournalRejectsTerminalWriteAfterLeaseLoss(t *testing.T) {
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapter_effects SET outcome='failure' WHERE job_id='job_1'`); err != nil {
 		t.Fatal(err)
 	}
-	err = journal.Finish(t.Context(), effect, adapter.Completion{Outcome: "success", State: adapter.Owned})
+	err = journal.Finish(t.Context(), effect, adapter.Completion{Outcome: adapter.OutcomeSuccess, State: adapter.Owned})
 	if err == nil {
 		t.Fatal("Finish accepted a non-exclusive terminal transition")
 	}


### PR DESCRIPTION
Closes #374

## Representation

- Adds closed `adapter.Outcome` constants for existing `success`, `failure`, and `unknown` audit values. `unknown` is retained because current Forgejo and GitHub Actions indeterminate-write paths already emit it.
- Adds `Completion.ReleaseLedger`; only this explicit command deletes a ledger row.
- Rejects zero, misspelled, and ambiguous completions at the store boundary.
- Keeps `State: Released` as a retained ledger-history row and preserves independent conflict semantics.

## Validation

- Static Standards review: CLEAN.
- Static issue-spec review: CLEAN, with `unknown` retained for current byte-identical audit behavior.
- `gofmt`: pass.
- `git diff --check`: pass.
- Focused/full local Go tests: deferred before first push because host memory pressure is high; hosted CI is running now. Results will be added before merge.

## Handoff

- `docs/handoff/issue-374-explicit-adapter-completion.md`