### PR TITLE
Centralize browser API helpers #372

### DIFF
--- a/docs/handoff/372-browser-api-helper.md
+++ b/docs/handoff/372-browser-api-helper.md
@@ -1,0 +1,25 @@
+# Handoff: #372 browser API helper ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/372 (parent #326; audit finding
+`F-S32-2`). Implementation base: `428dd6a5`.
+
+## Contract
+
+- `web/e2e/fixtures/api.ts` owns the only page-session API helper.
+- Successful response bodies cross the caller-supplied Zod schema; `204` maps
+  to `null`, matching existing `browserApi` behavior.
+- Non-2xx responses throw `BrowserApiError` with typed `status` and byte-exact
+  text `body`. Callers inspect `status`, never parse error-message text.
+- The helper scopes CSRF-cookie lookup and requests to the primary e2e instance
+  so the second-instance cookie jar cannot supply the wrong token.
+- Fixture setup and repair use generated endpoint response schemas; the
+  response-discarding `zFixtureIgnored` schema no longer exists.
+
+## Coverage
+
+- `api.test.ts` pins `BrowserApiError` construction and typed fields.
+- `registry.test.ts` passes with all registered flows still closed.
+- Web typecheck passes after installing both locked web and generated-client
+  dependencies.
+- Full web Vitest suite passes: 38 files, 311 tests.
+- Generated files are unaffected.

--- a/web/e2e/fixtures/api.test.ts
+++ b/web/e2e/fixtures/api.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { BrowserApiError } from './api.ts';
+
+describe('BrowserApiError', () => {
+  it('keeps the response status and body as typed error data', () => {
+    const error = new BrowserApiError('DELETE', '/api/v1/orgs/missing', 404, '{"error":"gone"}');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('BrowserApiError');
+    expect(error.status).toBe(404);
+    expect(error.body).toBe('{"error":"gone"}');
+    expect(error.message).toBe(
+      'DELETE /api/v1/orgs/missing answered 404: {"error":"gone"}',
+    );
+  });
+});

--- a/web/e2e/fixtures/api.ts
+++ b/web/e2e/fixtures/api.ts
@@ -3,7 +3,6 @@ import type { Page } from '@playwright/test';
 
 import { ADMIN, BASE_URL } from './instance.ts';
 
-export const zFixtureIgnored = z.object({});
 export const zFixtureStaged = z.object({ version_id: z.string() });
 export const zFixtureRevisionList = z.object({
   items: z.array(
@@ -62,37 +61,41 @@ export async function fixtureApiCall<T>(
   return parsed.data;
 }
 
-/** Drive the same typed fixture call through an authenticated browser cookie. */
-export async function fixtureBrowserCall<T>(
+export class BrowserApiError extends Error {
+  constructor(
+    method: string,
+    path: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`${method} ${path} answered ${String(status)}: ${body}`);
+    this.name = 'BrowserApiError';
+  }
+}
+
+/** Drive a typed API call through the page's authenticated browser session. */
+export async function browserApi<T>(
   page: Page,
-  method: string,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
   path: string,
   schema: z.ZodType<T>,
-  body?: Record<string, unknown>,
+  body?: unknown,
 ): Promise<T> {
-  const result = await page.evaluate(
-    async (input: { method: string; path: string; body: Record<string, unknown> | null }) => {
-      const csrf = document.cookie
-        .split(';')
-        .map((part) => part.trim().split('='))
-        .find(([name]) => name === '__Host-hikyo-csrf')
-        ?.slice(1)
-        .join('=') ?? '';
-      const response = await fetch(input.path, {
-        method: input.method,
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf },
-        ...(input.body === null ? {} : { body: JSON.stringify(input.body) }),
-      });
-      return {
-        status: response.status,
-        body: response.status === 204 ? {} : await response.json(),
-      };
-    },
-    { method, path, body: body ?? null },
-  );
-  if (result.status < 200 || result.status >= 300) {
-    throw new Error(`${method} ${path} answered ${String(result.status)}`);
+  // Scope the synchronizer-token lookup to this instance. The shared browser
+  // jar also carries the second e2e instance's cookies (#71).
+  const cookies = await page.context().cookies(BASE_URL);
+  const csrf = cookies.find((cookie) => cookie.name === '__Host-hikyo-csrf')?.value;
+  if (csrf === undefined || csrf === '') {
+    throw new Error(`${method} ${path} cannot run: the page has no CSRF cookie for ${BASE_URL}`);
   }
-  return schema.parse(result.body);
+  const response = await page.request.fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf },
+    ...(body === undefined ? {} : { data: body }),
+  });
+  if (!response.ok()) {
+    throw new BrowserApiError(method, path, response.status(), await response.text());
+  }
+  const value: unknown = response.status() === 204 ? null : await response.json();
+  return schema.parse(value);
 }

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -1,5 +1,5 @@
 import { chromium, type Page } from '@playwright/test';
