### PR TITLE
Share retention bounds fields #367

### DIFF
--- a/docs/handoff/367-retention-bounds-fields.md
+++ b/docs/handoff/367-retention-bounds-fields.md
@@ -1,0 +1,31 @@
+# Handoff: #367 shared retention bounds fields
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/367. Base:
+`428dd6a5e347479a7a3697e2953ce10b7543db58`.
+
+## Contract
+
+- `RetentionBoundsFields` is the single owner of the whole-day and revision
+  controls, exact-seconds warning, deliberate day replacement, and absent-age
+  status shared by organisation and project retention editors.
+- Each editor still owns its draft bounds, validation refusal, and local mode
+  selector. Editing either shared bound clears an existing refusal.
+- Policy or entity-scope changes reset editor drafts through the existing
+  effects. The redundant route-key remounts were removed, leaving one reset
+  mechanism even when two entities have equal-valued policies.
+- Organisation `unlimited` and project `inherit` saves both send null bounds.
+  Existing retention wire shapes and validation remain unchanged. Generated
+  outputs: none.
+
+## Coverage
+
+- The new render suite covers exact-second protection and replacement,
+  refusal clearing, the bounded organisation payload, and both null-bound mode
+  flips.
+- `pnpm --dir web run typecheck` passed.
+- `pnpm --dir web run test` passed: 317 tests across 38 files.
+- Standards and issue-spec reviews reached `CLEAN` in round 2 of 3 after
+  making entity identity part of the single reset effect and exercising edited
+  bounds in the payload test.
+- `pnpm --dir web run build` passed.
+- `git diff --check` passed.

--- a/web/src/routes/OrgSettings.tsx
+++ b/web/src/routes/OrgSettings.tsx
@@ -21,6 +21,7 @@ import {
 } from '../api/settings.ts';
 import { surfaceById } from '../app/navigation.ts';
 import { notifySuccess } from '../app/notifications.tsx';
