### PR TITLE
Parse SCIM PATCH payloads once #364

### DIFF
--- a/docs/handoff/364-scim-typed-patch-payloads.md
+++ b/docs/handoff/364-scim-typed-patch-payloads.md
@@ -1,0 +1,40 @@
+# Handoff: #364 typed SCIM PATCH payloads
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/364 (parent #326; audit ID
+`F-S24-1`).
+
+## Contract
+
+- `scimproto.ParsePatch` returns one sealed, typed payload variant per accepted
+  matrix cell; `ParsedPatch` never exposes undecoded operation bytes.
+- Operation values are decoded into typed payloads by `scimproto`; the server
+  consumes them without re-marshalling, re-decoding, or owning PATCH value
+  decode helpers.
+- Direct and pathless Group member payloads run `CheckMembers` before
+  `ParsePatch` succeeds. Nested groups, empty references, and bounded-reference
+  refusals retain their existing `invalidValue` codes.
+- Matrix cells, operation order, atomic conversion, active normalization, and
+  service command semantics are unchanged.
+
+## Regression evidence
+
+`TestPatchMembersAreValidatedByParser` pins direct and pathless member
+refusals. `TestPatchReturnsTypedPayloadPerKind` covers all five payload kinds,
+including value-free removals. `FuzzParsePatch` now asserts that every
+successful operation has a non-nil typed payload.
+
+Generated outputs: none.
+
+## Validation
+
+```text
+go test -count=1 ./internal/scimproto ./internal/server ./internal/service
+                                                     566 passed
+go vet ./internal/scimproto ./internal/server ./internal/service
+                                                     passed
+git diff --check                                   passed
+```
+
+Two-axis code review round 2: clean. SCIM isolation, bounded fuzz, and full
+suite remain to be rerun on the committed head when host memory pressure
+subsides.

--- a/internal/scimproto/scimproto.go
+++ b/internal/scimproto/scimproto.go
@@ -14,6 +14,7 @@
 package scimproto
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -749,15 +750,65 @@ const (
 	PathMemberValue
 )
 
-// ParsedPatch is one validated operation: the matrix cell it landed in, plus
-// whatever the cell needs.
+// PatchPayload is the closed set of decoded values carried by accepted PATCH
+// matrix cells. Keeping raw JSON out of ParsedPatch makes the parser the one
+// owner of operation-value decoding.
+type PatchPayload interface {
+	Kind() PathKind
+	patchPayload()
+}
+
+// PatchUserObjectPayload is a validated pathless Users merge.
+type PatchUserObjectPayload struct {
+	User User
+}
+
+// PatchGroupObjectPayload is a validated pathless Groups merge.
+type PatchGroupObjectPayload struct {
+	Group Group
+}
+
+// PatchPlainPayload is an ordinary attribute assignment or removal. Value is
+// nil only for a remove operation.
+type PatchPlainPayload struct {
+	Attribute string
+	Value     any
+}
+
+// PatchActivePayload is a normalized Users active assignment.
+type PatchActivePayload struct {
+	Active bool
+}
+
+// PatchMemberSetPayload is a validated Groups members assignment or clear.
+// Members is nil only for a remove operation.
+type PatchMemberSetPayload struct {
+	Members []Member
+}
+
+// PatchMemberRemovalPayload is the member ID named by a filtered remove.
+type PatchMemberRemovalPayload struct {
+	MemberID string
+}
+
+func (PatchUserObjectPayload) Kind() PathKind    { return PathNone }
+func (PatchGroupObjectPayload) Kind() PathKind   { return PathNone }
+func (PatchPlainPayload) Kind() PathKind         { return PathPlain }
+func (PatchActivePayload) Kind() PathKind        { return PathActive }
+func (PatchMemberSetPayload) Kind() PathKind     { return PathMembers }
+func (PatchMemberRemovalPayload) Kind() PathKind { return PathMemberValue }
+func (PatchUserObjectPayload) patchPayload()     {}
+func (PatchGroupObjectPayload) patchPayload()    {}
+func (PatchPlainPayload) patchPayload()          {}
+func (PatchActivePayload) patchPayload()         {}
+func (PatchMemberSetPayload) patchPayload()      {}
+func (PatchMemberRemovalPayload) patchPayload()  {}
+
+// ParsedPatch is one validated operation with the typed payload for its
+// accepted matrix cell.
 type ParsedPatch struct {
-	Op    string
-	Kind  PathKind
-	Attr  string
-	Value json.RawMessage
-	// MemberValue is the id named by `members[value eq "..."]`.
-	MemberValue string
+	Op      string
+	Payload PatchPayload
 }
 
 // matrixCell is one accepted cell of §8's operation x path table.
