### PR TITLE
Centralize operator workload traversal #366

### DIFF
--- a/docs/handoff/366-operator-workload-walk.md
+++ b/docs/handoff/366-operator-workload-walk.md
@@ -1,0 +1,44 @@
+# Handoff: #366 operator workload walk
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/366 (parent #326; audit
+finding `F-S23-2`). Implementation base:
+`428dd6a5e347479a7a3697e2953ce10b7543db58`.
+
+## Contract
+
+- `walkWorkloads` is the private owner for Deployment, StatefulSet, and
+  DaemonSet opt-in filtering, pod-template stamp comparison, stalled reporting,
+  and optional patching.
+- The per-kind table retains Deployment → StatefulSet → DaemonSet traversal and
+  each Kubernetes list's item order.
+- Patch mode requests a rollout only when the pod-template stamp differs.
+  Observe mode remains read-only and reports only workloads already carrying
+  the current stamp.
+- Trigger gating, empty-stamp gating, patch error text, list errors, condition
+  text, wire/audit contracts, and generated outputs are unchanged. Database
+  migrations: none. Generated outputs: none.
+
+## Regression evidence
+
+- `TestStalledObservedOnCurrentPath` now drives all three supported workload
+  kinds through a full delivery followed by a read-only current response.
+- The test asserts the exact persisted stalled-condition message and the
+  Deployment → StatefulSet → DaemonSet order.
+- The initial full delivery also proves all three workload kinds use the shared
+  patch path before the read-only observation.
+
+## Validation
+
+```text
+go test -count=1 ./internal/operator -run '^TestStalledObservedOnCurrentPath$'  passed
+go test -count=1 ./internal/operator                                     passed
+go test -count=1 ./...                                                    passed (61 packages)
+go vet ./...                                                             passed
+gofmt -l <changed-go-files>                                              clean
+git diff --check                                                         clean
+```
+
+## Review
+
+- Standards round 1 found duplicated test helpers; fixed. Round 2: `CLEAN`.
+- Spec round 1: `CLEAN`.

--- a/internal/operator/harness_test.go
+++ b/internal/operator/harness_test.go
@@ -194,12 +194,23 @@ func (h *harness) getSecret(ns, name string) (*corev1.Secret, bool) {
 }
 
 func (h *harness) getDeployment(name string) *appsv1.Deployment {
+	return getWorkload(h, name, "deployment", &appsv1.Deployment{})
+}
+
+func (h *harness) getStatefulSet(name string) *appsv1.StatefulSet {
+	return getWorkload(h, name, "statefulset", &appsv1.StatefulSet{})
+}
+
+func (h *harness) getDaemonSet(name string) *appsv1.DaemonSet {
+	return getWorkload(h, name, "daemonset", &appsv1.DaemonSet{})
+}
+
+func getWorkload[T client.Object](h *harness, name, kind string, workload T) T {
 	h.t.Helper()
-	var d appsv1.Deployment
-	if err := h.cl.Get(context.Background(), types.NamespacedName{Namespace: testNS, Name: name}, &d); err != nil {
-		h.t.Fatalf("get deployment %q: %v", name, err)
+	if err := h.cl.Get(context.Background(), types.NamespacedName{Namespace: testNS, Name: name}, workload); err != nil {
+		h.t.Fatalf("get %s %q: %v", kind, name, err)
 	}
-	return &d
+	return workload
 }
 
 // drainEvents collects the reasons emitted so far without blocking.
@@ -338,16 +349,42 @@ func makeOwnedSecret(t *testing.T, sch *runtime.Scheme, cr *hikyov1.HikyoSecret,
 
 // makeOptedInDeployment builds a Deployment consuming the target (opt-in).
 func makeOptedInDeployment(name string, consumesTargets ...string) *appsv1.Deployment {
-	ann := map[string]string{}
-	if len(consumesTargets) > 0 {
-		ann[hikyov1.AnnotationWorkloadSecrets] = strings.Join(consumesTargets, ",")
-	}
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name, Annotations: ann},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name, Annotations: workloadAnnotations(consumesTargets)},
 		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+			Template: emptyPodTemplate(),
 		},
 	}
