### PR TITLE
Centralize session OIDC provider derivation #369

### DIFF
--- a/docs/handoff/369-session-oidc-provider.md
+++ b/docs/handoff/369-session-oidc-provider.md
@@ -1,0 +1,47 @@
+# Issue #369 — session OIDC provider owner
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/369 (parent #326; audit finding
+`F-S30-2`). Implementation base:
+`428dd6a5e347479a7a3697e2953ce10b7543db58`.
+
+## Contract
+
+- `useSessionOIDCProvider` is the single owner of deriving a configured OIDC
+  provider from the current session assurance and authentication-method query.
+- A non-OIDC session, pending method data, missing provider slug, removed
+  provider, or non-OIDC provider with the same slug resolves to `null`.
+- `Ceremony` and `CLIReauth` offer OIDC reauthentication only for the resolved
+  provider. Their passkey paths remain available when resolution returns
+  `null`.
+- Zero-window OIDC sessions retain the existing explanation that their identity
+  provider cannot satisfy a per-disclosure gate.
+
+Generated outputs: none. Database migrations: none. Wire and audit contracts:
+unchanged.
+
+## Regression evidence
+
+Before implementation, the new hook test failed with
+`TypeError: useSessionOIDCProvider is not a function`. Both consumers then
+failed against the migrated hook boundary until their duplicated derivations
+were removed.
+
+## Validation
+
+```text
+pnpm --dir web exec vitest run \
+  src/api/account.session-oidc-provider.test.tsx \
+  src/routes/Ceremony.task-key.test.tsx \
+  src/routes/CLIReauth.oidc.test.tsx                         8 passed
+pnpm --dir web run typecheck                                passed
+pnpm --dir web run test                       313 passed / 38 files
+pnpm --dir web run build                                    passed
+git diff --check                                            passed
+```
+
+## Review
+
+- Standards axis: one unnecessary test-only assertion removed; no remaining
+  documented violation or baseline smell.
+- Specification axis: `CLEAN`; no missing requirement, scope creep, or
+  incorrect behavior.

--- a/web/src/api/account.session-oidc-provider.test.tsx
+++ b/web/src/api/account.session-oidc-provider.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { settleTask } from '../testkit/renderForm.tsx';
+import { useSessionOIDCProvider } from './account.ts';
+
+const mocks = vi.hoisted(() => ({
+  assurance: { method: 'oidc:strict', provider: 'removed' },
+  methods: {
+    local_login_enabled: true,
+    providers: [{ kind: 'oidc', slug: 'strict', display_name: 'Corporate IdP' }],
+  },
+}));
+
+vi.mock('../app/AuthProvider.tsx', () => ({
+  useAuth: () => ({ identity: { session: { assurance: mocks.assurance } } }),
+}));
+
+vi.mock('./client.ts', async (importActual) => {
+  const actual = await importActual<typeof import('./client.ts')>();
+  return {
+    ...actual,
+    parsed: vi.fn(() => Promise.resolve(mocks.methods)),
+  };
+});
+
+beforeEach(() => {
+  mocks.assurance = { method: 'oidc:strict', provider: 'removed' };
+});
+
+describe('useSessionOIDCProvider', () => {
+  it('returns null when the session provider slug is no longer configured', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <ProviderName />
+        </QueryClientProvider>,
+      );
+    });
+    await settleTask();
+
+    expect(container.textContent).toBe('passkey-only');
+
+    await act(async () => root.unmount());
+    client.clear();
+    container.remove();
+  });
+});
+
+function ProviderName() {
+  const provider = useSessionOIDCProvider();
+  return <span>{provider?.display_name ?? 'passkey-only'}</span>;
+}

--- a/web/src/api/account.ts
+++ b/web/src/api/account.ts
@@ -55,6 +55,7 @@ import { fromBase64URL, toBase64URL } from './values.ts';
 type PasskeyList = z.infer<typeof zPasskeyList>;
 type IdentityList = z.infer<typeof zIdentityList>;
 type AuthMethods = z.infer<typeof zAuthMethods>;
+export type OIDCProvider = AuthMethods['providers'][number] & { readonly kind: 'oidc' };
 type TotpStatus = z.infer<typeof zTotpStatus>;
 
 const passkeysKey = ['passkeys'] as const;
@@ -104,6 +105,22 @@ export function useAuthMethods(): UseQueryResult<AuthMethods> {
     queryFn: () => parsed(authMethodsOp, {}),
     retry: false,
   });
+}
+
+/** Resolve an OIDC-backed session only while its configured provider still exists. */
+export function useSessionOIDCProvider(): OIDCProvider | null {
+  const auth = useAuth();
+  const methods = useAuthMethods();
+  const assurance = auth.identity?.session.assurance;
+  if (assurance?.method.startsWith('oidc:') !== true) {
+    return null;
+  }
+  return (
+    methods.data?.providers.find(
+      (provider): provider is OIDCProvider =>
+        provider.kind === 'oidc' && provider.slug === assurance.provider,
+    ) ?? null
+  );
 }
 
 /** invalidate everything: a reissued session invalidates every cached answer. */

