### PR TITLE
Centralize crypto derivation rotation handles #365

### DIFF
--- a/docs/handoff/365-crypto-rotation-handles.md
+++ b/docs/handoff/365-crypto-rotation-handles.md
@@ -1,0 +1,56 @@
+# Issue #365 — crypto token/scanning rotation handles
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/365 (parent #326; audit
+finding `F-S17-1`).
+
+**State: implemented.** Token and scanning derivation-key rotation now share
+one atomic, monotonic handle owner.
+
+## Contract
+
+- `swapHandle` owns one immutable `keyHandle` behind an `atomic.Pointer`.
+- `get` returns one atomic snapshot. `adopt` advances only to a strictly newer
+  version, so a late predecessor callback cannot regress live key material.
+- `PrepareTokenKeyRotation` and `PrepareScanningKeyRotation` delegate their
+  common mint/adopt/abort sequence to `prepareDerivationKeyRotation`; callers
+  defer abort so rolled-back candidates are zeroed, then adopt only after
+  persistence commits.
+- Superseded key bytes remain unzeroed because an in-flight derivation may
+  still hold the immutable handle.
+- `rootRotationPending` is an `atomic.Bool`, removing the finalize/read race
+  between the service and app warning path.
+
+`swapHandle` embeds `redactor`, is pinned by the crypto compile-time redaction
+surface and `lint.SensitiveTypes`, and is covered by the planted-secret test.
+
+Generated outputs: none. Database migrations: none.
+
+## Regression evidence
+
+Before the atomic pending-state change,
+`TestRootRotationPendingConcurrentAccess` failed under `-race` with concurrent
+accesses in `RootRotationPending` and `ClearRootRotationPending`. The same test
+passes after the change. `TestTokenKeyRotationAdoptIsMonotonic` additionally
+proves through token output that a late predecessor adopt cannot replace the
+newer live key.
+
+## Validation
+
+```text
+go test -race -count=1 ./internal/crypto                         135 passed
+go test -count=1 ./internal/lint                                 30 passed
+go test -count=1 ./internal/service -run 'Rotation|TokenKey|ScanningKey'
+                                                                   1 passed
+go test -count=1 ./internal/conformance \
+  -run '^TestConformanceSQLite/(keyring_lifecycle|keyring_one_active_key_per_scope)$'
+                                                                   3 passed
+go test -count=1 ./...                                           3595 passed
+git diff --check                                                   passed
+```
+
+## Review
+
+- Standards axis: `CLEAN` after round 2; nil-handle refusal and candidate-key
+  abort zeroing findings fixed and verified.
+- Specification axis: `CLEAN`; #365 is complete without merging instance or
+  master key ownership into the new handle.

--- a/internal/crypto/keyring.go
+++ b/internal/crypto/keyring.go
@@ -216,6 +216,34 @@ type keyHandle struct {
 	key     []byte
 }
 
+// swapHandle owns one immutable derivation-key handle. Readers take one
+// atomic snapshot; adopt advances the live handle monotonically, so a late
+// callback from an older committed rotation cannot regress the process.
+type swapHandle struct {
+	redactor
+	current atomic.Pointer[keyHandle]
+}
+
+func (h *swapHandle) get() keyHandle {
+	current := h.current.Load()
+	if current == nil {
+		panic("crypto: uninitialized derivation key handle")
+	}
+	return *current
+}
+
+func (h *swapHandle) adopt(next keyHandle) bool {
+	for {
+		current := h.current.Load()
+		if current != nil && next.version <= current.version {
+			return false
+		}
+		if h.current.CompareAndSwap(current, &next) {
+			return true
+		}
+	}
+}
+
 // versionSet is the unwrapped key material for one tier-3 scope across every
 // still-openable version: the active version new writes seal under, plus every
 // retiring version whose ciphertext a reencrypt has not yet moved. It is built