+}
+
+func makeOptedInStatefulSet(name string, consumesTargets ...string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name, Annotations: workloadAnnotations(consumesTargets)},
+		Spec: appsv1.StatefulSetSpec{
+			Template: emptyPodTemplate(),
+		},
+	}
+}
+
+func makeOptedInDaemonSet(name string, consumesTargets ...string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name, Annotations: workloadAnnotations(consumesTargets)},
+		Spec: appsv1.DaemonSetSpec{
+			Template: emptyPodTemplate(),
+		},
+	}
+}
+
+func workloadAnnotations(consumesTargets []string) map[string]string {
+	annotations := map[string]string{}
+	if len(consumesTargets) > 0 {
+		annotations[hikyov1.AnnotationWorkloadSecrets] = strings.Join(consumesTargets, ",")
+	}
+	return annotations
+}
+
+func emptyPodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}}
 }
 
 // deliveryJSON builds a 200 response body.

--- a/internal/operator/reconcile_scenarios_test.go
+++ b/internal/operator/reconcile_scenarios_test.go
@@ -321,7 +321,9 @@ func TestStalledObservedOnCurrentPath(t *testing.T) {
 	cr := makeCR("app")
 	h := newHarness(t, interceptor.Funcs{},
 		makeInstance(""), makeBootstrapSecret("boot", testInstance, "tok", true),
-		makeOptedInDeployment("web", testTarget), cr)
+		makeOptedInDeployment("web", testTarget),
+		makeOptedInStatefulSet("database", testTarget),
+		makeOptedInDaemonSet("agent", testTarget), cr)
 	h.stub.set(200, deliveryJSON(false, "v1:cur1", "v1:t", []deliveredKey{secretVal("API_KEY", "v")}, nil))
 	if _, err := h.reconcile("app"); err != nil {
 		t.Fatalf("reconcile1: %v", err)
@@ -334,6 +336,21 @@ func TestStalledObservedOnCurrentPath(t *testing.T) {
 	if err := h.cl.Update(context.Background(), web); err != nil {
 		t.Fatalf("update web status: %v", err)
 	}
+	database := h.getStatefulSet("database")
+	database.Generation = 2
+	database.Status.ObservedGeneration = 1
+	database.Status.Replicas = 1
+	database.Status.UpdatedReplicas = 0
+	if err := h.cl.Update(context.Background(), database); err != nil {
+		t.Fatalf("update database status: %v", err)
+	}
+	agent := h.getDaemonSet("agent")
+	agent.Generation = 2
+	agent.Status.ObservedGeneration = 1
+	agent.Status.NumberUnavailable = 1
+	if err := h.cl.Update(context.Background(), agent); err != nil {
+		t.Fatalf("update agent status: %v", err)
+	}
 	// Reconcile 2: eligible cursor, server answers current; rollout is evaluated
 	// read-only and the stall surfaces.
 	h.stub.set(200, deliveryJSON(true, "v1:cur1", "v1:t", nil, nil))
@@ -343,4 +360,14 @@ func TestStalledObservedOnCurrentPath(t *testing.T) {
 	got := h.getCR("app")
 	requireCond(t, got, hikyov1.ConditionSynced, metav1.ConditionTrue, hikyov1.ReasonCurrent)
 	requireCond(t, got, hikyov1.ConditionRollout, metav1.ConditionFalse, hikyov1.ReasonStalled)
+	for _, cond := range got.Status.Conditions {
+		if cond.Type == hikyov1.ConditionRollout {
+			want := "opted-in workloads not progressed after the stamp patch: Deployment/web, StatefulSet/database, DaemonSet/agent"
+			if cond.Message != want {
+				t.Fatalf("rollout condition message = %q, want %q", cond.Message, want)
+			}
+			return
+		}
+	}
+	t.Fatal("rollout condition absent")
 }

--- a/internal/operator/workload.go
+++ b/internal/operator/workload.go
@@ -70,71 +70,7 @@ func (r *HikyoSecretReconciler) patchWorkloads(ctx context.Context, cr *hikyov1.
 	if !r.Config.TriggerRollouts {
 		return nil, nil
 	}
-	annKey := hikyov1.StampAnnotationPrefix + cr.Spec.Target.Name
-
-	var stalled []string
-
-	deploys := &appsv1.DeploymentList{}
-	if err := r.List(ctx, deploys, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range deploys.Items {
-		d := &deploys.Items[i]
-		if !consumesTarget(d.Annotations, cr.Spec.Target.Name) {
-			continue
-		}
-		if podAnnotation(d.Spec.Template.Annotations, annKey) == stamp {
-			if !deploymentProgressed(d) {
-				stalled = append(stalled, "Deployment/"+d.Name)
-			}
-			continue
-		}
-		if err := r.patchPodTemplateAnnotation(ctx, d, annKey, stamp); err != nil {
-			return nil, fmt.Errorf("patch Deployment %q: %w", d.Name, err)
-		}
-	}
-
-	sts := &appsv1.StatefulSetList{}
-	if err := r.List(ctx, sts, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range sts.Items {
-		s := &sts.Items[i]
-		if !consumesTarget(s.Annotations, cr.Spec.Target.Name) {
-			continue
-		}
-		if podAnnotation(s.Spec.Template.Annotations, annKey) == stamp {
-			if !statefulSetProgressed(s) {
-				stalled = append(stalled, "StatefulSet/"+s.Name)
-			}
-			continue
-		}
-		if err := r.patchPodTemplateAnnotation(ctx, s, annKey, stamp); err != nil {
-			return nil, fmt.Errorf("patch StatefulSet %q: %w", s.Name, err)
-		}
-	}
-
-	ds := &appsv1.DaemonSetList{}
-	if err := r.List(ctx, ds, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range ds.Items {
-		d := &ds.Items[i]
-		if !consumesTarget(d.Annotations, cr.Spec.Target.Name) {
-			continue
-		}
-		if podAnnotation(d.Spec.Template.Annotations, annKey) == stamp {
-			if !daemonSetProgressed(d) {
-				stalled = append(stalled, "DaemonSet/"+d.Name)
-			}
-			continue
-		}
-		if err := r.patchPodTemplateAnnotation(ctx, d, annKey, stamp); err != nil {
-			return nil, fmt.Errorf("patch DaemonSet %q: %w", d.Name, err)
-		}
-	}
-
-	return stalled, nil
+	return r.walkWorkloads(ctx, cr, stamp, true)
 }
 
 // observeRollout is the READ-ONLY rollout evaluation used on the `current` path
@@ -146,44 +82,102 @@ func (r *HikyoSecretReconciler) observeRollout(ctx context.Context, cr *hikyov1.
 	if !r.Config.TriggerRollouts || stamp == "" {
 		return nil, nil
 	}
+	return r.walkWorkloads(ctx, cr, stamp, false)
+}
+
+type rolloutWorkloadKind struct {
+	name       string
+	list       client.ObjectList
+	count      func() int
+	workloadAt func(int) rolloutWorkload
+}
+
+type rolloutWorkload struct {
+	object              client.Object
+	templateAnnotations map[string]string
+	progressed          bool
+}
+
+// rolloutWorkloadKinds adapts each Kubernetes workload list to the one walk
+// that owns opt-in, stamp, progress, ordering, and patch-error behavior.
+func rolloutWorkloadKinds() []rolloutWorkloadKind {
+	deployments := &appsv1.DeploymentList{}
+	statefulSets := &appsv1.StatefulSetList{}
+	daemonSets := &appsv1.DaemonSetList{}
+
+	return []rolloutWorkloadKind{
+		{
+			name:  "Deployment",
+			list:  deployments,
+			count: func() int { return len(deployments.Items) },
+			workloadAt: func(i int) rolloutWorkload {
+				workload := &deployments.Items[i]
+				return rolloutWorkload{
+					object:              workload,
+					templateAnnotations: workload.Spec.Template.Annotations,
+					progressed:          deploymentProgressed(workload),
+				}
+			},
+		},
+		{
+			name:  "StatefulSet",
+			list:  statefulSets,
+			count: func() int { return len(statefulSets.Items) },
+			workloadAt: func(i int) rolloutWorkload {
+				workload := &statefulSets.Items[i]
+				return rolloutWorkload{
+					object:              workload,
+					templateAnnotations: workload.Spec.Template.Annotations,
+					progressed:          statefulSetProgressed(workload),
+				}
+			},
+		},
+		{
+			name:  "DaemonSet",
+			list:  daemonSets,
+			count: func() int { return len(daemonSets.Items) },
+			workloadAt: func(i int) rolloutWorkload {
+				workload := &daemonSets.Items[i]
+				return rolloutWorkload{
+					object:              workload,
+					templateAnnotations: workload.Spec.Template.Annotations,
+					progressed:          daemonSetProgressed(workload),
+				}
+			},
+		},
+	}
+}
+
+// walkWorkloads owns the common workload invariant. patch requests rollouts for
+// stale stamps; observe-only walks report stalls without writing.
+func (r *HikyoSecretReconciler) walkWorkloads(ctx context.Context, cr *hikyov1.HikyoSecret, stamp string, patch bool) ([]string, error) {
 	annKey := hikyov1.StampAnnotationPrefix + cr.Spec.Target.Name
 	var stalled []string
 
-	deploys := &appsv1.DeploymentList{}
-	if err := r.List(ctx, deploys, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range deploys.Items {
-		d := &deploys.Items[i]
-		if consumesTarget(d.Annotations, cr.Spec.Target.Name) &&
-			podAnnotation(d.Spec.Template.Annotations, annKey) == stamp && !deploymentProgressed(d) {
-			stalled = append(stalled, "Deployment/"+d.Name)
+	for _, kind := range rolloutWorkloadKinds() {
+		if err := r.List(ctx, kind.list, client.InNamespace(cr.Namespace)); err != nil {
+			return nil, err
+		}
+		for i := 0; i < kind.count(); i++ {
+			workload := kind.workloadAt(i)
+			if !consumesTarget(workload.object.GetAnnotations(), cr.Spec.Target.Name) {
+				continue
+			}
+			if podAnnotation(workload.templateAnnotations, annKey) == stamp {
+				if !workload.progressed {
+					stalled = append(stalled, kind.name+"/"+workload.object.GetName())
+				}
+				continue
+			}
+			if !patch {
+				continue
+			}
+			if err := r.patchPodTemplateAnnotation(ctx, workload.object, annKey, stamp); err != nil {
+				return nil, fmt.Errorf("patch %s %q: %w", kind.name, workload.object.GetName(), err)
+			}
 		}
 	}
 
-	sts := &appsv1.StatefulSetList{}
-	if err := r.List(ctx, sts, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range sts.Items {
-		s := &sts.Items[i]
-		if consumesTarget(s.Annotations, cr.Spec.Target.Name) &&
-			podAnnotation(s.Spec.Template.Annotations, annKey) == stamp && !statefulSetProgressed(s) {
-			stalled = append(stalled, "StatefulSet/"+s.Name)
-		}
-	}
-
-	ds := &appsv1.DaemonSetList{}
-	if err := r.List(ctx, ds, client.InNamespace(cr.Namespace)); err != nil {
-		return nil, err
-	}
-	for i := range ds.Items {
-		d := &ds.Items[i]
-		if consumesTarget(d.Annotations, cr.Spec.Target.Name) &&
-			podAnnotation(d.Spec.Template.Annotations, annKey) == stamp && !daemonSetProgressed(d) {
-			stalled = append(stalled, "DaemonSet/"+d.Name)
-		}
-	}
 	return stalled, nil
 }
 


### PR DESCRIPTION
Closes #366

## Contract

- One walkWorkloads owner handles Deployment, StatefulSet, and DaemonSet opt-in filtering, pod-template stamp comparison, stalled reporting, and optional patching.
- Per-kind table preserves Deployment -> StatefulSet -> DaemonSet traversal and per-list item order.
- Patch mode writes only stale stamps; observe mode remains read-only and reports only workloads carrying the current stamp.
- Trigger and empty-stamp gates, patch/list error text, condition text, wire/audit behavior, and failure modes remain unchanged.

## Migration and generated outputs

- Database migrations: none.
- Contract changes: none.
- Generated outputs: none.

## Validation

- go test -count=1 ./internal/operator -run ^TestStalledObservedOnCurrentPath$: passed
- go test -count=1 ./internal/operator: passed
- go test -count=1 ./...: passed across 61 packages
- go vet ./...: passed
- gofmt -l changed Go files: clean
- git diff --check: clean

## Review

- Standards round 1 found duplicated test helpers; fixed. Round 2: CLEAN.
- Spec round 1: CLEAN.

## Merge coordination

Branch intentionally remains on its implementation base until this PR is the lowest-numbered open non-draft PR. At that point it may be updated onto current main and revalidated.