-import { z, type ZodType } from 'zod';
+import { z } from 'zod';
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash, X509Certificate } from 'node:crypto';
@@ -1252,45 +1252,6 @@ export async function installPasskeyAuthenticator(
     // counter looks like a cloned authenticator and disables the credential.
     writePasskey(parseCredential(advanced));
   };
-}
-
-/**
- * browserApi performs one API call on the PAGE's own session — its cookies,
- * its synchronizer token.
- *
- * Flows use it for fixture work a surface has no control for (creating the
- * throwaway project a settings drill deletes, reading a service account's
- * principal id). Deliberately the page's session rather than a bearer one: a
- * second artifact would be a second thing that can be stale, and the CSRF
- * contract is exercised on the way through rather than bypassed.
- */
-export async function browserApi<T>(
-  page: Page,
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-  path: string,
-  schema: ZodType<T>,
-  body?: unknown,
-): Promise<T> {
-  // Scoped to THIS instance's origin. The shared jar also carries the serving
-  // instance's cookies (#71 runs two instances), and an unscoped read can hand
-  // back the other origin's synchronizer token — which the CSRF gate refuses
-  // with a 401 that looks exactly like a dead session, several calls from the
-  // mistake.
-  const cookies = await page.context().cookies(BASE_URL);
-  const csrf = cookies.find((cookie) => cookie.name === '__Host-hikyo-csrf')?.value;
-  if (csrf === undefined || csrf === '') {
-    throw new Error(`${method} ${path} cannot run: the page has no CSRF cookie for ${BASE_URL}`);
-  }
-  const response = await page.request.fetch(`${BASE_URL}${path}`, {
-    method,
-    headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf },
-    ...(body === undefined ? {} : { data: body }),
-  });
-  if (!response.ok()) {
-    throw new Error(`${method} ${path} answered ${response.status()}: ${await response.text()}`);
-  }
-  const value: unknown = response.status() === 204 ? null : await response.json();
-  return schema.parse(value);
 }
 
 export async function establishSession(page: Page, stepUp = true): Promise<void> {

--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -1,11 +1,18 @@
 import { createHmac } from 'node:crypto';
 
+import {
+  zEnvironmentSettings,
+  zFederatedBinding,
+  zGrantResult,
+  zKey,
+  zPublishResult,
+  zRevisionPinResult,
+} from '@hikyo/zod';
 import { z } from 'zod';
 
 import {
   fixtureApiCall as call,
   fixtureBearer,
-  zFixtureIgnored as zIgnored,
   zFixtureRevisionList as zRevisionList,
   zFixtureStaged as zStaged,
 } from './api.ts';
@@ -300,7 +307,7 @@ export const MACHINE = {
 
 /** grantReveal creates the revocable instance-scope `reveal` grant. */
 export async function grantReveal(token: string, principal: string): Promise<void> {
-  await call(token, 'POST', '/api/v1/instance/grants', zIgnored, {
+  await call(token, 'POST', '/api/v1/instance/grants', zGrantResult, {
     principal,
     capability: REVEAL_GRANT.capability,
   });
@@ -484,7 +491,7 @@ export async function seedTenant(
     token,
     'POST',
     `/api/v1/orgs/${org}/projects/${project}/environments/${dev}/grants`,
-    zIgnored,
+    zGrantResult,
     { principal: workload.principal_id, capability: 'read' },
   );
   // A binding whose service account reaches no plaintext: `read` delivers
@@ -494,7 +501,7 @@ export async function seedTenant(
     token,
     'POST',
     `/api/v1/orgs/${org}/projects/${project}/service-accounts/${workload.id}/bindings`,
-    zIgnored,
+    zFederatedBinding,
     {
       issuer: MACHINE.issuer,
       subject: MACHINE.subject,
@@ -562,7 +569,7 @@ export async function seedTenant(
     token,
     'POST',
     `/api/v1/orgs/${org}/projects/${project}/environments/${dev}/publish`,
-    zIgnored,
+    zPublishResult,
     { version_ids: devVersions },
   );
 
@@ -591,7 +598,7 @@ export async function seedTenant(
     token,
     'POST',
     `/api/v1/orgs/${org}/projects/${project}/environments/${prod}/publish`,
-    zIgnored,
+    zPublishResult,
     { version_ids: prodVersions },
   );
 
@@ -606,7 +613,7 @@ export async function seedTenant(
     token,
     'PUT',
     `/api/v1/orgs/${org}/projects/${project}/keys/${matrixRequiredID}/declaration`,
-    zIgnored,
+    zKey,
     {
       declaration: { rule: { type: 'string' } },
       presence: {
@@ -630,7 +637,7 @@ export async function seedTenant(
     token,
     'PUT',
     `/api/v1/orgs/${org}/projects/${project}/environments/${dev}/settings`,
-    zIgnored,
+    zEnvironmentSettings,
     { protected: false, reauth_window_seconds: 300 },
   );
 
@@ -640,7 +647,7 @@ export async function seedTenant(
     token,
     'PUT',
     `/api/v1/orgs/${org}/projects/${project}/environments/${prod}/settings`,
-    zIgnored,
+    zEnvironmentSettings,
     { protected: true },
   );
 
@@ -684,7 +691,7 @@ export async function seedTenant(
       token,
       'POST',
       `/api/v1/orgs/${org}/projects/${historyProject}/environments/${environment}/publish`,
-      zIgnored,
+      zPublishResult,
       { version_ids: versions },
     );
   };
@@ -720,7 +727,7 @@ export async function seedTenant(
     token,
     'PUT',
     `/api/v1/orgs/${org}/projects/${historyProject}/keys/${tightenedID}/declaration`,
-    zIgnored,
+    zKey,
     {
       declaration: { rule: { type: 'integer' } },
       presence: { required_in: { mode: 'none' }, forbidden_in: { mode: 'none' } },
@@ -734,7 +741,7 @@ export async function seedTenant(
     token,
     'PUT',
     `/api/v1/orgs/${org}/projects/${historyProject}/environments/${historyDev}/settings`,
-    zIgnored,
+    zEnvironmentSettings,
     { protected: false, reauth_window_seconds: 300 },
   );
 
@@ -765,7 +772,7 @@ export async function seedTenant(
     token,
     'POST',
     `/api/v1/orgs/${org}/projects/${historyProject}/environments/${historyDev}/pins`,
-    zIgnored,
+    zRevisionPinResult,
     {
       workload_principal_id: pinnedWorkload.principal_id,
       // The CURRENT revision, so seeding takes no reveal-history ceremony.

--- a/web/e2e/flows/history.spec.ts
+++ b/web/e2e/flows/history.spec.ts
@@ -2,8 +2,11 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import {
   zExportValuesRequest,
   zPendingDraftList,
+  zPublishResult,
   zPublishRequest,
   zRevisionPinList,
+  zRevisionPinReleaseResult,
+  zRevisionPinResult,
   zValueCell,
 } from '@hikyo/zod';
 
@@ -14,8 +17,7 @@ import {
   expectTouchTargets,
 } from '../fixtures/assertions.ts';
 import {
-  fixtureBrowserCall as api,
-  zFixtureIgnored as zAny,
+  browserApi as api,
   zFixtureRevisionList as zRevisions,
   zFixtureStaged as zStaged,
 } from '../fixtures/api.ts';
@@ -118,7 +120,9 @@ test.beforeAll(async ({ browser }) => {
     const repaired = await api(apiPage, 'PUT', `${DEV}/values/${seed.history.tightenedKey}`, zStaged, {
       value: '12',
     });
-    await api(apiPage, 'POST', `${DEV}/publish`, zAny, { version_ids: [repaired.version_id] });
+    await api(apiPage, 'POST', `${DEV}/publish`, zPublishResult, {
+      version_ids: [repaired.version_id],
+    });
   }
 
   const dev = await api(apiPage, 'GET', `${DEV}/revisions`, zRevisions);
@@ -168,10 +172,15 @@ test.beforeAll(async ({ browser }) => {
     new Date(pins.items[0].expires_at).getTime() - Date.now() < 31 * 24 * 60 * 60 * 1000;
   if (!canonical) {
     for (const pin of pins.items) {
-      await api(apiPage, 'DELETE', `${DEV}/pins/${pin.workload_principal_id}`, zAny);
+      await api(
+        apiPage,
+        'DELETE',
+        `${DEV}/pins/${pin.workload_principal_id}`,
+        zRevisionPinReleaseResult,
+      );
     }
     const expiry = new Date(Date.now() + (seed.history.pinExpiryDays * 24 + 12) * 60 * 60 * 1000);
-    await api(apiPage, 'POST', `${DEV}/pins`, zAny, {
+    await api(apiPage, 'POST', `${DEV}/pins`, zRevisionPinResult, {
       workload_principal_id: seed.history.pinnedWorkloadPrincipal,
       revision: current,
       expires_at: expiry.toISOString(),
@@ -523,7 +532,9 @@ test.describe('revision history', () => {
     const advanced = await api(page, 'PUT', `${DEV}/values/${seed.history.configKey}`, zStaged, {
       value: 'trace',
     });
-    await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [advanced.version_id] });
+    await api(page, 'POST', `${DEV}/publish`, zPublishResult, {
+      version_ids: [advanced.version_id],
+    });
     await page.reload();
     const drawer = page.getByRole('complementary', { name: 'Revision history' });
     await expectNoFixtureSecret(drawer);
@@ -639,7 +650,9 @@ test.describe('revision history', () => {
       const reset = await api(page, 'PUT', `${DEV}/values/${seed.history.secretKey}`, zStaged, {
         value: liveSecret,
       });
-      await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [reset.version_id] });
+      await api(page, 'POST', `${DEV}/publish`, zPublishResult, {
+        version_ids: [reset.version_id],
+      });
     } finally {
       await persistPasskey();
       await refreshSharedSession();
@@ -764,7 +777,9 @@ test.describe('revision history', () => {
       const advanced = await api(page, 'PUT', `${DEV}/values/${seed.history.configKey}`, zStaged, {
         value: 'current-after-pin-target',
       });
-      await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [advanced.version_id] });
+      await api(page, 'POST', `${DEV}/publish`, zPublishResult, {
+        version_ids: [advanced.version_id],
+      });
       await page.reload();
       const revisions = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
       const latest = revisions.items[0]?.revision;
@@ -844,7 +859,7 @@ test.describe('revision history', () => {
 
       // Restore canonical state for the remaining lifecycle test without
       // opening historical material.
-      await api(page, 'POST', `${DEV}/pins`, zAny, {
+      await api(page, 'POST', `${DEV}/pins`, zRevisionPinResult, {
         workload_principal_id: seed.history.pinnedWorkloadPrincipal,
         revision: latest,
         expires_at: new Date(Date.now() + (seed.history.pinExpiryDays * 24 + 12) * 60 * 60 * 1000).toISOString(),

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -16,8 +16,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
+import { browserApi } from '../fixtures/api.ts';
 import {
-  browserApi,
   BASE_URL,
   establishSession,
   INSTANCE_GRANT_TARGET,

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -5,7 +5,7 @@ import {
   expectPinnedAssertionSet,
   expectStatusIsTextAndAria,
 } from '../fixtures/assertions.ts';
-import { fixtureBrowserCall } from '../fixtures/api.ts';
+import { browserApi } from '../fixtures/api.ts';
 import {
   installPasskeyAuthenticator,
   readSeed,
@@ -119,7 +119,7 @@ test.describe('environment matrix', () => {
     const environmentsPath =
       `/api/v1/orgs/${seed.org}/projects/${seed.project}/environments`;
     const orderPath = `${environmentsPath}/order`;
-    await fixtureBrowserCall(page, 'PUT', orderPath, zEnvironmentList, {
+    await browserApi(page, 'PUT', orderPath, zEnvironmentList, {
       environment_ids: [seed.prod, seed.dev],
     });
 
@@ -169,7 +169,7 @@ test.describe('environment matrix', () => {
       await expect.poll(() => readResources.size).toBe(3 + 4 * 2);
     } finally {
       page.off('request', recordMatrixRead);
-      await fixtureBrowserCall(page, 'PUT', orderPath, zEnvironmentList, {
+      await browserApi(page, 'PUT', orderPath, zEnvironmentList, {
         environment_ids: [seed.dev, seed.prod],
       });
     }

--- a/web/e2e/flows/members.spec.ts
+++ b/web/e2e/flows/members.spec.ts
@@ -3,8 +3,8 @@ import { zServiceAccountList } from '@hikyo/zod';
 import { z } from 'zod';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
+import { browserApi } from '../fixtures/api.ts';
 import {
-  browserApi,
   readSeed,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';

--- a/web/e2e/flows/reveal.spec.ts
+++ b/web/e2e/flows/reveal.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { zGrantResult, zPublishResult, zReauthResult } from '@hikyo/zod';
+import { z } from 'zod';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
+import { BrowserApiError, browserApi } from '../fixtures/api.ts';
 import {
   ADMIN,
   countDisclosureEvents,
@@ -50,36 +53,6 @@ function orgGrantPath(principal: string, capability: string): string {
   return `/api/v1/orgs/${seed.org}/grants?${query.toString()}`;
 }
 
-/** apiCall drives the API from inside the page, on the page's own cookies. */
-async function apiCall(
-  page: Page,
-  method: string,
-  path: string,
-  body?: Record<string, string>,
-): Promise<number> {
-  return page.evaluate(
-    async (input: { method: string; path: string; body: Record<string, string> | null }) => {
-      const csrf = (): string => {
-        for (const part of document.cookie.split(';')) {
-          const [name, ...rest] = part.trim().split('=');
-          if (name === '__Host-hikyo-csrf') {
-            return rest.join('=');
-          }
-        }
-        return '';
-      };
-      const resp = await fetch(input.path, {
-        method: input.method,
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf() },
-        ...(input.body === null ? {} : { body: JSON.stringify(input.body) }),
-      });
-      return resp.status;
-    },
-    { method, path, body: body ?? null },
-  );
-}
-
 /** ROTATED is what the blind replacement writes, and what the readback expects. */
 const ROTATED = 'rotated-blind';
 
@@ -119,8 +92,10 @@ async function valueUpdatedAt(page: Page, environment: string, key: string): Pro
  * `pending_version_id` off the signals endpoint and publishes exactly that.
  */
 async function publishOwnDraft(page: Page, environment: string, key: string): Promise<void> {
-  const published = await page.evaluate(
-    async (input: { org: string; project: string; environment: string; key: string }) => {
+  const pending = await page.evaluate(
+    async (
+      input: { org: string; project: string; environment: string; key: string },
+    ): Promise<{ versionID: string | null; error: string | null }> => {
       const base = `/api/v1/orgs/${input.org}/projects/${input.project}/environments/${input.environment}`;
       // The save is fire-and-forget from the DOM's point of view, so the
       // draft may not have committed by the time this runs. Poll the signals
@@ -131,15 +106,15 @@ async function publishOwnDraft(page: Page, environment: string, key: string): Pr
       for (let attempt = 0; attempt < 50 && versionID === undefined; attempt++) {
         const signals = await fetch(`${base}/signals`, { credentials: 'same-origin' });
         if (!signals.ok) {
-          return `signals ${String(signals.status)}`;
+          return { versionID: null, error: `signals ${String(signals.status)}` };
         }
         const body: unknown = await signals.json();
         if (typeof body !== 'object' || body === null) {
-          return 'signals: not a cells object';
+          return { versionID: null, error: 'signals: not a cells object' };
         }
         const cells: unknown = Object(body)['cells'];
         if (!Array.isArray(cells)) {
-          return 'signals: not a cells object';
+          return { versionID: null, error: 'signals: not a cells object' };
         }
         const cell = cells.find((candidate: unknown) => {
           if (typeof candidate !== 'object' || candidate === null) {
@@ -154,29 +129,19 @@ async function publishOwnDraft(page: Page, environment: string, key: string): Pr
         }
       }
       if (versionID === undefined) {
-        return 'no pending draft for key';
+        return { versionID: null, error: 'no pending draft for key' };
       }
-      const cell = { pending_version_id: versionID };
-      const csrf = (): string => {
-        for (const part of document.cookie.split(';')) {
-          const [name, ...rest] = part.trim().split('=');
-          if (name === '__Host-hikyo-csrf') {
-            return rest.join('=');
-          }
-        }
-        return '';
-      };
-      const resp = await fetch(`${base}/publish`, {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf() },
-        body: JSON.stringify({ version_ids: [cell.pending_version_id] }),
-      });
-      return resp.ok ? 'published' : `publish ${String(resp.status)}`;
+      return { versionID, error: null };
     },
     { org: seed.org, project: seed.project, environment, key },
   );
-  expect(published, 'publishing the staged draft').toBe('published');
+  if (pending.error !== null || pending.versionID === null) {
+    throw new Error(`publishing the staged draft: ${pending.error ?? 'missing version id'}`);
+  }
+  const base = `/api/v1/orgs/${seed.org}/projects/${seed.project}/environments/${environment}`;
+  await browserApi(page, 'POST', `${base}/publish`, zPublishResult, {
+    version_ids: [pending.versionID],
+  });
 }
 
 /** auditLines is the surface's per-key disclosure record. */
@@ -538,31 +503,21 @@ test.describe('reveal ceremonies', () => {
 
     // And the server agrees: a code presented against this environment is
     // refused by the ENVIRONMENT's state (409), not as a bad code (401).
-    const status = await page.evaluate(
-      async ({ environment, code }: { environment: string; code: string }) => {
-        const csrf = (() => {
-          for (const part of document.cookie.split(';')) {
-            const [name, ...rest] = part.trim().split('=');
-            if (name === '__Host-hikyo-csrf') {
-              return rest.join('=');
-            }
-          }
-          return '';
-        })();
-        const resp = await fetch('/api/v1/auth/reauth/totp', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json', 'X-Hikyo-CSRF': csrf },
-          body: JSON.stringify({ environment_id: environment, code }),
-        });
-        return resp.status;
-      },
-      // The code's VALUE is irrelevant and that is the point: the window
-      // check runs before any code is verified, so a 409 here proves the
-      // environment refused the factor rather than the code being wrong.
-      { environment: seed.prod, code: '000000' },
-    );
-    expect(status, 'a TOTP reauth against a 0-window environment').toBe(409);
+    try {
+      await browserApi(page, 'POST', '/api/v1/auth/reauth/totp', zReauthResult, {
+        // The code's VALUE is irrelevant and that is the point: the window
+        // check runs before any code is verified, so a 409 here proves the
+        // environment refused the factor rather than the code being wrong.
+        environment_id: seed.prod,
+        code: '000000',
+      });
+      throw new Error('a TOTP reauth against a 0-window environment unexpectedly succeeded');
+    } catch (error) {
+      if (!(error instanceof BrowserApiError)) {
+        throw error;
+      }
+      expect(error.status, 'a TOTP reauth against a 0-window environment').toBe(409);
+    }
 
     // And the positive half of "per disclosure": the passkey ceremony
     // authorises ONE, and the next disclosure asks again. A window that
@@ -691,13 +646,11 @@ test.describe('write-only editing', () => {
 
     // Take both inherited `reveal` lines away: the original instance grant and
     // the creator-admin grant now installed at org scope.
-    let revoked = await apiCall(page, 'DELETE', instanceGrantPath(seed.principal, 'reveal'));
-    expect(revoked, 'revoking instance reveal').toBe(204);
+    await browserApi(page, 'DELETE', instanceGrantPath(seed.principal, 'reveal'), z.null());
     await context.clearCookies();
     await page.goto(VALUES_PATH);
     await establishSession(page);
-    revoked = await apiCall(page, 'DELETE', orgGrantPath(seed.principal, 'reveal'));
-    expect(revoked, 'revoking org reveal').toBe(204);
+    await browserApi(page, 'DELETE', orgGrantPath(seed.principal, 'reveal'), z.null());
 
     try {
       // The revoke killed that session with it, which is the deprovisioning
@@ -746,19 +699,17 @@ test.describe('write-only editing', () => {
       await context.clearCookies();
       await page.goto(VALUES_PATH);
       await establishSession(page);
-      let restored = await apiCall(page, 'POST', '/api/v1/instance/grants', {
+      await browserApi(page, 'POST', '/api/v1/instance/grants', zGrantResult, {
         principal: seed.principal,
         capability: 'reveal',
       });
-      expect(restored, 'restoring instance reveal').toBe(200);
       await context.clearCookies();
       await page.goto(VALUES_PATH);
       await establishSession(page);
-      restored = await apiCall(page, 'POST', `/api/v1/orgs/${seed.org}/grants`, {
+      await browserApi(page, 'POST', `/api/v1/orgs/${seed.org}/grants`, zGrantResult, {
         principal: seed.principal,
         capability: 'reveal',
       });
-      expect(restored, 'restoring org reveal').toBe(200);
     }
 
     // Restored, so read it back: the blind rotation stored exactly what was

--- a/web/e2e/flows/scanning.spec.ts
+++ b/web/e2e/flows/scanning.spec.ts
@@ -2,7 +2,8 @@ import { expect, test } from '@playwright/test';
 import { z } from 'zod';
 
 import { expectPinnedAssertionSet } from '../fixtures/assertions.ts';
-import { browserApi, readSeed, STORAGE_STATE } from '../fixtures/instance.ts';
+import { browserApi } from '../fixtures/api.ts';
+import { readSeed, STORAGE_STATE } from '../fixtures/instance.ts';
 import { surfacesForFlow } from '../registry.ts';
 
 /**

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -12,8 +12,8 @@ import { generatePath } from 'react-router';
 import { z } from 'zod';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
+import { BrowserApiError, browserApi } from '../fixtures/api.ts';
 import {
-  browserApi,
   establishSession,
   installPasskeyAuthenticator,
   readSeed,
@@ -44,7 +44,7 @@ const seed = readSeed();
 const SETTINGS_SURFACES = surfacesForFlow('chrome-settings');
 
 function isBrowserApiStatus(error: unknown, status: number): boolean {
-  return error instanceof Error && error.message.includes(` answered ${status}:`);
+  return error instanceof BrowserApiError && error.status === status;
 }
 
 test.describe('organisation settings', () => {


### PR DESCRIPTION
Closes #372

## Contract

- One page-session `browserApi` owns scoped CSRF lookup, request execution, success parsing, and error construction.
- Non-2xx responses throw `BrowserApiError` with typed `status` and response `body`.
- 204 responses retain the existing `null` contract.
- Fixture callers use generated endpoint response schemas; `zFixtureIgnored` is removed.

## Migration

- Migrated matrix, history, reveal, settings, scanning, members, and instance-admin callers.
- Replaced settings message parsing and reveal raw-status handling with typed catches.
- Removed the duplicate `fixtureBrowserCall`, reveal mutation helpers, and prior `browserApi` owner.

## Generated outputs

None.

## Validation

- `pnpm --dir web test e2e/fixtures/api.test.ts e2e/registry.test.ts` — 16/16 passed.
- `pnpm --dir web run typecheck` — passed.
- `pnpm --dir web run test` — exact head: 38 files, 311/311 passed.
- DCO — 1 commit signed.
- Two-axis review R2 — Standards CLEAN; Spec CLEAN.