@@ -798,10 +849,10 @@ func isRequiredAttribute(attr string) bool {
 
 // ParsePatch decodes and validates a whole PATCH request against the matrix.
 //
-// It validates EVERYTHING before returning, because a PATCH is atomic: any
-// invalid operation fails the whole request with nothing committed. Validating
-// as you apply would leave the first half of a request applied when the second
-// half is refused.
+// It validates every operation's matrix cell and value payload before
+// returning, because a PATCH is atomic: any invalid operation fails the whole
+// request with nothing committed. Resource-to-command conversion may impose
+// additional resource rules, and also completes before any command is applied.
 func ParsePatch(raw []byte, res Resource) ([]ParsedPatch, *Error) {
 	if len(raw) > bodyBound {
 		return nil, ErrBodyTooLarge
@@ -849,52 +900,84 @@ func parseOne(op PatchOp, res Resource) (ParsedPatch, *Error) {
 	if verb != "remove" && len(op.Value) == 0 {
 		return ParsedPatch{}, bad(TypeInvalidValue, "The operation %q requires a value.", verb)
 	}
-	// The value's SHAPE is part of the cell, not a later concern. Checking only
-	// presence lets `active: null`, a scalar where an object belongs and a
-	// non-array `members` through the matrix and into the fold, where they
-	// become a silent no-op instead of the mandated `invalidValue`.
-	if verb != "remove" {
-		if e := checkValueShape(res, kind, op.Value); e != nil {
-			return ParsedPatch{}, e
-		}
+	payload, e := decodePatchPayload(verb, res, kind, attr, memberValue, op.Value)
+	if e != nil {
+		return ParsedPatch{}, e
 	}
-	return ParsedPatch{Op: verb, Kind: kind, Attr: attr, Value: op.Value, MemberValue: memberValue}, nil
+	return ParsedPatch{Op: verb, Payload: payload}, nil
 }
 
-// checkValueShape validates the value against the column it landed in.
-func checkValueShape(res Resource, kind PathKind, raw json.RawMessage) *Error {
-	var decoded any
-	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return bad(TypeInvalidValue, "The operation value is not valid JSON.")
+// decodePatchPayload decodes each operation value exactly once, into the
+// semantic payload owned by its matrix column.
+func decodePatchPayload(verb string, res Resource, kind PathKind, attr, memberValue string, raw json.RawMessage) (PatchPayload, *Error) {
+	if verb == "remove" {
+		switch kind {
+		case PathPlain:
+			return PatchPlainPayload{Attribute: attr}, nil
+		case PathMembers:
+			return PatchMemberSetPayload{}, nil
+		case PathMemberValue:
+			return PatchMemberRemovalPayload{MemberID: memberValue}, nil
+		}
 	}
+
 	switch kind {
 	case PathNone:
-		values, ok := decoded.(map[string]any)
-		if !ok {
-			return bad(TypeInvalidValue, "A pathless operation's value must be an object.")
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || trimmed[0] != '{' {
+			return nil, bad(TypeInvalidValue, "A pathless operation's value must be an object.")
 		}
 		if res == ResourceGroup {
-			for attribute := range values {
+			group, e := DecodeGroup(raw)
+			if e != nil {
+				return nil, e
+			}
+			for attribute := range group.Extra {
 				if !isGroupPatchAttribute(attribute) {
-					return bad(TypeInvalidPath,
+					return nil, bad(TypeInvalidPath,
 						"The pathless Group operation contains unsupported attribute %q.", attribute)
 				}
 			}
+			if e := CheckMembers(group.Members); e != nil {
+				return nil, e
+			}
+			return PatchGroupObjectPayload{Group: group}, nil
 		}
+		user, e := DecodeUser(raw)
+		if e != nil {
+			return nil, e
+		}
+		return PatchUserObjectPayload{User: user}, nil
 	case PathActive:
-		if _, e := NormalizeActive(decoded); e != nil {
-			return e
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, bad(TypeInvalidValue, "The operation value is not valid JSON.")
 		}
+		active, e := NormalizeActive(value)
+		if e != nil {
+			return nil, e
+		}
+		return PatchActivePayload{Active: active}, nil
 	case PathMembers:
-		if _, ok := decoded.([]any); !ok {
-			return bad(TypeInvalidValue, "The members value must be an array of references.")
+		var members []Member
+		if err := json.Unmarshal(raw, &members); err != nil || members == nil {
+			return nil, bad(TypeInvalidValue, "The members value must be an array of references.")
 		}
+		if e := CheckMembers(members); e != nil {
+			return nil, e
+		}
+		return PatchMemberSetPayload{Members: members}, nil
 	case PathPlain:
-		if decoded == nil {
-			return bad(TypeInvalidValue, "A null value is not an assignment; use remove.")
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, bad(TypeInvalidValue, "The operation value is not valid JSON.")
 		}
+		if value == nil {
+			return nil, bad(TypeInvalidValue, "A null value is not an assignment; use remove.")
+		}
+		return PatchPlainPayload{Attribute: attr, Value: value}, nil
 	}
-	return nil
+	return nil, bad(TypeInvalidPath, "The PATCH operation did not land in a supported path kind.")
 }
 
 // classifyPath maps a raw path onto a matrix column. The matrix is PER

--- a/internal/scimproto/scimproto_fuzz_test.go
+++ b/internal/scimproto/scimproto_fuzz_test.go
@@ -25,7 +25,15 @@ func FuzzParsePatch(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		for _, resource := range fuzzResources {
-			_, _ = ParsePatch(raw, resource)
+			ops, e := ParsePatch(raw, resource)
+			if e != nil {
+				continue
+			}
+			for i, op := range ops {
+				if op.Payload == nil {
+					t.Fatalf("operation %d has nil typed payload", i)
+				}
+			}
 		}
 	})
 }

--- a/internal/scimproto/scimproto_test.go
+++ b/internal/scimproto/scimproto_test.go
@@ -2,6 +2,7 @@ package scimproto
 
 import (
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -91,8 +92,49 @@ func TestPatchMatrixCells(t *testing.T) {
 			if e != nil {
 				t.Fatalf("cell refused but the matrix accepts it: %v", e)
 			}
-			if len(ops) != 1 || ops[0].Kind != tc.wantKind {
-				t.Fatalf("kind = %v, want %v", ops[0].Kind, tc.wantKind)
+			if len(ops) != 1 || ops[0].Payload.Kind() != tc.wantKind {
+				t.Fatalf("kind = %v, want %v", ops[0].Payload.Kind(), tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestPatchReturnsTypedPayloadPerKind(t *testing.T) {
+	const head = `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[`
+	tests := []struct {
+		name string
+		res  Resource
+		body string
+		want PatchPayload
+	}{
+		{"pathless", ResourceUser, head + `{"op":"add","value":{"userName":"alice"}}]}`,
+			PatchUserObjectPayload{User: User{UserName: "alice", Extra: map[string]any{"userName": "alice"}}}},
+		{"pathless group", ResourceGroup, head + `{"op":"replace","value":{"displayName":"Ops","members":[{"value":"u1"}]}}]}`,
+			PatchGroupObjectPayload{Group: Group{DisplayName: "Ops", Members: []Member{{Value: "u1"}}, Extra: map[string]any{"displayName": "Ops", "members": []any{map[string]any{"value": "u1"}}}}}},
+		{"plain assignment", ResourceUser, head + `{"op":"replace","path":"externalId","value":"ext-1"}]}`,
+			PatchPlainPayload{Attribute: "externalId", Value: "ext-1"}},
+		{"plain removal", ResourceUser, head + `{"op":"remove","path":"externalId"}]}`,
+			PatchPlainPayload{Attribute: "externalId"}},
+		{"active", ResourceUser, head + `{"op":"replace","path":"active","value":"False"}]}`,
+			PatchActivePayload{Active: false}},
+		{"members", ResourceGroup, head + `{"op":"add","path":"members","value":[{"value":"u1"}]}]}`,
+			PatchMemberSetPayload{Members: []Member{{Value: "u1"}}}},
+		{"members clear", ResourceGroup, head + `{"op":"remove","path":"members"}]}`,
+			PatchMemberSetPayload{}},
+		{"member removal", ResourceGroup, head + `{"op":"remove","path":"members[value eq \"u1\"]"}]}`,
+			PatchMemberRemovalPayload{MemberID: "u1"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops, e := ParsePatch([]byte(tc.body), tc.res)
+			if e != nil {
+				t.Fatalf("ParsePatch: %v", e)
+			}
+			if len(ops) != 1 {
+				t.Fatalf("operations = %d, want 1", len(ops))
+			}
+			if !reflect.DeepEqual(ops[0].Payload, tc.want) {
+				t.Fatalf("payload = %#v, want %#v", ops[0].Payload, tc.want)
 			}
 		})
 	}
@@ -116,8 +158,10 @@ func TestPatchValueShapeIsValidated(t *testing.T) {
 	const head = `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[`
 	for name, body := range map[string]string{
 		"pathless scalar": head + `{"op":"add","value":"nope"}]}`,
+		"pathless null":   head + `{"op":"add","value":null}]}`,
 		"active null":     head + `{"op":"replace","path":"active","value":null}]}`,
 		"members scalar":  head + `{"op":"add","path":"members","value":"u1"}]}`,
+		"members null":    head + `{"op":"add","path":"members","value":null}]}`,
 		"plain null":      head + `{"op":"replace","path":"externalId","value":null}]}`,
 	} {
 		res := ResourceUser
@@ -127,6 +171,31 @@ func TestPatchValueShapeIsValidated(t *testing.T) {
 		if _, e := ParsePatch([]byte(body), res); e == nil || e.SCIMType != TypeInvalidValue {
 			t.Fatalf("%s: want invalidValue, got %v", name, e)
 		}
+	}
+}
+
+// Member validity belongs to the parser that owns PatchOp decoding. Callers
+// must not receive a successful ParsedPatch that a second decoder can refuse.
+func TestPatchMembersAreValidatedByParser(t *testing.T) {
+	const head = `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[`
+	for name, body := range map[string]string{
+		"members path nested group": head + `{"op":"add","path":"members","value":[{"value":"g1","type":"Group"}]}]}`,
+		"members path empty ref":    head + `{"op":"replace","path":"members","value":[{"value":""}]}]}`,
+		"pathless nested group":     head + `{"op":"add","value":{"members":[{"value":"g1","type":"Group"}]}}]}`,
+		"pathless empty ref":        head + `{"op":"replace","value":{"members":[{"value":""}]}}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, e := ParsePatch([]byte(body), ResourceGroup); e == nil || e.SCIMType != TypeInvalidValue {
+				t.Fatalf("want invalidValue, got %v", e)
+			}
+		})
+	}
+}
+
+func TestPatchPathlessMalformedMemberKeepsInvalidSyntax(t *testing.T) {
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"members":[{"value":7}]}}]}`
+	if _, e := ParsePatch([]byte(body), ResourceGroup); e == nil || e.SCIMType != TypeInvalidSyntax {
+		t.Fatalf("want invalidSyntax, got %v", e)
 	}
 }
 

--- a/internal/server/scim_handlers.go
+++ b/internal/server/scim_handlers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -301,16 +300,10 @@ func scimPatchUserCommands(body map[string]any) ([]service.UserPatchCommand, *sc
 	}
 	commands := make([]service.UserPatchCommand, 0, len(ops))
 	for _, op := range ops {
-		switch op.Kind {
-		case scimproto.PathNone:
-			values, e := decodeObjectValue(op.Value)
-			if e != nil {
-				return nil, e
-			}
-			desired, e := scimDesiredUser(values)
-			if e != nil {
-				return nil, e
-			}
+		switch payload := op.Payload.(type) {
+		case scimproto.PatchUserObjectPayload:
+			values := payload.User.Extra
+			desired := scimDesiredDecodedUser(payload.User)
 			if _, present := scimAttribute(values, "userName"); present {
 				commands = append(commands, service.UserPatchSetUserName{UserName: desired.UserName})
 			}
@@ -327,22 +320,14 @@ func scimPatchUserCommands(body map[string]any) ([]service.UserPatchCommand, *sc
 			if len(desired.Attributes) > 0 {
 				commands = append(commands, service.UserPatchMergeAttributes{Attributes: desired.Attributes})
 			}
-		case scimproto.PathActive:
-			var v any
-			if e := decodeInto(op.Value, &v); e != nil {
-				return nil, e
-			}
-			on, e := scimproto.NormalizeActive(v)
-			if e != nil {
-				return nil, e
-			}
-			commands = append(commands, service.UserPatchSetActive{Active: on})
-		case scimproto.PathPlain:
+		case scimproto.PatchActivePayload:
+			commands = append(commands, service.UserPatchSetActive{Active: payload.Active})
+		case scimproto.PatchPlainPayload:
 			if op.Op == "remove" {
-				if strings.EqualFold(op.Attr, "externalId") {
+				if strings.EqualFold(payload.Attribute, "externalId") {
 					commands = append(commands, service.UserPatchClearExternalID{})
 				} else {
-					desired, e := scimDesiredUser(map[string]any{op.Attr: nil})
+					desired, e := scimDesiredUser(map[string]any{payload.Attribute: nil})
 					if e != nil {
 						return nil, e
 					}
@@ -352,25 +337,21 @@ func scimPatchUserCommands(body map[string]any) ([]service.UserPatchCommand, *sc
 				}
 				continue
 			}
-			var v any
-			if e := decodeInto(op.Value, &v); e != nil {
-				return nil, e
-			}
 			switch {
-			case strings.EqualFold(op.Attr, "userName"):
-				desired, e := scimDesiredUser(map[string]any{op.Attr: v})
+			case strings.EqualFold(payload.Attribute, "userName"):
+				desired, e := scimDesiredUser(map[string]any{payload.Attribute: payload.Value})
 				if e != nil {
 					return nil, e
 				}
 				commands = append(commands, service.UserPatchSetUserName{UserName: desired.UserName})
-			case strings.EqualFold(op.Attr, "externalId"):
-				desired, e := scimDesiredUser(map[string]any{op.Attr: v})
+			case strings.EqualFold(payload.Attribute, "externalId"):
+				desired, e := scimDesiredUser(map[string]any{payload.Attribute: payload.Value})
 				if e != nil {
 					return nil, e
 				}
 				commands = append(commands, service.UserPatchSetExternalID{ExternalID: desired.ExternalID})
 			default:
-				desired, e := scimDesiredUser(map[string]any{op.Attr: v})
+				desired, e := scimDesiredUser(map[string]any{payload.Attribute: payload.Value})
 				if e != nil {
 					return nil, e
 				}
@@ -378,6 +359,8 @@ func scimPatchUserCommands(body map[string]any) ([]service.UserPatchCommand, *sc
 					commands = append(commands, service.UserPatchMergeAttributes{Attributes: desired.Attributes})
 				}
 			}
+		default:
+			return nil, scimproto.ErrInvalidValue("The PATCH parser returned an unsupported User payload.")
 		}
 	}
 	return commands, nil
@@ -403,16 +386,10 @@ func scimPatchGroupCommands(body map[string]any) ([]service.GroupPatchCommand, *
 	}
 	commands := make([]service.GroupPatchCommand, 0, len(ops))
 	for _, op := range ops {
-		switch op.Kind {
-		case scimproto.PathNone:
-			values, e := decodeObjectValue(op.Value)
-			if e != nil {
-				return nil, e
-			}
-			desired, e := scimDesiredGroup(values)
-			if e != nil {
-				return nil, e
-			}
+		switch payload := op.Payload.(type) {
+		case scimproto.PatchGroupObjectPayload:
+			values := payload.Group.Extra
+			desired := scimDesiredDecodedGroup(payload.Group)
 			if _, present := scimAttribute(values, "displayName"); present {
 				commands = append(commands, service.GroupPatchSetDisplayName{DisplayName: desired.DisplayName})
 			}
@@ -422,82 +399,44 @@ func scimPatchGroupCommands(body map[string]any) ([]service.GroupPatchCommand, *
 			if _, present := scimAttribute(values, "members"); present {
 				commands = append(commands, service.GroupPatchReplaceMembers{Members: desired.Members})
 			}
-		case scimproto.PathPlain:
+		case scimproto.PatchPlainPayload:
 			if op.Op == "remove" {
-				if strings.EqualFold(op.Attr, "externalId") {
+				if strings.EqualFold(payload.Attribute, "externalId") {
 					commands = append(commands, service.GroupPatchClearExternalID{})
 				}
 				continue
 			}
-			var v any
-			if e := decodeInto(op.Value, &v); e != nil {
-				return nil, e
-			}
-			desired, e := scimDesiredGroup(map[string]any{op.Attr: v})
+			desired, e := scimDesiredGroup(map[string]any{payload.Attribute: payload.Value})
 			if e != nil {
 				return nil, e
 			}
 			switch {
-			case strings.EqualFold(op.Attr, "displayName"):
+			case strings.EqualFold(payload.Attribute, "displayName"):
 				commands = append(commands, service.GroupPatchSetDisplayName{DisplayName: desired.DisplayName})
-			case strings.EqualFold(op.Attr, "externalId"):
+			case strings.EqualFold(payload.Attribute, "externalId"):
 				commands = append(commands, service.GroupPatchSetExternalID{ExternalID: desired.ExternalID})
 			}
-		case scimproto.PathMembers:
+		case scimproto.PatchMemberSetPayload:
 			if op.Op == "remove" {
 				commands = append(commands, service.GroupPatchClearMembers{})
 				continue
 			}
-			refs, e := decodeMemberRefs(op.Value)
-			if e != nil {
-				return nil, e
+			refs := make([]string, 0, len(payload.Members))
+			for _, member := range payload.Members {
+				refs = append(refs, member.Value)
 			}
 			if op.Op == "replace" {
 				commands = append(commands, service.GroupPatchReplaceMembers{Members: refs})
 			} else {
 				commands = append(commands, service.GroupPatchAddMembers{Members: refs})
 			}
-		case scimproto.PathMemberValue:
-			commands = append(commands, service.GroupPatchRemoveMember{Member: op.MemberValue})
+		case scimproto.PatchMemberRemovalPayload:
+			commands = append(commands, service.GroupPatchRemoveMember{Member: payload.MemberID})
+		default:
+			return nil, scimproto.ErrInvalidValue("The PATCH parser returned an unsupported Group payload.")
 		}
 	}
 	return commands, nil
-}
-
-func decodeObjectValue(raw []byte) (map[string]any, *scimproto.Error) {
-	var out map[string]any
-	if e := decodeInto(raw, &out); e != nil {
-		return nil, e
-	}
-	return out, nil
-}
-
-func decodeMemberRefs(raw []byte) ([]string, *scimproto.Error) {
-	var refs []scimproto.Member
-	if e := decodeInto(raw, &refs); e != nil {
-		return nil, e
-	}
-	if e := scimproto.CheckMembers(refs); e != nil {
-		return nil, e
-	}
-	out := make([]string, 0, len(refs))
-	for _, m := range refs {
-		out = append(out, m.Value)
-	}
-	return out, nil
-}
-
-// decodeInto parses a PATCH operation's `value` under the same discipline the
-// rest of the boundary uses: a decode failure is `invalidValue`, never a
-// silently-zero field.
-func decodeInto(raw []byte, into any) *scimproto.Error {
-	if len(raw) == 0 {
-		return scimproto.ErrInvalidValue("The operation carries no value.")
-	}
-	if err := json.Unmarshal(raw, into); err != nil {
-		return scimproto.ErrInvalidValue("The operation value has the wrong shape.")
-	}
-	return nil
 }
 
 func strPtr[T ~string](p *T) *string {

--- a/internal/server/scim_wire.go
+++ b/internal/server/scim_wire.go
@@ -183,16 +183,17 @@ func scimDesiredUser(body map[string]any) (service.DesiredUser, *scimproto.Error
 	if e != nil {
 		return service.DesiredUser{}, e
 	}
+	return scimDesiredDecodedUser(u), nil
+}
+
+// scimDesiredDecodedUser converts a value already validated by scimproto.
+func scimDesiredDecodedUser(u scimproto.User) service.DesiredUser {
 	desired := service.DesiredUser{UserName: u.UserName, ExternalID: u.ExternalID, Active: true}
-	if v, ok := scimAttribute(body, "active"); ok {
-		active, e := scimproto.NormalizeActive(v)
-		if e != nil {
-			return service.DesiredUser{}, e
-		}
-		desired.Active = active
+	if u.Active != nil {
+		desired.Active = *u.Active
 	}
-	desired.Attributes = scimDisplayAttributes(body)
-	return desired, nil
+	desired.Attributes = scimDisplayAttributes(u.Extra)
+	return desired
 }
 
 // scimDisplayAttributes keeps everything this server does not interpret, as
@@ -244,11 +245,17 @@ func scimDesiredGroup(body map[string]any) (service.DesiredGroup, *scimproto.Err
 	if e := scimproto.CheckMembers(g.Members); e != nil {
 		return service.DesiredGroup{}, e
 	}
+	return scimDesiredDecodedGroup(g), nil
+}
+
+// scimDesiredDecodedGroup converts a value already validated by scimproto,
+// including its member invariants.
+func scimDesiredDecodedGroup(g scimproto.Group) service.DesiredGroup {
 	desired := service.DesiredGroup{DisplayName: g.DisplayName, ExternalID: g.ExternalID}
 	for _, m := range g.Members {
 		desired.Members = append(desired.Members, m.Value)
 	}
-	return desired, nil
+	return desired
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace ParsedPatch raw operation values with sealed typed payload variants
- validate direct and pathless Group members inside scimproto
- remove server PATCH decode helpers and consume decoded resources without re-decoding

## Contract
- SCIM operation order, atomicity, matrix cells, active normalization, and scimType codes are preserved
- successful parsed operations always carry a non-nil typed payload
- generated outputs: none

## Validation
- go test -count=1 ./internal/scimproto ./internal/server ./internal/service (566 passed)
- go vet ./internal/scimproto ./internal/server ./internal/service
- git diff --check
- two-axis code review R2: clean
- SCIM isolation, bounded fuzz, and full suite will run when host memory pressure subsides

Closes #364