### PR TITLE
Centralize e2e passkey lifecycle #371

### DIFF
--- a/docs/handoff/371-e2e-passkey-lifecycle.md
+++ b/docs/handoff/371-e2e-passkey-lifecycle.md
@@ -1,0 +1,37 @@
+# #371 — e2e passkey lifecycle ownership
+
+## Outcome
+
+Passkey-bearing Playwright flows now request `passkeyPage`. Its teardown always
+persists the shared credential's advanced signature counter, then probes the
+file-backed shared session and re-mints it only after a `401`.
+
+## Decisions
+
+- `web/e2e/fixtures/passkey.ts` owns passkey page setup, persistence, and shared-session repair.
+- Setup and flow authenticators share one `VIRTUAL_AUTHENTICATOR` definition.
+- A missing shared credential fails loud before the credential file can be overwritten.
+- Unexpected session-probe statuses fail the suite; only `401` authorizes re-minting.
+- Settings drill cleanup uses the same lifecycle owner so filtered runs do not leak resources.
+- The scanning flow deletes its temporary key, keeping desktop and mobile projects isolated in one run.
+
+## Generated outputs
+
+None.
+
+## Validation
+
+```text
+pnpm --dir web run typecheck
+  passed
+
+pnpm --dir web run test
+  38 files passed; 315 tests passed
+
+pnpm --dir web run e2e
+  297 passed; 1 expected desktop skip; desktop and mobile projects
+
+code-review
+  Standards: CLEAN
+  Spec: CLEAN
+```

