### PR TITLE
Centralize isolation bootstrap-admin fixtures #370

### DIFF
--- a/docs/handoff/370-bootstrap-admin-fixtures.md
+++ b/docs/handoff/370-bootstrap-admin-fixtures.md
@@ -1,0 +1,40 @@
+# Handoff: #370 isolation bootstrap-admin fixtures
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/370 (parent #326; audit finding
+`F-S33-1`). Implementation base:
+`428dd6a5e347479a7a3697e2953ce10b7543db58`.
+
+## Contract
+
+- `bootstrapAdmin` in the isolation harness owns first-administrator creation,
+  password establishment, optional CLI login, and the returned administrator
+  representation.
+- `service.BootstrapResult` is the source of truth for account and principal
+  identity; bootstrap fixtures no longer re-query account rows for those IDs.
+- Per-suite usernames, passwords, Auth configuration, read grants, passkey
+  enrollment, and ceremony ordering remain explicit at their existing seams.
+- Factor and backup-drill fixtures still create no login during bootstrap. The
+  backup drill still mints its reset authority before any session exists.
+- Direct bootstrap calls remain only where bootstrap refusal/intermediate state
+  or the CLI establishment ceremony is itself under test. Wire/audit bytes,
+  schema, migrations, and generated outputs are unchanged.
+
+## Validation
+
+```text
+go test -count=1 -timeout 90m ./internal/isolation/   1,122 passed
+go test -count=1 -timeout 120m ./...                  3,591 passed / 61 packages
+go vet ./...                                          passed
+gofmt -l <changed-go-files>                           clean
+git diff --check                                      clean
+```
+
+Local PostgreSQL execution was unavailable because `HIKYO_TEST_POSTGRES_DSN`
+was unset; required CI supplies it. Exact-head CI results are recorded in the
+pull request.
+
+## Review
+
+- Standards round 1 found two SQL identity re-derivations and one missed
+  lock-test bootstrap sibling; fixed. Round 2: `CLEAN`.
+- Spec round 1 found the same missed sibling; fixed. Round 2: `CLEAN`.

--- a/internal/isolation/access_wire_test.go
+++ b/internal/isolation/access_wire_test.go
@@ -64,10 +64,14 @@ type accessWireEnv struct {
 // org, and hands back a live server.
 func newAccessWireEnv(t *testing.T, db *store.DB) accessWireEnv {
 	t.Helper()
-	auth, boot, password := bootstrapWebAuthnAdminBoot(t, db)
+	auth := webauthnAuthService(t, db)
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: waAdmin, displayName: "WA Admin",
+		password: "a perfectly ordinary wire passphrase", auth: auth, login: true,
+	})
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
-	token := enrolPasskey(t, auth, ctx, boot.token, password, dev)
+	token := enrolPasskey(t, auth, ctx, administrator.token, administrator.password, dev)
 	token = stepUpPasskey(t, auth, ctx, token, dev)
 
 	orgs := &service.Orgs{DB: db}
@@ -78,7 +82,7 @@ func newAccessWireEnv(t *testing.T, db *store.DB) accessWireEnv {
 	// Creation granted this principal org-admin access and therefore killed the
 	// creating session. Re-login and present the already-enrolled passkey before
 	// the wire assertions begin.
-	login, err := auth.LocalLogin(ctx, waAdmin, password, service.ArtifactCLI)
+	login, err := auth.LocalLogin(ctx, waAdmin, administrator.password, service.ArtifactCLI)
 	if err != nil {
 		t.Fatalf("login after org create: %v", err)
 	}
@@ -115,35 +119,9 @@ func newAccessWireEnv(t *testing.T, db *store.DB) accessWireEnv {
 	}, nil))
 	t.Cleanup(srv.Close)
 	return accessWireEnv{
-		srv: srv, token: token, db: db, auth: auth, admin: boot.principal,
+		srv: srv, token: token, db: db, auth: auth, admin: administrator.boot.PrincipalID,
 		org: org.ID, project: wireProject, env: wireEnv,
 	}