@@ -259,18 +287,10 @@ type Keyring struct {
 	// immutable set.
 	instance atomic.Pointer[versionSet]
 
-	// tokenMu guards the root token key handle against `rotate-token-key`
-	// swapping it under a concurrent derivation. It is separate from mu (the
-	// DEK cache's lock) so a rotation's datastore write never holds the lock
-	// every value read needs.
-	tokenMu sync.Mutex
-	token   keyHandle
-
-	// scanningMu guards the scanning-fingerprint key handle against
-	// `rotate-scanning-key` swapping it under a concurrent fingerprint
-	// computation, exactly as tokenMu guards the token key.
-	scanningMu sync.Mutex
-	scanning   keyHandle
+	// token and scanning own the two replace-in-place derivation keys. Each
+	// reader sees one immutable handle; rotation adoption is monotonic.
+	token    swapHandle
+	scanning swapHandle
 
 	mu   sync.Mutex
 	deks map[string]*list.Element // scope → *list.Element holding *dekEntry
@@ -289,15 +309,15 @@ type Keyring struct {
 	// rootRotationPending records whether load saw more than one active master
 	// wrapper — the dual-wrapped transition state of an unfinished root
 	// rotation. Boot warns on it every start until finalize (encryption-model
-	// ADR § Rotation). Set once at load.
-	rootRotationPending bool
+	// ADR § Rotation). Initialized at load and cleared after finalize.
+	rootRotationPending atomic.Bool
 }
 
 // RootRotationPending reports whether this instance booted with a root rotation
 // half-done (the master dual-wrapped under two roots). Boot warns on it every
 // start until `rotate-root-key --finalize` — a rotation half-done must be
 // visible, not silent.
-func (k *Keyring) RootRotationPending() bool { return k.rootRotationPending }
+func (k *Keyring) RootRotationPending() bool { return k.rootRotationPending.Load() }
 
 // LockHierarchyRotation / UnlockHierarchyRotation serialize master and root
 // rotations process-wide (see hierarchyRotationMu). The caller holds the lock
@@ -355,7 +375,7 @@ func LoadKeyring(ctx context.Context, ks KeyStore, root []byte) (*Keyring, error
 	// More than one active wrapper is the dual-wrapped transition of an
 	// unfinished root rotation: bootable under either root, warned on every
 	// start until finalized.
-	k.rootRotationPending = len(wrappers) > 1
+	k.rootRotationPending.Store(len(wrappers) > 1)
 
 	master, err := k.unwrapMaster(root, wrappers)
 	if err != nil {
@@ -368,12 +388,16 @@ func LoadKeyring(ctx context.Context, ks KeyStore, root []byte) (*Keyring, error
 		return nil, err
 	}
 	k.instance.Store(instance)
-	if k.token, err = k.loadTier3(ctx, PurposeToken, "", ""); err != nil {
+	token, err := k.loadTier3(ctx, PurposeToken, "", "")
+	if err != nil {
 		return nil, err
 	}
-	if k.scanning, err = k.loadOrMintScanning(ctx); err != nil {
+	k.token.adopt(token)
+	scanning, err := k.loadOrMintScanning(ctx)
+	if err != nil {
 		return nil, err
 	}
+	k.scanning.adopt(scanning)
 	return k, nil
 }
 
@@ -474,8 +498,8 @@ func (k *Keyring) mintHierarchy(ctx context.Context, root []byte) error {
 		active: instance.version,
 		byVer:  map[uint32]keyHandle{instance.version: instance},
 	})
-	k.token = token
-	k.scanning = scanning
+	k.token.adopt(token)
+	k.scanning.adopt(scanning)
 	return nil
 }
 
@@ -511,6 +535,23 @@ func (k *Keyring) mintTier3At(p Purpose, orgID, projectID string, version uint32
 		return keyHandle{}, WrappedKey{}, err
 	}
 	return keyHandle{id: row.ID, version: row.Version, key: key}, row, nil
+}
+
+func (k *Keyring) prepareDerivationKeyRotation(p Purpose, live *swapHandle) (WrappedKey, func(), func(), error) {
+	next, row, err := k.mintTier3At(p, "", "", live.get().version+1)
+	if err != nil {
+		return WrappedKey{}, nil, nil, err
+	}
+	var finish sync.Once
+	adopt := func() {
+		finish.Do(func() {
+			if !live.adopt(next) {
+				Zero(next.key)
+			}
+		})
+	}
+	abort := func() { finish.Do(func() { Zero(next.key) }) }
+	return row, adopt, abort, nil
 }
 
 // tier3AAD is the one place the tier-3 row → AAD mapping lives: the token
@@ -773,7 +814,7 @@ func (k *Keyring) VerifyRootKeyRotation(ctx context.Context, primaryRoot []byte)
 // ClearRootRotationPending records that the pending root rotation has been
 // finalized in this process, so RootRotationPending stops reporting the
 // dual-wrapped state without waiting for a reboot.
-func (k *Keyring) ClearRootRotationPending() { k.rootRotationPending = false }
+func (k *Keyring) ClearRootRotationPending() { k.rootRotationPending.Store(false) }
 
 // PrepareMasterKeyRotation generates a new master key, re-wraps every openable
 // tier-3 key under it, and returns the new master row, the re-wrapped tier-3

--- a/internal/crypto/keyring_test.go
+++ b/internal/crypto/keyring_test.go
@@ -516,6 +516,33 @@ func TestRootKeyRotationCrashSafe(t *testing.T) {
 	}
 }
 