+import { RetentionBoundsFields } from './RetentionBoundsFields.tsx';
 import { Alert, Done, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
 import { useFeedback } from './useModalDialog.ts';
 
@@ -168,7 +169,7 @@ export function OrgSettings() {
         ) : null}
         {retention.data === undefined ? null : (
           <RetentionEditor
-            key={org}
+            scope={org}
             policy={retention.data}
             busy={setRetention.isPending}
             onSave={(next) =>
@@ -299,18 +300,18 @@ function ProjectRetentionList({
  * would have to hide a bound the operator is accountable for. `unlimited` is
  * explicit organisation state, never a missing value.
  */
-function RetentionEditor({
+export function RetentionEditor({
+  scope,
   policy,
   busy,
   onSave,
 }: {
+  scope: string;
   policy: RetentionPolicy;
   busy: boolean;
   onSave: (next: RetentionPolicy) => void;
 }) {
   const modeId = useId();
-  const ageId = useId();
-  const countId = useId();
   const [mode, setMode] = useState(policy.mode);
   const [age, setAge] = useState<RetentionDayState>(() =>
     retentionDayState(policy.max_age_seconds),
@@ -331,29 +332,13 @@ function RetentionEditor({
         : String(policy.last_revisions),
     );
     setRefusal(null);
-  }, [policy.last_revisions, policy.max_age_seconds, policy.mode]);
+  }, [scope, policy.last_revisions, policy.max_age_seconds, policy.mode]);
 
   return (
     <>
       <p className="retention__current" role="status">
         {retentionSentence(policy)}
       </p>
-      {mode === 'keep-if-either' && age.kind === 'exact' ? (
-        <Alert>
-          Current maximum age is exact ({age.seconds} seconds), not whole days. The day editor is
-          disabled so that exact value cannot look absent.
-          <button
-            type="button"
-            className="btn"
-            onClick={() => setAge({ kind: 'days', days: '' })}
-          >
-            Replace with whole days
-          </button>
-        </Alert>
-      ) : null}
-      {mode === 'keep-if-either' && age.kind === 'absent' ? (
-        <p role="status">No maximum age is present. Enter a whole-day replacement deliberately.</p>
-      ) : null}
       {refusal === null ? null : <Alert>{refusal}</Alert>}
       <div className="field">
         <label htmlFor={modeId}>Mode</label>
@@ -370,37 +355,18 @@ function RetentionEditor({
         </select>
       </div>
       {mode === 'keep-if-either' ? (
-        <div className="retention__bounds">
-          <div className="field">
-            <label htmlFor={ageId}>Maximum age, in days</label>
-            <input
-              id={ageId}
-              type="number"
-              min={1}
-              inputMode="numeric"
-              value={age.kind === 'days' ? age.days : ''}
-              disabled={age.kind === 'exact'}
-              onChange={(event) => {
-                setRefusal(null);
-                setAge({ kind: 'days', days: event.target.value });
-              }}
-            />
-          </div>
-          <div className="field">
-            <label htmlFor={countId}>Revisions kept per environment</label>
-            <input
-              id={countId}
-              type="number"
-              min={1}
-              inputMode="numeric"
-              value={count}
-              onChange={(event) => {
-                setRefusal(null);
-                setCount(event.target.value);
-              }}
-            />
-          </div>
-        </div>
+        <RetentionBoundsFields
+          age={age}
+          count={count}
+          onAgeChange={(next) => {
+            setRefusal(null);
+            setAge(next);
+          }}
+          onCountChange={(next) => {
+            setRefusal(null);
+            setCount(next);
+          }}
+        />
       ) : (
         <p className="field__hint">
           Unlimited is the only policy a project cannot copy: a project override is always bounded.

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -32,6 +32,7 @@ import {
   type SettingsOperation,
 } from '../api/settings.ts';
 import { surfaceById } from '../app/navigation.ts';
+import { RetentionBoundsFields } from './RetentionBoundsFields.tsx';
 import { Alert, Done, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
 import { useFeedback } from './useModalDialog.ts';
 
@@ -216,8 +217,7 @@ export function ProjectSettings() {
           <Alert>This project&apos;s retention policy could not be read.</Alert>
         ) : null}
         {projectRetention.data === undefined || orgRetention.data === undefined ? null : (
-          <ProjectRetentionEditor
-            key={`${org}/${project}`}
+          <ProjectRetentionEditorController
             org={org}
             project={project}
             policy={projectRetention.data}
@@ -600,7 +600,7 @@ function EnvironmentRow({
 }
 
 /** ProjectRetentionEditor sends the policy to the authoritative cap validator. */
-function ProjectRetentionEditor({
+function ProjectRetentionEditorController({
   org,
   project,
   policy,
@@ -614,9 +614,32 @@ function ProjectRetentionEditor({
   onError: (error: unknown) => void;
 }) {
   const save = useSetProjectRetention(org, project);
+  return (
+    <ProjectRetentionEditor
+      scope={`${org}/${project}`}
+      policy={policy}
+      busy={save.isPending}
+      onSave={(input) => saveProjectRetention(save, input, onDone, onError)}
+    />
+  );
+}
+
+export function ProjectRetentionEditor({
+  scope,
+  policy,
+  busy,
+  onSave,
+}: {
+  scope: string;
+  policy: ProjectRetentionPolicy;
+  busy: boolean;
+  onSave: (input: {
+    inherited: boolean;
+    maxAgeSeconds: number | null;
+    lastRevisions: number | null;
+  }) => void;
+}) {
   const modeId = useId();
-  const ageId = useId();
-  const countId = useId();
   const [inherited, setInherited] = useState(policy.inherited);
   const [age, setAge] = useState<RetentionDayState>(() =>
     retentionDayState(policy.max_age_seconds),
@@ -637,7 +660,7 @@ function ProjectRetentionEditor({
         : String(policy.last_revisions),
     );
     setRefusal(null);
-  }, [policy.inherited, policy.last_revisions, policy.max_age_seconds]);
+  }, [scope, policy.inherited, policy.last_revisions, policy.max_age_seconds]);
 
   return (
     <>
@@ -646,22 +669,6 @@ function ProjectRetentionEditor({
           ? `This project inherits the organisation cap and follows it when it changes. Effective: ${retentionSentence(policy)}`
           : `This project holds its own override, detached from later organisation changes. Effective: ${retentionSentence(policy)}`}
       </p>
-      {!inherited && age.kind === 'exact' ? (
-        <Alert>
-          Current maximum age is exact ({age.seconds} seconds), not whole days. The day editor is
-          disabled so that exact value cannot look absent.
-          <button
-            type="button"
-            className="btn"
-            onClick={() => setAge({ kind: 'days', days: '' })}
-          >
-            Replace with whole days
-          </button>
-        </Alert>
-      ) : null}
-      {!inherited && age.kind === 'absent' ? (
-        <p role="status">No maximum age is present. Enter a whole-day replacement deliberately.</p>
-      ) : null}
       {refusal !== null ? <Alert>{refusal}</Alert> : null}
       <div className="field">
         <label htmlFor={modeId}>Policy</label>
@@ -678,52 +685,28 @@ function ProjectRetentionEditor({
         </select>
       </div>
       {inherited ? null : (
-        <div className="retention__bounds">
-          <div className="field">
-            <label htmlFor={ageId}>Maximum age, in days</label>
-            <input
-              id={ageId}
-              type="number"
-              min={1}
-              inputMode="numeric"
-              value={age.kind === 'days' ? age.days : ''}
-              disabled={age.kind === 'exact'}
-              onChange={(event) => {
-                setRefusal(null);
-                setAge({ kind: 'days', days: event.target.value });
-              }}
-            />
-          </div>
-          <div className="field">
-            <label htmlFor={countId}>Revisions kept per environment</label>
-            <input
-              id={countId}
-              type="number"
-              min={1}
-              inputMode="numeric"
-              value={count}
-              onChange={(event) => {
-                setRefusal(null);
-                setCount(event.target.value);
-              }}
-            />
-          </div>
-        </div>
+        <RetentionBoundsFields
+          age={age}
+          count={count}
+          onAgeChange={(next) => {
+            setRefusal(null);
+            setAge(next);
+          }}
+          onCountChange={(next) => {
+            setRefusal(null);
+            setCount(next);
+          }}
+        />
       )}
       <div className="panel__actions">
         <button
           type="button"
           className="btn"
-          disabled={save.isPending}
+          disabled={busy}
           onClick={() => {
             if (inherited) {
               setRefusal(null);
-              saveProjectRetention(
-                save,
-                { inherited: true, maxAgeSeconds: null, lastRevisions: null },
-                onDone,
-                onError,
-              );
+              onSave({ inherited: true, maxAgeSeconds: null, lastRevisions: null });
               return;
             }
             const payload = retentionBoundsPayload(
@@ -735,16 +718,11 @@ function ProjectRetentionEditor({
               return;
             }
             setRefusal(null);
-            saveProjectRetention(
-              save,
-              {
-                inherited: false,
-                maxAgeSeconds: payload.maxAgeSeconds,
-                lastRevisions: payload.lastRevisions,
-              },
-              onDone,
-              onError,
-            );
+            onSave({
+              inherited: false,
+              maxAgeSeconds: payload.maxAgeSeconds,
+              lastRevisions: payload.lastRevisions,
+            });
           }}
         >
           Save retention

--- a/web/src/routes/RetentionBoundsFields.tsx
+++ b/web/src/routes/RetentionBoundsFields.tsx
@@ -1,0 +1,66 @@
+import { useId } from 'react';
+
+import type { RetentionDayState } from '../api/settings.ts';
+import { Alert } from './Sections.tsx';
+
+/** Shared whole-day and revision-bound controls for both retention editors. */
+export function RetentionBoundsFields({
+  age,
+  count,
+  onAgeChange,
+  onCountChange,
+}: {
+  readonly age: RetentionDayState;
+  readonly count: string;
+  readonly onAgeChange: (next: RetentionDayState) => void;
+  readonly onCountChange: (next: string) => void;
+}) {
+  const ageId = useId();
+  const countId = useId();
+
+  return (
+    <>
+      {age.kind === 'exact' ? (
+        <Alert>
+          Current maximum age is exact ({age.seconds} seconds), not whole days. The day editor is
+          disabled so that exact value cannot look absent.
+          <button
+            type="button"
+            className="btn"
+            onClick={() => onAgeChange({ kind: 'days', days: '' })}
+          >
+            Replace with whole days
+          </button>
+        </Alert>
+      ) : null}
+      {age.kind === 'absent' ? (
+        <p role="status">No maximum age is present. Enter a whole-day replacement deliberately.</p>
+      ) : null}
+      <div className="retention__bounds">
+        <div className="field">
+          <label htmlFor={ageId}>Maximum age, in days</label>
+          <input
+            id={ageId}
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={age.kind === 'days' ? age.days : ''}
+            disabled={age.kind === 'exact'}
+            onChange={(event) => onAgeChange({ kind: 'days', days: event.target.value })}
+          />
+        </div>
+        <div className="field">
+          <label htmlFor={countId}>Revisions kept per environment</label>
+          <input
+            id={countId}
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={count}
+            onChange={(event) => onCountChange(event.target.value)}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/routes/RetentionEditors.test.tsx
+++ b/web/src/routes/RetentionEditors.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment happy-dom
+import { act, useState, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetentionDayState, RetentionPolicy } from '../api/settings.ts';
+import { renderForm, typeInto } from '../testkit/renderForm.tsx';
+import { RetentionEditor } from './OrgSettings.tsx';
+import { ProjectRetentionEditor } from './ProjectSettings.tsx';
+import { RetentionBoundsFields } from './RetentionBoundsFields.tsx';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) {
+    await cleanup();
+  }
+});
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const rendered = await renderForm(node);
+  cleanups.push(rendered.unmount);
+  return rendered.container;
+}
+
+function controlByLabel(container: HTMLElement, text: string): HTMLElement {
+  const label = [...container.querySelectorAll('label')].find(
+    (candidate) => candidate.textContent === text,
+  );
+  const control = label?.control;
+  if (!(control instanceof HTMLElement)) {
+    throw new Error(`no control labelled ${text}`);
+  }
+  return control;
+}
+
+async function click(button: Element): Promise<void> {
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('expected a button');
+  }
+  await act(async () => button.click());
+}
+
+async function choose(select: Element, value: string): Promise<void> {
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error('expected a select');
+  }
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+  if (setter === undefined) {
+    throw new Error('HTMLSelectElement exposes no value setter');
+  }
+  await act(async () => {
+    setter.call(select, value);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+function BoundsHarness() {
+  const [age, setAge] = useState<RetentionDayState>({ kind: 'exact', seconds: 90 });
+  const [count, setCount] = useState('5');
+  return (
+    <RetentionBoundsFields
+      age={age}
+      count={count}
+      onAgeChange={setAge}
+      onCountChange={setCount}
+    />
+  );
+}
+
+const boundedPolicy: RetentionPolicy = {
+  mode: 'keep-if-either',
+  max_age_seconds: 30 * 86_400,
+  last_revisions: 5,
+};
+
+describe('RetentionBoundsFields', () => {
+  it('protects an exact-seconds age until it is deliberately replaced with days', async () => {
+    const container = await render(<BoundsHarness />);
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Current maximum age is exact (90 seconds)',
+    );
+    const age = controlByLabel(container, 'Maximum age, in days');
+    if (!(age instanceof HTMLInputElement)) {
+      throw new Error('maximum age is not an input');
+    }
+    expect(age.disabled).toBe(true);
+
+    const replace = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Replace with whole days',
+    );
+    if (replace === undefined) {
+      throw new Error('replace action is missing');
+    }
+    await click(replace);
+
+    expect(age.disabled).toBe(false);
+    expect(age.value).toBe('');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+describe('RetentionEditor', () => {
+  it('clears a validation refusal when a bound is edited', async () => {
+    const container = await render(
+      <RetentionEditor
+        scope="org_a"
+        policy={{ ...boundedPolicy, last_revisions: null }}
+        busy={false}
+        onSave={vi.fn()}
+      />,
+    );
+
+    const save = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Save retention',
+    );
+    if (save === undefined) {
+      throw new Error('save action is missing');
+    }
+    await click(save);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+
+    const count = controlByLabel(container, 'Revisions kept per environment');
+    if (!(count instanceof HTMLInputElement)) {
+      throw new Error('revision bound is not an input');
+    }
+    await act(async () => typeInto(count, '7'));
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('submits the exact bounded payload shown by the shared fields', async () => {
+    const onSave = vi.fn<(next: RetentionPolicy) => void>();
+    const container = await render(
+      <RetentionEditor scope="org_a" policy={boundedPolicy} busy={false} onSave={onSave} />,
+    );
+
+    const age = controlByLabel(container, 'Maximum age, in days');
+    const count = controlByLabel(container, 'Revisions kept per environment');
+    if (!(age instanceof HTMLInputElement) || !(count instanceof HTMLInputElement)) {
+      throw new Error('retention bounds are not inputs');
+    }
+    await act(async () => {
+      typeInto(age, '45');
+      typeInto(count, '7');
+    });
+
+    const save = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Save retention',
+    );
+    if (save === undefined) {
+      throw new Error('save action is missing');
+    }
+    await click(save);
+
+    expect(onSave).toHaveBeenCalledWith({
+      mode: 'keep-if-either',
+      max_age_seconds: 45 * 86_400,
+      last_revisions: 7,
+    });
+  });
+
+  it('resets an unsaved draft when the organisation scope changes', async () => {
+    function ScopeHarness() {
+      const [scope, setScope] = useState('org_a');
+      return (
+        <>
+          <RetentionEditor scope={scope} policy={boundedPolicy} busy={false} onSave={vi.fn()} />
+          <button type="button" onClick={() => setScope('org_b')}>
+            Change organisation
+          </button>
+        </>
+      );
+    }
+
+    const container = await render(<ScopeHarness />);
+    const count = controlByLabel(container, 'Revisions kept per environment');
+    if (!(count instanceof HTMLInputElement)) {
+      throw new Error('revision bound is not an input');
+    }
+    await act(async () => typeInto(count, '99'));
+    expect(count.value).toBe('99');
+
+    const change = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Change organisation',
+    );
+    if (change === undefined) {
+      throw new Error('scope change action is missing');
+    }
+    await click(change);
+
+    expect(count.value).toBe('5');
+  });
+
+  it('submits null bounds after switching the organisation policy to unlimited', async () => {
+    const onSave = vi.fn<(next: RetentionPolicy) => void>();
+    const container = await render(
+      <RetentionEditor scope="org_a" policy={boundedPolicy} busy={false} onSave={onSave} />,
+    );
+
+    await choose(controlByLabel(container, 'Mode'), 'unlimited');
+    const save = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Save retention',
+    );
+    if (save === undefined) {
+      throw new Error('save action is missing');
+    }
+    await click(save);
+
+    expect(onSave).toHaveBeenCalledWith({
+      mode: 'unlimited',
+      max_age_seconds: null,
+      last_revisions: null,
+    });
+  });
+});
+
+describe('ProjectRetentionEditor', () => {
+  it('submits null bounds after switching the project policy to inherit', async () => {
+    const onSave = vi.fn();
+    const container = await render(
+      <ProjectRetentionEditor
+        scope="org_a/project_a"
+        policy={{ ...boundedPolicy, inherited: false }}
+        busy={false}
+        onSave={onSave}
+      />,
+    );
+
+    await choose(controlByLabel(container, 'Policy'), 'inherit');
+    const save = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Save retention',
+    );
+    if (save === undefined) {
+      throw new Error('save action is missing');
+    }
+    await click(save);
+
+    expect(onSave).toHaveBeenCalledWith({
+      inherited: true,
+      maxAgeSeconds: null,
+      lastRevisions: null,
+    });
+  });
+
+  it('resets an unsaved draft when the project scope changes', async () => {
+    function ScopeHarness() {
+      const [scope, setScope] = useState('org_a/project_a');
+      return (
+        <>
+          <ProjectRetentionEditor
+            scope={scope}
+            policy={{ ...boundedPolicy, inherited: false }}
+            busy={false}
+            onSave={vi.fn()}
+          />
+          <button type="button" onClick={() => setScope('org_a/project_b')}>
+            Change project
+          </button>
+        </>
+      );
+    }
+
+    const container = await render(<ScopeHarness />);
+    const age = controlByLabel(container, 'Maximum age, in days');
+    if (!(age instanceof HTMLInputElement)) {
+      throw new Error('maximum age is not an input');
+    }
+    await act(async () => typeInto(age, '99'));
+    expect(age.value).toBe('99');
+
+    const change = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Change project',
+    );
+    if (change === undefined) {
+      throw new Error('scope change action is missing');
+    }
+    await click(change);
+
+    expect(age.value).toBe('30');
+  });
+});


### PR DESCRIPTION
Closes #367

## Contract
- RetentionBoundsFields owns shared exact-seconds warning, deliberate whole-day replacement, and both bound inputs.
- Organisation/project editors retain local draft and mode state.
- One identity-aware effect resets drafts on policy or entity changes; redundant route-key remounts are removed.
- Unlimited/inherit mode flips send null bounds.

## Generated outputs
None.

## Validation
- pnpm --dir web run typecheck
- pnpm --dir web run test: 317 tests across 38 files
- pnpm --dir web run build
- git diff --check
- Standards + issue-spec review: CLEAN (round 2/3)