--- a/web/src/routes/CLIReauth.oidc.test.tsx
+++ b/web/src/routes/CLIReauth.oidc.test.tsx
@@ -9,7 +9,8 @@ import { CLIReauth } from './CLIReauth.tsx';
 
 const mocks = vi.hoisted(() => ({
   load: vi.fn(),
-  provider: { kind: 'oidc' as const, slug: 'strict', display_name: 'Corporate IdP' },
+  providerAvailable: true,
+  provider: { kind: 'oidc', slug: 'strict', display_name: 'Corporate IdP' },
 }));
 
 vi.mock('../api/cliReauth.ts', () => ({
@@ -20,7 +21,7 @@ vi.mock('../api/cliReauth.ts', () => ({
 
 vi.mock('../api/account.ts', () => ({
   useTotpStatus: () => ({ isSuccess: false }),
-  useAuthMethods: () => ({ data: { local_login_enabled: true, providers: [mocks.provider] } }),
+  useSessionOIDCProvider: () => (mocks.providerAvailable ? mocks.provider : null),
 }));
 
 vi.mock('../app/AuthProvider.tsx', () => ({
@@ -75,7 +76,10 @@ async function renderTransaction(environments: Array<{
   };
 }
 
-beforeEach(() => mocks.load.mockReset());
+beforeEach(() => {
+  mocks.load.mockReset();
+  mocks.providerAvailable = true;
+});
 
 describe('CLI OIDC disclosure handoff', () => {
   it('offers the current provider when any environment has a reusable window', async () => {
@@ -99,6 +103,17 @@ describe('CLI OIDC disclosure handoff', () => {
 
     expect(view.container.textContent).not.toContain('Re-authenticate with Corporate IdP');
     expect(view.container.textContent).toContain('locked — passkey required');
+    await view.unmount();
+  });
+
+  it('keeps a removed OIDC provider passkey-only', async () => {
+    mocks.providerAvailable = false;
+    const view = await renderTransaction([
+      { environment_id: 'production', effective_window_seconds: 300, requires_webauthn: false },
+    ]);
+
+    expect(view.container.textContent).not.toContain('Re-authenticate with');
+    expect(view.container.textContent).toContain('Authorize CLI');
     await view.unmount();
   });
 });

--- a/web/src/routes/CLIReauth.tsx
+++ b/web/src/routes/CLIReauth.tsx
@@ -6,7 +6,7 @@ import {
   cliReauthCallbackURL,
   loadCLIReauthTransaction,
 } from '../api/cliReauth.ts';
-import { useAuthMethods, useTotpStatus } from '../api/account.ts';
+import { useSessionOIDCProvider, useTotpStatus } from '../api/account.ts';
 import { useAuth } from '../app/AuthProvider.tsx';
 import {
   runAdapterPasskeyCeremony,
@@ -25,12 +25,7 @@ export function CLIReauth() {
   );
   const [totp, setTOTP] = useState('');
   const totpStatus = useTotpStatus();
-  const methods = useAuthMethods();
-  const assurance = auth.identity?.session.assurance;
-  const oidcSession = assurance?.method.startsWith('oidc:') === true;
-  const oidcProvider = methods.data?.providers.find(
-    (provider) => provider.kind === 'oidc' && provider.slug === assurance?.provider,
-  );
+  const oidcProvider = useSessionOIDCProvider();
   const transaction = useQuery({
     queryKey: ['cli-reauth', state] as const,
     queryFn: () => loadCLIReauthTransaction(state),
@@ -67,7 +62,7 @@ export function CLIReauth() {
         // window TOTP always opens (human-auth ADR: TOTP is a per-step gate,
         // not a per-operation one), never a per-key decision.
         for (const environment of handoff.environments) {
-          if (strategy === 'oidc' && !environment.requires_webauthn && oidcProvider !== undefined) {
+          if (strategy === 'oidc' && !environment.requires_webauthn && oidcProvider !== null) {
             await runOIDCCeremony(oidcProvider.slug, environment.environment_id);
           } else if (!environment.requires_webauthn && totp.trim() !== '') {
             await runTOTPCeremony(environment.environment_id, totp.trim());
@@ -107,7 +102,7 @@ export function CLIReauth() {
   const requiresTOTP = !disclosure && slidingEnvironments.length > 0;
   const offersTOTP = disclosure && slidingEnvironments.length > 0 && hasTotp;
   const offersOIDC =
-    disclosure && oidcSession && slidingEnvironments.length > 0 && oidcProvider !== undefined;
+    disclosure && slidingEnvironments.length > 0 && oidcProvider !== null;
 
   return (
     <main className="login">

--- a/web/src/routes/Ceremony.task-key.test.tsx
+++ b/web/src/routes/Ceremony.task-key.test.tsx
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   identity: null as null | {
     session: { assurance: { method: string; provider?: string } };
   },
-  providers: [] as Array<{ kind: 'oidc'; slug: string; display_name: string }>,
+  providerAvailable: false,
+  provider: { kind: 'oidc', slug: 'strict', display_name: 'Corporate IdP' },
 }));
 
 vi.mock('../api/values.ts', async (importActual) => {
@@ -32,7 +33,7 @@ vi.mock('../app/AuthProvider.tsx', () => ({
 }));
 
 vi.mock('../api/account.ts', () => ({
-  useAuthMethods: () => ({ data: { local_login_enabled: true, providers: mocks.providers } }),
+  useSessionOIDCProvider: () => (mocks.providerAvailable ? mocks.provider : null),
 }));
 
 vi.mock('../api/transport.tsx', () => ({
@@ -87,7 +88,7 @@ beforeEach(() => {
   mocks.runOIDCCeremony.mockReset();
   mocks.refreshSession.mockReset();
   mocks.identity = null;
-  mocks.providers = [];
+  mocks.providerAvailable = false;
 });
 
 describe('Ceremony task identity', () => {
@@ -124,7 +125,7 @@ describe('Ceremony task identity', () => {
 
   it('offers the current OIDC provider only when a reusable window is allowed', async () => {
     mocks.identity = { session: { assurance: { method: 'oidc:strict', provider: 'strict' } } };
-    mocks.providers = [{ kind: 'oidc', slug: 'strict', display_name: 'Corporate IdP' }];
+    mocks.providerAvailable = true;
     mocks.runOIDCCeremony.mockResolvedValue(undefined);
     mocks.refreshSession.mockResolvedValue(undefined);
     const container = document.createElement('div');
@@ -157,9 +158,39 @@ describe('Ceremony task identity', () => {
     await act(async () => root.unmount());
   });
 
+  it('keeps a removed OIDC provider passkey-only', async () => {
+    mocks.identity = { session: { assurance: { method: 'oidc:removed', provider: 'removed' } } };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () =>
+      root.render(
+        <Ceremony
+          request={{
+            ...ceremonyRequest('production'),
+            window: {
+              protected: false,
+              effective_window_seconds: 300,
+              live: false,
+              single_decision: false,
+              can_reveal: false,
+              totp_offered: true,
+            },
+          }}
+          onAuthorised={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      ),
+    );
+
+    expect(container.textContent).not.toContain('Re-authenticate with');
+    expect(container.textContent).toContain('Use a passkey');
+    await act(async () => root.unmount());
+  });
+
   it('keeps a zero-window OIDC session passkey-only and explains why', async () => {
     mocks.identity = { session: { assurance: { method: 'oidc:strict', provider: 'strict' } } };
-    mocks.providers = [{ kind: 'oidc', slug: 'strict', display_name: 'Corporate IdP' }];
+    mocks.providerAvailable = true;
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);

--- a/web/src/routes/Ceremony.tsx
+++ b/web/src/routes/Ceremony.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react';
 
 import { useWorkspaceContext } from '../api/transport.tsx';
-import { useAuthMethods } from '../api/account.ts';
+import { useSessionOIDCProvider } from '../api/account.ts';
 import { useAuth } from '../app/AuthProvider.tsx';
 import {
   ceremonyRefusalText,
@@ -133,13 +133,10 @@ export function Ceremony({
   // workspace session — the same modal, a different executor.
   const workspace = useWorkspaceContext();
   const auth = useAuth();
-  const methods = useAuthMethods();
   const assurance = auth.identity?.session.assurance;
   const oidcSession = assurance?.method.startsWith('oidc:') === true;
-  const oidcProvider = methods.data?.providers.find(
-    (provider) => provider.kind === 'oidc' && provider.slug === assurance?.provider,
-  );
-  const offersOIDC = oidcSession && request.window.totp_offered && oidcProvider !== undefined;
+  const oidcProvider = useSessionOIDCProvider();
+  const offersOIDC = request.window.totp_offered && oidcProvider !== null;
 
   const attempt = async (run: () => Promise<void>) => {
     setBusy(true);
@@ -169,7 +166,7 @@ export function Ceremony({
   };
 
   const onOIDC = () => {
-    if (oidcProvider === undefined) return;
+    if (oidcProvider === null) return;
     void attempt(async () => {
       await runOIDCCeremony(oidcProvider.slug, request.environmentId);
       await auth.refreshSession();


### PR DESCRIPTION
Closes #369

## Contract

- Adds useSessionOIDCProvider as the single session-to-configured-provider owner.
- Migrates Ceremony and CLIReauth; removed providers fail closed to passkey-only behavior.
- Preserves zero-window OIDC explanatory copy.
- No migration, wire/audit change, or generated output.

## Validation

- Targeted Vitest: 8 passed
- pnpm --dir web run typecheck: passed
- pnpm --dir web run test: 313 passed across 38 files
- pnpm --dir web run build: passed
- git diff --check: passed

## Review

- Standards: one test-only assertion fixed; no remaining finding
- Spec: CLEAN