+func TestRootRotationPendingConcurrentAccess(t *testing.T) {
+	kr := &Keyring{}
+	kr.rootRotationPending.Store(true)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 1_000 {
+			_ = kr.RootRotationPending()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 1_000 {
+			kr.ClearRootRotationPending()
+		}
+	}()
+	close(start)
+	wg.Wait()
+	if kr.RootRotationPending() {
+		t.Fatal("cleared root rotation still reports pending")
+	}
+}
+
 // Prepare is refused while a root rotation is already pending (dual-wrapped):
 // two pending rotations are the four-way matrix the ADR refuses.
 func TestRootKeyRotationPrepareBlockedWhenPending(t *testing.T) {

--- a/internal/crypto/redact.go
+++ b/internal/crypto/redact.go
@@ -48,5 +48,6 @@ var (
 	_ redactionSurface = (*ProjectSealer)(nil)
 	_ redactionSurface = (*InstanceSealer)(nil)
 	_ redactionSurface = keyHandle{}
+	_ redactionSurface = swapHandle{}
 	_ redactionSurface = dekEntry{}
 )

--- a/internal/crypto/redact_test.go
+++ b/internal/crypto/redact_test.go
@@ -16,9 +16,8 @@ import (
 // exactly what these surfaces exist to intercept.
 func TestRedactionSurfacesAgainstPlantedSecret(t *testing.T) {
 	planted := []byte("PLANTED-SECRET-0123456789abcdef01")
-	kr := &Keyring{
-		token: keyHandle{id: "token-root", version: 1, key: planted},
-	}
+	kr := &Keyring{}
+	kr.token.adopt(keyHandle{id: "token-root", version: 1, key: planted})
 	kr.master.Store(singleMaster(1, planted))
 	kr.instance.Store(&versionSet{active: 1, byVer: map[uint32]keyHandle{1: {id: "dek-instance", version: 1, key: planted}}})
 	dekSet := &versionSet{active: 1, byVer: map[uint32]keyHandle{1: {id: "dek", key: planted}}}
@@ -27,6 +26,7 @@ func TestRedactionSurfacesAgainstPlantedSecret(t *testing.T) {
 		"project sealer":  &ProjectSealer{kr: kr, orgID: "o", projectID: "p", deks: dekSet},
 		"instance sealer": &InstanceSealer{kr: kr},
 		"key handle":      keyHandle{id: "h", key: planted},
+		"swap handle":     &kr.token,
 		"version set":     dekSet,
 		"master set":      kr.master.Load(),
 		"dek entry":       dekEntry{scope: "s", set: dekSet},

--- a/internal/crypto/scanning.go
+++ b/internal/crypto/scanning.go
@@ -50,20 +50,18 @@ func (k *Keyring) ScanningFingerprint(orgID, projectID, envID, keyID string, val
 	return mac.Sum(nil)
 }
 
-// scanningKey reads the live scanning-fingerprint key under the rotation mutex,
-// so a fingerprint racing `rotate-scanning-key` sees exactly one version rather
-// than a torn handle. Callers fingerprint per use and never retain the key.
+// scanningKey atomically snapshots the live scanning-fingerprint key, so a
+// fingerprint racing `rotate-scanning-key` sees exactly one immutable handle.
+// Callers fingerprint per use and never retain the key.
 func (k *Keyring) scanningKey() []byte {
-	k.scanningMu.Lock()
-	defer k.scanningMu.Unlock()
-	return k.scanning.key
+	return k.scanning.get().key
 }
 
-// PrepareScanningKeyRotation mints the next scanning-fingerprint key and returns
-// its wrapped row plus the function that adopts it, mirroring
-// PrepareTokenKeyRotation: the material never leaves this package, the caller
-// persists the row inside its own authorized transaction, and adopt runs only
-// AFTER that transaction commits.
+// PrepareScanningKeyRotation mints the next scanning-fingerprint key and
+// returns its wrapped row plus mutually exclusive adopt and abort functions,
+// mirroring PrepareTokenKeyRotation: the material never leaves this package,
+// the caller defers abort, persists the row inside its own authorized
+// transaction, and adopt runs only AFTER that transaction commits.
 //
 // `rotate-scanning-key` is OUTRIGHT REPLACEMENT (secret-scanning ADR §4): there
 // is no version keyring and no reencrypt walk, because a fingerprint is a keyed
@@ -79,22 +77,6 @@ func (k *Keyring) scanningKey() []byte {
 // holding the buffer, and computing under a zeroed key would be a silent
 // break rather than a loud failure — the same reason the token key and the DEK
 // cache do not zero superseded material.
-func (k *Keyring) PrepareScanningKeyRotation() (WrappedKey, func(), error) {
-	k.scanningMu.Lock()
-	current := k.scanning
-	k.scanningMu.Unlock()
-
-	handle, row, err := k.mintTier3At(PurposeScanning, "", "", current.version+1)
-	if err != nil {
-		return WrappedKey{}, nil, err
-	}
-	return row, func() {
-		k.scanningMu.Lock()
-		defer k.scanningMu.Unlock()
-		// Monotonic: a late adopt from a slower winner cannot regress the live
-		// handle to a retired key (see PrepareTokenKeyRotation).
-		if handle.version > k.scanning.version {
-			k.scanning = handle
-		}
-	}, nil
+func (k *Keyring) PrepareScanningKeyRotation() (WrappedKey, func(), func(), error) {
+	return k.prepareDerivationKeyRotation(PurposeScanning, &k.scanning)
 }

--- a/internal/crypto/scanning_test.go
+++ b/internal/crypto/scanning_test.go
@@ -17,7 +17,9 @@ func fixedScanningKeyring() *Keyring {
 	for i := range key {
 		key[i] = byte(i)
 	}
-	return &Keyring{scanning: keyHandle{version: 1, key: key}}
+	kr := &Keyring{}
+	kr.scanning.adopt(keyHandle{version: 1, key: key})
+	return kr
 }
 
 // Golden known-answer vector (SS4): pins the exact fingerprint bytes for a
@@ -153,12 +155,13 @@ func TestScanningKeyRotationAdopt(t *testing.T) {
 		t.Fatal(err)
 	}
 	before := kr.ScanningFingerprint("o", "p", "e", "k", []byte("v"))
-	v0 := kr.scanning.version
+	v0 := kr.scanning.get().version
 
-	row, adopt, err := kr.PrepareScanningKeyRotation()
+	row, adopt, abort, err := kr.PrepareScanningKeyRotation()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer abort()
 	if row.Version != v0+1 {
 		t.Fatalf("rotated row version = %d, want %d", row.Version, v0+1)
 	}
@@ -167,8 +170,8 @@ func TestScanningKeyRotationAdopt(t *testing.T) {
 		t.Fatal("fingerprint changed before adopt")
 	}
 	adopt()
-	if kr.scanning.version != v0+1 {
-		t.Fatalf("live version after adopt = %d, want %d", kr.scanning.version, v0+1)
+	if kr.scanning.get().version != v0+1 {
+		t.Fatalf("live version after adopt = %d, want %d", kr.scanning.get().version, v0+1)
 	}
 	if bytes.Equal(before, kr.ScanningFingerprint("o", "p", "e", "k", []byte("v"))) {
 		t.Fatal("fingerprint unchanged after rotation adopt — old fingerprints must die")
@@ -180,7 +183,8 @@ func TestScanningKeyRotationAdopt(t *testing.T) {
 // relies on to invalidate every dismissal at once.
 func TestScanningFingerprintKeySeparation(t *testing.T) {
 	k1 := fixedScanningKeyring()
-	k2 := &Keyring{scanning: keyHandle{version: 2, key: bytes.Repeat([]byte{0xA5}, KeySize)}}
+	k2 := &Keyring{}
+	k2.scanning.adopt(keyHandle{version: 2, key: bytes.Repeat([]byte{0xA5}, KeySize)})
 	const value = "AKIAIOSFODNN7EXAMPLE"
 	if bytes.Equal(
 		k1.ScanningFingerprint("o", "p", "e", "k", []byte(value)),

--- a/internal/crypto/token.go
+++ b/internal/crypto/token.go
@@ -79,19 +79,17 @@ func (k *Keyring) PublishPreviewToken(orgID, projectID, envID string, encoding [
 	return tag(key, encoding), nil
 }
 
-// rootTokenKey reads the live root token key under the rotation mutex, so a
-// derivation racing `rotate-token-key` sees exactly one version rather than a
-// torn handle. Callers derive per use and never retain the result.
+// rootTokenKey atomically snapshots the live root token key, so a derivation
+// racing `rotate-token-key` sees exactly one immutable handle. Callers derive
+// per use and never retain the result.
 func (k *Keyring) rootTokenKey() []byte {
-	k.tokenMu.Lock()
-	defer k.tokenMu.Unlock()
-	return k.token.key
+	return k.token.get().key
 }
 
-// PrepareTokenKeyRotation mints the next root token key and returns its
-// wrapped row plus the function that adopts it. The material never leaves this
-// package: the caller persists the row inside its own authorized transaction
-// and calls adopt only AFTER that transaction commits.
+// PrepareTokenKeyRotation mints the next root token key and returns its wrapped
+// row plus mutually exclusive adopt and abort functions. The material never
+// leaves this package: the caller defers abort, persists the row inside its own
+// authorized transaction, and calls adopt only AFTER that transaction commits.
 //
 // The split exists because the persistence closure runs inside a retryable
 // transaction: an attempt that is rolled back and retried mints fresh material
@@ -112,25 +110,6 @@ func (k *Keyring) rootTokenKey() []byte {
 // holding the buffer, and deriving under a zeroed key would be a silent
 // confidentiality break rather than a loud failure — the same reason the DEK
 // cache does not zero evicted entries.
-func (k *Keyring) PrepareTokenKeyRotation() (WrappedKey, func(), error) {
-	k.tokenMu.Lock()
-	current := k.token
-	k.tokenMu.Unlock()
-
-	handle, row, err := k.mintTier3At(PurposeToken, "", "", current.version+1)
-	if err != nil {
-		return WrappedKey{}, nil, err
-	}
-	return row, func() {
-		k.tokenMu.Lock()
-		defer k.tokenMu.Unlock()
-		// Monotonic: two concurrent rotations commit in some serial order, but
-		// their adopts may run in the other order. The store's retire is a
-		// compare-and-swap on the predecessor version, so at most one of them
-		// committed -- this guard makes the losing (or late) adopt a no-op
-		// instead of regressing the live handle to a retired key.
-		if handle.version > k.token.version {
-			k.token = handle
-		}
-	}, nil
+func (k *Keyring) PrepareTokenKeyRotation() (WrappedKey, func(), func(), error) {
+	return k.prepareDerivationKeyRotation(PurposeToken, &k.token)
 }

--- a/internal/crypto/token_test.go
+++ b/internal/crypto/token_test.go
@@ -2,8 +2,23 @@ package crypto
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
+
+type keyCaptureReader struct {
+	key []byte
+}
+
+func (r *keyCaptureReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0xA5
+	}
+	if len(p) == KeySize && r.key == nil {
+		r.key = p
+	}
+	return len(p), nil
+}
 
 func TestScopedTokenFamiliesPreserveGoldenVectorsAndScopeSeparation(t *testing.T) {
 	t.Parallel()
@@ -11,7 +26,9 @@ func TestScopedTokenFamiliesPreserveGoldenVectorsAndScopeSeparation(t *testing.T
 	// Fixed root, scope and payload make these known-answer vectors protocol
 	// sentinels: changing a label or field encoding changes the literal output.
 	newKeyring := func() *Keyring {
-		return &Keyring{token: keyHandle{key: bytes.Repeat([]byte{0x42}, KeySize)}}
+		kr := &Keyring{}
+		kr.token.adopt(keyHandle{key: bytes.Repeat([]byte{0x42}, KeySize)})
+		return kr
 	}
 	type tokenFn func(*Keyring, string, string, string, []byte) (string, error)
 	tests := []struct {
@@ -62,4 +79,88 @@ func TestScopedTokenFamiliesPreserveGoldenVectorsAndScopeSeparation(t *testing.T
 			}
 		})
 	}
+}
+
+func TestTokenKeyRotationAdoptIsMonotonic(t *testing.T) {
+	ctx := context.Background()
+	kr, err := LoadKeyring(ctx, newMemStore(), newRoot(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const payload = "canonical payload"
+
+	staleV2, adoptStaleV2, abortStaleV2, err := kr.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer abortStaleV2()
+	v2, adoptV2, abortV2, err := kr.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer abortV2()
+	if staleV2.Version != v2.Version {
+		t.Fatalf("concurrent candidates = versions %d and %d, want same predecessor", staleV2.Version, v2.Version)
+	}
+	adoptV2()
+	tokenV2, err := kr.ChangeToken("org_1", "project_1", "production", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v3, adoptV3, abortV3, err := kr.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer abortV3()
+	if v3.Version <= v2.Version {
+		t.Fatalf("successor version = %d, want greater than %d", v3.Version, v2.Version)
+	}
+	adoptV3()
+	tokenV3, err := kr.ChangeToken("org_1", "project_1", "production", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokenV3 == tokenV2 {
+		t.Fatal("successor rotation did not change token")
+	}
+
+	adoptStaleV2()
+	afterLateAdopt, err := kr.ChangeToken("org_1", "project_1", "production", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterLateAdopt != tokenV3 {
+		t.Fatal("late predecessor adopt regressed live token key")
+	}
+}
+
+func TestDerivationKeyRotationAbortZeroesCandidate(t *testing.T) {
+	kr, err := LoadKeyring(context.Background(), newMemStore(), newRoot(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rnd := &keyCaptureReader{}
+	kr.rnd = rnd
+
+	_, _, abort, err := kr.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rnd.key == nil {
+		t.Fatal("rotation did not draw candidate key material")
+	}
+	abort()
+	if !bytes.Equal(rnd.key, make([]byte, KeySize)) {
+		t.Fatal("aborted rotation retained candidate key material")
+	}
+}
+
+func TestDerivationRefusesUninitializedHandle(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("uninitialized derivation key did not panic")
+		}
+	}()
+	_, _ = (&Keyring{}).ChangeToken("org_1", "project_1", "production", []byte("payload"))
 }

--- a/internal/lint/redaction.go
+++ b/internal/lint/redaction.go
@@ -34,6 +34,7 @@ var SensitiveTypes = map[string]bool{
 	Module + "/internal/crypto.Keyring":        true,
 	Module + "/internal/crypto.ProjectSealer":  true,
 	Module + "/internal/crypto.InstanceSealer": true,
+	Module + "/internal/crypto.swapHandle":     true,
 }
 
 // sensitiveOwner may format its own types (deliberate extraction inside the

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -591,10 +591,11 @@ func (s *Revisions) RotateTokenKey(ctx context.Context, actor Actor) (TokenKeyRo
 	if s.Keyring == nil {
 		return TokenKeyRotation{}, errors.New("service: token key rotation requires a keyring")
 	}
-	next, adopt, err := s.Keyring.PrepareTokenKeyRotation()
+	next, adopt, abort, err := s.Keyring.PrepareTokenKeyRotation()
 	if err != nil {
 		return TokenKeyRotation{}, err
 	}
+	defer abort()
 	next.CreatedAt = store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, s.now())
@@ -661,10 +662,11 @@ func (s *Revisions) RotateScanningKey(ctx context.Context, actor Actor) (Scannin
 	if s.Keyring == nil {
 		return ScanningKeyRotation{}, errors.New("service: scanning key rotation requires a keyring")
 	}
-	next, adopt, err := s.Keyring.PrepareScanningKeyRotation()
+	next, adopt, abort, err := s.Keyring.PrepareScanningKeyRotation()
 	if err != nil {
 		return ScanningKeyRotation{}, err
 	}
+	defer abort()
 	next.CreatedAt = store.CanonTime(s.now())
 	dropped, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (int64, error) {
 		caller, err := actor.resolve(ctx, az, s.now())


### PR DESCRIPTION
Closes #365.

## Contract
- Token and scanning derivation keys now use one atomic swapHandle owner with snapshot reads and monotonic CAS adoption.
- PrepareTokenKeyRotation and PrepareScanningKeyRotation share prepareDerivationKeyRotation while preserving persist-before-adopt ordering.
- Failed and stale candidates are zeroed through mutually exclusive adopt and abort callbacks.
- rootRotationPending is atomic, removing the finalize versus app-warning race.
- swapHandle embeds redactor and is pinned in lint.SensitiveTypes.

Instance and master key sets remain separate. Byte-level token and scanning contracts are unchanged.

Generated outputs: none.
Database migrations: none.

## Validation
- go test -race -count=1 ./internal/crypto — 135 passed
- go test -count=1 ./internal/lint — 30 passed
- go test -count=1 ./internal/service -run Rotation|TokenKey|ScanningKey — passed
- SQLite keyring conformance scenarios — passed
- go test -count=1 ./... — 3595 passed in 61 packages
- git diff --check — passed

## Review
- Standards: CLEAN after round 2; both findings fixed and verified.
- Specification: CLEAN.