--- a/web/e2e/fixtures/instance.test.ts
+++ b/web/e2e/fixtures/instance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  persistSharedPasskey,
+  refreshSharedSessionFromProbe,
+  type VirtualCredential,
+} from './instance.ts';
+
+const credential: VirtualCredential = {
+  credentialId: 'shared-passkey',
+  isResidentCredential: true,
+  privateKey: 'private-key',
+  rpId: 'localhost',
+  signCount: 1,
+  userHandle: 'user',
+};
+
+describe('shared passkey persistence', () => {
+  it('throws when the authenticator no longer holds the shared credential', () => {
+    expect(() => persistSharedPasskey([], credential)).toThrow(
+      'the shared virtual authenticator lost its passkey credential',
+    );
+  });
+});
+
+describe('shared session refresh decision', () => {
+  it('does not re-mint a live file-backed session', async () => {
+    const remint = vi.fn();
+
+    await refreshSharedSessionFromProbe(async () => 200, remint);
+
+    expect(remint).not.toHaveBeenCalled();
+  });
+
+  it('re-mints only when the file-backed session is unauthenticated', async () => {
+    const remint = vi.fn();
+
+    await refreshSharedSessionFromProbe(async () => 401, remint);
+
+    expect(remint).toHaveBeenCalledOnce();
+  });
+
+  it('fails loud when the probe itself fails', async () => {
+    const remint = vi.fn();
+
+    await expect(refreshSharedSessionFromProbe(async () => 500, remint)).rejects.toThrow(
+      'shared session probe answered 500',
+    );
+    expect(remint).not.toHaveBeenCalled();
+  });
+});

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -1,4 +1,4 @@
-import { chromium, type Page } from '@playwright/test';
+import { chromium, type CDPSession, type Page } from '@playwright/test';
 import { z, type ZodType } from 'zod';
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
@@ -126,6 +126,23 @@ export const SEEDED = fileURLToPath(new URL('../.auth/seed.json', import.meta.ur
  * account.
  */
 export const PASSKEY = fileURLToPath(new URL('../.auth/passkey.json', import.meta.url));
+
+/** One authenticator contract for setup and every passkey-bearing flow page. */
+const VIRTUAL_AUTHENTICATOR = Object.freeze({
+  protocol: 'ctap2',
+  transport: 'internal',
+  hasResidentKey: true,
+  hasUserVerification: true,
+  isUserVerified: true,
+  automaticPresenceSimulation: true,
+});
+
+async function addVirtualAuthenticator(session: CDPSession): Promise<string> {
+  const { authenticatorId } = await session.send('WebAuthn.addVirtualAuthenticator', {
+    options: VIRTUAL_AUTHENTICATOR,
+  });
+  return authenticatorId;
+}
 
 type Instance = {
   proc: ChildProcess;
@@ -1115,16 +1132,7 @@ async function mintStorageState(keepForeign?: readonly Cookie[]): Promise<void> 
 
     const cdp = await context.newCDPSession(page);
     await cdp.send('WebAuthn.enable');
-    const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
-      options: {
-        protocol: 'ctap2',
-        transport: 'internal',
-        hasResidentKey: true,
-        hasUserVerification: true,
-        isUserVerified: true,
-        automaticPresenceSimulation: true,
-      },
-    });
+    const authenticatorId = await addVirtualAuthenticator(cdp);
     if (!initialMint) {
       await cdp.send('WebAuthn.addCredential', {
         authenticatorId,
@@ -1212,6 +1220,20 @@ export function parseCredential(value: unknown): VirtualCredential {
   return zVirtualCredential.parse(value);
 }
 
+/** Persist the shared credential, refusing a silently empty authenticator. */
+export function persistSharedPasskey(
+  credentials: readonly unknown[],
+  sharedPasskey: VirtualCredential,
+): void {
+  const advanced = credentials
+    .map((credential) => parseCredential(credential))
+    .find((credential) => credential.credentialId === sharedPasskey.credentialId);
+  if (advanced === undefined) {
+    throw new Error('the shared virtual authenticator lost its passkey credential');
+  }
+  writePasskey(advanced);
+}
+
 /** Attach a virtual authenticator and persist the shared credential when it is loaded. */
 export async function installPasskeyAuthenticator(
   page: Page,
@@ -1219,16 +1241,7 @@ export async function installPasskeyAuthenticator(
 ): Promise<() => Promise<void>> {
   const session = await page.context().newCDPSession(page);
   await session.send('WebAuthn.enable');
-  const { authenticatorId } = await session.send('WebAuthn.addVirtualAuthenticator', {
-    options: {
-      protocol: 'ctap2',
-      transport: 'internal',
-      hasResidentKey: true,
-      hasUserVerification: true,
-      isUserVerified: true,
-      automaticPresenceSimulation: true,
-    },
-  });
+  const authenticatorId = await addVirtualAuthenticator(session);
   // Most flows load the already-enrolled credential instead of enrolling
   // again. The account enrolment drill deliberately uses an empty, second
   // authenticator: creating another discoverable credential for the same user
@@ -1242,15 +1255,9 @@ export async function installPasskeyAuthenticator(
       return;
     }
     const { credentials } = await session.send('WebAuthn.getCredentials', { authenticatorId });
-    const advanced = credentials.find(
-      (credential) => credential.credentialId === sharedPasskey.credentialId,
-    );
-    if (advanced === undefined) {
-      throw new Error('the shared virtual authenticator lost its passkey credential');
-    }
     // Persist the authenticator's advanced signature counter: replaying a seen
     // counter looks like a cloned authenticator and disables the credential.
-    writePasskey(parseCredential(advanced));
+    persistSharedPasskey(credentials, sharedPasskey);
   };
 }
 
@@ -1518,17 +1525,49 @@ export async function nextTotpCode(): Promise<string> {
   return totpCode(seed.otpauth, new Date(want * TOTP_PERIOD * 1000));
 }
 
+/** Decide from the file-cookie probe whether re-minting is necessary. */
+export async function refreshSharedSessionFromProbe(
+  probe: () => Promise<number>,
+  remint: () => Promise<void>,
+): Promise<void> {
+  const status = await probe();
+  if (status === 200) {
+    return;
+  }
+  if (status === 401) {
+    await remint();
+    return;
+  }
+  throw new Error(`shared session probe answered ${String(status)}`);
+}
+
+function storageStateCookieHeader(): string {
+  const cookies = zStorageState
+    .parse(JSON.parse(readFileSync(STORAGE_STATE, 'utf8')))
+    .cookies.filter((cookie) => cookie.domain === HOST || cookie.domain === `.${HOST}`);
+  if (!cookies.some((cookie) => cookie.name === '__Host-hikyo')) {
+    throw new Error('the shared storage state has no viewing-instance session cookie');
+  }
+  return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+}
+
 /**
- * refreshSharedSession re-mints the storage state and the shared passkey.
+ * Repair the shared session only when its file-backed cookie is stale.
  *
- * A flow that has to change the administrator's GRANTS advances their session
- * generation, which kills every session that principal holds — the suite's
- * shared storage state included. Re-minting is how such a flow leaves the
- * suite as it found it, and it preserves the serving instance's jar by reading
- * it back out of the file it is about to rewrite.
+ * Grant and account-security mutations invalidate every session generation,
+ * while ordinary passkey ceremonies do not. Probing avoids launching a whole
+ * browser for the common live-session case; any non-auth failure stays loud.
  */
 export async function refreshSharedSession(): Promise<void> {
-  await mintStorageState();
+  await refreshSharedSessionFromProbe(
+    async () => {
+      const response = await fetch(`${BASE_URL}/api/v1/me/sessions`, {
+        headers: { Cookie: storageStateCookieHeader() },
+      });
+      return response.status;
+    },
+    mintStorageState,
+  );
 }
 
 export function stopInstance(): void {

--- a/web/e2e/fixtures/passkey.ts
+++ b/web/e2e/fixtures/passkey.ts
@@ -1,0 +1,33 @@
+import { test as base, type Page } from '@playwright/test';
+
+import { installPasskeyAuthenticator, refreshSharedSession } from './instance.ts';
+
+export type PasskeyCredential = 'shared' | 'empty';
+
+type PasskeyFixtures = {
+  passkeyCredential: PasskeyCredential;
+  passkeyPage: Page;
+};
+
+/** Run work on a passkey-bearing page, then persist and repair before it closes. */
+export async function withPasskeyPage(
+  page: Page,
+  credential: PasskeyCredential,
+  use: (page: Page) => Promise<void>,
+): Promise<void> {
+  const persistPasskey = await installPasskeyAuthenticator(page, credential);
+  try {
+    await use(page);
+  } finally {
+    await persistPasskey();
+    await refreshSharedSession();
+  }
+}
+
+/** Page fixture that owns passkey counter persistence and shared-session repair. */
+export const test = base.extend<PasskeyFixtures>({
+  passkeyCredential: ['shared', { option: true }],
+  passkeyPage: async ({ page, passkeyCredential }, use) => {
+    await withPasskeyPage(page, passkeyCredential, use);
+  },
+});

--- a/web/e2e/flows/account.spec.ts
+++ b/web/e2e/flows/account.spec.ts
@@ -1,16 +1,15 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { zLoginResult, zWhoAmI } from '@hikyo/zod';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
 import {
   ADMIN,
   BASE_URL,
-  installPasskeyAuthenticator,
   nextTotpCode,
   OIDC_PROVIDER,
-  refreshSharedSession,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 
 /**
  * Flow: account & security (registry surface `settings`) — mvp-boundary S3's
@@ -218,9 +217,10 @@ test.describe('account and security', () => {
    * generation. The refresh restores the shared suite state before the final
    * display-once drill.
    */
-  test('reports the existing TOTP factor and enrols then removes an additional passkey', async ({ page }) => {
-    const persistPasskey = await installPasskeyAuthenticator(page, 'empty');
-    try {
+  test.describe('passkey mutation', () => {
+    test.use({ passkeyCredential: 'empty' });
+
+    test('reports the existing TOTP factor and enrols then removes an additional passkey', async ({ passkeyPage: page }) => {
       // The factor state is now readable: the suite's administrator has a
       // confirmed authenticator, and the panel reports it rather than
       // disclaiming knowledge.
@@ -247,10 +247,7 @@ test.describe('account and security', () => {
       await removeProof.getByRole('button', { name: 'Confirm' }).click();
       await expect(rows).toHaveCount(before);
       await expect(page.getByRole('status').filter({ hasText: 'Passkey removed' })).toBeVisible();
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
+    });
   });
 
   /**
@@ -262,8 +259,7 @@ test.describe('account and security', () => {
    * leaves the run as it was found; every later test builds its context from
    * that file.
    */
-  test('replaces the recovery codes and shows them exactly once', async ({ page }) => {
-    try {
+  test('replaces the recovery codes and shows them exactly once', async ({ passkeyPage: page }) => {
       await page.getByRole('button', { name: 'Replace recovery codes' }).click();
       const proof = page.getByRole('dialog');
       await expect(proof).toContainText('never authorise their own regeneration');
@@ -298,8 +294,5 @@ test.describe('account and security', () => {
       for (const code of captured) {
         await expect(page.locator('body')).not.toContainText(code.trim());
       }
-    } finally {
-      await refreshSharedSession();
-    }
   });
 });

--- a/web/e2e/flows/history.spec.ts
+++ b/web/e2e/flows/history.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import {
   zExportValuesRequest,
   zPendingDraftList,
@@ -22,11 +22,10 @@ import {
 import {
   countDisclosureEvents,
   establishSession,
-  installPasskeyAuthenticator,
   readSeed,
-  refreshSharedSession,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 import { surfacesForFlow } from '../registry.ts';
 import { zHistoryRollbackResult } from '../../src/api/history.ts';
 
@@ -404,10 +403,8 @@ test.describe('revision history', () => {
   });
 
   test('restores an environment to an earlier revision and publishes the staged drafts', async ({
-    page,
+    passkeyPage: page,
   }) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
       await page.goto(DEV_HISTORY);
       const drawer = page.getByRole('complementary', { name: 'Revision history' });
       await expectNoFixtureSecret(drawer);
@@ -465,14 +462,6 @@ test.describe('revision history', () => {
       expect(publishBody.preview_token).toBe(rollback.preview.token);
       expect([...publishBody.version_ids].sort()).toEqual([...restoredVersions].sort());
       await expect(drawer.locator('.notice')).toContainText('Published the restore');
-    } finally {
-      // A disclosure ceremony REISSUES the browser session, so the suite's
-      // shared storage state now holds a dead cookie — the next test would land
-      // on the sign-in page for a reason several tests in its past. Persist the
-      // counter, then re-mint, exactly as the matrix flow does.
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
   test('restores one key from the changed-key row', async ({ page }) => {
@@ -593,9 +582,7 @@ test.describe('revision history', () => {
     await expect(drawer.locator('.notice')).toContainText('Published the restore');
   });
 
-  test('renders secret restore impact status-only and never exposes its value', async ({ page }) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
+  test('renders secret restore impact status-only and never exposes its value', async ({ passkeyPage: page }) => {
       await page.goto(DEV_HISTORY);
       const drawer = page.getByRole('complementary', { name: 'Revision history' });
       await expectNoFixtureSecret(drawer);
@@ -640,10 +627,6 @@ test.describe('revision history', () => {
         value: liveSecret,
       });
       await api(page, 'POST', `${DEV}/publish`, zAny, { version_ids: [reset.version_id] });
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
   test('refuses a schema-failing restore loud, naming the key', async ({ page }) => {
@@ -751,13 +734,9 @@ test.describe('revision history', () => {
   });
 
   test('requires a fresh-session ceremony for a historical move and audits comparison', async ({
-    browser,
+    passkeyPage: page,
   }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto(DEV_HISTORY);
       await establishSession(page);
       await page.goto(DEV_HISTORY);
@@ -849,10 +828,6 @@ test.describe('revision history', () => {
         revision: latest,
         expires_at: new Date(Date.now() + (seed.history.pinExpiryDays * 24 + 12) * 60 * 60 * 1000).toISOString(),
       });
-    } finally {
-      await persistPasskey();
-      await context.close();
-    }
   });
 
   test('keeps the mobile matrix inert and restores drawer focus', async ({ page }, testInfo) => {
@@ -872,9 +847,7 @@ test.describe('revision history', () => {
     await expectNoFixtureSecret(drawer);
   });
 
-  test('runs renew, schema override, and retention-gated one-click release', async ({ page }) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
+  test('runs renew, schema override, and retention-gated one-click release', async ({ passkeyPage: page }) => {
       await page.goto(DEV_HISTORY);
       const revisions = await api(page, 'GET', `${DEV}/revisions`, zRevisions);
       const latest = revisions.items[0]?.revision;
@@ -944,10 +917,6 @@ test.describe('revision history', () => {
       // Clean up the override pin when the product classifier exposes it.
       await drifted.getByRole('button', { name: 'Release' }).click();
       await expect(drawer.locator('.notice')).toContainText('resumes latest');
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
 });

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   zGrantList,
   zOrg,
@@ -21,12 +21,11 @@ import {
   BASE_URL,
   establishSession,
   INSTANCE_GRANT_TARGET,
-  installPasskeyAuthenticator,
   nextTotpCode,
   readSeed,
-  refreshSharedSession,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 
 /**
  * Flow: instance administration (registry surface `instance-admin`) —
@@ -382,10 +381,8 @@ test.describe('instance administration', () => {
     }
   });
 
-  test('creates an organisation, grants its creator admin access, and requires a fresh login', async ({ page }, testInfo) => {
+  test('creates an organisation, grants its creator admin access, and requires a fresh login', async ({ passkeyPage: page }, testInfo) => {
     const name = `Instance drill ${testInfo.project.name}`;
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
       await page.getByLabel('New organisation name').fill(name);
       const responsePromise = page.waitForResponse(
         (response) =>
@@ -406,10 +403,6 @@ test.describe('instance administration', () => {
       await page.goto(`/orgs/${created.id}/settings`);
       await expect(page.getByRole('heading', { name: 'Organisation settings', level: 1 })).toBeVisible();
       await expect(page.getByLabel('Name')).toHaveValue(name);
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
   test('answers a password-only session with the second-factor state, not an empty list', async ({

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -1,13 +1,11 @@
-import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
 import {
   establishSession,
-  parseCredential,
-  readPasskey,
   readSeed,
-  writePasskey,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 
 /**
  * Flow: machine access (registry surface `machine-access`) — mvp-boundary S3's
@@ -37,37 +35,6 @@ import {
 const seed = readSeed();
 const PATH = `/orgs/${seed.org}/projects/${seed.project}/machine-access`;
 
-/**
- * installAuthenticator attaches Chromium's virtual authenticator preloaded with
- * the passkey global setup enrolled — never a fresh one. Enrolment is an
- * account-security mutation that deletes every other session the principal
- * holds, so a flow that enrolled would invalidate the suite's shared session.
- */
-async function installAuthenticator(page: Page): Promise<() => Promise<void>> {
-  const session = await page.context().newCDPSession(page);
-  await session.send('WebAuthn.enable');
-  const { authenticatorId } = await session.send('WebAuthn.addVirtualAuthenticator', {
-    options: {
-      protocol: 'ctap2',
-      transport: 'internal',
-      hasResidentKey: true,
-      hasUserVerification: true,
-      isUserVerified: true,
-      automaticPresenceSimulation: true,
-    },
-  });
-  await session.send('WebAuthn.addCredential', { authenticatorId, credential: readPasskey() });
-  // Hand the ADVANCED signature counter back: the next Playwright project's
-  // authenticator must carry on from here or the server sees a clone.
-  return async () => {
-    const { credentials } = await session.send('WebAuthn.getCredentials', { authenticatorId });
-    const advanced: unknown = credentials[0];
-    if (advanced !== undefined) {
-      writePasskey(parseCredential(advanced));
-    }
-  };
-}
-
 /** accountRow is the disclosure button that expands one service account. */
 function accountRow(page: Page, name: string) {
   return page.getByRole('button', { name, exact: false }).first();
@@ -95,24 +62,13 @@ async function revokeMinted(page: Page) {
 
 test.describe('machine access', () => {
   test.describe.configure({ mode: 'serial' });
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
 
-  let context: BrowserContext;
   let page: Page;
-  let persistPasskey: () => Promise<void>;
 
-  test.beforeAll(async ({ browser }) => {
-    context = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
-    page = await context.newPage();
-    persistPasskey = await installAuthenticator(page);
-  });
-
-  test.afterAll(async () => {
-    await persistPasskey();
-    await context.close();
-  });
-
-  test.beforeEach(async () => {
-    await context.clearCookies();
+  test.beforeEach(async ({ passkeyPage }) => {
+    page = passkeyPage;
+    await page.context().clearCookies();
     await page.goto(PATH);
     await establishSession(page);
     await page.goto(PATH);

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { zEnvironmentList } from '@hikyo/zod';
 
 import {
@@ -7,11 +7,10 @@ import {
 } from '../fixtures/assertions.ts';
 import { fixtureBrowserCall } from '../fixtures/api.ts';
 import {
-  installPasskeyAuthenticator,
   readSeed,
-  refreshSharedSession,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 import { surfacesForFlow } from '../registry.ts';
 
 /**
@@ -37,9 +36,7 @@ test.describe('environment matrix', () => {
     await expect(page.getByRole('button', { name: /LOG_LEVEL in development:/ })).toBeVisible();
   });
 
-  test('keeps problems visible and publishes only selected clean environments', async ({ page }, testInfo) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
+  test('keeps problems visible and publishes only selected clean environments', async ({ passkeyPage: page }, testInfo) => {
       await page.getByRole('button', { name: /LOG_LEVEL in development:/ }).click();
       await page.getByRole('dialog').getByLabel('development value').fill(`selective-${testInfo.project.name}`);
       await page.getByRole('dialog').getByRole('button', { name: 'Save 1 draft' }).click();
@@ -109,10 +106,6 @@ test.describe('environment matrix', () => {
       );
       await page.getByRole('button', { name: 'Use a passkey' }).click();
       await expect(page.locator('.notice')).toContainText('Published atomically: production');
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
   test('keeps values on their environment IDs after display reorder without adding queries', async ({ page }) => {
@@ -195,14 +188,12 @@ test.describe('environment matrix', () => {
     await expect(group).toHaveAttribute('aria-expanded', 'true');
   });
 
-  test('refreshes a mounted copy destination and routes secret work to Values', async ({ page }, testInfo) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
+  test('refreshes a mounted copy destination and routes secret work to Values', async ({ passkeyPage: page }, testInfo) => {
       // Both cells are already mounted. The destination starts warm with its
       // pre-copy value, so only successful destination invalidation can replace
       // it inside React Query's five-second freshness window.
       await expect(
-        page.getByRole('button', { name: `${seed.config} in production: warn` }),
+        page.getByRole('button', { name: new RegExp(`${seed.config} in production:`) }),
       ).toBeVisible();
       await page
         .getByRole('button', { name: new RegExp(`${seed.config} in development:`) })
@@ -244,15 +235,9 @@ test.describe('environment matrix', () => {
         'href',
         `/orgs/${seed.org}/projects/${seed.project}/environments/${seed.dev}/values`,
       );
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
-  test('edits and publishes from the matrix at desktop and 375px mobile', async ({ page }, testInfo) => {
-    const persistPasskey = await installPasskeyAuthenticator(page);
-    try {
+  test('edits and publishes from the matrix at desktop and 375px mobile', async ({ passkeyPage: page }, testInfo) => {
       if (testInfo.project.name === 'mobile') {
         await page.setViewportSize({ width: 375, height: 812 });
       }
@@ -330,10 +315,6 @@ test.describe('environment matrix', () => {
       await expect(page.locator('.notice')).toContainText(/Published atomically: .*Signals updated/);
       await expect(page.getByRole('button', { name: /LOG_LEVEL in development:/ })).not.toHaveAccessibleName(/draft set/);
       await expect(page.getByRole('button', { name: /LOG_LEVEL in development:/ })).toContainText('changed in r');
-    } finally {
-      await persistPasskey();
-      await refreshSharedSession();
-    }
   });
 
   for (const surface of surfacesForFlow('matrix')) {

--- a/web/e2e/flows/reveal.spec.ts
+++ b/web/e2e/flows/reveal.spec.ts
@@ -1,16 +1,15 @@
-import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
 import {
   ADMIN,
   countDisclosureEvents,
   establishSession,
-  installPasskeyAuthenticator,
   nextTotpCode,
   OIDC_PROVIDER,
   readSeed,
-  refreshSharedSession,
 } from '../fixtures/instance.ts';
+import { test } from '../fixtures/passkey.ts';
 
 /**
  * Flow: the reveal, copy and publish-into-protected ceremonies (registry
@@ -185,16 +184,11 @@ function auditLines(page: Page) {
 }
 
 /**
- * ONE context and ONE authenticator for the whole file, with a FRESH SESSION
- * per test. Both halves are forced by the product, not by convenience:
+ * A fresh page, authenticator, and session per test. The passkey fixture writes
+ * the advanced counter before Playwright closes each page, so the next test
+ * starts where the previous authenticator stopped instead of looking cloned.
  *
- *  - one authenticator, because a passkey's signature counter is how a cloned
- *    authenticator is detected. A context per test would hand the server the
- *    same credential with a counter that went backwards, the credential would
- *    be disabled as cloned, and every later test would fail for a reason that
- *    has nothing to do with the ceremony. A real security key's counter only
- *    ever goes up, and so does this one.
- *  - a fresh session per test, because a reauthentication window is a property
+ * A fresh session matters because a reauthentication window is a property
  *    of the SESSION. Carrying one over would mean the second test's first
  *    disclosure quietly skipped the ceremony it exists to assert.
  *
@@ -203,31 +197,14 @@ function auditLines(page: Page) {
  */
 test.describe('reveal ceremonies', () => {
   test.describe.configure({ mode: 'serial' });
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
 
-  let context: BrowserContext;
   let page: Page;
-  let persistPasskey: () => Promise<void>;
 
-  test.beforeAll(async ({ browser }) => {
-    context = await browser.newContext({
-      permissions: ['clipboard-read', 'clipboard-write'],
-    });
-    page = await context.newPage();
-    persistPasskey = await installPasskeyAuthenticator(page);
-  });
-
-  test.afterAll(async () => {
-    await persistPasskey();
-    await context.close();
-  });
-
-  test.beforeEach(async () => {
-    // Cookies first. The context is shared, so the previous test's session is
-    // still on it — and a LIVE cookie makes the login itself a
-    // cookie-authenticated POST, which the server refuses without the
-    // synchronizer token. Clearing is also what guarantees the next test
-    // starts with no reauthentication window.
-    await context.clearCookies();
+  test.beforeEach(async ({ passkeyPage }) => {
+    page = passkeyPage;
+    // An empty jar guarantees this test starts with no reauthentication window.
+    await page.context().clearCookies();
     await page.goto(VALUES_PATH);
     await establishSession(page);
     await page.goto(VALUES_PATH);
@@ -519,7 +496,7 @@ test.describe('reveal ceremonies', () => {
    * the criterion is about what the server will accept.
    */
   test('the ceremony offers no code option, and the server refuses one', async () => {
-    await context.clearCookies();
+    await page.context().clearCookies();
     await page.goto(PROD_PATH);
     await establishSession(page);
     await page.goto(PROD_PATH);
@@ -668,24 +645,8 @@ test.describe('OIDC disclosure reauthentication', () => {
 test.describe('write-only editing', () => {
   test.describe.configure({ mode: 'serial' });
 
-  let context: BrowserContext;
-  let page: Page;
-  let persistPasskey: () => Promise<void>;
-
-  test.beforeAll(async ({ browser }) => {
-    context = await browser.newContext();
-    page = await context.newPage();
-    persistPasskey = await installPasskeyAuthenticator(page);
-  });
-
-  test.afterAll(async () => {
-    await persistPasskey();
-    await context.close();
-    await refreshSharedSession();
-  });
-
-  test('replaces a value the principal may not read', async () => {
-    await context.clearCookies();
+  test('replaces a value the principal may not read', async ({ passkeyPage: page }) => {
+    await page.context().clearCookies();
     await page.goto(VALUES_PATH);
     await establishSession(page);
 
@@ -693,7 +654,7 @@ test.describe('write-only editing', () => {
     // the creator-admin grant now installed at org scope.
     let revoked = await apiCall(page, 'DELETE', instanceGrantPath(seed.principal, 'reveal'));
     expect(revoked, 'revoking instance reveal').toBe(204);
-    await context.clearCookies();
+    await page.context().clearCookies();
     await page.goto(VALUES_PATH);
     await establishSession(page);
     revoked = await apiCall(page, 'DELETE', orgGrantPath(seed.principal, 'reveal'));
@@ -702,7 +663,7 @@ test.describe('write-only editing', () => {
     try {
       // The revoke killed that session with it, which is the deprovisioning
       // rule working; sign in again.
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto(VALUES_PATH);
       await establishSession(page);
       await page.goto(VALUES_PATH);
@@ -743,7 +704,7 @@ test.describe('write-only editing', () => {
         .poll(async () => valueUpdatedAt(page, seed.dev, secret), { timeout: 5_000 })
         .not.toBe(before);
     } finally {
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto(VALUES_PATH);
       await establishSession(page);
       let restored = await apiCall(page, 'POST', '/api/v1/instance/grants', {
@@ -751,7 +712,7 @@ test.describe('write-only editing', () => {
         capability: 'reveal',
       });
       expect(restored, 'restoring instance reveal').toBe(200);
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto(VALUES_PATH);
       await establishSession(page);
       restored = await apiCall(page, 'POST', `/api/v1/orgs/${seed.org}/grants`, {
@@ -764,7 +725,7 @@ test.describe('write-only editing', () => {
     // Restored, so read it back: the blind rotation stored exactly what was
     // typed, which is the only thing that proves a write-only edit is a real
     // edit rather than a form that looked like one.
-    await context.clearCookies();
+    await page.context().clearCookies();
     await page.goto(VALUES_PATH);
     await establishSession(page);
     await page.goto(VALUES_PATH);

--- a/web/e2e/flows/scanning.spec.ts
+++ b/web/e2e/flows/scanning.spec.ts
@@ -55,61 +55,70 @@ test.describe('secret scanning warn dialog', () => {
 
     // The matrix has no create-key control; a surface's fixture work goes
     // through the page's own session (browserApi), exactly as other flows do.
-    await browserApi(
+    const created = await browserApi(
       page,
       'POST',
       `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys`,
       zCreatedKey,
       { name: keyName, classification: 'config', declaration: { rule: { type: 'string' } } },
     );
-    await page.reload();
-    const cell = page.getByRole('button', { name: new RegExp(`${keyName} in development:`) });
-    await expect(cell).toBeVisible();
+    try {
+      await page.reload();
+      const cell = page.getByRole('button', { name: new RegExp(`${keyName} in development:`) });
+      await expect(cell).toBeVisible();
 
-    const warn = page.locator('dialog.scan-warn');
+      const warn = page.locator('dialog.scan-warn');
 
     // --- SS2: plant the credential; the save succeeds and the warn fires -----
-    await plantValue(page, cell, CANARY);
+      await plantValue(page, cell, CANARY);
 
-    await expect(
-      warn.getByRole('heading', { name: 'Possible secret in a config value' }),
-    ).toBeVisible();
+      await expect(
+        warn.getByRole('heading', { name: 'Possible secret in a config value' }),
+      ).toBeVisible();
     // The finding names its rule and offers both first-class resolutions.
-    await expect(warn.getByText('aws-access-token')).toBeVisible();
-    await expect(
-      warn.getByRole('button', { name: `Reclassify ${keyName} as secret` }),
-    ).toBeVisible();
-    await expect(warn.getByRole('button', { name: 'Keep as config' })).toBeVisible();
+      await expect(warn.getByText('aws-access-token')).toBeVisible();
+      await expect(
+        warn.getByRole('button', { name: `Reclassify ${keyName} as secret` }),
+      ).toBeVisible();
+      await expect(warn.getByRole('button', { name: 'Keep as config' })).toBeVisible();
     // No blanket ignore-all input exists on the dialog (ADR §4).
-    await expect(warn.getByRole('button', { name: /ignore all/i })).toHaveCount(0);
+      await expect(warn.getByRole('button', { name: /ignore all/i })).toHaveCount(0);
 
     // --- SS4 [UI]: the canary is nowhere in the dialog, nowhere in the console
-    await expect(warn).not.toContainText(CANARY);
-    expect(consoleLines.filter((line) => line.includes(CANARY))).toEqual([]);
+      await expect(warn).not.toContainText(CANARY);
+      expect(consoleLines.filter((line) => line.includes(CANARY))).toEqual([]);
 
     // --- SS2: keep-as-config is the sticky dismissal. It re-submits the
     // identical value with the finding's token; the server re-scans that exact
     // value under the fresh dismissal and returns no finding, so the dialog
     // closes. The dialog closing IS "the identical value no longer warns",
     // proven through the real dismissal path rather than a second editor round.
-    await warn.getByRole('button', { name: 'Keep as config' }).click();
-    await expect(warn).toHaveCount(0);
+      await warn.getByRole('button', { name: 'Keep as config' }).click();
+      await expect(warn).toHaveCount(0);
     // Let the dismissal's re-save cascade (values/signals/pending) settle before
     // reopening the editor: the dev cell now carries a staged draft.
-    await expect(cell).toHaveAccessibleName(/draft set/);
+      await expect(cell).toHaveAccessibleName(/draft set/);
 
     // --- SS2: a distinct offending value re-fires -----------------------------
-    await plantValue(page, cell, DISTINCT);
-    await expect(
-      warn.getByRole('heading', { name: 'Possible secret in a config value' }),
-    ).toBeVisible();
+      await plantValue(page, cell, DISTINCT);
+      await expect(
+        warn.getByRole('heading', { name: 'Possible secret in a config value' }),
+      ).toBeVisible();
 
     // --- SS2: reclassify-as-secret completes ----------------------------------
-    await warn.getByRole('button', { name: `Reclassify ${keyName} as secret` }).click();
-    await expect(warn).toHaveCount(0);
+      await warn.getByRole('button', { name: `Reclassify ${keyName} as secret` }).click();
+      await expect(warn).toHaveCount(0);
     // The key is now secret: the matrix re-fetches and the key row shows the
     // lock. That is reclassification completing, observed end to end.
-    await expect(page.locator('.matrix__key').filter({ hasText: keyName })).toContainText('🔒');
+      await expect(page.locator('.matrix__key').filter({ hasText: keyName })).toContainText('🔒');
+    } finally {
+      await browserApi(
+        page,
+        'DELETE',
+        `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${created.id}`,
+        z.null(),
+      );
+    }
   });
 
   for (const surface of surfacesForFlow('scanning')) {

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   zDefinitionsSettings,
   zEnvironment,
@@ -15,11 +15,10 @@ import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures
 import {
   browserApi,
   establishSession,
-  installPasskeyAuthenticator,
   readSeed,
-  refreshSharedSession,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { test, withPasskeyPage } from '../fixtures/passkey.ts';
 import { surfacesForFlow } from '../registry.ts';
 
 /**
@@ -51,38 +50,44 @@ test.describe('organisation settings', () => {
   test.describe.configure({ mode: 'serial' });
   test.use({ storageState: STORAGE_STATE });
 
-  let context: BrowserContext;
   let page: Page;
-  let persistPasskey: () => Promise<void>;
   let drillOrg = '';
   let drillName = '';
 
-  test.beforeAll(async ({ browser }, testInfo) => {
-    context = await browser.newContext({ storageState: STORAGE_STATE });
-    page = await context.newPage();
-    persistPasskey = await installPasskeyAuthenticator(page);
-    await page.goto('/');
+  test.beforeAll(async ({}, testInfo) => {
     drillName = `Settings drill ${testInfo.project.name}`;
-    const created = await browserApi(page, 'POST', '/api/v1/orgs', zOrg, { name: drillName });
-    drillOrg = created.id;
-    await establishSession(page);
   });
 
-  test.afterAll(async () => {
-    if (drillOrg !== '') {
-      // The delete drill below may already have taken it; either way the
-      // instance is left as it was found.
-      try {
-        await browserApi(page, 'DELETE', `/api/v1/orgs/${drillOrg}`, z.null());
-      } catch (error) {
-        if (!isBrowserApiStatus(error, 404)) {
-          throw error;
-        }
-      }
+  test.beforeEach(async ({ passkeyPage }) => {
+    page = passkeyPage;
+    await page.goto('/');
+    if (drillOrg === '') {
+      const created = await browserApi(page, 'POST', '/api/v1/orgs', zOrg, { name: drillName });
+      drillOrg = created.id;
+      await establishSession(page);
     }
-    await persistPasskey();
-    await context.close();
-    await refreshSharedSession();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (drillOrg === '') {
+      return;
+    }
+    const context = await browser.newContext({ storageState: STORAGE_STATE });
+    const cleanupPage = await context.newPage();
+    try {
+      await withPasskeyPage(cleanupPage, 'shared', async (page) => {
+        try {
+          await browserApi(page, 'DELETE', `/api/v1/orgs/${drillOrg}`, z.null());
+        } catch (error) {
+          if (!isBrowserApiStatus(error, 404)) {
+            throw error;
+          }
+        }
+        drillOrg = '';
+      });
+    } finally {
+      await context.close();
+    }
   });
 
   test('states the organisation cap and saves a new one', async () => {
@@ -204,7 +209,7 @@ test.describe('organisation settings', () => {
       await browserApi(page, 'DELETE', `/api/v1/orgs/${target.id}`, z.null());
       // Org deletion removes its contained creator grants and therefore kills
       // this principal's sessions. Re-mint before the next serial drill.
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto('/');
       await establishSession(page);
     }
@@ -244,55 +249,64 @@ test.describe('project settings', () => {
   test.describe.configure({ mode: 'serial' });
   test.use({ storageState: STORAGE_STATE });
 
-  let context: BrowserContext;
   let page: Page;
-  let persistPasskey: () => Promise<void>;
   let drillProject = '';
   let drillEnv = '';
   let drillName = '';
 
   const base = () => `/api/v1/orgs/${seed.org}/projects/${drillProject}`;
 
-  test.beforeAll(async ({ browser }, testInfo) => {
-    context = await browser.newContext({ storageState: STORAGE_STATE });
-    page = await context.newPage();
-    persistPasskey = await installPasskeyAuthenticator(page);
-    await page.goto('/');
+  test.beforeAll(async ({}, testInfo) => {
     drillName = `drill-${testInfo.project.name}`;
-    const project = await browserApi(
-      page,
-      'POST',
-      `/api/v1/orgs/${seed.org}/projects`,
-      zProject,
-      { name: drillName },
-    );
-    drillProject = project.id;
-    const environment = await browserApi(
-      page,
-      'POST',
-      `${base()}/environments`,
-      zEnvironment,
-      { name: 'staging' },
-    );
-    drillEnv = environment.id;
   });
 
-  test.afterAll(async () => {
-    if (drillProject !== '') {
-      try {
-        if (drillEnv !== '') {
-          await browserApi(page, 'DELETE', `${base()}/environments/${drillEnv}`, z.null());
-        }
-        await browserApi(page, 'DELETE', base(), z.null());
-      } catch (error) {
-        if (!isBrowserApiStatus(error, 404)) {
-          throw error;
-        }
-      }
+  test.beforeEach(async ({ passkeyPage }) => {
+    page = passkeyPage;
+    await page.goto('/');
+    if (drillProject === '') {
+      const project = await browserApi(
+        page,
+        'POST',
+        `/api/v1/orgs/${seed.org}/projects`,
+        zProject,
+        { name: drillName },
+      );
+      drillProject = project.id;
+      const environment = await browserApi(
+        page,
+        'POST',
+        `${base()}/environments`,
+        zEnvironment,
+        { name: 'staging' },
+      );
+      drillEnv = environment.id;
     }
-    await persistPasskey();
-    await context.close();
-    await refreshSharedSession();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (drillProject === '') {
+      return;
+    }
+    const context = await browser.newContext({ storageState: STORAGE_STATE });
+    const cleanupPage = await context.newPage();
+    try {
+      await withPasskeyPage(cleanupPage, 'shared', async (page) => {
+        try {
+          if (drillEnv !== '') {
+            await browserApi(page, 'DELETE', `${base()}/environments/${drillEnv}`, z.null());
+          }
+          await browserApi(page, 'DELETE', base(), z.null());
+        } catch (error) {
+          if (!isBrowserApiStatus(error, 404)) {
+            throw error;
+          }
+        }
+        drillProject = '';
+        drillEnv = '';
+      });
+    } finally {
+      await context.close();
+    }
   });
 
   test('renames the project and leaves the identifier alone', async () => {
@@ -622,7 +636,7 @@ test.describe('project settings', () => {
         z.null(),
       );
       await browserApi(page, 'DELETE', `/api/v1/orgs/${otherOrg.id}`, z.null());
-      await context.clearCookies();
+      await page.context().clearCookies();
       await page.goto('/');
       await establishSession(page);
     }

--- a/web/e2e/registry.test.ts
+++ b/web/e2e/registry.test.ts
@@ -98,6 +98,17 @@ describe('surfacesForFlow', () => {
   });
 });
 
+describe('passkey flow ownership', () => {
+  it('leaves authenticator persistence and shared-session repair to the passkey fixture', () => {
+    const offenders = FLOWS.map((flow) => flow.spec).filter((spec) => {
+      const source = readFileSync(fileURLToPath(new URL(spec, import.meta.url)), 'utf8');
+      return /installPasskeyAuthenticator|persistPasskey|refreshSharedSession/.test(source);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('the execution half of closure', () => {
   const log = (...lines: string[]) => lines.map((l) => `${l}\n`).join('');
 


### PR DESCRIPTION
Closes #371

## Outcome
- add a `passkeyPage` Playwright fixture with always-persist teardown
- probe the file-backed shared session and re-mint only after `401`
- centralize virtual-authenticator options and fail loud when the shared credential disappears
- migrate all passkey-bearing flows away from hand-paired persistence/refresh calls
- clean temporary settings/scanning state so filtered and two-project runs stay isolated

## Contract and migration decisions
- ordinary passkey ceremonies now perform one cheap session probe; only an unauthenticated file cookie launches the re-mint browser
- non-`200`/`401` probe responses fail the suite instead of silently falling back
- no wire, audit, generated API, or product behavior changes

## Generated outputs
None.

## Validation
- `pnpm --dir web run typecheck`
- `pnpm --dir web run test` — 315 passed
- `pnpm --dir web run e2e` — 297 passed, 1 expected desktop skip; desktop + mobile
- code review — Standards CLEAN; Spec CLEAN