-}
-
-// bootstrapWebAuthnAdminBoot is bootstrapWebAuthnAdmin plus the principal id,
-// which these tests need to revoke the administrator's own authority.
-type bootInfo struct {
-	token     string
-	principal domain.PrincipalID
-}
-
-func bootstrapWebAuthnAdminBoot(t *testing.T, db *store.DB) (*service.Auth, bootInfo, string) {
-	t.Helper()
-	auth := webauthnAuthService(t, db)
-	ctx := t.Context()
-	boot, err := auth.BootstrapAdmin(ctx, waAdmin, "WA Admin", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	const password = "a perfectly ordinary wire passphrase"
-	if err := auth.EstablishCredential(ctx, boot.Authority, password); err != nil {
-		t.Fatal(err)
-	}
-	login, err := auth.LocalLogin(ctx, waAdmin, password, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return auth, bootInfo{token: login.SessionToken, principal: boot.PrincipalID}, password
 }
 
 // call issues one request against the live server and returns status + body.

--- a/internal/isolation/audit_e2e_test.go
+++ b/internal/isolation/audit_e2e_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Hikyo-Org/hikyo/internal/admission"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
@@ -27,44 +26,6 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
-
-// authService builds a real Auth against the harness database: a live
-// keyring (verifiers are envelope-encrypted, so there is nothing to fake) and
-// a real admission limiter. The Argon2id cost is dialled to the floor because
-// the floor is what production runs and the flow exercises it a handful of
-// times.
-func authService(t *testing.T, db *store.DB) *service.Auth {
-	return authServiceWithKeyring(t, db)
-}
-
-// authServiceWithKeyring is authService plus access to the keyring it loaded.
-// The keyring hierarchy is minted ONCE per datastore under one root, so a
-// later loader with a fresh root is refused (correctly) — anything in this
-// suite that needs to seal must therefore share this one.
-func authServiceWithKeyring(t *testing.T, db *store.DB) *service.Auth {
-	t.Helper()
-	kr := probeKeyring(t, db)
-	limiter, err := admission.New(admission.Config{ArgonMemoryKiB: crypto.PasswordFloor.MemoryKiB})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &service.Auth{DB: db, Keyring: kr, KDF: crypto.PasswordFloor, Admission: limiter}
-}
-
-func queryString(t *testing.T, db *store.DB, q string) string {
-	t.Helper()
-	var s string
-	var err error
-	if db.Engine() == store.EnginePostgres {
-		err = db.PG().QueryRow(t.Context(), q).Scan(&s)
-	} else {
-		err = db.SQLiteRead().QueryRowContext(t.Context(), q).Scan(&s)
-	}
-	if err != nil {
-		t.Fatalf("query %q: %v", q, err)
-	}
-	return s
-}
 
 // hookWriter triggers a side effect on its first write — the mid-export
 // revocation lever.

--- a/internal/isolation/backup_drill_e2e_test.go
+++ b/internal/isolation/backup_drill_e2e_test.go
@@ -269,19 +269,16 @@ func buildInstance(t *testing.T, target drillTarget, c custody) (*store.DB, arti
 	ctx := t.Context()
 	a := artifacts{password: "correct horse battery staple drill", adminUser: "drill-admin"}
 
-	boot, err := auth.BootstrapAdmin(ctx, a.adminUser, "Drill Admin", "terminal")
-	if err != nil {
-		t.Fatalf("bootstrap admin: %v", err)
-	}
-	a.adminPrin = boot.PrincipalID
-	if err := auth.EstablishCredential(ctx, boot.Authority, a.password); err != nil {
-		t.Fatalf("establish credential: %v", err)
-	}
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: a.adminUser, displayName: "Drill Admin",
+		password: a.password, auth: auth,
+	})
+	a.adminPrin = administrator.boot.PrincipalID
 	// An UNCONSUMED single-use artifact, minted BEFORE any session exists so
 	// that the reset's own session sweep is not what kills the session the
 	// drill later replays. "Single-use artifacts dead" needs a live subject,
 	// not a spent one.
-	reset, err := auth.BreakGlassResetCredential(ctx, string(boot.PrincipalID), "terminal")
+	reset, err := auth.BreakGlassResetCredential(ctx, string(administrator.boot.PrincipalID), "terminal")
 	if err != nil {
 		t.Fatalf("break-glass reset: %v", err)
 	}

--- a/internal/isolation/browser_session_e2e_test.go
+++ b/internal/isolation/browser_session_e2e_test.go
@@ -31,7 +31,8 @@ func TestBrowserLoginMintsACSRFBoundSessionPostgres(t *testing.T) {
 }
 
 func runBrowserSessionFlow(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	ctx := t.Context()
 
 	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactBrowser)
@@ -115,7 +116,8 @@ func runBrowserSessionFlow(t *testing.T, db *store.DB) {
 // work happens — never silently downgraded to CLI, which would hand a browser
 // its session token in a script-readable body.
 func TestUnknownLoginArtifactIsRefusedBeforeVerification(t *testing.T) {
-	auth, _, password := bootstrapFactorAdmin(t, seededDB(t, openSQLite))
+	factorAdmin := bootstrapFactorAdmin(t, seededDB(t, openSQLite))
+	auth, password := factorAdmin.auth, factorAdmin.password
 	_, err := auth.LocalLogin(t.Context(), "factor-admin", password, "kiosk")
 	if !errors.Is(err, domain.ErrInvalid) {
 		t.Fatalf("err = %v, want invalid", err)
@@ -166,7 +168,8 @@ func browserSessionCheck(
 }
 
 func runBrowserMutationFlow(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	ctx := t.Context()
 
 	// A clock the test advances, so each TOTP step is a fresh unspent one.
@@ -241,7 +244,8 @@ func TestBrowserFederationPreservesTheArtifactPostgres(t *testing.T) {
 }
 
 func runBrowserFederationFlow(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	ctx := t.Context()
 	configureProvider(t, auth, ctx, boot.PrincipalID, "browser-idp", service.ProviderInput{
 		DisplayName: "Browser IdP", ClientID: "client", ClientSecret: "secret",
@@ -353,7 +357,8 @@ func TestListMineNeedsNoSecondFactorPostgres(t *testing.T) {
 }
 
 func runListMineFromABrowserSession(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	ctx := t.Context()
 	orgs := &service.Orgs{DB: db}
 

--- a/internal/isolation/demo_e2e_test.go
+++ b/internal/isolation/demo_e2e_test.go
@@ -398,14 +398,11 @@ func TestLoginDoesNotHoldTheWriteLockWhileDeriving(t *testing.T) {
 	auth := authService(t, db)
 	orgs := &service.Orgs{DB: db}
 
-	boot, err := auth.BootstrapAdmin(t.Context(), "lockcheck", "Lock Check", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
 	const password = "another perfectly ordinary passphrase"
-	if err := auth.EstablishCredential(t.Context(), boot.Authority, password); err != nil {
-		t.Fatal(err)
-	}
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: "lockcheck", displayName: "Lock Check",
+		password: password, auth: auth,
+	})
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
@@ -434,7 +431,7 @@ func TestLoginDoesNotHoldTheWriteLockWhileDeriving(t *testing.T) {
 		if time.Now().After(deadline) {
 			t.Fatal("unrelated writes could not make progress while logins were deriving")
 		}
-		if _, err := orgs.Create(t.Context(), service.LocalPrincipal(boot.PrincipalID), fmt.Sprintf("lockcheck-%d", i), true, []byte(`{}`)); err != nil {
+		if _, err := orgs.Create(t.Context(), service.LocalPrincipal(administrator.boot.PrincipalID), fmt.Sprintf("lockcheck-%d", i), true, []byte(`{}`)); err != nil {
 			t.Fatalf("write %d blocked behind a login derivation: %v", i, err)
 		}
 	}

--- a/internal/isolation/factors_e2e_test.go
+++ b/internal/isolation/factors_e2e_test.go
@@ -40,25 +40,20 @@ func totpCode(t *testing.T, otpauthURI string, at time.Time) string {
 	return code
 }
 
-// bootstrapFactorAdmin mints a first administrator and establishes its
-// password, returning the acting service and the credential. One service (one
-// root key) drives the whole flow so sealed material stays readable.
-func bootstrapFactorAdmin(t *testing.T, db *store.DB) (*service.Auth, service.BootstrapResult, string) {
+// bootstrapFactorAdmin adds the environment read needed by factor
+// reauthentication flows to the shared first-administrator fixture. One Auth
+// (one root key) drives the whole flow so sealed material stays readable.
+func bootstrapFactorAdmin(t *testing.T, db *store.DB) admin {
 	t.Helper()
-	auth := authService(t, db)
-	boot, err := auth.BootstrapAdmin(t.Context(), "factor-admin", "Factor Admin", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	const password = "correct horse battery staple factor"
-	if err := auth.EstablishCredential(t.Context(), boot.Authority, password); err != nil {
-		t.Fatal(err)
-	}
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: "factor-admin", displayName: "Factor Admin",
+		password: "correct horse battery staple factor",
+	})
 	// See bootstrapWebAuthnAdmin: the reauth routes authorize the environment
 	// under `read` before inspecting its policy, and bootstrap seeds no tenant
 	// capability.
-	grantRead(t, db, boot.PrincipalID)
-	return auth, boot, password
+	grantRead(t, db, administrator.boot.PrincipalID)
+	return administrator
 }
 
 // runFactorLifecycle drives every factor audit event once, so a suite sharing a
@@ -135,7 +130,8 @@ func TestRecoveryCodeRegenerationTOTPReplayPostgres(t *testing.T) {
 }
 
 func runPasswordReauthEvidenceRejectsReplacedCredential(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	ctx := t.Context()
 	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
 	if err != nil {
@@ -180,7 +176,8 @@ func runPasswordReauthEvidenceRejectsReplacedCredential(t *testing.T, db *store.
 }
 
 func runRecoveryCodeRegenerationTOTPReplay(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	ctx := t.Context()
 	now := time.Now().UTC()
 	auth.Now = func() time.Time { return now }
@@ -212,7 +209,8 @@ func runRecoveryCodeRegenerationTOTPReplay(t *testing.T, db *store.DB) {
 // session-less flow (code -> authority -> establish -> login), and the mid-reset
 // invariant that the authority is not a session.
 func runRecoveryFlow(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	ctx := t.Context()
 	orgs := &service.Orgs{DB: db}
 
@@ -278,7 +276,8 @@ func TestAccountSecurityCannotSelfAuthorizePostgres(t *testing.T) {
 // enrolling TOTP requires the PRE-EXISTING password, and the code of the factor
 // being enrolled is not that proof.
 func runSelfAuthorize(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -324,7 +323,8 @@ func TestStepUpElevatesPostgres(t *testing.T) { runStepUpElevates(t, seededDB(t,
 // runStepUpElevates asserts a password-only session is refused an MFA-mandatory
 // operation and that a TOTP step-up unlocks it.
 func runStepUpElevates(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -377,7 +377,8 @@ func TestTOTPConfirmSameStepPostgres(t *testing.T) {
 // the creation step has consumed nothing yet, so it must not be pre-consumed),
 // and that a code from an earlier step is refused.
 func runConfirmSameStep(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -420,7 +421,8 @@ func TestTOTPStepUpReplayPostgres(t *testing.T) {
 // refused by name with the already-used sentinel (human-auth ADR §141, §207 —
 // the user waits for the next code), not the uniform bad-code refusal.
 func runStepUpReplay(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }

--- a/internal/isolation/grants_e2e_test.go
+++ b/internal/isolation/grants_e2e_test.go
@@ -603,7 +603,8 @@ func TestRevokeKillsSessionPostgres(t *testing.T) {
 // principal — the administrator's own — so the demo reads as one story rather
 // than two halves about two people.
 func runRevokeKillsSession(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	ctx := t.Context()
 	g := &service.Grants{DB: db}
 
@@ -1041,7 +1042,8 @@ func TestOriginAddKeepsSessionAlivePostgres(t *testing.T) {
 // the same holder's session DOES die when the same grant is revoked, so the
 // session-kill machinery is demonstrably wired to this principal.
 func runOriginAddKeepsSessionAlive(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	ctx := t.Context()
 	g := grantSvc(db)
 

--- a/internal/isolation/harness_test.go
+++ b/internal/isolation/harness_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/Hikyo-Org/hikyo/internal/admission"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -32,6 +33,93 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store/keyring"
 	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
 )
+
+// adminOpts describes the per-suite identity and authentication configuration
+// while bootstrapAdmin owns the shared first-administrator ceremony.
+type adminOpts struct {
+	username    string
+	displayName string
+	password    string
+	auth        *service.Auth
+	login       bool
+}
+
+type admin struct {
+	auth      *service.Auth
+	boot      service.BootstrapResult
+	accountID string
+	token     string
+	password  string
+}
+
+// bootstrapAdmin creates the first administrator, establishes its password,
+// and optionally logs in. BootstrapResult is the source of truth for account
+// and principal identity; callers must not re-derive either through SQL.
+func bootstrapAdmin(t *testing.T, db *store.DB, opts adminOpts) admin {
+	t.Helper()
+	auth := opts.auth
+	if auth == nil {
+		auth = authService(t, db)
+	}
+	boot, err := auth.BootstrapAdmin(t.Context(), opts.username, opts.displayName, "terminal")
+	if err != nil {
+		t.Fatalf("bootstrap admin: %v", err)
+	}
+	if err := auth.EstablishCredential(t.Context(), boot.Authority, opts.password); err != nil {
+		t.Fatalf("establish credential: %v", err)
+	}
+
+	result := admin{
+		auth:      auth,
+		boot:      boot,
+		accountID: boot.AccountID,
+		password:  opts.password,
+	}
+	if !opts.login {
+		return result
+	}
+	login, err := auth.LocalLogin(t.Context(), opts.username, opts.password, service.ArtifactCLI)
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	result.token = login.SessionToken
+	return result
+}
+
+// authService builds a real Auth against the harness database: a live
+// keyring (verifiers are envelope-encrypted, so there is nothing to fake) and
+// a real admission limiter. The Argon2id cost is dialled to the production
+// floor because the flow exercises it only a handful of times.
+func authService(t *testing.T, db *store.DB) *service.Auth {
+	return authServiceWithKeyring(t, db)
+}
+
+// authServiceWithKeyring is authService plus access to the keyring it loaded.
+// The keyring hierarchy is minted once per datastore under one root.
+func authServiceWithKeyring(t *testing.T, db *store.DB) *service.Auth {
+	t.Helper()
+	kr := probeKeyring(t, db)
+	limiter, err := admission.New(admission.Config{ArgonMemoryKiB: crypto.PasswordFloor.MemoryKiB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &service.Auth{DB: db, Keyring: kr, KDF: crypto.PasswordFloor, Admission: limiter}
+}
+
+func queryString(t *testing.T, db *store.DB, q string) string {
+	t.Helper()
+	var s string
+	var err error
+	if db.Engine() == store.EnginePostgres {
+		err = db.PG().QueryRow(t.Context(), q).Scan(&s)
+	} else {
+		err = db.SQLiteRead().QueryRowContext(t.Context(), q).Scan(&s)
+	}
+	if err != nil {
+		t.Fatalf("query %q: %v", q, err)
+	}
+	return s
+}
 
 // Fixture principals.
 const (

--- a/internal/isolation/oidc_e2e_test.go
+++ b/internal/isolation/oidc_e2e_test.go
@@ -147,30 +147,22 @@ func isUnauth(err error) bool {
 
 // --- A1 fixtures ---
 
-// oidcAdmin bootstraps an admin, establishes a password, and returns the acting
-// service, principal and password.
-func oidcAdmin(t *testing.T, db *store.DB) (*service.Auth, domain.PrincipalID, string) {
+// oidcAdmin configures the external origin around the shared
+// first-administrator fixture.
+func oidcAdmin(t *testing.T, db *store.DB) admin {
 	t.Helper()
 	auth := authService(t, db)
 	auth.ExternalOrigin = "https://hikyo.test"
-	boot, err := auth.BootstrapAdmin(t.Context(), "oidc-admin", "OIDC Admin", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	const password = "correct horse battery staple oidc"
-	if err := auth.EstablishCredential(t.Context(), boot.Authority, password); err != nil {
-		t.Fatal(err)
-	}
-	acc, err := auth.LocalLogin(t.Context(), "oidc-admin", password, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return auth, acc.Principal, password
+	return bootstrapAdmin(t, db, adminOpts{
+		username: "oidc-admin", displayName: "OIDC Admin",
+		password: "correct horse battery staple oidc", auth: auth, login: true,
+	})
 }
 
 func runOIDCMixup(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	_, idpA := configureProvider(t, auth, ctx, admin, "prov-a", service.ProviderInput{
 		DisplayName: "A", ClientID: "ca", ClientSecret: "sa", Scopes: "openid", Enabled: true,
 	})
@@ -219,7 +211,8 @@ func TestOIDCMixupPostgres(t *testing.T) { runOIDCMixup(t, seededDB(t, openPostg
 // identities, both loginable, never merged.
 func runOIDCByteExactSubject(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	configureProvider(t, auth, ctx, admin, "idp", service.ProviderInput{
 		DisplayName: "IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["alice","Alice"]}`), Enabled: true,
@@ -258,7 +251,8 @@ func oidcRefusedCount(t *testing.T, db *store.DB, cause string) int64 {
 // purpose's branch.
 func runOIDCBinding(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	configureProvider(t, auth, ctx, admin, "idp", service.ProviderInput{
 		DisplayName: "IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["user"]}`), Enabled: true,
@@ -319,7 +313,8 @@ func TestOIDCBindingPostgres(t *testing.T) { runOIDCBinding(t, seededDB(t, openP
 // carries no auth_time (A7). Each cause is audited.
 func runOIDCReauthRefusals(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	_, strict := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "Strict", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		AssurancePolicy: strptr(`{"amr_sets":[["mfa"]]}`), Enabled: true,
@@ -403,7 +398,8 @@ func runOIDCReauthRefusals(t *testing.T, db *store.DB) {
 // and the refusal is named and audited rather than silently opening authority.
 func runOIDCReauthZeroWindow(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = 0
 	_, idp := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "Strict", ClientID: "c", ClientSecret: "s", Scopes: "openid",
@@ -444,7 +440,8 @@ func TestOIDCReauthZeroWindowPostgres(t *testing.T) {
 // cookie at the transport boundary, so the service returns no stored metadata.
 func runOIDCBrowserOverloadMetadata(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	_, idp := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "Strict", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		AssurancePolicy: strptr(`{"amr_sets":[["mfa"]]}`), Enabled: true,
@@ -499,7 +496,8 @@ func TestOIDCReauthRefusalsPostgres(t *testing.T) {
 
 func runOIDCDisclosureAndCLIHandoff(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = 5 * time.Minute
 	_, idp := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "Corporate IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid",
@@ -577,7 +575,8 @@ func TestOIDCDisclosureAndCLIHandoffPostgres(t *testing.T) {
 // runOIDCIssuerImmutable: a provider's issuer cannot change on update (A3).
 func runOIDCIssuerImmutable(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	_, idp := configureProvider(t, auth, ctx, admin, "idp", service.ProviderInput{
 		DisplayName: "IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid", Enabled: true,
 	})
@@ -613,7 +612,8 @@ func TestOIDCIssuerImmutablePostgres(t *testing.T) {
 // authenticated through it (A4).
 func runOIDCProviderChangeSweeps(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	providers, idp := configureProvider(t, auth, ctx, admin, "idp", service.ProviderInput{
 		DisplayName: "IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["user"]}`), Enabled: true,
@@ -685,7 +685,8 @@ func reauthOn(t *testing.T, auth *service.Auth, ctx context.Context, slug, subje
 // imply possession.
 func runOIDCReauthPossession(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = time.Minute
 
 	// (a) amr_sets [["pwd"]] satisfied by amr=["pwd"] — possession absent.
@@ -757,7 +758,8 @@ func TestOIDCReauthPossessionPostgres(t *testing.T) {
 // refused, never opens a window (B2), matching completeLogin.
 func runOIDCReauthEpochInert(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = time.Minute
 	_, idp := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "strict", ClientID: "c", ClientSecret: "s", Scopes: "openid",
@@ -792,7 +794,8 @@ func TestOIDCReauthEpochInertPostgres(t *testing.T) {
 // authenticate through the replacement (A3, provider_id mismatch).
 func runOIDCReauthProviderRebind(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = time.Minute
 	idp, err := oidctest.New()
 	if err != nil {
@@ -853,7 +856,8 @@ func TestOIDCReauthProviderRebindPostgres(t *testing.T) {
 // session can (positive control).
 func runOIDCReauthDowngrade(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = time.Minute
 	_, idp := configureProvider(t, auth, ctx, admin, "strict", service.ProviderInput{
 		DisplayName: "strict", ClientID: "c", ClientSecret: "s", Scopes: "openid",
@@ -897,7 +901,8 @@ func TestOIDCReauthDowngradePostgres(t *testing.T) {
 // the race, so a stale policy evaluation cannot open a window (A4/TOCTOU).
 func runOIDCReauthProviderRace(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ReauthWindow = time.Minute
 	providers, idp := configureProvider(t, auth, ctx, admin, "race", service.ProviderInput{
 		DisplayName: "race", ClientID: "c", ClientSecret: "s", Scopes: "openid",
@@ -946,7 +951,8 @@ func TestOIDCReauthProviderRacePostgres(t *testing.T) {
 // session is created in its place.
 func runOIDCLoginProviderRace(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	providers, idp := configureProvider(t, auth, ctx, admin, "race-login", service.ProviderInput{
 		DisplayName: "race-login", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["race-login-user"]}`), Enabled: true,
@@ -1005,7 +1011,8 @@ func TestOIDCLoginProviderRacePostgres(t *testing.T) {
 // deleted — a compromised provider cannot be deleted yet keep live sessions.
 func runOIDCLoginProviderDeleteRace(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	providers, idp := configureProvider(t, auth, ctx, admin, "race-del", service.ProviderInput{
 		DisplayName: "race-del", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["race-del-user"]}`), Enabled: true,
@@ -1066,7 +1073,8 @@ func TestOIDCLoginProviderDeleteRacePostgres(t *testing.T) {
 // 00007 actually enforces the cascade. Without the FK edit this test fails.
 func runOIDCProviderDeleteCascade(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	configureProvider(t, auth, ctx, admin, "cascade", service.ProviderInput{
 		DisplayName: "cascade", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["cascade-user"]}`), Enabled: true,
@@ -1099,7 +1107,8 @@ func TestOIDCProviderDeleteCascadePostgres(t *testing.T) {
 // refused (A validation completeness), audited cause=signature.
 func runOIDCIATRejected(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	_, idp := configureProvider(t, auth, ctx, admin, "idp", service.ProviderInput{
 		DisplayName: "IdP", ClientID: "c", ClientSecret: "s", Scopes: "openid",
 		JITPolicy: strptr(`{"claim":"sub","values":["iat-user"]}`), Enabled: true,

--- a/internal/isolation/reauth_e2e_test.go
+++ b/internal/isolation/reauth_e2e_test.go
@@ -158,7 +158,8 @@ func TestInvalidReauthWindowBindingPostgres(t *testing.T) {
 }
 
 func runInvalidReauthWindowBinding(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
 	auth.Now = func() time.Time { return now }
 	auth.ReauthWindow = 5 * time.Minute
@@ -214,7 +215,8 @@ func TestCLIAdapterReauthHandoffPostgres(t *testing.T) {
 }
 
 func runCLIAdapterReauthHandoff(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	execRaw(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('g_cli_adapter_manage','`+string(boot.PrincipalID)+`','manage-adapters','org_a','prj_a1',NULL,`+ts+`)`)
 	execRaw(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('g_cli_adapter_reveal','`+string(boot.PrincipalID)+`','reveal','org_a','prj_a1','env_prod',`+ts+`)`)
 	execRaw(t, db, `INSERT INTO grant_origins (id,grant_id,kind,subject,created_at) VALUES ('gor_cli_adapter_manage','g_cli_adapter_manage','manual','`+string(boot.PrincipalID)+`',`+ts+`)`)
@@ -349,7 +351,8 @@ func runCLIAdapterReauthHandoff(t *testing.T, db *store.DB) {
 }
 
 func runAdapterReauthWebAuthnBindsFullEnvironmentSet(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
@@ -385,7 +388,8 @@ func runAdapterReauthWebAuthnBindsFullEnvironmentSet(t *testing.T, db *store.DB)
 }
 
 func runAdapterReauthTOTPMixedPolicy(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	base := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
 	clock := base
 	auth.Now = func() time.Time { return clock }
@@ -430,7 +434,8 @@ func runAdapterReauthTOTPMixedPolicy(t *testing.T, db *store.DB) {
 }
 
 func runAdapterReauthWindowExactBinding(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	now := time.Now().UTC()
 	auth.Now = func() time.Time { return now }
 	auth.ReauthWindow = 5 * time.Minute
@@ -492,7 +497,8 @@ func TestReauthConsumeSingleDecisionPostgres(t *testing.T) {
 // (B11 double-spend). A single-decision window needs a bounded life, so the hard
 // cap is set (the flag limits it to one decision; the clock keeps it alive).
 func runReauthConsumeSingleDecision(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	auth.ReauthWindow = 0 // 0 effective window -> single-decision
 	auth.ReauthHardCap = 5 * time.Minute
 	ctx := t.Context()
@@ -551,7 +557,8 @@ func TestReauthConsumeSlidingHardCapPostgres(t *testing.T) {
 // hard cap (measured from the ceremony, never extended) bounds it, and a
 // disclosure past the hard cap fails closed. An epoch-inert window is also refused.
 func runReauthConsumeSlidingHardCap(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	base := time.Now().UTC().Truncate(time.Second)
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -623,7 +630,8 @@ func TestReauthWebAuthnOpenClampsHardCapPostgres(t *testing.T) {
 // opens. The effective window (30m) exceeds the hard cap (10m), so the clamp is
 // load-bearing: without it the row would open to +30m, past its +10m cap.
 func runReauthWebAuthnOpenClampsHardCap(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	auth.ReauthWindow = 30 * time.Minute
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
@@ -671,7 +679,8 @@ func TestReauthSlideUsesEffectiveWindowPostgres(t *testing.T) {
 // bounds the slide to the lowered value rather than the value the window opened
 // with. The seam is thus the single source shared by open and consume.
 func runReauthSlideUsesEffectiveWindow(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	base := time.Now().UTC().Truncate(time.Second)
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -738,7 +747,8 @@ func TestReauthConsumeInvalidationFailsClosedPostgres(t *testing.T) {
 // slide's `consumed_at IS NULL` guard matches 0 rows — which the fix now refuses
 // (before the fix, the dropped rows-affected result let the disclosure proceed).
 func runReauthConsumeInvalidationFailsClosed(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	base := time.Now().UTC().Truncate(time.Second)
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -782,7 +792,8 @@ func TestReauthTOTPZeroWindowPostgres(t *testing.T) {
 // effective window it refuses reauth naming the remedy (only WebAuthn opens a
 // 0-window gate); at a non-zero window it opens a sliding window.
 func runReauthTOTPZeroWindow(t *testing.T, db *store.DB) {
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }
@@ -907,7 +918,8 @@ func grantInstanceCapability(t *testing.T, db *store.DB, target domain.Principal
 // principal-row lock every grant writer also takes (B14, analyzer-enforced), so a
 // concurrent grant landing serializes against the reset.
 func runCredentialResetNetwork(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	grantInstanceCapability(t, db, boot.PrincipalID, domain.CapCredentialReset)
 	base := time.Now().UTC()
 	clk := base
@@ -1001,7 +1013,8 @@ func TestCredentialResetMFAMandatoryPostgres(t *testing.T) {
 // the credential-reset operation: uniform on the wire (mapped to 401), detailed
 // in the trail.
 func runCredentialResetMFAMandatory(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	grantInstanceCapability(t, db, boot.PrincipalID, domain.CapCredentialReset)
 	ctx := t.Context()
 
@@ -1090,7 +1103,8 @@ func TestCLIDisclosureReauthHandoffPostgres(t *testing.T) {
 // UNBOUND window mirroring the browser's, under which the CLI's reveal
 // succeeds, while the adapter-bound shape is untouched.
 func runCLIDisclosureReauthHandoff(t *testing.T, db *store.DB) {
-	auth, boot, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, boot, password := factorAdmin.auth, factorAdmin.boot, factorAdmin.password
 	identityFixtures(t, db)
 	seedDeliveryCatalogue(t, db)
 	for _, row := range [][2]string{{"read", "g_cli_disc_read"}, {"reveal", "g_cli_disc_reveal"}} {
@@ -1211,7 +1225,8 @@ func TestCLIDisclosureHandoffPasskeyBindingPostgres(t *testing.T) {
 // never satisfy a disclosure handoff.
 func runCLIDisclosureHandoffPasskeyBinding(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, browserToken, values, dev := ceremonyFixture(t, db, "handoff-zero")
+	ceremony := ceremonyFixture(t, db, "handoff-zero")
+	auth, browserToken, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 0
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)

--- a/internal/isolation/reveal_ceremony_e2e_test.go
+++ b/internal/isolation/reveal_ceremony_e2e_test.go
@@ -58,9 +58,13 @@ const (
 // The Values service takes this Auth deliberately: the window a ceremony opens
 // and the window a disclosure consumes must come from one configuration, and a
 // fixture that wired two would pass while the product could not.
-func ceremonyFixture(t *testing.T, db *store.DB, username string) (
-	*service.Auth, string, *service.Values, *webauthntest.Device,
-) {
+type ceremonyEnv struct {
+	admin  admin
+	values *service.Values
+	device *webauthntest.Device
+}
+
+func ceremonyFixture(t *testing.T, db *store.DB, username string) ceremonyEnv {
 	t.Helper()
 	ctx := t.Context()
 	auth := authService(t, db)
@@ -68,19 +72,12 @@ func ceremonyFixture(t *testing.T, db *store.DB, username string) (
 	if err := auth.ConfigureWebAuthnRP(); err != nil {
 		t.Fatalf("configuring the webauthn relying party: %v", err)
 	}
-	boot, err := auth.BootstrapAdmin(ctx, username, "Ceremony Admin", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := auth.EstablishCredential(ctx, boot.Authority, ceremonyPassword); err != nil {
-		t.Fatal(err)
-	}
-	login, err := auth.LocalLogin(ctx, username, ceremonyPassword, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: username, displayName: "Ceremony Admin",
+		password: ceremonyPassword, auth: auth, login: true,
+	})
 	dev := webauthntest.New(ceremonyRPID, ceremonyOrigin)
-	token := enrolPasskey(t, auth, ctx, login.SessionToken, ceremonyPassword, dev)
+	token := enrolPasskey(t, auth, ctx, administrator.token, ceremonyPassword, dev)
 	// `reveal` is MFA-mandatory, and that check sits at authorize() ahead of
 	// the ceremony gate. A password-only session is refused there — correctly,
 	// and for a different reason than the one these fixtures are about — so the
@@ -107,9 +104,9 @@ func ceremonyFixture(t *testing.T, db *store.DB, username string) (
 	for _, cap := range []string{"read", "edit", "publish", "reveal", "project-settings"} {
 		id := "g_cer_" + username + "_" + cap
 		execRaw(t, db, `INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) `+
-			`VALUES ('`+id+`', '`+string(boot.PrincipalID)+`', '`+cap+`', 'org_a', NULL, NULL, `+ts+`)`)
+			`VALUES ('`+id+`', '`+string(administrator.boot.PrincipalID)+`', '`+cap+`', 'org_a', NULL, NULL, `+ts+`)`)
 		execRaw(t, db, `INSERT INTO grant_origins (id, grant_id, kind, subject, created_at) `+
-			`VALUES ('gor_`+id+`', '`+id+`', 'manual', '`+string(boot.PrincipalID)+`', `+ts+`)`)
+			`VALUES ('gor_`+id+`', '`+id+`', 'manual', '`+string(administrator.boot.PrincipalID)+`', `+ts+`)`)
 	}
 
 	values := &service.Values{DB: db, Keyring: probeKeyring(t, db), Auth: auth}
@@ -126,7 +123,8 @@ func ceremonyFixture(t *testing.T, db *store.DB, username string) (
 		publishValue(t, values, service.LocalPrincipal(custodian),
 			scopeEnv(orgA, prjA1, envA1), name, "plaintext-"+name)
 	}
-	return auth, token, values, dev
+	administrator.token = token
+	return ceremonyEnv{admin: administrator, values: values, device: dev}
 }
 
 // publishValue stages a value and then publishes it, which is what "seed a
@@ -197,7 +195,8 @@ func TestTOTPOpensARevealWindowPostgres(t *testing.T) {
 // not capped at 0.
 func runTOTPOpensARevealWindow(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, _ := ceremonyFixture(t, db, "ceremony-totp")
+	ceremony := ceremonyFixture(t, db, "ceremony-totp")
+	auth, token, values := ceremony.admin.auth, ceremony.admin.token, ceremony.values
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
@@ -288,7 +287,8 @@ func TestRevealNeedsACeremonyPostgres(t *testing.T) {
 // not the check.
 func runRevealNeedsACeremony(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-sliding")
+	ceremony := ceremonyFixture(t, db, "ceremony-sliding")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
@@ -381,7 +381,8 @@ func TestZeroWindowForcesAPasskeyPerDisclosurePostgres(t *testing.T) {
 // path at all.
 func runZeroWindowForcesAPasskeyPerDisclosure(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-zero")
+	ceremony := ceremonyFixture(t, db, "ceremony-zero")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 0
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
@@ -447,7 +448,8 @@ func TestProtectedEnvironmentCapsTheWindowAtZeroPostgres(t *testing.T) {
 // what lets the browser decide whether to offer the option.
 func runProtectedEnvironmentCapsTheWindow(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-protected")
+	ceremony := ceremonyFixture(t, db, "ceremony-protected")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
@@ -512,7 +514,8 @@ func TestCopySourceTakesTheCeremonyPostgres(t *testing.T) {
 // prototype's copy-without-display.
 func runCopySourceTakesTheCeremony(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-copy")
+	ceremony := ceremonyFixture(t, db, "ceremony-copy")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	req := service.CopyRequest{
@@ -572,11 +575,12 @@ func TestRestorePinAndProtectedPublishTakeCeremoniesPostgres(t *testing.T) {
 
 func runRestorePinAndProtectedPublishTakeCeremonies(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-restore-pin")
+	ceremony := ceremonyFixture(t, db, "ceremony-restore-pin")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 0
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
-	principal := queryString(t, db, "SELECT principal_id FROM accounts WHERE username = 'ceremony-restore-pin'")
+	principal := string(ceremony.admin.boot.PrincipalID)
 	for _, capability := range []string{"reveal-history", "pin"} {
 		execRaw(t, db, "INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('g_ceremony_extra_"+
 			capability+"', '"+principal+"', '"+capability+"', 'org_a', 'prj_a1', 'env_a1', "+ts+")")
@@ -662,7 +666,8 @@ func TestAMachineNeverReauthenticatesPostgres(t *testing.T) {
 // would prove the exemption for a caller class this assertion is not about.
 func runAMachineNeverReauthenticates(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, _, values, _ := ceremonyFixture(t, db, "ceremony-machine")
+	ceremony := ceremonyFixture(t, db, "ceremony-machine")
+	auth, values := ceremony.admin.auth, ceremony.values
 	auth.ReauthWindow = 0
 	scope := scopeEnv(orgA, prjA1, envA1)
 
@@ -742,7 +747,8 @@ func TestProtectedDestinationRefusesAConfirmationFlagPostgres(t *testing.T) {
 // the copy names, and the flag is the machine plan field it always was.
 func runProtectedDestinationRefusesAConfirmationFlag(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-configonly")
+	ceremony := ceremonyFixture(t, db, "ceremony-configonly")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	project := scopeProject(orgA, prjA1)
@@ -796,7 +802,8 @@ func TestACeremonyIsBoundToItsPurposePostgres(t *testing.T) {
 // the same unit and one they were never shown.
 func runACeremonyIsBoundToItsPurpose(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-purpose")
+	ceremony := ceremonyFixture(t, db, "ceremony-purpose")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 0
 	auth.ReauthHardCap = time.Hour
 	scope := scopeEnv(orgA, prjA1, envA1)
@@ -843,7 +850,8 @@ func TestTheTOTPRouteIsNotAnEnvironmentOraclePostgres(t *testing.T) {
 // nonexistent one by presenting nonsense and reading the refusal.
 func runTheTOTPRouteIsNotAnEnvironmentOracle(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, _, _ := ceremonyFixture(t, db, "ceremony-oracle")
+	ceremony := ceremonyFixture(t, db, "ceremony-oracle")
+	auth, token := ceremony.admin.auth, ceremony.admin.token
 	auth.ReauthWindow = 5 * time.Minute
 
 	// env_b1 belongs to org B: a real environment this principal cannot reach.
@@ -881,7 +889,8 @@ func TestConcurrentCeremoniesSupersedePostgres(t *testing.T) {
 // into an intermittent failure. The upsert makes the loser update.
 func runConcurrentCeremoniesSupersede(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, _, dev := ceremonyFixture(t, db, "ceremony-concurrent")
+	ceremony := ceremonyFixture(t, db, "ceremony-concurrent")
+	auth, token, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.device
 	auth.ReauthWindow = 0
 	auth.ReauthHardCap = time.Hour
 	keyA := "key_" + ceremonySecretA
@@ -965,7 +974,8 @@ func TestAWindowExpiringDuringACopyIsNotSpentPostgres(t *testing.T) {
 // instant would not notice at all.
 func runAWindowExpiringDuringACopyIsNotSpent(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, values, dev := ceremonyFixture(t, db, "ceremony-expiry")
+	ceremony := ceremonyFixture(t, db, "ceremony-expiry")
+	auth, token, values, dev := ceremony.admin.auth, ceremony.admin.token, ceremony.values, ceremony.device
 	auth.ReauthWindow = 5 * time.Minute
 	auth.ReauthHardCap = time.Hour
 	project := scopeProject(orgA, prjA1)
@@ -1036,7 +1046,8 @@ func TestThePasskeyRouteIsNotAnEnvironmentOraclePostgres(t *testing.T) {
 // requiring `read(E)` first collapses them into the uniform outcome.
 func runThePasskeyRouteIsNotAnEnvironmentOracle(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, token, _, _ := ceremonyFixture(t, db, "ceremony-pk-oracle")
+	ceremony := ceremonyFixture(t, db, "ceremony-pk-oracle")
+	auth, token := ceremony.admin.auth, ceremony.admin.token
 	auth.ReauthWindow = 5 * time.Minute
 
 	// env_b1 is org B's: real, reachable by someone, not by this principal.

--- a/internal/isolation/saml_e2e_test.go
+++ b/internal/isolation/saml_e2e_test.go
@@ -72,7 +72,8 @@ func samlResponseForStart(t *testing.T, idp *samltest.IdP, start service.SAMLSta
 func runSAMLLoginReplay(t *testing.T, db *store.DB) {
 	t.Helper()
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ExternalOrigin = "https://hikyo.test"
 	idp := configureSAMLProvider(t, auth, admin)
 	providers := &service.SAMLProviders{DB: auth.DB, Keyring: auth.Keyring, ExternalOrigin: auth.ExternalOrigin}
@@ -314,7 +315,8 @@ func TestSAMLLoginReplayPostgres(t *testing.T) {
 func runSAMLProviderRecreation(t *testing.T, db *store.DB) {
 	t.Helper()
 	ctx := t.Context()
-	auth, admin, password := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin, password := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID, oidcAdministrator.password
 	auth.ExternalOrigin = "https://hikyo.test"
 	idp := configureSAMLProvider(t, auth, admin)
 	providers := &service.SAMLProviders{DB: auth.DB, Keyring: auth.Keyring, ExternalOrigin: auth.ExternalOrigin}
@@ -379,7 +381,8 @@ func TestSAMLProviderRecreationPostgres(t *testing.T) {
 func runSAMLSPKeyLifecycle(t *testing.T, db *store.DB) {
 	t.Helper()
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	auth.ExternalOrigin = "https://hikyo.test"
 	configureSAMLProvider(t, auth, admin)
 	providers := &service.SAMLProviders{DB: auth.DB, Keyring: auth.Keyring, ExternalOrigin: auth.ExternalOrigin}

--- a/internal/isolation/scanning_sweep_e2e_test.go
+++ b/internal/isolation/scanning_sweep_e2e_test.go
@@ -333,12 +333,16 @@ func newSweepEnv(t *testing.T, db *store.DB) sweepEnv {
 		t.Fatalf("load ruleset: %v", err)
 	}
 	kr := probeKeyring(t, db)
-	auth, boot, password := bootstrapWebAuthnAdminBoot(t, db)
+	auth := webauthnAuthService(t, db)
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: waAdmin, displayName: "WA Admin",
+		password: "a perfectly ordinary wire passphrase", auth: auth, login: true,
+	})
 	ctx := tctx(t)
 	// A stepped-up passkey session — org creation and the tenant writes below are
 	// MFA-mandatory, so a password-only session answers unauthorized.
 	dev := webauthntest.New(waRPID, waOrigin)
-	token := enrolPasskey(t, auth, ctx, boot.token, password, dev)
+	token := enrolPasskey(t, auth, ctx, administrator.token, administrator.password, dev)
 	token = stepUpPasskey(t, auth, ctx, token, dev)
 
 	orgs := &service.Orgs{DB: db}
@@ -346,7 +350,7 @@ func newSweepEnv(t *testing.T, db *store.DB) sweepEnv {
 	if err != nil {
 		t.Fatalf("create org: %v", err)
 	}
-	login, err := auth.LocalLogin(ctx, waAdmin, password, service.ArtifactCLI)
+	login, err := auth.LocalLogin(ctx, waAdmin, administrator.password, service.ArtifactCLI)
 	if err != nil {
 		t.Fatalf("login after org create: %v", err)
 	}
@@ -357,12 +361,12 @@ func newSweepEnv(t *testing.T, db *store.DB) sweepEnv {
 	for i, capability := range []string{"read", "edit", "publish", "definitions-edit", "manage-projects", "reveal", "audit-read"} {
 		execRaw(t, db, fmt.Sprintf(
 			"INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('grt_sweep_%d', '%s', '%s', '%s', NULL, NULL, %s)",
-			i, boot.principal, capability, org.ID, ts))
+			i, administrator.boot.PrincipalID, capability, org.ID, ts))
 	}
 	// Instance-scope audit-read so the instance-trail export leg authorizes.
 	execRaw(t, db, fmt.Sprintf(
 		"INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES ('grt_sweep_iar', '%s', 'audit-read', NULL, NULL, NULL, %s)",
-		boot.principal, ts))
+		administrator.boot.PrincipalID, ts))
 	// Project and environment seeded directly with contract-valid ids.
 	execRaw(t, db, fmt.Sprintf(
 		"INSERT INTO projects (id, org_id, name, created_at) VALUES ('%s', '%s', 'sweep-project', %s)", sweepProject, org.ID, ts))
@@ -375,7 +379,7 @@ func newSweepEnv(t *testing.T, db *store.DB) sweepEnv {
 	// A config key the value-warn surface writes to.
 	keys := &service.Keys{DB: db, Keyring: kr, Scan: rs}
 	scope := domain.Scope{Org: domain.OrgID(org.ID), Project: domain.ProjectID(sweepProject)}
-	if _, err := keys.Create(ctx, service.LocalPrincipal(boot.principal), scope, service.KeySpec{
+	if _, err := keys.Create(ctx, service.LocalPrincipal(administrator.boot.PrincipalID), scope, service.KeySpec{
 		Name: "CONFIG_KEY", Classification: "config", Declaration: stringDeclaration(), Presence: nonePresence()}, nil); err != nil {
 		t.Fatalf("create config key: %v", err)
 	}
@@ -398,7 +402,7 @@ func newSweepEnv(t *testing.T, db *store.DB) sweepEnv {
 	writeTrustStore(t, stateDir, srv.URL)
 
 	return sweepEnv{
-		srv: srv, token: token, admin: boot.principal,
+		srv: srv, token: token, admin: administrator.boot.PrincipalID,
 		audits: &service.Audits{DB: db},
 		org:    org.ID, project: sweepProject, env: sweepEnvID,
 		stateDir: stateDir,

--- a/internal/isolation/scim_invariants_test.go
+++ b/internal/isolation/scim_invariants_test.go
@@ -147,7 +147,8 @@ func runSCIMCredentialRejected(t *testing.T, db *store.DB) {
 	// artifact here would prove only that nonsense is refused, which is a
 	// different claim.
 	s := scimSvc(db)
-	_, _, human := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	human := oidcAdministrator.password
 	if _, err := s.GetUser(ctx, service.Bearer(human), orgA, bindingID, "scu_none"); !isUnauth(err) {
 		t.Fatalf("a live human session must not authenticate the provisioning wire, got %v", err)
 	}

--- a/internal/isolation/scim_login_e2e_test.go
+++ b/internal/isolation/scim_login_e2e_test.go
@@ -34,7 +34,8 @@ func TestSCIMProvisionThenLoginOIDCPostgres(t *testing.T) {
 
 func runSCIMProvisionThenLoginOIDC(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	// No JIT policy: an unmatched subject must NOT be provisioned into
 	// existence, or "the provisioned identity reached the known-identity path"
 	// would be unfalsifiable.
@@ -119,7 +120,8 @@ const samlSPEntityID = "https://hikyo.test/api/v1/auth/saml"
 
 func runSCIMProvisionThenLoginSAML(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	auth.ExternalOrigin = "https://hikyo.test"
 	idp := configureSAMLProvider(t, auth, admin)
 	s := scimSvc(db)
@@ -528,7 +530,8 @@ func TestSCIMRestoreDrillPostgres(t *testing.T) { runSCIMRestoreDrill(t, seededD
 
 func runSCIMRestoreDrill(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	_, _ = configureProvider(t, auth, ctx, admin, "okta", service.ProviderInput{
 		DisplayName: "Okta", ClientID: "c", ClientSecret: "s", Scopes: "openid", Enabled: true,
 	})

--- a/internal/isolation/scim_wire_coverage_test.go
+++ b/internal/isolation/scim_wire_coverage_test.go
@@ -350,7 +350,8 @@ func TestSCIMZeroAuthorityOnCreatePostgres(t *testing.T) {
 
 func runSCIMZeroAuthorityOnCreate(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	_, _ = configureProvider(t, auth, ctx, admin, "okta", service.ProviderInput{
 		DisplayName: "Okta", ClientID: "c", ClientSecret: "s", Scopes: "openid", Enabled: true,
 	})
@@ -418,7 +419,8 @@ const samlEmailFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 
 func runSCIMProvisionThenLoginSAMLEmailCarve(t *testing.T, db *store.DB) {
 	ctx := t.Context()
-	auth, admin, _ := oidcAdmin(t, db)
+	oidcAdministrator := oidcAdmin(t, db)
+	auth, admin := oidcAdministrator.auth, oidcAdministrator.boot.PrincipalID
 	auth.ExternalOrigin = "https://hikyo.test"
 	idp := configureSAMLProviderWithEmailCarve(t, auth, admin)
 	s := scimSvc(db)

--- a/internal/isolation/webauthn_e2e_test.go
+++ b/internal/isolation/webauthn_e2e_test.go
@@ -41,33 +41,24 @@ func webauthnAuthService(t *testing.T, db *store.DB) *service.Auth {
 	return auth
 }
 
-// bootstrapWebAuthnAdmin mints a first administrator, establishes its password
-// and logs in, returning the acting service, the account id and a live session.
-func bootstrapWebAuthnAdmin(t *testing.T, db *store.DB) (*service.Auth, string, string) {
+// bootstrapWebAuthnAdmin configures the WebAuthn relying party around the
+// shared first-administrator fixture and grants the environment read needed by
+// every reauthentication test in this suite.
+func bootstrapWebAuthnAdmin(t *testing.T, db *store.DB) admin {
 	t.Helper()
 	auth := webauthnAuthService(t, db)
-	ctx := t.Context()
-	boot, err := auth.BootstrapAdmin(ctx, waAdmin, "WA Admin", "terminal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := auth.EstablishCredential(ctx, boot.Authority, waPassword); err != nil {
-		t.Fatal(err)
-	}
-	login, err := auth.LocalLogin(ctx, waAdmin, waPassword, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	accountID := queryString(t, db, "SELECT id FROM accounts WHERE username = '"+waAdmin+"'")
+	administrator := bootstrapAdmin(t, db, adminOpts{
+		username: waAdmin, displayName: "WA Admin", password: waPassword,
+		auth: auth, login: true,
+	})
 	// The reauth routes resolve and authorize the environment under `read`
 	// before they will discuss its reauthentication policy — otherwise the
 	// route is an oracle for which environment ids exist and which are
 	// protected. Every reauth fixture in this package addresses org A's
 	// `env_prod`, so the bootstrap administrator is given the `read` that gate
 	// sits behind; bootstrap itself deliberately seeds no tenant capability.
-	grantRead(t, db, domain.PrincipalID(queryString(t, db,
-		"SELECT principal_id FROM accounts WHERE username = '"+waAdmin+"'")))
-	return auth, accountID, login.SessionToken
+	grantRead(t, db, administrator.boot.PrincipalID)
+	return administrator
 }
 
 // enrolPasskey runs a full enrolment with the given device and returns the
@@ -111,7 +102,8 @@ func TestWebAuthnRoundtripPostgres(t *testing.T) { runWebAuthnRoundtrip(t, seede
 // single webauthn factor class, and passes an MFA-mandatory operation the
 // password-only session is refused — the "UV is inherent 2FA" rule made real.
 func runWebAuthnRoundtrip(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	orgs := &service.Orgs{DB: db}
 
@@ -151,7 +143,7 @@ func runWebAuthnRoundtrip(t *testing.T, db *store.DB) {
 	if err != nil {
 		t.Fatalf("a webauthn session must pass an MFA-mandatory op: %v", err)
 	}
-	principal := queryString(t, db, "SELECT principal_id FROM accounts WHERE username = '"+waAdmin+"'")
+	principal := string(administrator.boot.PrincipalID)
 	caps, err := domain.ExpandTemplate(domain.TemplateAdmin, domain.LevelOrg)
 	if err != nil {
 		t.Fatal(err)
@@ -183,7 +175,8 @@ func TestWebAuthnUVRefusedPostgres(t *testing.T) { runWebAuthnUVRefused(t, seede
 // runWebAuthnUVRefused: an assertion whose UV bit is not set is refused. UV is
 // required on every ceremony and re-asserted server-side.
 func runWebAuthnUVRefused(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -209,7 +202,8 @@ func TestWebAuthnClonePostgres(t *testing.T) { runWebAuthnClone(t, seededDB(t, o
 // it, sweeps every session it minted and audits passkey_cloned, before refusing
 // (B9).
 func runWebAuthnClone(t *testing.T, db *store.DB) {
-	auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin) // non-backup by default
 	enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -256,7 +250,8 @@ func TestWebAuthnSyncedNotFlaggedPostgres(t *testing.T) {
 // runWebAuthnSyncedNotFlagged: a backup-eligible (synced) credential whose
 // counter stays 0 across logins is NOT falsely flagged as cloned (B9 skip).
 func runWebAuthnSyncedNotFlagged(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	dev.SetBackupEligible(true)
@@ -297,7 +292,8 @@ func runWebAuthnPasskeyOnly(t *testing.T, open func(*testing.T) *store.DB) {
 	// refused structurally.
 	t.Run("second_to_last_discoverable_refused", func(t *testing.T) {
 		db := seededDB(t, open)
-		auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+		administrator := bootstrapWebAuthnAdmin(t, db)
+		auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 		ctx := t.Context()
 		d1, d2 := webauthntest.New(waRPID, waOrigin), webauthntest.New(waRPID, waOrigin)
 		token = enrolPasskey(t, auth, ctx, token, waPassword, d1)
@@ -321,7 +317,8 @@ func runWebAuthnPasskeyOnly(t *testing.T, open func(*testing.T) *store.DB) {
 	// passwordless account holds no recovery batch.
 	t.Run("no_recovery_batch_refused", func(t *testing.T) {
 		db := seededDB(t, open)
-		auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+		administrator := bootstrapWebAuthnAdmin(t, db)
+		auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 		ctx := t.Context()
 		for range 3 {
 			token = enrolPasskey(t, auth, ctx, token, waPassword, webauthntest.New(waRPID, waOrigin))
@@ -345,7 +342,8 @@ func TestWebAuthnEnrolProofPostgres(t *testing.T) {
 // ceremony. A wrong password is refused, and the removal that follows a
 // successful enrol proves with the password, never the passkey.
 func runWebAuthnEnrolProof(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 
 	// Enrolment demands the pre-existing password up front; a wrong one refuses
@@ -376,7 +374,8 @@ func TestWebAuthnStepUpReauthPostgres(t *testing.T) {
 // original authentication), and a passkey reauth opens a window over an
 // enumerated unit — single-decision at the default 0 effective window (B11).
 func runWebAuthnStepUpReauth(t *testing.T, db *store.DB) {
-	auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -448,7 +447,8 @@ func TestWebAuthnReauthBindingMismatchPostgres(t *testing.T) {
 // fail-closed, in the same validCeremony check the write tx re-runs against the
 // reloaded row.
 func runWebAuthnReauthBindingMismatch(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -486,7 +486,8 @@ func TestWebAuthnDeleteAccountScopedPostgres(t *testing.T) {
 // surrogate id — so an IDOR cannot appear even if a service-layer ownership
 // check regresses. The true owner still deletes its own credential.
 func runWebAuthnDeleteAccountScoped(t *testing.T, db *store.DB) {
-	auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 	ctx := t.Context()
 	enrolPasskey(t, auth, ctx, token, waPassword, webauthntest.New(waRPID, waOrigin))
 	credID := queryString(t, db, "SELECT id FROM webauthn_credentials WHERE account_id = '"+accountID+"' LIMIT 1")
@@ -536,7 +537,8 @@ func TestWebAuthnLoginNoAccountThrottlePostgres(t *testing.T) {
 // admission budget only; per-account backoff lives on the authenticated paths.
 // So after six bad assertions naming the victim, a genuine login still succeeds.
 func runWebAuthnLoginNoAccountThrottle(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -570,7 +572,8 @@ func TestWebAuthnLoginHandleMismatchPostgres(t *testing.T) {
 // credential's account is refused (the account is chosen by the credential,
 // never by the client-supplied handle).
 func runWebAuthnLoginHandleMismatch(t *testing.T, db *store.DB) {
-	auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -596,7 +599,8 @@ func TestWebAuthnStepUpThrottlePostgres(t *testing.T) {
 // per-account backoff and, once armed, the next step-up finish is refused before
 // verification. Reauth shares the identical finishAssertionElevation gate.
 func runWebAuthnStepUpThrottle(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
 	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
@@ -638,7 +642,8 @@ func TestWebAuthnCeremonyExpiryPostgres(t *testing.T) {
 // against the current clock (both before verification and again inside the write
 // tx), so a challenge accepted just before expiry cannot complete after it.
 func runWebAuthnCeremonyExpiry(t *testing.T, db *store.DB) {
-	auth, _, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, token := administrator.auth, administrator.token
 	ctx := t.Context()
 	// A controllable server clock, installed after bootstrap so the ceremony's
 	// life is measured against it.
@@ -675,7 +680,8 @@ func TestRecoveryLastCodePasswordlessPostgres(t *testing.T) {
 // recovery batch. The refusal is non-destructive: the batch is not re-sealed, so
 // the reserve code is not burned (its row_version is unchanged).
 func runRecoveryLastCodePasswordless(t *testing.T, db *store.DB) {
-	auth, accountID, token := bootstrapWebAuthnAdmin(t, db)
+	administrator := bootstrapWebAuthnAdmin(t, db)
+	auth, accountID, token := administrator.auth, administrator.accountID, administrator.token
 	ctx := t.Context()
 	// A legitimate passkey-only account: two discoverable passkeys and a batch.
 	token = enrolPasskey(t, auth, ctx, token, waPassword, webauthntest.New(waRPID, waOrigin))

--- a/internal/isolation/workspace_stepup_test.go
+++ b/internal/isolation/workspace_stepup_test.go
@@ -670,7 +670,8 @@ func TestStepUpRevealIsSpentByValuePathPostgres(t *testing.T) {
 func TestStepUpDemandsARealFactorVerification(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	ctx := t.Context()
-	auth, _, password := bootstrapFactorAdmin(t, db)
+	factorAdmin := bootstrapFactorAdmin(t, db)
+	auth, password := factorAdmin.auth, factorAdmin.password
 	base := time.Now().UTC()
 	clk := base
 	auth.Now = func() time.Time { return clk }


### PR DESCRIPTION
Closes #370

## Contract

- Centralizes first-administrator creation, credential establishment, optional login, and returned fixture state in the isolation harness.
- Uses BootstrapResult as the account/principal identity owner; removes SQL re-derivation.
- Preserves factor and backup no-login ordering, including reset authority creation before the first backup-drill session.
- Keeps direct bootstrap calls only where bootstrap/intermediate state or CLI establishment is under test.

Migrations: none. Generated outputs: none. Wire/audit contracts: unchanged.

## Validation

- go test -count=1 -timeout 90m ./internal/isolation/ — 1,122 passed
- go test -count=1 -timeout 120m ./... — 3,591 passed / 61 packages
- go vet ./... — passed
- gofmt — clean
- git diff --check — clean

Local HIKYO_TEST_POSTGRES_DSN was unset; exact-head CI supplies the required PostgreSQL leg.

## Review

- Standards R1: 3 ownership leaks found and fixed; R2 CLEAN
- Spec R1: 1 missed sibling found and fixed; R2 CLEAN