### PR TITLE
Centralize adapter query ownership #373

### DIFF
--- a/docs/handoff/373-adapter-query-ownership.md
+++ b/docs/handoff/373-adapter-query-ownership.md
@@ -1,0 +1,42 @@
+# Issue #373 — adapter query ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/373 (parent #326; audit
+finding `F-S04-2`, after #352).
+
+**State: implemented.** Thirteen hand-twinned SQLite/PostgreSQL repository
+methods now delegate to one dialect-aware `adapterQueries` owner. Adapter
+runtime reads and transactions use the same SQL and timestamp contract, and
+the three copies of the active-ledger orphan query are one function.
+
+## Contract
+
+- `adapterQueries` owns the thirteen repository operations named by #373.
+- `adapterDBTX` owns query selection and timestamp conversion for every
+  transactional adapter-runtime operation.
+- Runtime read paths receive one `adapterDB`; no query-site engine branch remains.
+- SQLite integer and PostgreSQL boolean ledger values are still scanned by
+  their concrete driver representation before conversion to `bool`.
+- PostgreSQL locking and `SKIP LOCKED` clauses, SQLite timestamp bytes, public
+  `AdapterRepo`, ordering, authorization, audit, and failure behavior are
+  unchanged.
+
+## Migration and generated outputs
+
+No schema migration or generated output is needed.
+
+## Validation
+
+```text
+TestAdapterTransactionOwnsDialectSelection passed (red-before-green compile seam)
+internal/store adapter tests              30 passed
+internal/store + internal/service         317 passed
+go test -count=1 ./...                     3605 passed in 61 packages
+```
+
+## Review disposition
+
+Two-axis review is clean. Standards review found the shared DB interface still
+carried its adoption-only name; it is now `adapterDB`. Spec review found unused
+transaction placeholder methods and duplicate auth-token ownership; both were
+removed. Final standards and issue-spec rechecks returned `CLEAN` with zero
+findings.

--- a/internal/cli/compose_internal_test.go
+++ b/internal/cli/compose_internal_test.go
@@ -68,6 +68,15 @@ func machineState(t *testing.T, origin string) (*State, string) {
 	return st, stateDir
 }
 
+func composeCommonFlags(t *testing.T, operation AuthOperation) commonFlags {
+	t.Helper()
+	flags, err := commonFlagsForOperation(string(operation))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return flags
+}
+
 func TestOpenComposeStackNoConfig(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -77,9 +86,9 @@ func TestOpenComposeStackNoConfig(t *testing.T) {
 
 	st, stateDir := machineState(t, server.URL)
 	ios, _, _ := composeIO(stateDir, t.TempDir(), "wl_token", nil)
-	stack, err := openComposeStack(st, ios, commonFlags{
-		Flags: Flags{Instance: "local", Org: "org_1", Project: "prj_1", Env: "env_1"}, operation: "run",
-	}, composeStackOptions{})
+	runFlags := composeCommonFlags(t, "run")
+	runFlags.Flags = Flags{Instance: "local", Org: "org_1", Project: "prj_1", Env: "env_1"}
+	stack, err := openComposeStack(st, ios, runFlags, composeStackOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +127,7 @@ func TestOpenComposeStackRuntimeDirUnresolved(t *testing.T) {
 	}
 	st, stateDir := machineState(t, server.URL)
 	ios, _, _ := composeIO(stateDir, projectDir, "wl_token", map[string]string{"HIKYO_COMPOSE_DOCKER": "/usr/bin/false"})
-	doctorFlags := commonFlags{operation: "compose doctor"}
+	doctorFlags := composeCommonFlags(t, "compose doctor")
 	stack, err := openComposeStack(st, ios, doctorFlags, composeStackOptions{requireConfig: true})
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +142,7 @@ func TestOpenComposeStackRuntimeDirUnresolved(t *testing.T) {
 	if !hasCode(findings, "runtime_dir_unresolved") {
 		t.Fatalf("doctor findings = %+v, want runtime_dir_unresolved", findings)
 	}
-	_, _, err = composeRenderCore(t.Context(), ios, st, commonFlags{operation: "compose render"}, "", false)
+	_, _, err = composeRenderCore(t.Context(), ios, st, composeCommonFlags(t, "compose render"), "", false)
 	if err == nil || !strings.Contains(err.Error(), "no runtime directory") {
 		t.Fatalf("render err=%v, want unresolved runtime refusal", err)
 	}

--- a/internal/store/adapter_db_test.go
+++ b/internal/store/adapter_db_test.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAdapterTransactionOwnsDialectSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		db        adapterDB
+		wantSQL   string
+		wantStamp any
+	}{
+		{
+			name:      "sqlite",
+			db:        sqliteAdapterTx{},
+			wantSQL:   "sqlite",
+			wantStamp: "2026-08-23T12:00:00.000000Z",
+		},
+		{
+			name:      "postgres",
+			db:        pgAdapterTx{},
+			wantSQL:   "postgres",
+			wantStamp: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.db.SQL("sqlite", "postgres"); got != tt.wantSQL {
+				t.Fatalf("SQL() = %q, want %q", got, tt.wantSQL)
+			}
+			at := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+			if got := tt.db.Stamp(at); got != tt.wantStamp {
+				t.Fatalf("Stamp() = %#v, want %#v", got, tt.wantStamp)
+			}
+		})
+	}
+}

--- a/internal/store/adapter_runtime.go
+++ b/internal/store/adapter_runtime.go
@@ -50,28 +50,37 @@ type AdapterActivation struct {
 	Target                              adapter.Target
 }
 
+func adapterJobScope(job adapter.Job) domain.Scope {
+	return domain.Scope{
+		Org:     domain.OrgID(job.OrgID),
+		Project: domain.ProjectID(job.ProjectID),
+	}
+}
+
 func NewAdapterRuntime(db *DB, authorize AdapterAuthorizer) *AdapterRuntime {
 	return &AdapterRuntime{db: db, authorize: authorize}
+}
+
+func (r *AdapterRuntime) readDB() adapterDB {
+	if r.db.Engine() == EnginePostgres {
+		return pgAdoptDB{db: r.db.PG()}
+	}
+	return sqliteAdoptDB{db: r.db.SQLiteRead()}
 }
 
 // LoadExecution reads only the immutable inputs named by a leased job. The
 // caller must Gate immediately before this method; every query repeats the
 // complete job chain and generation fence. Ciphertexts remain sealed here.
 func (r *AdapterRuntime) LoadExecution(ctx context.Context, job adapter.Job) (AdapterExecution, error) {
+	db := r.readDB()
 	var out AdapterExecution
 	var kind string
-	query := r.query(
+	query := db.SQL(
 		`SELECT a.provider,a.origin,a.id,a.credential_ciphertext,t.destination_kind,t.destination_owner,t.destination_name,t.destination_environment,t.destination_id,t.repository_id,t.visibility,t.selected_repository_ids,t.name_prefix,t.generation FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_outbox j ON j.id=? AND j.target_id=t.id AND j.org_id=t.org_id AND j.project_id=t.project_id AND j.environment_id=t.environment_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.generation=? AND j.state='running' AND j.lease_owner=?`,
 		`SELECT a.provider,a.origin,a.id,a.credential_ciphertext,t.destination_kind,t.destination_owner,t.destination_name,t.destination_environment,t.destination_id,t.repository_id,t.visibility,t.selected_repository_ids,t.name_prefix,t.generation FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_outbox j ON j.id=$1 AND j.target_id=t.id AND j.org_id=t.org_id AND j.project_id=t.project_id AND j.environment_id=t.environment_id WHERE t.id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.environment_id=$5 AND t.generation=$6 AND j.state='running' AND j.lease_owner=$7`)
 	args := []any{job.ID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation, job.LeaseOwner}
-	var row adapterRow
-	if r.db.Engine() == EnginePostgres {
-		row = r.db.PG().QueryRow(ctx, query, args...)
-	} else {
-		row = r.db.SQLiteRead().QueryRowContext(ctx, query, args...)
-	}
 	var credential, selectedRaw []byte
-	if err := row.Scan(&out.Provider, &out.Origin, &out.CredentialOwnerID, &credential, &kind, &out.Target.Destination.Owner, &out.Target.Destination.Name, &out.Target.Destination.Environment, &out.Target.Destination.NumericID, &out.Target.Destination.RepositoryID, &out.Target.Destination.Visibility, &selectedRaw, &out.Target.NamePrefix, &out.Target.Generation); err != nil {
+	if err := db.QueryRow(ctx, query, args...).Scan(&out.Provider, &out.Origin, &out.CredentialOwnerID, &credential, &kind, &out.Target.Destination.Owner, &out.Target.Destination.Name, &out.Target.Destination.Environment, &out.Target.Destination.NumericID, &out.Target.Destination.RepositoryID, &out.Target.Destination.Visibility, &selectedRaw, &out.Target.NamePrefix, &out.Target.Generation); err != nil {
 		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 			return AdapterExecution{}, ErrNotFound
 		}
@@ -88,103 +97,55 @@ func (r *AdapterRuntime) LoadExecution(ctx context.Context, job adapter.Job) (Ad
 		return AdapterExecution{}, fmt.Errorf("store: adapter selected repository ids: %w", err)
 	}
 
-	ledgerQuery := r.query(
+	ledgerQuery := db.SQL(
 		`SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released' ORDER BY surface,normalized_name`,
 		`SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state<>'released' ORDER BY surface,normalized_name`)
-	if r.db.Engine() == EnginePostgres {
-		rows, err := r.db.PG().Query(ctx, ledgerQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID)
+	ledgerRows, err := db.Query(ctx, ledgerQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID)
+	if err != nil {
+		return AdapterExecution{}, err
+	}
+	defer closeAdapterRows(ledgerRows)
+	for ledgerRows.Next() {
+		entry, err := scanAdapterLedgerEntry(ledgerRows)
 		if err != nil {
 			return AdapterExecution{}, err
 		}
-		defer rows.Close()
-		for rows.Next() {
-			var surface, state string
-			var entry adapter.LedgerEntry
-			if err := rows.Scan(&surface, &entry.EffectiveName, &state, &entry.Missing); err != nil {
-				return AdapterExecution{}, err
-			}
-			entry.Surface, entry.State = adapter.Surface(surface), adapter.LedgerState(state)
-			out.Ledger = append(out.Ledger, entry)
-		}
-		if err := rows.Err(); err != nil {
-			return AdapterExecution{}, err
-		}
-	} else {
-		rows, err := r.db.SQLiteRead().QueryContext(ctx, ledgerQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID)
-		if err != nil {
-			return AdapterExecution{}, err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var surface, state string
-			var entry adapter.LedgerEntry
-			var missing int
-			if err := rows.Scan(&surface, &entry.EffectiveName, &state, &missing); err != nil {
-				return AdapterExecution{}, err
-			}
-			entry.Missing = missing != 0
-			entry.Surface, entry.State = adapter.Surface(surface), adapter.LedgerState(state)
-			out.Ledger = append(out.Ledger, entry)
-		}
-		if err := rows.Err(); err != nil {
-			return AdapterExecution{}, err
-		}
+		out.Ledger = append(out.Ledger, entry)
+	}
+	if err := ledgerRows.Err(); err != nil {
+		return AdapterExecution{}, err
 	}
 	if job.Kind == adapter.Scrub {
 		return out, nil
 	}
 
-	snapshotQuery := r.query(
+	snapshotQuery := db.SQL(
 		`SELECT id,revision FROM snapshots WHERE org_id=? AND project_id=? AND environment_id=? AND payload_present=1 ORDER BY revision DESC LIMIT 1`,
 		`SELECT id,revision FROM snapshots WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND payload_present=true ORDER BY revision DESC LIMIT 1`)
 	var snapshotID string
-	var snapshotRow adapterRow
-	if r.db.Engine() == EnginePostgres {
-		snapshotRow = r.db.PG().QueryRow(ctx, snapshotQuery, job.OrgID, job.ProjectID, job.EnvironmentID)
-	} else {
-		snapshotRow = r.db.SQLiteRead().QueryRowContext(ctx, snapshotQuery, job.OrgID, job.ProjectID, job.EnvironmentID)
-	}
-	if err := snapshotRow.Scan(&snapshotID, &out.Revision); err != nil {
+	if err := db.QueryRow(ctx, snapshotQuery, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&snapshotID, &out.Revision); err != nil {
 		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 			return out, nil
 		}
 		return AdapterExecution{}, err
 	}
-	entryQuery := r.query(
+	entryQuery := db.SQL(
 		`SELECT e.id,e.snapshot_id,e.key_id,e.key_name,e.classification,e.ciphertext FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=? AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=? AND e.org_id=? AND e.project_id=? AND e.environment_id=? ORDER BY e.key_name`,
 		`SELECT e.id,e.snapshot_id,e.key_id,e.key_name,e.classification,e.ciphertext FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=$1 AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=$2 AND e.org_id=$3 AND e.project_id=$4 AND e.environment_id=$5 ORDER BY e.key_name`)
-	if r.db.Engine() == EnginePostgres {
-		rows, err := r.db.PG().Query(ctx, entryQuery, job.TargetID, snapshotID, job.OrgID, job.ProjectID, job.EnvironmentID)
-		if err != nil {
+	entryRows, err := db.Query(ctx, entryQuery, job.TargetID, snapshotID, job.OrgID, job.ProjectID, job.EnvironmentID)
+	if err != nil {
+		return AdapterExecution{}, err
+	}
+	defer closeAdapterRows(entryRows)
+	for entryRows.Next() {
+		var entry AdapterSnapshotEntry
+		if err := entryRows.Scan(&entry.ID, &entry.SnapshotID, &entry.KeyID, &entry.KeyName, &entry.Classification, &entry.Ciphertext); err != nil {
 			return AdapterExecution{}, err
 		}
-		defer rows.Close()
-		for rows.Next() {
-			var entry AdapterSnapshotEntry
-			if err := rows.Scan(&entry.ID, &entry.SnapshotID, &entry.KeyID, &entry.KeyName, &entry.Classification, &entry.Ciphertext); err != nil {
-				return AdapterExecution{}, err
-			}
-			out.Entries = append(out.Entries, entry)
-		}
-		if err := rows.Err(); err != nil {
-			return AdapterExecution{}, err
-		}
-	} else {
-		rows, err := r.db.SQLiteRead().QueryContext(ctx, entryQuery, job.TargetID, snapshotID, job.OrgID, job.ProjectID, job.EnvironmentID)
-		if err != nil {
-			return AdapterExecution{}, err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var entry AdapterSnapshotEntry
-			if err := rows.Scan(&entry.ID, &entry.SnapshotID, &entry.KeyID, &entry.KeyName, &entry.Classification, &entry.Ciphertext); err != nil {
-				return AdapterExecution{}, err
-			}
-			out.Entries = append(out.Entries, entry)
-		}
-		if err := rows.Err(); err != nil {
-			return AdapterExecution{}, err
-		}
+		out.Entries = append(out.Entries, entry)
+	}
+	if err := entryRows.Err(); err != nil {
+		return AdapterExecution{}, err
 	}
 	return out, nil
 }
@@ -196,20 +157,15 @@ func (r *AdapterRuntime) LoadActivation(ctx context.Context, job adapter.Job) (A
 	if job.Kind != adapter.Activate || job.RouteMoveID == "" {
 		return AdapterActivation{}, fmt.Errorf("%w: job is not a route activation", domain.ErrInvalid)
 	}
-	query := r.query(
+	db := r.readDB()
+	query := db.SQL(
 		`SELECT a.provider,COALESCE(m.pending_origin,a.origin),a.id,COALESCE(m.pending_credential_ciphertext,a.credential_ciphertext),mt.environment_id,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.destination_id,mt.repository_id,mt.visibility,mt.selected_repository_ids,mt.name_prefix,t.generation FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_moves m ON m.id=j.route_move_id AND m.org_id=j.org_id AND m.project_id=j.project_id AND m.adapter_id=a.id JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.target_id=t.id AND mt.org_id=t.org_id AND mt.project_id=t.project_id WHERE j.id=? AND j.route_move_id=? AND j.target_id=? AND j.org_id=? AND j.project_id=? AND j.environment_id=? AND j.generation=? AND j.kind='activate' AND j.state='running' AND j.lease_owner=? AND m.state='activating' AND t.state='moving'`,
 		`SELECT a.provider,COALESCE(m.pending_origin,a.origin),a.id,COALESCE(m.pending_credential_ciphertext,a.credential_ciphertext),mt.environment_id,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.destination_id,mt.repository_id,mt.visibility,mt.selected_repository_ids,mt.name_prefix,t.generation FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_moves m ON m.id=j.route_move_id AND m.org_id=j.org_id AND m.project_id=j.project_id AND m.adapter_id=a.id JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.target_id=t.id AND mt.org_id=t.org_id AND mt.project_id=t.project_id WHERE j.id=$1 AND j.route_move_id=$2 AND j.target_id=$3 AND j.org_id=$4 AND j.project_id=$5 AND j.environment_id=$6 AND j.generation=$7 AND j.kind='activate' AND j.state='running' AND j.lease_owner=$8 AND m.state='activating' AND t.state='moving'`)
 	var out AdapterActivation
 	var credential, selectedRaw []byte
 	var kind string
-	var row adapterRow
 	args := []any{job.ID, job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation, job.LeaseOwner}
-	if r.db.Engine() == EnginePostgres {
-		row = r.db.PG().QueryRow(ctx, query, args...)
-	} else {
-		row = r.db.SQLiteRead().QueryRowContext(ctx, query, args...)
-	}
-	if err := row.Scan(&out.Provider, &out.Origin, &out.CredentialOwnerID, &credential, &out.Target.Environment, &kind,
+	if err := db.QueryRow(ctx, query, args...).Scan(&out.Provider, &out.Origin, &out.CredentialOwnerID, &credential, &out.Target.Environment, &kind,
 		&out.Target.Destination.Owner, &out.Target.Destination.Name, &out.Target.Destination.Environment, &out.Target.Destination.NumericID, &out.Target.Destination.RepositoryID, &out.Target.Destination.Visibility, &selectedRaw,
 		&out.Target.NamePrefix, &out.Target.Generation); err != nil {
 		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
@@ -229,18 +185,14 @@ func (r *AdapterRuntime) LoadActivation(ctx context.Context, job adapter.Job) (A
 	return out, nil
 }
 
-type adapterRow interface{ Scan(...any) error }
-type adapterRows interface {
-	Next() bool
-	Scan(...any) error
-	Err() error
-	Close()
-}
+type adapterRow = interface{ Scan(...any) error }
+type adapterRows = adapterTargetRows
 
 type adapterDBTX interface {
 	Exec(context.Context, string, ...any) (int64, error)
 	QueryRow(context.Context, string, ...any) adapterRow
 	Query(context.Context, string, ...any) (adapterRows, error)
+	adapterDialect
 	Commit(context.Context) error
 	Rollback(context.Context) error
 }
@@ -270,6 +222,8 @@ func (s sqliteAdapterTx) Query(ctx context.Context, query string, args ...any) (
 	}
 	return sqliteAdapterRows{rows: rows}, nil
 }
+func (sqliteAdapterTx) SQL(sqliteQuery, _ string) string { return sqliteQuery }
+func (sqliteAdapterTx) Stamp(value time.Time) any        { return adapterTimestamp(EngineSQLite, value) }
 func (s sqliteAdapterTx) Commit(context.Context) error   { return s.tx.Commit() }
 func (s sqliteAdapterTx) Rollback(context.Context) error { return s.tx.Rollback() }
 
@@ -285,6 +239,8 @@ func (p pgAdapterTx) QueryRow(ctx context.Context, query string, args ...any) ad
 func (p pgAdapterTx) Query(ctx context.Context, query string, args ...any) (adapterRows, error) {
 	return p.tx.Query(ctx, query, args...)
 }
+func (pgAdapterTx) SQL(_, postgresQuery string) string   { return postgresQuery }
+func (pgAdapterTx) Stamp(value time.Time) any            { return CanonTime(value) }
 func (p pgAdapterTx) Commit(ctx context.Context) error   { return p.tx.Commit(ctx) }
 func (p pgAdapterTx) Rollback(ctx context.Context) error { return p.tx.Rollback(ctx) }
 
@@ -311,13 +267,6 @@ func (r *AdapterRuntime) transaction(ctx context.Context, fn func(adapterDBTX) e
 		return err
 	}
 	return wrapped.Commit(ctx)
-}
-
-func (r *AdapterRuntime) query(sqliteQuery, postgresQuery string) string {
-	if r.db.Engine() == EnginePostgres {
-		return postgresQuery
-	}
-	return sqliteQuery
 }
 
 func adapterTimestamp(engine Engine, value time.Time) any {
@@ -365,14 +314,14 @@ func (r *AdapterRuntime) Enqueue(ctx context.Context, job adapter.Job, now time.
 func (r *AdapterRuntime) tryEnqueue(ctx context.Context, job adapter.Job, now time.Time) (adapter.Job, error) {
 	now = now.UTC()
 	err := r.transaction(ctx, func(tx adapterDBTX) error {
-		lookup := r.query(
+		lookup := tx.SQL(
 			`SELECT generation FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=?)`,
 			`SELECT generation FROM adapter_targets WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=$5) FOR UPDATE`)
 		var current int64
-		err := tx.QueryRow(ctx, lookup, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, adapterTimestamp(r.db.Engine(), now)).Scan(&current)
+		err := tx.QueryRow(ctx, lookup, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, tx.Stamp(now)).Scan(&current)
 		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 			var exists int
-			existsQuery := r.query(
+			existsQuery := tx.SQL(
 				`SELECT COUNT(*) FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=?`,
 				`SELECT COUNT(*) FROM adapter_targets WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
 			if scanErr := tx.QueryRow(ctx, existsQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&exists); scanErr != nil {
@@ -387,7 +336,7 @@ func (r *AdapterRuntime) tryEnqueue(ctx context.Context, job adapter.Job, now ti
 			return err
 		}
 		var depth int
-		depthQuery := r.query(
+		depthQuery := tx.SQL(
 			`SELECT COUNT(*) FROM adapter_outbox WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('queued','running')`,
 			`SELECT COUNT(*) FROM adapter_outbox WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state IN ('queued','running')`)
 		if err := tx.QueryRow(ctx, depthQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&depth); err != nil {
@@ -396,23 +345,23 @@ func (r *AdapterRuntime) tryEnqueue(ctx context.Context, job adapter.Job, now ti
 		if depth >= 1000 {
 			return adapter.ErrQueueFull
 		}
-		finished := adapterTimestamp(r.db.Engine(), now)
+		finished := tx.Stamp(now)
 		var previousJob string
-		previousQuery := r.query(
+		previousQuery := tx.SQL(
 			`SELECT id FROM adapter_outbox WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('queued','running') ORDER BY created_at DESC LIMIT 1`,
 			`SELECT id FROM adapter_outbox WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state IN ('queued','running') ORDER BY created_at DESC LIMIT 1`)
 		previousErr := tx.QueryRow(ctx, previousQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&previousJob)
 		if previousErr != nil && !errors.Is(previousErr, sql.ErrNoRows) && !errors.Is(previousErr, pgx.ErrNoRows) {
 			return previousErr
 		}
-		supersede := r.query(
+		supersede := tx.SQL(
 			`UPDATE adapter_outbox SET state='superseded',finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('queued','running')`,
 			`UPDATE adapter_outbox SET state='superseded',finished_at=$1,lease_owner=NULL,lease_expires_at=NULL WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state IN ('queued','running')`)
 		if _, err := tx.Exec(ctx, supersede, finished, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID); err != nil {
 			return err
 		}
 		job.Generation = current + 1
-		insert := r.query(
+		insert := tx.SQL(
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES (?,?,?,?,?,?,?,?,?,0,?,'queued',?)`,
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,0,$10,'queued',$11)`)
 		if _, err := tx.Exec(ctx, insert, job.ID, job.OrgID, job.ProjectID, job.EnvironmentID, job.TargetID, string(job.Kind), job.AuthorityPrincipal, job.Generation, job.TargetID, finished, finished); err != nil {
@@ -422,7 +371,7 @@ func (r *AdapterRuntime) tryEnqueue(ctx context.Context, job adapter.Job, now ti
 		if job.Kind == adapter.Scrub {
 			state = "tombstoned"
 		}
-		update := r.query(
+		update := tx.SQL(
 			`UPDATE adapter_targets SET generation=?,state=?,sync_status='converging',active_job_id=?,provider_lease_job_id=NULL,provider_lease_effect_id=NULL,provider_lease_expires_at=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=?)`,
 			`UPDATE adapter_targets SET generation=$1,state=$2,sync_status='converging',active_job_id=$3,provider_lease_job_id=NULL,provider_lease_effect_id=NULL,provider_lease_expires_at=NULL WHERE id=$4 AND org_id=$5 AND project_id=$6 AND environment_id=$7 AND generation=$8 AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=$9)`)
 		rows, err := tx.Exec(ctx, update, job.Generation, state, job.ID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, current, finished)
@@ -446,7 +395,7 @@ func (r *AdapterRuntime) tryEnqueue(ctx context.Context, job adapter.Job, now ti
 func (r *AdapterRuntime) ClaimDue(ctx context.Context, worker string, now, leaseUntil time.Time) (adapter.Job, bool, error) {
 	var out adapter.Job
 	err := r.transaction(ctx, func(tx adapterDBTX) error {
-		selectQuery := r.query(
+		selectQuery := tx.SQL(
 			`SELECT j.id,j.org_id,j.project_id,j.environment_id,j.target_id,j.kind,COALESCE(j.route_move_id,''),j.authority_principal_id,j.generation,j.attempt_count,j.created_at
              FROM adapter_outbox j
              WHERE ((j.state='queued' AND j.next_attempt_at<=?) OR (j.state='running' AND j.lease_expires_at<=?))
@@ -459,7 +408,7 @@ func (r *AdapterRuntime) ClaimDue(ctx context.Context, worker string, now, lease
                AND (SELECT COUNT(*) FROM adapter_outbox x WHERE x.org_id=j.org_id AND x.state='running' AND x.lease_expires_at>$3) < 4
                AND NOT EXISTS (SELECT 1 FROM adapter_outbox x WHERE x.target_id=j.target_id AND x.id<>j.id AND x.state='running' AND x.lease_expires_at>$4)
              ORDER BY j.next_attempt_at,j.id FOR UPDATE SKIP LOCKED LIMIT 1`)
-		nowArg := adapterTimestamp(r.db.Engine(), now)
+		nowArg := tx.Stamp(now)
 		row := tx.QueryRow(ctx, selectQuery, nowArg, nowArg, nowArg, nowArg)
 		var kind string
 		var created any
@@ -480,10 +429,10 @@ func (r *AdapterRuntime) ClaimDue(ctx context.Context, worker string, now, lease
 		out.Kind = adapter.JobKind(kind)
 		out.Attempt++
 		out.LeaseOwner = worker
-		update := r.query(
+		update := tx.SQL(
 			`UPDATE adapter_outbox SET state='running',attempt_count=?,lease_owner=?,lease_expires_at=? WHERE id=?`,
 			`UPDATE adapter_outbox SET state='running',attempt_count=$1,lease_owner=$2,lease_expires_at=$3 WHERE id=$4`)
-		_, err := tx.Exec(ctx, update, out.Attempt, worker, adapterTimestamp(r.db.Engine(), leaseUntil), out.ID)
+		_, err := tx.Exec(ctx, update, out.Attempt, worker, tx.Stamp(leaseUntil), out.ID)
 		return err
 	})
 	if errors.Is(err, ErrNotFound) {
@@ -510,21 +459,14 @@ func (j *adapterJournal) Gate(ctx context.Context, effect adapter.Effect) error 
 	if err := j.runtime.authorize(ctx, j.job, effect); err != nil {
 		return fmt.Errorf("%w", adapter.ErrUnauthorized)
 	}
-	query := j.runtime.query(
+	db := j.runtime.readDB()
+	query := db.SQL(
 		`SELECT COUNT(*) FROM adapter_targets t JOIN adapter_outbox j ON j.target_id=t.id AND j.org_id=t.org_id AND j.project_id=t.project_id AND j.environment_id=t.environment_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.generation=? AND j.id=? AND j.state='running' AND j.lease_owner=? AND j.lease_expires_at>?`,
 		`SELECT COUNT(*) FROM adapter_targets t JOIN adapter_outbox j ON j.target_id=t.id AND j.org_id=t.org_id AND j.project_id=t.project_id AND j.environment_id=t.environment_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3 AND t.environment_id=$4 AND t.generation=$5 AND j.id=$6 AND j.state='running' AND j.lease_owner=$7 AND j.lease_expires_at>$8`)
 	var count int
-	now := adapterTimestamp(j.runtime.db.Engine(), time.Now().UTC())
-	if j.runtime.db.Engine() == EnginePostgres {
-		err := j.runtime.db.PG().QueryRow(ctx, query, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.Generation, j.job.ID, j.job.LeaseOwner, now).Scan(&count)
-		if err != nil {
-			return err
-		}
-	} else {
-		err := j.runtime.db.SQLiteRead().QueryRowContext(ctx, query, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.Generation, j.job.ID, j.job.LeaseOwner, now).Scan(&count)
-		if err != nil {
-			return err
-		}
+	now := db.Stamp(time.Now().UTC())
+	if err := db.QueryRow(ctx, query, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.Generation, j.job.ID, j.job.LeaseOwner, now).Scan(&count); err != nil {
+		return err
 	}
 	if count != 1 {
 		return adapter.ErrSuperseded
@@ -541,7 +483,7 @@ func newAdapterID(prefix string) string { return prefix + "_" + uuid.Must(uuid.N
 func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (adapter.LedgerState, error) {
 	state := adapter.Reserved
 	err := j.runtime.transaction(ctx, func(tx adapterDBTX) error {
-		pendingQuery := j.runtime.query(
+		pendingQuery := tx.SQL(
 			`SELECT COUNT(*) FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_move_claims c ON c.provider_origin=a.origin AND c.destination_kind=t.destination_kind AND c.destination_owner=t.destination_owner AND c.destination_name=t.destination_name AND c.destination_environment=t.destination_environment WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=? AND c.target_id<>t.id AND c.surface=? AND c.normalized_name=?`,
 			`SELECT COUNT(*) FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_move_claims c ON c.provider_origin=a.origin AND c.destination_kind=t.destination_kind AND c.destination_owner=t.destination_owner AND c.destination_name=t.destination_name AND c.destination_environment=t.destination_environment WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3 AND t.environment_id=$4 AND c.target_id<>t.id AND c.surface=$5 AND c.normalized_name=$6`)
 		var pending int
@@ -552,7 +494,7 @@ func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (ad
 		if pending != 0 {
 			return adapter.ErrConflict
 		}
-		selectQuery := j.runtime.query(
+		selectQuery := tx.SQL(
 			`SELECT state FROM adapter_ledger WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=?`,
 			`SELECT state FROM adapter_ledger WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND target_id=$4 AND surface=$5 AND normalized_name=$6`)
 		var raw string
@@ -561,16 +503,16 @@ func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (ad
 			if adapter.LedgerState(raw) == adapter.Released {
 				var origin, destinationKind string
 				var destinationID, repositoryID int64
-				currentRoute := j.runtime.query(
+				currentRoute := tx.SQL(
 					`SELECT a.origin,t.destination_kind,t.destination_id,t.repository_id FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=?`,
 					`SELECT a.origin,t.destination_kind,t.destination_id,t.repository_id FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3 AND t.environment_id=$4`)
 				if err := tx.QueryRow(ctx, currentRoute, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID).Scan(&origin, &destinationKind, &destinationID, &repositoryID); err != nil {
 					return err
 				}
-				reactivate := j.runtime.query(
+				reactivate := tx.SQL(
 					`UPDATE adapter_ledger SET state='reserved',missing=0,effective_name=?,provider_origin=?,destination_kind=?,repository_id=?,destination_id=?,updated_at=? WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND state='released'`,
 					`UPDATE adapter_ledger SET state='reserved',missing=false,effective_name=$1,provider_origin=$2,destination_kind=$3,repository_id=$4,destination_id=$5,updated_at=$6 WHERE org_id=$7 AND project_id=$8 AND environment_id=$9 AND target_id=$10 AND surface=$11 AND normalized_name=$12 AND state='released'`)
-				rows, updateErr := tx.Exec(ctx, reactivate, effect.EffectiveName, origin, destinationKind, repositoryID, destinationID, adapterTimestamp(j.runtime.db.Engine(), time.Now()), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), normalized)
+				rows, updateErr := tx.Exec(ctx, reactivate, effect.EffectiveName, origin, destinationKind, repositoryID, destinationID, tx.Stamp(time.Now()), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), normalized)
 				if constraint(updateErr) != nil {
 					return adapter.ErrConflict
 				}
@@ -589,7 +531,7 @@ func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (ad
 		if !errors.Is(err, sql.ErrNoRows) && !errors.Is(err, pgx.ErrNoRows) {
 			return err
 		}
-		countQuery := j.runtime.query(
+		countQuery := tx.SQL(
 			`SELECT COUNT(*) FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
 			`SELECT COUNT(*) FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state<>'released'`)
 		var ledgerRows int
@@ -601,16 +543,16 @@ func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (ad
 		}
 		var origin, destinationKind string
 		var destinationID, repositoryID int64
-		lookup := j.runtime.query(
+		lookup := tx.SQL(
 			`SELECT a.origin,t.destination_kind,t.destination_id,t.repository_id FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=?`,
 			`SELECT a.origin,t.destination_kind,t.destination_id,t.repository_id FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3 AND t.environment_id=$4`)
 		if err := tx.QueryRow(ctx, lookup, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID).Scan(&origin, &destinationKind, &destinationID, &repositoryID); err != nil {
 			return err
 		}
-		insert := j.runtime.query(
+		insert := tx.SQL(
 			`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 			`INSERT INTO adapter_ledger (id,org_id,project_id,environment_id,target_id,provider_origin,destination_kind,repository_id,destination_id,surface,effective_name,normalized_name,state,updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`)
-		_, err = tx.Exec(ctx, insert, newAdapterID("led"), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, origin, destinationKind, repositoryID, destinationID, string(effect.Surface), effect.EffectiveName, normalized, string(adapter.Reserved), adapterTimestamp(j.runtime.db.Engine(), time.Now()))
+		_, err = tx.Exec(ctx, insert, newAdapterID("led"), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, origin, destinationKind, repositoryID, destinationID, string(effect.Surface), effect.EffectiveName, normalized, string(adapter.Reserved), tx.Stamp(time.Now()))
 		if constraint(err) != nil {
 			return adapter.ErrConflict
 		}
@@ -624,11 +566,11 @@ func (j *adapterJournal) Prepare(ctx context.Context, effect adapter.Effect, pri
 	intentID := newAdapterID("aud")
 	now := time.Now().UTC()
 	err := j.runtime.transaction(ctx, func(tx adapterDBTX) error {
-		providerLease := j.runtime.query(
+		providerLease := tx.SQL(
 			`UPDATE adapter_targets SET provider_lease_job_id=?,provider_lease_effect_id=?,provider_lease_expires_at=? WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=?)`,
 			`UPDATE adapter_targets SET provider_lease_job_id=$1,provider_lease_effect_id=$2,provider_lease_expires_at=$3 WHERE id=$4 AND org_id=$5 AND project_id=$6 AND environment_id=$7 AND generation=$8 AND (provider_lease_job_id IS NULL OR provider_lease_expires_at<=$9)`)
-		leaseUntil := adapterTimestamp(j.runtime.db.Engine(), now.Add(adapter.LeaseTime))
-		nowStamp := adapterTimestamp(j.runtime.db.Engine(), now)
+		leaseUntil := tx.Stamp(now.Add(adapter.LeaseTime))
+		nowStamp := tx.Stamp(now)
 		rows, err := tx.Exec(ctx, providerLease, j.job.ID, effectID, leaseUntil, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.Generation, nowStamp)
 		if err != nil {
 			return err
@@ -636,7 +578,7 @@ func (j *adapterJournal) Prepare(ctx context.Context, effect adapter.Effect, pri
 		if rows != 1 {
 			return adapter.ErrProviderBusy
 		}
-		lease := j.runtime.query(
+		lease := tx.SQL(
 			`UPDATE adapter_outbox SET lease_expires_at=? WHERE id=? AND state='running' AND lease_owner=?`,
 			`UPDATE adapter_outbox SET lease_expires_at=$1 WHERE id=$2 AND state='running' AND lease_owner=$3`)
 		rows, err = tx.Exec(ctx, lease, leaseUntil, j.job.ID, j.job.LeaseOwner)
@@ -644,10 +586,10 @@ func (j *adapterJournal) Prepare(ctx context.Context, effect adapter.Effect, pri
 			return adapter.ErrSuperseded
 		}
 		if prior == adapter.Reserved {
-			update := j.runtime.query(
+			update := tx.SQL(
 				`UPDATE adapter_ledger SET state='dispatched',updated_at=? WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND state='reserved'`,
 				`UPDATE adapter_ledger SET state='dispatched',updated_at=$1 WHERE org_id=$2 AND project_id=$3 AND environment_id=$4 AND target_id=$5 AND surface=$6 AND normalized_name=$7 AND state='reserved'`)
-			rows, err := tx.Exec(ctx, update, adapterTimestamp(j.runtime.db.Engine(), now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
+			rows, err := tx.Exec(ctx, update, tx.Stamp(now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
 			if err != nil || rows != 1 {
 				return adapter.ErrSuperseded
 			}
@@ -656,10 +598,10 @@ func (j *adapterJournal) Prepare(ctx context.Context, effect adapter.Effect, pri
 		if err := j.insertAudit(ctx, tx, intentID, "adapter.push_intent", "intent", now, payload); err != nil {
 			return err
 		}
-		insert := j.runtime.query(
+		insert := tx.SQL(
 			`INSERT INTO adapter_effects (id,org_id,project_id,environment_id,target_id,job_id,surface,effective_name,disposition,intent_audit_id,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
 			`INSERT INTO adapter_effects (id,org_id,project_id,environment_id,target_id,job_id,surface,effective_name,disposition,intent_audit_id,created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`)
-		_, err = tx.Exec(ctx, insert, effectID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, j.job.ID, string(effect.Surface), effect.EffectiveName, string(effect.Disposition), intentID, adapterTimestamp(j.runtime.db.Engine(), now))
+		_, err = tx.Exec(ctx, insert, effectID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, j.job.ID, string(effect.Surface), effect.EffectiveName, string(effect.Disposition), intentID, tx.Stamp(now))
 		return err
 	})
 	if err == nil {
@@ -697,10 +639,10 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 		if err := j.insertAudit(ctx, tx, outcomeID, "adapter.push_outcome", completion.Outcome, now, payloadJSON); err != nil {
 			return err
 		}
-		updateEffect := j.runtime.query(
+		updateEffect := tx.SQL(
 			`UPDATE adapter_effects SET outcome_audit_id=?,outcome=?,finished_at=? WHERE id=? AND outcome IS NULL`,
 			`UPDATE adapter_effects SET outcome_audit_id=$1,outcome=$2,finished_at=$3 WHERE id=$4 AND outcome IS NULL`)
-		rows, err := tx.Exec(ctx, updateEffect, outcomeID, completion.Outcome, adapterTimestamp(j.runtime.db.Engine(), now), effectID)
+		rows, err := tx.Exec(ctx, updateEffect, outcomeID, completion.Outcome, tx.Stamp(now), effectID)
 		if err != nil || rows != 1 {
 			return errors.New("store: adapter effect OUTCOME was not recorded exactly once")
 		}
@@ -710,15 +652,15 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 			}
 		}
 		if completion.State == "" {
-			remove := j.runtime.query(
+			remove := tx.SQL(
 				`DELETE FROM adapter_ledger WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=?`,
 				`DELETE FROM adapter_ledger WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND target_id=$4 AND surface=$5 AND normalized_name=$6`)
 			rows, err = tx.Exec(ctx, remove, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
 		} else {
-			update := j.runtime.query(
+			update := tx.SQL(
 				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE ? END,missing=?,updated_at=? WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND NOT (state='released' AND ?)`,
 				`UPDATE adapter_ledger SET state=CASE WHEN state='released' THEN 'released' ELSE $1 END,missing=$2,updated_at=$3 WHERE org_id=$4 AND project_id=$5 AND environment_id=$6 AND target_id=$7 AND surface=$8 AND normalized_name=$9 AND NOT (state='released' AND $10)`)
-			rows, err = tx.Exec(ctx, update, string(completion.State), completion.Missing, adapterTimestamp(j.runtime.db.Engine(), now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName), completion.Missing)
+			rows, err = tx.Exec(ctx, update, string(completion.State), completion.Missing, tx.Stamp(now), j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName), completion.Missing)
 		}
 		if err != nil {
 			return err
@@ -732,7 +674,7 @@ func (j *adapterJournal) Finish(ctx context.Context, effect adapter.Effect, comp
 				return err
 			}
 		}
-		releaseLease := j.runtime.query(
+		releaseLease := tx.SQL(
 			`UPDATE adapter_targets SET provider_lease_job_id=NULL,provider_lease_effect_id=NULL,provider_lease_expires_at=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND provider_lease_job_id=? AND provider_lease_effect_id=?`,
 			`UPDATE adapter_targets SET provider_lease_job_id=NULL,provider_lease_effect_id=NULL,provider_lease_expires_at=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND provider_lease_job_id=$5 AND provider_lease_effect_id=$6`)
 		rows, err = tx.Exec(ctx, releaseLease, j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.ID, effectID)
@@ -758,7 +700,7 @@ func (j *adapterJournal) Refuse(ctx context.Context, effect adapter.Effect) erro
 		if err := j.insertConflict(ctx, tx, effect, now); err != nil {
 			return err
 		}
-		remove := j.runtime.query(
+		remove := tx.SQL(
 			`DELETE FROM adapter_ledger WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND state='reserved'`,
 			`DELETE FROM adapter_ledger WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND target_id=$4 AND surface=$5 AND normalized_name=$6 AND state='reserved'`)
 		rows, err := tx.Exec(ctx, remove, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, string(effect.Surface), strings.ToUpper(effect.EffectiveName))
@@ -774,10 +716,10 @@ func (j *adapterJournal) Refuse(ctx context.Context, effect adapter.Effect) erro
 
 func (j *adapterJournal) ReleaseReservation(ctx context.Context, effect adapter.Effect) error {
 	return j.runtime.transaction(ctx, func(tx adapterDBTX) error {
-		remove := j.runtime.query(
+		remove := tx.SQL(
 			`DELETE FROM adapter_ledger WHERE org_id=? AND project_id=? AND environment_id=? AND target_id=? AND surface=? AND normalized_name=? AND state='reserved' AND EXISTS (SELECT 1 FROM adapter_targets t JOIN adapter_outbox o ON o.target_id=t.id AND o.org_id=t.org_id AND o.project_id=t.project_id AND o.environment_id=t.environment_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.generation=? AND o.id=? AND o.generation=t.generation AND o.state='running' AND o.lease_owner=? AND o.lease_expires_at>?)`,
 			`DELETE FROM adapter_ledger WHERE org_id=$1 AND project_id=$2 AND environment_id=$3 AND target_id=$4 AND surface=$5 AND normalized_name=$6 AND state='reserved' AND EXISTS (SELECT 1 FROM adapter_targets t JOIN adapter_outbox o ON o.target_id=t.id AND o.org_id=t.org_id AND o.project_id=t.project_id AND o.environment_id=t.environment_id WHERE t.id=$7 AND t.org_id=$8 AND t.project_id=$9 AND t.environment_id=$10 AND t.generation=$11 AND o.id=$12 AND o.generation=t.generation AND o.state='running' AND o.lease_owner=$13 AND o.lease_expires_at>$14)`)
-		now := adapterTimestamp(j.runtime.db.Engine(), time.Now().UTC())
+		now := tx.Stamp(time.Now().UTC())
 		rows, err := tx.Exec(ctx, remove,
 			j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID,
 			string(effect.Surface), strings.ToUpper(effect.EffectiveName),
@@ -794,11 +736,11 @@ func (j *adapterJournal) ReleaseReservation(ctx context.Context, effect adapter.
 }
 
 func (j *adapterJournal) insertConflict(ctx context.Context, tx adapterDBTX, effect adapter.Effect, now time.Time) error {
-	insert := j.runtime.query(
+	insert := tx.SQL(
 		`INSERT INTO adapter_conflicts (id,artifact_id,org_id,project_id,environment_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at) SELECT ?,?,?,?,?,?,?,destination_id,repository_id,?,?,?,? FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=?`,
 		`INSERT INTO adapter_conflicts (id,artifact_id,org_id,project_id,environment_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at) SELECT $1,$2,$3,$4,$5,$6,$7,destination_id,repository_id,$8,$9,$10,$11 FROM adapter_targets WHERE id=$12 AND org_id=$13 AND project_id=$14 AND environment_id=$15`)
 	artifactID := newAdapterID("acf")
-	rows, err := tx.Exec(ctx, insert, newAdapterID("acn"), artifactID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, j.job.ID, j.job.Generation, string(effect.Surface), effect.EffectiveName, adapterTimestamp(j.runtime.db.Engine(), now), j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID)
+	rows, err := tx.Exec(ctx, insert, newAdapterID("acn"), artifactID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID, j.job.TargetID, j.job.ID, j.job.Generation, string(effect.Surface), effect.EffectiveName, tx.Stamp(now), j.job.TargetID, j.job.OrgID, j.job.ProjectID, j.job.EnvironmentID)
 	if err != nil {
 		return err
 	}
@@ -817,10 +759,10 @@ func (r *AdapterRuntime) insertAdapterJobAudit(ctx context.Context, tx adapterDB
 }
 
 func (r *AdapterRuntime) insertAdapterJobAuditWithID(ctx context.Context, tx adapterDBTX, job adapter.Job, id, typ, outcome string, at time.Time, payload []byte) error {
-	query := r.query(
+	query := tx.SQL(
 		`INSERT INTO audit_tenant_events (id,type,schema_version,occurred_at,occurred_asserted,recorded_at,actor_id,actor_class,authority_id,scope_class,org_id,project_id,env_id,object_type,object_id,outcome,correlation_id,origin,payload) VALUES (?,?,1,?,0,?,NULL,'system',?,'env',?,?,?,'adapter-target',?,?,?,'adapter-job',?)`,
 		`INSERT INTO audit_tenant_events (id,type,schema_version,occurred_at,occurred_asserted,recorded_at,actor_id,actor_class,authority_id,scope_class,org_id,project_id,env_id,object_type,object_id,outcome,correlation_id,origin,payload) VALUES ($1,$2,1,$3,false,$4,NULL,'system',$5,'env',$6,$7,$8,'adapter-target',$9,$10,$11,'adapter-job',$12)`)
-	stamp := adapterTimestamp(r.db.Engine(), at)
+	stamp := tx.Stamp(at)
 	_, err := tx.Exec(ctx, query, id, typ, stamp, stamp, job.AuthorityPrincipal, job.OrgID, job.ProjectID, job.EnvironmentID, job.TargetID, outcome, job.ID, string(payload))
 	return err
 }
@@ -843,10 +785,10 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		return fmt.Errorf("%w: incomplete adapter route activation", domain.ErrInvalid)
 	}
 	return r.transaction(ctx, func(tx adapterDBTX) error {
-		finish := r.query(
+		finish := tx.SQL(
 			`UPDATE adapter_outbox SET state='succeeded',finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE id=? AND route_move_id=? AND target_id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND kind='activate' AND state='running' AND lease_owner=?`,
 			`UPDATE adapter_outbox SET state='succeeded',finished_at=$1,lease_owner=NULL,lease_expires_at=NULL WHERE id=$2 AND route_move_id=$3 AND target_id=$4 AND org_id=$5 AND project_id=$6 AND environment_id=$7 AND generation=$8 AND kind='activate' AND state='running' AND lease_owner=$9`)
-		stamp := adapterTimestamp(r.db.Engine(), at)
+		stamp := tx.Stamp(at)
 		rows, err := tx.Exec(ctx, finish, stamp, job.ID, job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation, job.LeaseOwner)
 		if err != nil {
 			return err
@@ -856,7 +798,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		}
 		var adapterID, currentEnvironment, pendingEnvironment, kind, owner, name, destinationEnvironment, visibility, prefix, moveKind, pendingOrigin string
 		var selectedRaw []byte
-		lookup := r.query(
+		lookup := tx.SQL(
 			`SELECT t.adapter_id,t.environment_id,mt.environment_id,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.visibility,mt.selected_repository_ids,mt.name_prefix,m.kind,COALESCE(m.pending_origin,a.origin) FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_moves m ON m.id=? AND m.org_id=t.org_id AND m.project_id=t.project_id AND m.adapter_id=t.adapter_id JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.target_id=t.id AND mt.org_id=t.org_id AND mt.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.generation=? AND t.state='moving' AND m.state='activating' AND (m.kind='origin' OR (m.kind='target' AND m.target_id=t.id))`,
 			`SELECT t.adapter_id,t.environment_id,mt.environment_id,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.visibility,mt.selected_repository_ids,mt.name_prefix,m.kind,COALESCE(m.pending_origin,a.origin) FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id JOIN adapter_route_moves m ON m.id=$1 AND m.org_id=t.org_id AND m.project_id=t.project_id AND m.adapter_id=t.adapter_id JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.target_id=t.id AND mt.org_id=t.org_id AND mt.project_id=t.project_id WHERE t.id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.environment_id=$5 AND t.generation=$6 AND t.state='moving' AND m.state='activating' AND (m.kind='origin' OR (m.kind='target' AND m.target_id=t.id)) FOR UPDATE OF t,a,m,mt`)
 		if err := tx.QueryRow(ctx, lookup, job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation).Scan(&adapterID, &currentEnvironment, &pendingEnvironment, &kind, &owner, &name, &destinationEnvironment, &visibility, &selectedRaw, &prefix, &moveKind, &pendingOrigin); err != nil {
@@ -868,7 +810,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		if pendingEnvironment != currentEnvironment {
 			return fmt.Errorf("%w: target environment move requires a replacement identity", domain.ErrConflict)
 		}
-		collisionQuery := r.query(
+		collisionQuery := tx.SQL(
 			`SELECT (SELECT COUNT(*) FROM adapter_route_move_claims c JOIN adapter_targets other ON other.org_id=c.org_id AND other.project_id=c.project_id AND other.id<>c.target_id AND other.state='active' JOIN adapters oa ON oa.id=other.adapter_id AND oa.org_id=other.org_id AND oa.project_id=other.project_id LEFT JOIN adapter_target_keys tk ON tk.target_id=other.id AND tk.org_id=other.org_id AND tk.project_id=other.project_id AND tk.environment_id=other.environment_id LEFT JOIN keys k ON k.id=tk.key_id AND k.org_id=tk.org_id AND k.project_id=tk.project_id WHERE c.move_id=? AND c.target_id=? AND oa.origin=? AND other.destination_kind=? AND other.repository_id=? AND other.destination_id=? AND (c.effective_name=other.name_prefix||? OR c.effective_name=other.name_prefix||k.name))+(SELECT COUNT(*) FROM adapter_route_move_claims c JOIN adapter_ledger l ON l.provider_origin=? AND l.destination_kind=? AND l.repository_id=? AND l.destination_id=? AND l.surface=c.surface AND l.normalized_name=c.normalized_name AND l.state<>'released' AND l.target_id<>c.target_id WHERE c.move_id=? AND c.target_id=?)`,
 			`SELECT (SELECT COUNT(*) FROM adapter_route_move_claims c JOIN adapter_targets other ON other.org_id=c.org_id AND other.project_id=c.project_id AND other.id<>c.target_id AND other.state='active' JOIN adapters oa ON oa.id=other.adapter_id AND oa.org_id=other.org_id AND oa.project_id=other.project_id LEFT JOIN adapter_target_keys tk ON tk.target_id=other.id AND tk.org_id=other.org_id AND tk.project_id=other.project_id AND tk.environment_id=other.environment_id LEFT JOIN keys k ON k.id=tk.key_id AND k.org_id=tk.org_id AND k.project_id=tk.project_id WHERE c.move_id=$1 AND c.target_id=$2 AND oa.origin=$3 AND other.destination_kind=$4 AND other.repository_id=$5 AND other.destination_id=$6 AND (c.effective_name=other.name_prefix||$7 OR c.effective_name=other.name_prefix||k.name))+(SELECT COUNT(*) FROM adapter_route_move_claims c JOIN adapter_ledger l ON l.provider_origin=$8 AND l.destination_kind=$9 AND l.repository_id=$10 AND l.destination_id=$11 AND l.surface=c.surface AND l.normalized_name=c.normalized_name AND l.state<>'released' AND l.target_id<>c.target_id WHERE c.move_id=$12 AND c.target_id=$13)`)
 		var collisions int
@@ -878,7 +820,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		if collisions != 0 {
 			return fmt.Errorf("%w: pending effective names collide on the resolved destination", adapter.ErrConflict)
 		}
-		setResolved := r.query(
+		setResolved := tx.SQL(
 			`UPDATE adapter_route_move_targets SET destination_id=?,repository_id=? WHERE move_id=? AND target_id=? AND org_id=? AND project_id=? AND environment_id=? AND destination_id=0`,
 			`UPDATE adapter_route_move_targets SET destination_id=$1,repository_id=$2 WHERE move_id=$3 AND target_id=$4 AND org_id=$5 AND project_id=$6 AND environment_id=$7 AND destination_id=0`)
 		rows, err = tx.Exec(ctx, setResolved, connection.DestinationID, connection.RepositoryID, job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, pendingEnvironment)
@@ -894,13 +836,13 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		if moveKind != "target" {
 			return fmt.Errorf("%w: unsupported adapter route move kind", domain.ErrInvalid)
 		}
-		deleteKeys := r.query(
+		deleteKeys := tx.SQL(
 			`DELETE FROM adapter_target_keys WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=?`,
 			`DELETE FROM adapter_target_keys WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
 		if _, err := tx.Exec(ctx, deleteKeys, job.TargetID, job.OrgID, job.ProjectID, currentEnvironment); err != nil {
 			return err
 		}
-		insertKeys := r.query(
+		insertKeys := tx.SQL(
 			`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) SELECT k.org_id,k.project_id,k.environment_id,k.target_id,?,k.key_id FROM adapter_route_move_keys k WHERE k.move_id=? AND k.target_id=? AND k.org_id=? AND k.project_id=? AND k.environment_id=?`,
 			`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) SELECT k.org_id,k.project_id,k.environment_id,k.target_id,$1,k.key_id FROM adapter_route_move_keys k WHERE k.move_id=$2 AND k.target_id=$3 AND k.org_id=$4 AND k.project_id=$5 AND k.environment_id=$6`)
 		inserted, err := tx.Exec(ctx, insertKeys, adapterID, job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, pendingEnvironment)
@@ -912,7 +854,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		}
 		convergeID := newAdapterID("job")
 		generation := job.Generation + 1
-		insertJob := r.query(
+		insertJob := tx.SQL(
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES (?,?,?,?,?,'converge',?,?,?,?,0,?,'queued',?)`,
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES ($1,$2,$3,$4,$5,'converge',$6,$7,$8,$9,0,$10,'queued',$11)`)
 		rows, err = tx.Exec(ctx, insertJob, convergeID, job.OrgID, job.ProjectID, pendingEnvironment, job.TargetID, job.RouteMoveID, job.AuthorityPrincipal, generation, job.TargetID, stamp, stamp)
@@ -922,7 +864,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 		if rows != 1 {
 			return ErrConflict
 		}
-		applyTarget := r.query(
+		applyTarget := tx.SQL(
 			`UPDATE adapter_targets SET destination_kind=?,destination_owner=?,destination_name=?,destination_environment=?,destination_id=?,repository_id=?,visibility=?,selected_repository_ids=?,name_prefix=?,generation=?,state='active',sync_status='converging',failure_names='[]',active_job_id=? WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND state='moving' AND provider_lease_job_id IS NULL`,
 			`UPDATE adapter_targets SET destination_kind=$1,destination_owner=$2,destination_name=$3,destination_environment=$4,destination_id=$5,repository_id=$6,visibility=$7,selected_repository_ids=$8,name_prefix=$9,generation=$10,state='active',sync_status='converging',failure_names='[]'::jsonb,active_job_id=$11 WHERE id=$12 AND org_id=$13 AND project_id=$14 AND environment_id=$15 AND generation=$16 AND state='moving' AND provider_lease_job_id IS NULL`)
 		rows, err = tx.Exec(ctx, applyTarget, kind, owner, name, destinationEnvironment, connection.DestinationID, connection.RepositoryID, visibility, selectedRaw, prefix, generation, convergeID, job.TargetID, job.OrgID, job.ProjectID, currentEnvironment, job.Generation)
@@ -933,10 +875,10 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 			return adapter.ErrSuperseded
 		}
 		if !connection.CredentialExpiresAt.IsZero() {
-			updateExpiry := r.query(
+			updateExpiry := tx.SQL(
 				`UPDATE adapters SET credential_expires_at=? WHERE id=? AND org_id=? AND project_id=? AND state='active'`,
 				`UPDATE adapters SET credential_expires_at=$1 WHERE id=$2 AND org_id=$3 AND project_id=$4 AND state='active'`)
-			rows, err = tx.Exec(ctx, updateExpiry, adapterTimestamp(r.db.Engine(), connection.CredentialExpiresAt), adapterID, job.OrgID, job.ProjectID)
+			rows, err = tx.Exec(ctx, updateExpiry, tx.Stamp(connection.CredentialExpiresAt), adapterID, job.OrgID, job.ProjectID)
 			if err != nil {
 				return err
 			}
@@ -944,11 +886,11 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 				return adapter.ErrSuperseded
 			}
 		}
-		deleteClaims := r.query(`DELETE FROM adapter_route_move_claims WHERE move_id=? AND org_id=? AND project_id=?`, `DELETE FROM adapter_route_move_claims WHERE move_id=$1 AND org_id=$2 AND project_id=$3`)
+		deleteClaims := tx.SQL(`DELETE FROM adapter_route_move_claims WHERE move_id=? AND org_id=? AND project_id=?`, `DELETE FROM adapter_route_move_claims WHERE move_id=$1 AND org_id=$2 AND project_id=$3`)
 		if _, err := tx.Exec(ctx, deleteClaims, job.RouteMoveID, job.OrgID, job.ProjectID); err != nil {
 			return err
 		}
-		completeMove := r.query(
+		completeMove := tx.SQL(
 			`UPDATE adapter_route_moves SET state='completed' WHERE id=? AND org_id=? AND project_id=? AND target_id=? AND state='activating'`,
 			`UPDATE adapter_route_moves SET state='completed' WHERE id=$1 AND org_id=$2 AND project_id=$3 AND target_id=$4 AND state='activating'`)
 		rows, err = tx.Exec(ctx, completeMove, job.RouteMoveID, job.OrgID, job.ProjectID, job.TargetID)
@@ -964,7 +906,7 @@ func (r *AdapterRuntime) Activate(ctx context.Context, job adapter.Job, connecti
 }
 
 func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapterDBTX, job adapter.Job, connection adapter.Connection, adapterID string, stamp any, at time.Time) error {
-	markProbe := r.query(
+	markProbe := tx.SQL(
 		`UPDATE adapter_targets SET active_job_id=NULL WHERE id=? AND adapter_id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND state='moving' AND active_job_id=? AND provider_lease_job_id IS NULL`,
 		`UPDATE adapter_targets SET active_job_id=NULL WHERE id=$1 AND adapter_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND generation=$6 AND state='moving' AND active_job_id=$7 AND provider_lease_job_id IS NULL`)
 	rows, err := tx.Exec(ctx, markProbe, job.TargetID, adapterID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation, job.ID)
@@ -979,7 +921,7 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 		return err
 	}
 	var unresolved int
-	countUnresolved := r.query(
+	countUnresolved := tx.SQL(
 		`SELECT COUNT(*) FROM adapter_route_move_targets WHERE move_id=? AND org_id=? AND project_id=? AND destination_id=0`,
 		`SELECT COUNT(*) FROM adapter_route_move_targets WHERE move_id=$1 AND org_id=$2 AND project_id=$3 AND destination_id=0`)
 	if err := tx.QueryRow(ctx, countUnresolved, job.RouteMoveID, job.OrgID, job.ProjectID).Scan(&unresolved); err != nil {
@@ -990,7 +932,7 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 	}
 	var pendingOrigin string
 	var pendingCredential []byte
-	loadPending := r.query(
+	loadPending := tx.SQL(
 		`SELECT pending_origin,pending_credential_ciphertext FROM adapter_route_moves WHERE id=? AND org_id=? AND project_id=? AND adapter_id=? AND kind='origin' AND target_id IS NULL AND state='activating'`,
 		`SELECT pending_origin,pending_credential_ciphertext FROM adapter_route_moves WHERE id=$1 AND org_id=$2 AND project_id=$3 AND adapter_id=$4 AND kind='origin' AND target_id IS NULL AND state='activating' FOR UPDATE`)
 	if err := tx.QueryRow(ctx, loadPending, job.RouteMoveID, job.OrgID, job.ProjectID, adapterID).Scan(&pendingOrigin, &pendingCredential); err != nil {
@@ -1002,7 +944,7 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 	if pendingOrigin == "" || len(pendingCredential) == 0 {
 		return fmt.Errorf("%w: origin move lost pending provider custody", adapter.ErrSuperseded)
 	}
-	targetQuery := r.query(
+	targetQuery := tx.SQL(
 		`SELECT t.id,t.environment_id,t.generation,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.destination_id,mt.repository_id,mt.visibility,mt.selected_repository_ids,mt.name_prefix FROM adapter_route_move_targets mt JOIN adapter_targets t ON t.id=mt.target_id AND t.org_id=mt.org_id AND t.project_id=mt.project_id AND t.environment_id=mt.environment_id WHERE mt.move_id=? AND mt.org_id=? AND mt.project_id=? AND t.adapter_id=? AND t.state='moving' AND t.active_job_id IS NULL AND t.provider_lease_job_id IS NULL ORDER BY t.id`,
 		`SELECT t.id,t.environment_id,t.generation,mt.destination_kind,mt.destination_owner,mt.destination_name,mt.destination_environment,mt.destination_id,mt.repository_id,mt.visibility,mt.selected_repository_ids,mt.name_prefix FROM adapter_route_move_targets mt JOIN adapter_targets t ON t.id=mt.target_id AND t.org_id=mt.org_id AND t.project_id=mt.project_id AND t.environment_id=mt.environment_id WHERE mt.move_id=$1 AND mt.org_id=$2 AND mt.project_id=$3 AND t.adapter_id=$4 AND t.state='moving' AND t.active_job_id IS NULL AND t.provider_lease_job_id IS NULL ORDER BY t.id FOR UPDATE OF t,mt`)
 	targetRows, err := tx.Query(ctx, targetQuery, job.RouteMoveID, job.OrgID, job.ProjectID, adapterID)
@@ -1018,31 +960,31 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 	for targetRows.Next() {
 		var target activatedTarget
 		if err := targetRows.Scan(&target.id, &target.environment, &target.generation, &target.kind, &target.owner, &target.name, &target.destinationEnvironment, &target.destinationID, &target.repositoryID, &target.visibility, &target.selectedRaw, &target.prefix); err != nil {
-			targetRows.Close()
+			_ = closeAdapterRows(targetRows)
 			return err
 		}
 		if target.destinationID <= 0 {
-			targetRows.Close()
+			_ = closeAdapterRows(targetRows)
 			return adapter.ErrSuperseded
 		}
 		targets = append(targets, target)
 	}
 	if err := targetRows.Err(); err != nil {
-		targetRows.Close()
+		_ = closeAdapterRows(targetRows)
 		return err
 	}
-	targetRows.Close()
+	_ = closeAdapterRows(targetRows)
 	if len(targets) == 0 {
 		return adapter.ErrSuperseded
 	}
 	for _, target := range targets {
-		deleteKeys := r.query(
+		deleteKeys := tx.SQL(
 			`DELETE FROM adapter_target_keys WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=?`,
 			`DELETE FROM adapter_target_keys WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
 		if _, err := tx.Exec(ctx, deleteKeys, target.id, job.OrgID, job.ProjectID, target.environment); err != nil {
 			return err
 		}
-		insertKeys := r.query(
+		insertKeys := tx.SQL(
 			`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) SELECT k.org_id,k.project_id,k.environment_id,k.target_id,?,k.key_id FROM adapter_route_move_keys k WHERE k.move_id=? AND k.target_id=? AND k.org_id=? AND k.project_id=? AND k.environment_id=?`,
 			`INSERT INTO adapter_target_keys (org_id,project_id,environment_id,target_id,adapter_id,key_id) SELECT k.org_id,k.project_id,k.environment_id,k.target_id,$1,k.key_id FROM adapter_route_move_keys k WHERE k.move_id=$2 AND k.target_id=$3 AND k.org_id=$4 AND k.project_id=$5 AND k.environment_id=$6`)
 		inserted, err := tx.Exec(ctx, insertKeys, adapterID, job.RouteMoveID, target.id, job.OrgID, job.ProjectID, target.environment)
@@ -1054,7 +996,7 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 		}
 		convergeID := newAdapterID("job")
 		generation := target.generation + 1
-		insertJob := r.query(
+		insertJob := tx.SQL(
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES (?,?,?,?,?,'converge',?,?,?,?,0,?,'queued',?)`,
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES ($1,$2,$3,$4,$5,'converge',$6,$7,$8,$9,0,$10,'queued',$11)`)
 		rows, err = tx.Exec(ctx, insertJob, convergeID, job.OrgID, job.ProjectID, target.environment, target.id, job.RouteMoveID, job.AuthorityPrincipal, generation, target.id, stamp, stamp)
@@ -1064,7 +1006,7 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 		if rows != 1 {
 			return ErrConflict
 		}
-		applyTarget := r.query(
+		applyTarget := tx.SQL(
 			`UPDATE adapter_targets SET destination_kind=?,destination_owner=?,destination_name=?,destination_environment=?,destination_id=?,repository_id=?,visibility=?,selected_repository_ids=?,name_prefix=?,generation=?,state='active',sync_status='converging',failure_names='[]',active_job_id=? WHERE id=? AND adapter_id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND state='moving' AND active_job_id IS NULL AND provider_lease_job_id IS NULL`,
 			`UPDATE adapter_targets SET destination_kind=$1,destination_owner=$2,destination_name=$3,destination_environment=$4,destination_id=$5,repository_id=$6,visibility=$7,selected_repository_ids=$8,name_prefix=$9,generation=$10,state='active',sync_status='converging',failure_names='[]'::jsonb,active_job_id=$11 WHERE id=$12 AND adapter_id=$13 AND org_id=$14 AND project_id=$15 AND environment_id=$16 AND generation=$17 AND state='moving' AND active_job_id IS NULL AND provider_lease_job_id IS NULL`)
 		rows, err = tx.Exec(ctx, applyTarget, target.kind, target.owner, target.name, target.destinationEnvironment, target.destinationID, target.repositoryID, target.visibility, target.selectedRaw, target.prefix, generation, convergeID, target.id, adapterID, job.OrgID, job.ProjectID, target.environment, target.generation)
@@ -1075,12 +1017,12 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 			return adapter.ErrSuperseded
 		}
 	}
-	activateAdapter := r.query(
+	activateAdapter := tx.SQL(
 		`UPDATE adapters SET origin=?,credential_ciphertext=?,credential_set_at=?,credential_expires_at=?,state='active' WHERE id=? AND org_id=? AND project_id=? AND state='moving'`,
 		`UPDATE adapters SET origin=$1,credential_ciphertext=$2,credential_set_at=$3,credential_expires_at=$4,state='active' WHERE id=$5 AND org_id=$6 AND project_id=$7 AND state='moving'`)
 	var expires any
 	if !connection.CredentialExpiresAt.IsZero() {
-		expires = adapterTimestamp(r.db.Engine(), connection.CredentialExpiresAt)
+		expires = tx.Stamp(connection.CredentialExpiresAt)
 	}
 	rows, err = tx.Exec(ctx, activateAdapter, pendingOrigin, pendingCredential, stamp, expires, adapterID, job.OrgID, job.ProjectID)
 	if err != nil {
@@ -1089,11 +1031,11 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 	if rows != 1 {
 		return adapter.ErrSuperseded
 	}
-	deleteClaims := r.query(`DELETE FROM adapter_route_move_claims WHERE move_id=? AND org_id=? AND project_id=?`, `DELETE FROM adapter_route_move_claims WHERE move_id=$1 AND org_id=$2 AND project_id=$3`)
+	deleteClaims := tx.SQL(`DELETE FROM adapter_route_move_claims WHERE move_id=? AND org_id=? AND project_id=?`, `DELETE FROM adapter_route_move_claims WHERE move_id=$1 AND org_id=$2 AND project_id=$3`)
 	if _, err := tx.Exec(ctx, deleteClaims, job.RouteMoveID, job.OrgID, job.ProjectID); err != nil {
 		return err
 	}
-	completeMove := r.query(
+	completeMove := tx.SQL(
 		`UPDATE adapter_route_moves SET state='completed',pending_origin=NULL,pending_credential_ciphertext=NULL WHERE id=? AND org_id=? AND project_id=? AND adapter_id=? AND kind='origin' AND state='activating'`,
 		`UPDATE adapter_route_moves SET state='completed',pending_origin=NULL,pending_credential_ciphertext=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND adapter_id=$4 AND kind='origin' AND state='activating'`)
 	rows, err = tx.Exec(ctx, completeMove, job.RouteMoveID, job.OrgID, job.ProjectID, adapterID)
@@ -1109,8 +1051,8 @@ func (r *AdapterRuntime) activateOriginRouteMove(ctx context.Context, tx adapter
 func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state string, due, finished time.Time, targetStatus string, revision int64, failed []adapter.Change, warnings []string, terminalErr error) error {
 	return r.transaction(ctx, func(tx adapterDBTX) error {
 		if state == "queued" {
-			query := r.query(`UPDATE adapter_outbox SET state='queued',next_attempt_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE id=? AND lease_owner=?`, `UPDATE adapter_outbox SET state='queued',next_attempt_at=$1,lease_owner=NULL,lease_expires_at=NULL WHERE id=$2 AND lease_owner=$3`)
-			rows, err := tx.Exec(ctx, query, adapterTimestamp(r.db.Engine(), due), job.ID, job.LeaseOwner)
+			query := tx.SQL(`UPDATE adapter_outbox SET state='queued',next_attempt_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE id=? AND lease_owner=?`, `UPDATE adapter_outbox SET state='queued',next_attempt_at=$1,lease_owner=NULL,lease_expires_at=NULL WHERE id=$2 AND lease_owner=$3`)
+			rows, err := tx.Exec(ctx, query, tx.Stamp(due), job.ID, job.LeaseOwner)
 			if err != nil {
 				return err
 			}
@@ -1118,8 +1060,8 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 				return adapter.ErrSuperseded
 			}
 		} else {
-			query := r.query(`UPDATE adapter_outbox SET state=?,finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE id=? AND lease_owner=?`, `UPDATE adapter_outbox SET state=$1,finished_at=$2,lease_owner=NULL,lease_expires_at=NULL WHERE id=$3 AND lease_owner=$4`)
-			rows, err := tx.Exec(ctx, query, state, adapterTimestamp(r.db.Engine(), finished), job.ID, job.LeaseOwner)
+			query := tx.SQL(`UPDATE adapter_outbox SET state=?,finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE id=? AND lease_owner=?`, `UPDATE adapter_outbox SET state=$1,finished_at=$2,lease_owner=NULL,lease_expires_at=NULL WHERE id=$3 AND lease_owner=$4`)
+			rows, err := tx.Exec(ctx, query, state, tx.Stamp(finished), job.ID, job.LeaseOwner)
 			if err != nil {
 				return err
 			}
@@ -1133,7 +1075,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 				return err
 			}
 			if job.Kind == adapter.Scrub {
-				orphaned, err := r.adapterLedgerNames(ctx, tx, job)
+				orphaned, err := adapterOrphans(ctx, tx, adapterJobScope(job), job.TargetID, job.EnvironmentID)
 				if err != nil {
 					return err
 				}
@@ -1150,11 +1092,11 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 				return r.finishRouteMoveScrub(ctx, tx, job, finished, nil)
 			}
 			var adapterID string
-			lookup := r.query(`SELECT adapter_id FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=?`, `SELECT adapter_id FROM adapter_targets WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
+			lookup := tx.SQL(`SELECT adapter_id FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=?`, `SELECT adapter_id FROM adapter_targets WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
 			if err := tx.QueryRow(ctx, lookup, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&adapterID); err != nil {
 				return err
 			}
-			markTarget := r.query(`UPDATE adapter_targets SET state='tombstoned',sync_status='converged',active_job_id=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND provider_lease_job_id IS NULL`, `UPDATE adapter_targets SET state='tombstoned',sync_status='converged',active_job_id=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND generation=$5 AND provider_lease_job_id IS NULL`)
+			markTarget := tx.SQL(`UPDATE adapter_targets SET state='tombstoned',sync_status='converged',active_job_id=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND provider_lease_job_id IS NULL`, `UPDATE adapter_targets SET state='tombstoned',sync_status='converged',active_job_id=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND generation=$5 AND provider_lease_job_id IS NULL`)
 			rows, err := tx.Exec(ctx, markTarget, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation)
 			if err != nil {
 				return err
@@ -1162,7 +1104,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 			if rows != 1 {
 				return adapter.ErrSuperseded
 			}
-			erase := r.query(
+			erase := tx.SQL(
 				`UPDATE adapters SET credential_ciphertext=NULL,credential_set_at=NULL WHERE id=? AND org_id=? AND project_id=? AND state='tombstoned' AND NOT EXISTS (SELECT 1 FROM adapter_targets WHERE adapter_id=? AND state<>'tombstoned') AND NOT EXISTS (SELECT 1 FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id WHERE t.adapter_id=? AND j.kind='scrub' AND j.state IN ('queued','running'))`,
 				`UPDATE adapters SET credential_ciphertext=NULL,credential_set_at=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND state='tombstoned' AND NOT EXISTS (SELECT 1 FROM adapter_targets WHERE adapter_id=$4 AND state<>'tombstoned') AND NOT EXISTS (SELECT 1 FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id WHERE t.adapter_id=$5 AND j.kind='scrub' AND j.state IN ('queued','running'))`)
 			_, err = tx.Exec(ctx, erase, adapterID, job.OrgID, job.ProjectID, adapterID, adapterID)
@@ -1173,7 +1115,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 			return r.insertAdapterJobAudit(ctx, tx, job, "adapter.scrub", "success", finished, payload)
 		}
 		if job.Kind == adapter.Activate && state == "failed" && (errors.Is(terminalErr, adapter.ErrProviderAuth) || errors.Is(terminalErr, adapter.ErrConflict)) {
-			attention := r.query(
+			attention := tx.SQL(
 				`UPDATE adapter_route_moves SET state='attention_required' WHERE id=? AND org_id=? AND project_id=? AND state='activating'`,
 				`UPDATE adapter_route_moves SET state='attention_required' WHERE id=$1 AND org_id=$2 AND project_id=$3 AND state='activating'`)
 			rows, err := tx.Exec(ctx, attention, job.RouteMoveID, job.OrgID, job.ProjectID)
@@ -1183,13 +1125,13 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 			if rows != 1 {
 				return adapter.ErrSuperseded
 			}
-			supersede := r.query(
+			supersede := tx.SQL(
 				`UPDATE adapter_outbox SET state='superseded',finished_at=?,lease_owner=NULL,lease_expires_at=NULL WHERE route_move_id=? AND org_id=? AND project_id=? AND id<>? AND kind='activate' AND state IN ('queued','running')`,
 				`UPDATE adapter_outbox SET state='superseded',finished_at=$1,lease_owner=NULL,lease_expires_at=NULL WHERE route_move_id=$2 AND org_id=$3 AND project_id=$4 AND id<>$5 AND kind='activate' AND state IN ('queued','running')`)
-			if _, err := tx.Exec(ctx, supersede, adapterTimestamp(r.db.Engine(), finished), job.RouteMoveID, job.OrgID, job.ProjectID, job.ID); err != nil {
+			if _, err := tx.Exec(ctx, supersede, tx.Stamp(finished), job.RouteMoveID, job.OrgID, job.ProjectID, job.ID); err != nil {
 				return err
 			}
-			markTargets := r.query(
+			markTargets := tx.SQL(
 				`UPDATE adapter_targets SET sync_status='failed',failure_names='["route"]',active_job_id=NULL WHERE org_id=? AND project_id=? AND id IN (SELECT target_id FROM adapter_route_move_targets WHERE move_id=? AND org_id=? AND project_id=?) AND state='moving'`,
 				`UPDATE adapter_targets SET sync_status='failed',failure_names='["route"]'::jsonb,active_job_id=NULL WHERE org_id=$1 AND project_id=$2 AND id IN (SELECT target_id FROM adapter_route_move_targets WHERE move_id=$3 AND org_id=$4 AND project_id=$5) AND state='moving'`)
 			if _, err := tx.Exec(ctx, markTargets, job.OrgID, job.ProjectID, job.RouteMoveID, job.OrgID, job.ProjectID); err != nil {
@@ -1213,7 +1155,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 		if err != nil {
 			return err
 		}
-		query := r.query(
+		query := tx.SQL(
 			`UPDATE adapter_targets SET sync_status=?,converged_revision=CASE WHEN ?>0 THEN ? ELSE converged_revision END,failure_names=?,warnings=?,active_job_id=`+activeJob+` WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND provider_lease_job_id IS NULL`,
 			`UPDATE adapter_targets SET sync_status=$1,converged_revision=CASE WHEN $2>0 THEN $3 ELSE converged_revision END,failure_names=$4,warnings=$5,active_job_id=`+activeJob+` WHERE id=$6 AND org_id=$7 AND project_id=$8 AND environment_id=$9 AND generation=$10 AND provider_lease_job_id IS NULL`)
 		var rev any
@@ -1234,7 +1176,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 			}
 		}
 		if job.Kind == adapter.Scrub && state == "failed" {
-			orphaned, err := r.adapterLedgerNames(ctx, tx, job)
+			orphaned, err := adapterOrphans(ctx, tx, adapterJobScope(job), job.TargetID, job.EnvironmentID)
 			if err != nil {
 				return err
 			}
@@ -1249,7 +1191,7 @@ func (r *AdapterRuntime) finishJob(ctx context.Context, job adapter.Job, state s
 
 func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBTX, job adapter.Job, finished time.Time, orphaned []string) error {
 	var moveKind string
-	lookupMove := r.query(
+	lookupMove := tx.SQL(
 		`SELECT m.kind FROM adapter_route_moves m JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.org_id=m.org_id AND mt.project_id=m.project_id WHERE m.id=? AND m.org_id=? AND m.project_id=? AND m.state='scrubbing' AND mt.target_id=? AND mt.environment_id=?`,
 		`SELECT m.kind FROM adapter_route_moves m JOIN adapter_route_move_targets mt ON mt.move_id=m.id AND mt.org_id=m.org_id AND mt.project_id=m.project_id WHERE m.id=$1 AND m.org_id=$2 AND m.project_id=$3 AND m.state='scrubbing' AND mt.target_id=$4 AND mt.environment_id=$5 FOR UPDATE OF m,mt`)
 	if err := tx.QueryRow(ctx, lookupMove, job.RouteMoveID, job.OrgID, job.ProjectID, job.TargetID, job.EnvironmentID).Scan(&moveKind); err != nil {
@@ -1259,7 +1201,7 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 		return err
 	}
 	var activeLedger int
-	activeLedgerQuery := r.query(
+	activeLedgerQuery := tx.SQL(
 		`SELECT COUNT(*) FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
 		`SELECT COUNT(*) FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state<>'released'`)
 	if err := tx.QueryRow(ctx, activeLedgerQuery, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&activeLedger); err != nil {
@@ -1273,7 +1215,7 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 	if len(orphaned) != 0 {
 		outcome = "failure"
 		orphanJSON, _ := json.Marshal(orphaned)
-		persistOrphans := r.query(
+		persistOrphans := tx.SQL(
 			`UPDATE adapter_route_move_targets SET orphaned_names=? WHERE move_id=? AND target_id=? AND org_id=? AND project_id=? AND environment_id=?`,
 			`UPDATE adapter_route_move_targets SET orphaned_names=$1 WHERE move_id=$2 AND target_id=$3 AND org_id=$4 AND project_id=$5 AND environment_id=$6`)
 		rows, err := tx.Exec(ctx, persistOrphans, string(orphanJSON), job.RouteMoveID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID)
@@ -1290,7 +1232,7 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 	if moveKind != "target" {
 		return fmt.Errorf("%w: unsupported adapter route move kind", domain.ErrInvalid)
 	}
-	move := r.query(
+	move := tx.SQL(
 		`UPDATE adapter_route_moves SET state='activating' WHERE id=? AND org_id=? AND project_id=? AND target_id=? AND state='scrubbing'`,
 		`UPDATE adapter_route_moves SET state='activating' WHERE id=$1 AND org_id=$2 AND project_id=$3 AND target_id=$4 AND state='scrubbing'`)
 	rows, err := tx.Exec(ctx, move, job.RouteMoveID, job.OrgID, job.ProjectID, job.TargetID)
@@ -1301,8 +1243,8 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 		return adapter.ErrSuperseded
 	}
 	activateID := newAdapterID("job")
-	stamp := adapterTimestamp(r.db.Engine(), finished)
-	insert := r.query(
+	stamp := tx.Stamp(finished)
+	insert := tx.SQL(
 		`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES (?,?,?,?,?,'activate',?,?,?,?,0,?,'queued',?)`,
 		`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES ($1,$2,$3,$4,$5,'activate',$6,$7,$8,$9,0,$10,'queued',$11)`)
 	rows, err = tx.Exec(ctx, insert, activateID, job.OrgID, job.ProjectID, job.EnvironmentID, job.TargetID, job.RouteMoveID, job.AuthorityPrincipal, job.Generation, job.TargetID, stamp, stamp)
@@ -1313,7 +1255,7 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 		return ErrConflict
 	}
 	failureJSON, _ := json.Marshal(orphaned)
-	mark := r.query(
+	mark := tx.SQL(
 		`UPDATE adapter_targets SET state='moving',sync_status='converging',failure_names=?,active_job_id=? WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND provider_lease_job_id IS NULL`,
 		`UPDATE adapter_targets SET state='moving',sync_status='converging',failure_names=$1,active_job_id=$2 WHERE id=$3 AND org_id=$4 AND project_id=$5 AND environment_id=$6 AND generation=$7 AND provider_lease_job_id IS NULL`)
 	rows, err = tx.Exec(ctx, mark, string(failureJSON), activateID, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation)
@@ -1328,7 +1270,7 @@ func (r *AdapterRuntime) finishRouteMoveScrub(ctx context.Context, tx adapterDBT
 
 func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adapterDBTX, job adapter.Job, finished time.Time, orphaned []string, payload []byte, outcome string) error {
 	failureJSON, _ := json.Marshal(orphaned)
-	markDone := r.query(
+	markDone := tx.SQL(
 		`UPDATE adapter_targets SET state='moving',sync_status='converging',failure_names=?,active_job_id=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND state='moving' AND active_job_id=? AND provider_lease_job_id IS NULL`,
 		`UPDATE adapter_targets SET state='moving',sync_status='converging',failure_names=$1,active_job_id=NULL WHERE id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND generation=$6 AND state='moving' AND active_job_id=$7 AND provider_lease_job_id IS NULL`)
 	rows, err := tx.Exec(ctx, markDone, string(failureJSON), job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation, job.ID)
@@ -1342,7 +1284,7 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 		return err
 	}
 	var pendingScrubs int
-	countPending := r.query(
+	countPending := tx.SQL(
 		`SELECT COUNT(*) FROM adapter_outbox WHERE route_move_id=? AND org_id=? AND project_id=? AND kind='scrub' AND state IN ('queued','running')`,
 		`SELECT COUNT(*) FROM adapter_outbox WHERE route_move_id=$1 AND org_id=$2 AND project_id=$3 AND kind='scrub' AND state IN ('queued','running')`)
 	if err := tx.QueryRow(ctx, countPending, job.RouteMoveID, job.OrgID, job.ProjectID).Scan(&pendingScrubs); err != nil {
@@ -1351,7 +1293,7 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 	if pendingScrubs != 0 {
 		return nil
 	}
-	activateMove := r.query(
+	activateMove := tx.SQL(
 		`UPDATE adapter_route_moves SET state='activating' WHERE id=? AND org_id=? AND project_id=? AND kind='origin' AND target_id IS NULL AND state='scrubbing'`,
 		`UPDATE adapter_route_moves SET state='activating' WHERE id=$1 AND org_id=$2 AND project_id=$3 AND kind='origin' AND target_id IS NULL AND state='scrubbing'`)
 	rows, err = tx.Exec(ctx, activateMove, job.RouteMoveID, job.OrgID, job.ProjectID)
@@ -1361,7 +1303,7 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 	if rows != 1 {
 		return adapter.ErrSuperseded
 	}
-	targetQuery := r.query(
+	targetQuery := tx.SQL(
 		`SELECT t.id,t.environment_id,t.generation,m.authority_principal_id FROM adapter_route_move_targets mt JOIN adapter_route_moves m ON m.id=mt.move_id AND m.org_id=mt.org_id AND m.project_id=mt.project_id JOIN adapter_targets t ON t.id=mt.target_id AND t.org_id=mt.org_id AND t.project_id=mt.project_id AND t.environment_id=mt.environment_id WHERE mt.move_id=? AND mt.org_id=? AND mt.project_id=? AND t.state='moving' AND t.active_job_id IS NULL ORDER BY t.id`,
 		`SELECT t.id,t.environment_id,t.generation,m.authority_principal_id FROM adapter_route_move_targets mt JOIN adapter_route_moves m ON m.id=mt.move_id AND m.org_id=mt.org_id AND m.project_id=mt.project_id JOIN adapter_targets t ON t.id=mt.target_id AND t.org_id=mt.org_id AND t.project_id=mt.project_id AND t.environment_id=mt.environment_id WHERE mt.move_id=$1 AND mt.org_id=$2 AND mt.project_id=$3 AND t.state='moving' AND t.active_job_id IS NULL ORDER BY t.id FOR UPDATE OF t`)
 	targetRows, err := tx.Query(ctx, targetQuery, job.RouteMoveID, job.OrgID, job.ProjectID)
@@ -1376,23 +1318,23 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 	for targetRows.Next() {
 		var target activationTarget
 		if err := targetRows.Scan(&target.id, &target.environment, &target.generation, &target.authority); err != nil {
-			targetRows.Close()
+			_ = closeAdapterRows(targetRows)
 			return err
 		}
 		targets = append(targets, target)
 	}
 	if err := targetRows.Err(); err != nil {
-		targetRows.Close()
+		_ = closeAdapterRows(targetRows)
 		return err
 	}
-	targetRows.Close()
+	_ = closeAdapterRows(targetRows)
 	if len(targets) == 0 {
 		return adapter.ErrSuperseded
 	}
-	stamp := adapterTimestamp(r.db.Engine(), finished)
+	stamp := tx.Stamp(finished)
 	for _, target := range targets {
 		activateID := newAdapterID("job")
-		insert := r.query(
+		insert := tx.SQL(
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES (?,?,?,?,?,'activate',?,?,?,?,0,?,'queued',?)`,
 			`INSERT INTO adapter_outbox (id,org_id,project_id,environment_id,target_id,kind,route_move_id,authority_principal_id,generation,dedup_key,attempt_count,next_attempt_at,state,created_at) VALUES ($1,$2,$3,$4,$5,'activate',$6,$7,$8,$9,0,$10,'queued',$11)`)
 		rows, err = tx.Exec(ctx, insert, activateID, job.OrgID, job.ProjectID, target.environment, target.id, job.RouteMoveID, target.authority, target.generation, target.id, stamp, stamp)
@@ -1402,7 +1344,7 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 		if rows != 1 {
 			return ErrConflict
 		}
-		mark := r.query(
+		mark := tx.SQL(
 			`UPDATE adapter_targets SET active_job_id=? WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND state='moving' AND active_job_id IS NULL AND provider_lease_job_id IS NULL`,
 			`UPDATE adapter_targets SET active_job_id=$1 WHERE id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND generation=$6 AND state='moving' AND active_job_id IS NULL AND provider_lease_job_id IS NULL`)
 		rows, err = tx.Exec(ctx, mark, activateID, target.id, job.OrgID, job.ProjectID, target.environment, target.generation)
@@ -1417,28 +1359,28 @@ func (r *AdapterRuntime) finishOriginRouteMoveScrub(ctx context.Context, tx adap
 }
 
 func (r *AdapterRuntime) finishDeadCredentialScrub(ctx context.Context, tx adapterDBTX, job adapter.Job, finished time.Time) error {
-	orphaned, err := r.adapterLedgerNames(ctx, tx, job)
+	orphaned, err := adapterOrphans(ctx, tx, adapterJobScope(job), job.TargetID, job.EnvironmentID)
 	if err != nil {
 		return err
 	}
 	var adapterID string
-	lookup := r.query(
+	lookup := tx.SQL(
 		`SELECT adapter_id FROM adapter_targets WHERE id=? AND org_id=? AND project_id=? AND environment_id=?`,
 		`SELECT adapter_id FROM adapter_targets WHERE id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4`)
 	if err := tx.QueryRow(ctx, lookup, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID).Scan(&adapterID); err != nil {
 		return err
 	}
-	releaseLedger := r.query(
+	releaseLedger := tx.SQL(
 		`UPDATE adapter_ledger SET state='released',missing=0,updated_at=? WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released'`,
 		`UPDATE adapter_ledger SET state='released',missing=false,updated_at=$1 WHERE target_id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND state<>'released'`)
-	if _, err := tx.Exec(ctx, releaseLedger, adapterTimestamp(r.db.Engine(), finished), job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID); err != nil {
+	if _, err := tx.Exec(ctx, releaseLedger, tx.Stamp(finished), job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID); err != nil {
 		return err
 	}
 	if job.RouteMoveID != "" {
 		return r.finishRouteMoveScrub(ctx, tx, job, finished, orphaned)
 	}
 	failureJSON, _ := json.Marshal(orphaned)
-	markTarget := r.query(
+	markTarget := tx.SQL(
 		`UPDATE adapter_targets SET state='tombstoned',sync_status='failed',failure_names=?,active_job_id=NULL WHERE id=? AND org_id=? AND project_id=? AND environment_id=? AND generation=? AND provider_lease_job_id IS NULL`,
 		`UPDATE adapter_targets SET state='tombstoned',sync_status='failed',failure_names=$1,active_job_id=NULL WHERE id=$2 AND org_id=$3 AND project_id=$4 AND environment_id=$5 AND generation=$6 AND provider_lease_job_id IS NULL`)
 	rows, err := tx.Exec(ctx, markTarget, string(failureJSON), job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID, job.Generation)
@@ -1448,7 +1390,7 @@ func (r *AdapterRuntime) finishDeadCredentialScrub(ctx context.Context, tx adapt
 	if rows != 1 {
 		return adapter.ErrSuperseded
 	}
-	erase := r.query(
+	erase := tx.SQL(
 		`UPDATE adapters SET credential_ciphertext=NULL,credential_set_at=NULL WHERE id=? AND org_id=? AND project_id=? AND state='tombstoned' AND NOT EXISTS (SELECT 1 FROM adapter_targets WHERE adapter_id=? AND state<>'tombstoned') AND NOT EXISTS (SELECT 1 FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id WHERE t.adapter_id=? AND j.kind='scrub' AND j.state IN ('queued','running'))`,
 		`UPDATE adapters SET credential_ciphertext=NULL,credential_set_at=NULL WHERE id=$1 AND org_id=$2 AND project_id=$3 AND state='tombstoned' AND NOT EXISTS (SELECT 1 FROM adapter_targets WHERE adapter_id=$4 AND state<>'tombstoned') AND NOT EXISTS (SELECT 1 FROM adapter_outbox j JOIN adapter_targets t ON t.id=j.target_id AND t.org_id=j.org_id AND t.project_id=j.project_id AND t.environment_id=j.environment_id WHERE t.adapter_id=$5 AND j.kind='scrub' AND j.state IN ('queued','running'))`)
 	if _, err := tx.Exec(ctx, erase, adapterID, job.OrgID, job.ProjectID, adapterID, adapterID); err != nil {
@@ -1456,24 +1398,4 @@ func (r *AdapterRuntime) finishDeadCredentialScrub(ctx context.Context, tx adapt
 	}
 	payload, _ := json.Marshal(map[string][]string{"orphaned": orphaned})
 	return r.insertAdapterJobAudit(ctx, tx, job, "adapter.scrub", "failure", finished, payload)
-}
-
-func (r *AdapterRuntime) adapterLedgerNames(ctx context.Context, tx adapterDBTX, job adapter.Job) ([]string, error) {
-	query := r.query(
-		`SELECT surface,effective_name FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('owned','dispatched') ORDER BY surface,effective_name`,
-		`SELECT surface,effective_name FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state IN ('owned','dispatched') ORDER BY surface,effective_name`)
-	rows, err := tx.Query(ctx, query, job.TargetID, job.OrgID, job.ProjectID, job.EnvironmentID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var names []string
-	for rows.Next() {
-		var surface, name string
-		if err := rows.Scan(&surface, &name); err != nil {
-			return nil, err
-		}
-		names = append(names, surface+":"+name)
-	}
-	return names, rows.Err()
 }

--- a/internal/store/repos_adapters.go
+++ b/internal/store/repos_adapters.go
@@ -19,17 +19,26 @@ import (
 )
 
 type sqliteAdapters struct {
-	db  sqlitegen.DBTX
-	tok *authz.TxToken
+	adapterQueries
+	db sqlitegen.DBTX
 }
 
 type pgAdapters struct {
-	db  pggen.DBTX
+	adapterQueries
+	db pggen.DBTX
+}
+
+type adapterQueries struct {
+	db  adapterDB
 	tok *authz.TxToken
 }
 
-func (r sqliteRepos) Adapters() AdapterRepo { return sqliteAdapters{db: r.db, tok: r.tok} }
-func (r pgRepos) Adapters() AdapterRepo     { return pgAdapters{db: r.db, tok: r.tok} }
+func (r sqliteRepos) Adapters() AdapterRepo {
+	return sqliteAdapters{adapterQueries: adapterQueries{db: sqliteAdoptDB{db: r.db}, tok: r.tok}, db: r.db}
+}
+func (r pgRepos) Adapters() AdapterRepo {
+	return pgAdapters{adapterQueries: adapterQueries{db: pgAdoptDB{db: r.db}, tok: r.tok}, db: r.db}
+}
 
 func scanAdapterTarget(row interface{ Scan(...any) error }) (AdapterTarget, error) {
 	var target AdapterTarget
@@ -65,32 +74,40 @@ func scanAdapterTarget(row interface{ Scan(...any) error }) (AdapterTarget, erro
 	return target, nil
 }
 
-func (r sqliteAdapters) Target(ctx context.Context, p authz.Proof, targetID string) (AdapterTarget, error) {
+func closeAdapterRows(rows adapterTargetRows) error {
+	if rows, ok := rows.(interface{ Close() error }); ok {
+		return rows.Close()
+	}
+	if rows, ok := rows.(interface{ Close() }); ok {
+		rows.Close()
+	}
+	return nil
+}
+
+func (r adapterQueries) Target(ctx context.Context, p authz.Proof, targetID string) (AdapterTarget, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersTarget, r.tok)
 	if err != nil {
 		return AdapterTarget{}, err
 	}
-	return scanAdapterTarget(r.db.QueryRowContext(ctx, `SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=?`, targetID, chain.Org, chain.Project))
+	query := r.db.SQL(
+		`SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=?`,
+		`SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3`)
+	return scanAdapterTarget(r.db.QueryRow(ctx, query, targetID, chain.Org, chain.Project))
 }
 
-func (r pgAdapters) Target(ctx context.Context, p authz.Proof, targetID string) (AdapterTarget, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersTarget, r.tok)
-	if err != nil {
-		return AdapterTarget{}, err
-	}
-	return scanAdapterTarget(r.db.QueryRow(ctx, `SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3`, targetID, chain.Org, chain.Project))
-}
-
-func (r sqliteAdapters) ListAdaptersForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
+func (r adapterQueries) ListAdaptersForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersListForReencrypt, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT id, credential_ciphertext FROM adapters WHERE org_id=? AND project_id=? AND id>? ORDER BY id LIMIT ?`, chain.Org, chain.Project, cursor, limit)
+	query := r.db.SQL(
+		`SELECT id, credential_ciphertext FROM adapters WHERE org_id=? AND project_id=? AND id>? ORDER BY id LIMIT ?`,
+		`SELECT id, credential_ciphertext FROM adapters WHERE org_id=$1 AND project_id=$2 AND id>$3 ORDER BY id LIMIT $4`)
+	rows, err := r.db.Query(ctx, query, chain.Org, chain.Project, cursor, limit)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []ReencryptFieldRow
 	for rows.Next() {
 		var id string
@@ -103,29 +120,34 @@ func (r sqliteAdapters) ListAdaptersForReencrypt(ctx context.Context, p authz.Pr
 	return out, rows.Err()
 }
 
-func (r sqliteAdapters) ReencryptAdapter(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
+func (r adapterQueries) ReencryptAdapter(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersReencrypt, r.tok)
 	if err != nil {
 		return false, err
 	}
-	res, err := r.db.ExecContext(ctx, `UPDATE adapters SET credential_ciphertext=? WHERE org_id=? AND project_id=? AND id=? AND credential_ciphertext=?`, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
+	query := r.db.SQL(
+		`UPDATE adapters SET credential_ciphertext=? WHERE org_id=? AND project_id=? AND id=? AND credential_ciphertext=?`,
+		`UPDATE adapters SET credential_ciphertext=$1 WHERE org_id=$2 AND project_id=$3 AND id=$4 AND credential_ciphertext=$5`)
+	rows, err := r.db.Exec(ctx, query, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
 	if err != nil {
 		return false, err
 	}
-	n, err := res.RowsAffected()
-	return n == 1, err
+	return rows == 1, nil
 }
 
-func (r sqliteAdapters) ListRouteMovesForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
+func (r adapterQueries) ListRouteMovesForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersListMovesForReencrypt, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT id, adapter_id, pending_credential_ciphertext FROM adapter_route_moves WHERE org_id=? AND project_id=? AND id>? ORDER BY id LIMIT ?`, chain.Org, chain.Project, cursor, limit)
+	query := r.db.SQL(
+		`SELECT id, adapter_id, pending_credential_ciphertext FROM adapter_route_moves WHERE org_id=? AND project_id=? AND id>? ORDER BY id LIMIT ?`,
+		`SELECT id, adapter_id, pending_credential_ciphertext FROM adapter_route_moves WHERE org_id=$1 AND project_id=$2 AND id>$3 ORDER BY id LIMIT $4`)
+	rows, err := r.db.Query(ctx, query, chain.Org, chain.Project, cursor, limit)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []ReencryptFieldRow
 	for rows.Next() {
 		var id, adapterID string
@@ -138,118 +160,34 @@ func (r sqliteAdapters) ListRouteMovesForReencrypt(ctx context.Context, p authz.
 	return out, rows.Err()
 }
 
-func (r sqliteAdapters) ReencryptRouteMove(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
+func (r adapterQueries) ReencryptRouteMove(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersReencryptMove, r.tok)
 	if err != nil {
 		return false, err
 	}
-	res, err := r.db.ExecContext(ctx, `UPDATE adapter_route_moves SET pending_credential_ciphertext=? WHERE org_id=? AND project_id=? AND id=? AND pending_credential_ciphertext=?`, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
+	query := r.db.SQL(
+		`UPDATE adapter_route_moves SET pending_credential_ciphertext=? WHERE org_id=? AND project_id=? AND id=? AND pending_credential_ciphertext=?`,
+		`UPDATE adapter_route_moves SET pending_credential_ciphertext=$1 WHERE org_id=$2 AND project_id=$3 AND id=$4 AND pending_credential_ciphertext=$5`)
+	rows, err := r.db.Exec(ctx, query, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
 	if err != nil {
 		return false, err
 	}
-	n, err := res.RowsAffected()
-	return n == 1, err
+	return rows == 1, nil
 }
 
-func (r sqliteAdapters) Mapping(ctx context.Context, p authz.Proof, targetID string) ([]adapter.ManifestEntry, error) {
+func (r adapterQueries) Mapping(ctx context.Context, p authz.Proof, targetID string) ([]adapter.ManifestEntry, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersMapping, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=? AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id JOIN adapter_targets t ON t.id=k.target_id AND t.org_id=k.org_id AND t.project_id=k.project_id AND t.environment_id=k.environment_id WHERE t.org_id=? AND t.project_id=? AND e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=t.org_id AND project_id=t.project_id AND environment_id=t.environment_id AND payload_present=1 ORDER BY revision DESC LIMIT 1) ORDER BY e.key_name`, targetID, chain.Org, chain.Project)
+	query := r.db.SQL(
+		`SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=? AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id JOIN adapter_targets t ON t.id=k.target_id AND t.org_id=k.org_id AND t.project_id=k.project_id AND t.environment_id=k.environment_id WHERE t.org_id=? AND t.project_id=? AND e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=t.org_id AND project_id=t.project_id AND environment_id=t.environment_id AND payload_present=1 ORDER BY revision DESC LIMIT 1) ORDER BY e.key_name`,
+		`SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=$1 AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id JOIN adapter_targets t ON t.id=k.target_id AND t.org_id=k.org_id AND t.project_id=k.project_id AND t.environment_id=k.environment_id WHERE t.org_id=$2 AND t.project_id=$3 AND e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=t.org_id AND project_id=t.project_id AND environment_id=t.environment_id AND payload_present=true ORDER BY revision DESC LIMIT 1) ORDER BY e.key_name`)
+	rows, err := r.db.Query(ctx, query, targetID, chain.Org, chain.Project)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	var out []adapter.ManifestEntry
-	for rows.Next() {
-		var row adapter.ManifestEntry
-		if err := rows.Scan(&row.KeyID, &row.CanonicalName, &row.Classification); err != nil {
-			return nil, err
-		}
-		out = append(out, row)
-	}
-	return out, rows.Err()
-}
-
-func (r pgAdapters) ListAdaptersForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersListForReencrypt, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT id, credential_ciphertext FROM adapters WHERE org_id=$1 AND project_id=$2 AND id>$3 ORDER BY id LIMIT $4`, chain.Org, chain.Project, cursor, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []ReencryptFieldRow
-	for rows.Next() {
-		var id string
-		var ct []byte
-		if err := rows.Scan(&id, &ct); err != nil {
-			return nil, err
-		}
-		out = append(out, ReencryptFieldRow{ID: id, Owner: id, Ciphertext: ct})
-	}
-	return out, rows.Err()
-}
-
-func (r pgAdapters) ReencryptAdapter(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersReencrypt, r.tok)
-	if err != nil {
-		return false, err
-	}
-	tag, err := r.db.Exec(ctx, `UPDATE adapters SET credential_ciphertext=$1 WHERE org_id=$2 AND project_id=$3 AND id=$4 AND credential_ciphertext=$5`, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
-	if err != nil {
-		return false, err
-	}
-	return tag.RowsAffected() == 1, nil
-}
-
-func (r pgAdapters) ListRouteMovesForReencrypt(ctx context.Context, p authz.Proof, cursor string, limit int) ([]ReencryptFieldRow, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersListMovesForReencrypt, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT id, adapter_id, pending_credential_ciphertext FROM adapter_route_moves WHERE org_id=$1 AND project_id=$2 AND id>$3 ORDER BY id LIMIT $4`, chain.Org, chain.Project, cursor, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []ReencryptFieldRow
-	for rows.Next() {
-		var id, adapterID string
-		var ct []byte
-		if err := rows.Scan(&id, &adapterID, &ct); err != nil {
-			return nil, err
-		}
-		out = append(out, ReencryptFieldRow{ID: id, Owner: adapterID, Ciphertext: ct})
-	}
-	return out, rows.Err()
-}
-
-func (r pgAdapters) ReencryptRouteMove(ctx context.Context, p authz.Proof, id string, newCiphertext, oldCiphertext []byte) (bool, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersReencryptMove, r.tok)
-	if err != nil {
-		return false, err
-	}
-	tag, err := r.db.Exec(ctx, `UPDATE adapter_route_moves SET pending_credential_ciphertext=$1 WHERE org_id=$2 AND project_id=$3 AND id=$4 AND pending_credential_ciphertext=$5`, newCiphertext, chain.Org, chain.Project, id, oldCiphertext)
-	if err != nil {
-		return false, err
-	}
-	return tag.RowsAffected() == 1, nil
-}
-
-func (r pgAdapters) Mapping(ctx context.Context, p authz.Proof, targetID string) ([]adapter.ManifestEntry, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersMapping, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=$1 AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id JOIN adapter_targets t ON t.id=k.target_id AND t.org_id=k.org_id AND t.project_id=k.project_id AND t.environment_id=k.environment_id WHERE t.org_id=$2 AND t.project_id=$3 AND e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=t.org_id AND project_id=t.project_id AND environment_id=t.environment_id AND payload_present=true ORDER BY revision DESC LIMIT 1) ORDER BY e.key_name`, targetID, chain.Org, chain.Project)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []adapter.ManifestEntry
 	for rows.Next() {
 		var row adapter.ManifestEntry
@@ -263,69 +201,49 @@ func (r pgAdapters) Mapping(ctx context.Context, p authz.Proof, targetID string)
 	return out, rows.Err()
 }
 
-func (r sqliteAdapters) PlanMaterial(ctx context.Context, p authz.Proof, targetID string) (AdapterPlanMaterial, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersPlanMaterial, r.tok)
-	if err != nil {
-		return AdapterPlanMaterial{}, err
+func scanAdapterLedgerEntry(row interface{ Scan(...any) error }) (adapter.LedgerEntry, error) {
+	var entry adapter.LedgerEntry
+	var surface, state string
+	var missing any
+	if err := row.Scan(&surface, &entry.EffectiveName, &state, &missing); err != nil {
+		return adapter.LedgerEntry{}, err
 	}
-	target, err := scanAdapterTarget(r.db.QueryRowContext(ctx, `SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=?`, targetID, chain.Org, chain.Project))
-	if err != nil {
-		return AdapterPlanMaterial{}, err
+	switch value := missing.(type) {
+	case bool:
+		entry.Missing = value
+	case int64:
+		entry.Missing = value != 0
+	default:
+		return adapter.LedgerEntry{}, fmt.Errorf("store: adapter ledger missing has unsupported type %T", missing)
 	}
-	var credential []byte
-	if err := r.db.QueryRowContext(ctx, `SELECT credential_ciphertext FROM adapters WHERE id=? AND org_id=? AND project_id=?`, target.AdapterID, chain.Org, chain.Project).Scan(&credential); err != nil {
-		return AdapterPlanMaterial{}, err
-	}
-	out := AdapterPlanMaterial{Target: target, CredentialCiphertext: credential}
-	manifestRows, err := r.db.QueryContext(ctx, `SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=? AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=? AND project_id=? AND environment_id=? AND payload_present=1 ORDER BY revision DESC LIMIT 1) AND e.org_id=? AND e.project_id=? AND e.environment_id=? ORDER BY e.key_name`, targetID, chain.Org, chain.Project, target.EnvironmentID, chain.Org, chain.Project, target.EnvironmentID)
-	if err != nil {
-		return AdapterPlanMaterial{}, err
-	}
-	for manifestRows.Next() {
-		var row adapter.ManifestEntry
-		if err := manifestRows.Scan(&row.KeyID, &row.CanonicalName, &row.Classification); err != nil {
-			_ = manifestRows.Close()
-			return AdapterPlanMaterial{}, err
-		}
-		out.Manifest = append(out.Manifest, row)
-	}
-	if err := manifestRows.Close(); err != nil {
-		return AdapterPlanMaterial{}, err
-	}
-	ledgerRows, err := r.db.QueryContext(ctx, `SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released' ORDER BY surface,effective_name`, targetID, chain.Org, chain.Project, target.EnvironmentID)
-	if err != nil {
-		return AdapterPlanMaterial{}, err
-	}
-	defer ledgerRows.Close()
-	for ledgerRows.Next() {
-		var surface, state string
-		var row adapter.LedgerEntry
-		var missing int
-		if err := ledgerRows.Scan(&surface, &row.EffectiveName, &state, &missing); err != nil {
-			return AdapterPlanMaterial{}, err
-		}
-		row.Missing = missing != 0
-		row.Surface, row.State = adapter.Surface(surface), adapter.LedgerState(state)
-		out.Ledger = append(out.Ledger, row)
-	}
-	return out, ledgerRows.Err()
+	entry.Surface, entry.State = adapter.Surface(surface), adapter.LedgerState(state)
+	return entry, nil
 }
 
-func (r pgAdapters) PlanMaterial(ctx context.Context, p authz.Proof, targetID string) (AdapterPlanMaterial, error) {
+func (r adapterQueries) PlanMaterial(ctx context.Context, p authz.Proof, targetID string) (AdapterPlanMaterial, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersPlanMaterial, r.tok)
 	if err != nil {
 		return AdapterPlanMaterial{}, err
 	}
-	target, err := scanAdapterTarget(r.db.QueryRow(ctx, `SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3`, targetID, chain.Org, chain.Project))
+	targetQuery := r.db.SQL(
+		`SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=?`,
+		`SELECT `+adapterTargetColumns+` FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$1 AND t.org_id=$2 AND t.project_id=$3`)
+	target, err := scanAdapterTarget(r.db.QueryRow(ctx, targetQuery, targetID, chain.Org, chain.Project))
 	if err != nil {
 		return AdapterPlanMaterial{}, err
 	}
+	credentialQuery := r.db.SQL(
+		`SELECT credential_ciphertext FROM adapters WHERE id=? AND org_id=? AND project_id=?`,
+		`SELECT credential_ciphertext FROM adapters WHERE id=$1 AND org_id=$2 AND project_id=$3`)
 	var credential []byte
-	if err := r.db.QueryRow(ctx, `SELECT credential_ciphertext FROM adapters WHERE id=$1 AND org_id=$2 AND project_id=$3`, target.AdapterID, chain.Org, chain.Project).Scan(&credential); err != nil {
+	if err := r.db.QueryRow(ctx, credentialQuery, target.AdapterID, chain.Org, chain.Project).Scan(&credential); err != nil {
 		return AdapterPlanMaterial{}, err
 	}
 	out := AdapterPlanMaterial{Target: target, CredentialCiphertext: credential}
-	manifestRows, err := r.db.Query(ctx, `SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=$1 AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=$2 AND project_id=$3 AND environment_id=$4 AND payload_present=true ORDER BY revision DESC LIMIT 1) AND e.org_id=$5 AND e.project_id=$6 AND e.environment_id=$7 ORDER BY e.key_name`, targetID, chain.Org, chain.Project, target.EnvironmentID, chain.Org, chain.Project, target.EnvironmentID)
+	manifestQuery := r.db.SQL(
+		`SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=? AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=? AND project_id=? AND environment_id=? AND payload_present=1 ORDER BY revision DESC LIMIT 1) AND e.org_id=? AND e.project_id=? AND e.environment_id=? ORDER BY e.key_name`,
+		`SELECT e.key_id,e.key_name,e.classification FROM snapshot_entries e JOIN adapter_target_keys k ON k.key_id=e.key_id AND k.target_id=$1 AND k.org_id=e.org_id AND k.project_id=e.project_id AND k.environment_id=e.environment_id WHERE e.snapshot_id=(SELECT id FROM snapshots WHERE org_id=$2 AND project_id=$3 AND environment_id=$4 AND payload_present=true ORDER BY revision DESC LIMIT 1) AND e.org_id=$5 AND e.project_id=$6 AND e.environment_id=$7 ORDER BY e.key_name`)
+	manifestRows, err := r.db.Query(ctx, manifestQuery, targetID, chain.Org, chain.Project, target.EnvironmentID, chain.Org, chain.Project, target.EnvironmentID)
 	if err != nil {
 		return AdapterPlanMaterial{}, err
 	}
@@ -333,43 +251,49 @@ func (r pgAdapters) PlanMaterial(ctx context.Context, p authz.Proof, targetID st
 		var row adapter.ManifestEntry
 		var classification string
 		if err := manifestRows.Scan(&row.KeyID, &row.CanonicalName, &classification); err != nil {
-			manifestRows.Close()
+			_ = closeAdapterRows(manifestRows)
 			return AdapterPlanMaterial{}, err
 		}
 		row.Classification = adapter.Classification(classification)
 		out.Manifest = append(out.Manifest, row)
 	}
-	manifestRows.Close()
+	if err := closeAdapterRows(manifestRows); err != nil {
+		return AdapterPlanMaterial{}, err
+	}
 	if err := manifestRows.Err(); err != nil {
 		return AdapterPlanMaterial{}, err
 	}
-	ledgerRows, err := r.db.Query(ctx, `SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state<>'released' ORDER BY surface,effective_name`, targetID, chain.Org, chain.Project, target.EnvironmentID)
+	ledgerQuery := r.db.SQL(
+		`SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state<>'released' ORDER BY surface,effective_name`,
+		`SELECT surface,effective_name,state,missing FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state<>'released' ORDER BY surface,effective_name`)
+	ledgerRows, err := r.db.Query(ctx, ledgerQuery, targetID, chain.Org, chain.Project, target.EnvironmentID)
 	if err != nil {
 		return AdapterPlanMaterial{}, err
 	}
-	defer ledgerRows.Close()
+	defer closeAdapterRows(ledgerRows)
 	for ledgerRows.Next() {
-		var surface, state string
-		var row adapter.LedgerEntry
-		if err := ledgerRows.Scan(&surface, &row.EffectiveName, &state, &row.Missing); err != nil {
+		row, err := scanAdapterLedgerEntry(ledgerRows)
+		if err != nil {
 			return AdapterPlanMaterial{}, err
 		}
-		row.Surface, row.State = adapter.Surface(surface), adapter.LedgerState(state)
 		out.Ledger = append(out.Ledger, row)
 	}
 	return out, ledgerRows.Err()
 }
 
-func (r sqliteAdapters) TargetEnvironments(ctx context.Context, p authz.Proof, targetID string) ([]string, error) {
+func (r adapterQueries) TargetEnvironments(ctx context.Context, p authz.Proof, targetID string) ([]string, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersTargetEnvironments, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT sibling.environment_id FROM adapter_targets target JOIN adapter_targets sibling ON sibling.adapter_id=target.adapter_id AND sibling.org_id=target.org_id AND sibling.project_id=target.project_id WHERE target.id=? AND target.org_id=? AND target.project_id=? AND sibling.state<>'tombstoned' ORDER BY sibling.environment_id`, targetID, chain.Org, chain.Project)
+	query := r.db.SQL(
+		`SELECT sibling.environment_id FROM adapter_targets target JOIN adapter_targets sibling ON sibling.adapter_id=target.adapter_id AND sibling.org_id=target.org_id AND sibling.project_id=target.project_id WHERE target.id=? AND target.org_id=? AND target.project_id=? AND sibling.state<>'tombstoned' ORDER BY sibling.environment_id`,
+		`SELECT sibling.environment_id FROM adapter_targets target JOIN adapter_targets sibling ON sibling.adapter_id=target.adapter_id AND sibling.org_id=target.org_id AND sibling.project_id=target.project_id WHERE target.id=$1 AND target.org_id=$2 AND target.project_id=$3 AND sibling.state<>'tombstoned' ORDER BY sibling.environment_id`)
+	rows, err := r.db.Query(ctx, query, targetID, chain.Org, chain.Project)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []string
 	for rows.Next() {
 		var id string
@@ -381,58 +305,19 @@ func (r sqliteAdapters) TargetEnvironments(ctx context.Context, p authz.Proof, t
 	return out, rows.Err()
 }
 
-func (r pgAdapters) TargetEnvironments(ctx context.Context, p authz.Proof, targetID string) ([]string, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersTargetEnvironments, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT sibling.environment_id FROM adapter_targets target JOIN adapter_targets sibling ON sibling.adapter_id=target.adapter_id AND sibling.org_id=target.org_id AND sibling.project_id=target.project_id WHERE target.id=$1 AND target.org_id=$2 AND target.project_id=$3 AND sibling.state<>'tombstoned' ORDER BY sibling.environment_id`, targetID, chain.Org, chain.Project)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		out = append(out, id)
-	}
-	return out, rows.Err()
-}
-
-func (r sqliteAdapters) Environments(ctx context.Context, p authz.Proof, adapterID string) ([]string, error) {
+func (r adapterQueries) Environments(ctx context.Context, p authz.Proof, adapterID string) ([]string, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersEnvironments, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT DISTINCT environment_id FROM adapter_targets WHERE adapter_id=? AND org_id=? AND project_id=? AND state='active' ORDER BY environment_id`, adapterID, chain.Org, chain.Project)
+	query := r.db.SQL(
+		`SELECT DISTINCT environment_id FROM adapter_targets WHERE adapter_id=? AND org_id=? AND project_id=? AND state='active' ORDER BY environment_id`,
+		`SELECT DISTINCT environment_id FROM adapter_targets WHERE adapter_id=$1 AND org_id=$2 AND project_id=$3 AND state='active' ORDER BY environment_id`)
+	rows, err := r.db.Query(ctx, query, adapterID, chain.Org, chain.Project)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		out = append(out, id)
-	}
-	return out, rows.Err()
-}
-
-func (r pgAdapters) Environments(ctx context.Context, p authz.Proof, adapterID string) ([]string, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersEnvironments, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT DISTINCT environment_id FROM adapter_targets WHERE adapter_id=$1 AND org_id=$2 AND project_id=$3 AND state='active' ORDER BY environment_id`, adapterID, chain.Org, chain.Project)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []string
 	for rows.Next() {
 		var id string
@@ -490,29 +375,19 @@ func collectAdapterConflicts(rows conflictScanner) ([]AdapterConflictArtifact, e
 	return out, rows.Err()
 }
 
-func (r sqliteAdapters) Conflicts(ctx context.Context, p authz.Proof, targetID string) ([]AdapterConflictArtifact, error) {
+func (r adapterQueries) Conflicts(ctx context.Context, p authz.Proof, targetID string) ([]AdapterConflictArtifact, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersConflicts, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT artifact_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at FROM adapter_conflicts WHERE target_id=? AND org_id=? AND project_id=? AND adopted_at IS NULL ORDER BY created_at,artifact_id,surface,effective_name`, targetID, chain.Org, chain.Project)
+	query := r.db.SQL(
+		`SELECT artifact_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at FROM adapter_conflicts WHERE target_id=? AND org_id=? AND project_id=? AND adopted_at IS NULL ORDER BY created_at,artifact_id,surface,effective_name`,
+		`SELECT artifact_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at FROM adapter_conflicts WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND adopted_at IS NULL ORDER BY created_at,artifact_id,surface,effective_name`)
+	rows, err := r.db.Query(ctx, query, targetID, chain.Org, chain.Project)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	return collectAdapterConflicts(rows)
-}
-
-func (r pgAdapters) Conflicts(ctx context.Context, p authz.Proof, targetID string) ([]AdapterConflictArtifact, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersConflicts, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT artifact_id,target_id,job_id,destination_id,repository_id,target_generation,surface,effective_name,created_at FROM adapter_conflicts WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND adopted_at IS NULL ORDER BY created_at,artifact_id,surface,effective_name`, targetID, chain.Org, chain.Project)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	return collectAdapterConflicts(rows)
 }
 
@@ -532,7 +407,7 @@ func (r pgAdapters) RecordPlan(ctx context.Context, p authz.Proof, targetID, art
 	return recordAdapterPlan(ctx, pgAdoptDB{db: r.db}, chain, targetID, artifactID, expectedGeneration, expectedRepositoryID, expectedDestinationID, entries, at)
 }
 
-func recordAdapterPlan(ctx context.Context, db adoptDB, chain domain.Scope, targetID, artifactID string, expectedGeneration, expectedRepositoryID, expectedDestinationID int64, entries []AdapterConflictEntry, at time.Time) error {
+func recordAdapterPlan(ctx context.Context, db adapterDB, chain domain.Scope, targetID, artifactID string, expectedGeneration, expectedRepositoryID, expectedDestinationID int64, entries []AdapterConflictEntry, at time.Time) error {
 	if targetID == "" || artifactID == "" || expectedGeneration <= 0 || expectedDestinationID <= 0 || at.IsZero() {
 		return fmt.Errorf("%w: incomplete adapter plan artifact", ErrConflict)
 	}
@@ -607,12 +482,16 @@ func (r pgAdapters) Adopt(ctx context.Context, p authz.Proof, adoption AdapterAd
 	return adoptAdapter(ctx, pgAdoptDB{db: r.db}, chain, adoption)
 }
 
-type adoptDB interface {
+type adapterDialect interface {
+	SQL(string, string) string
+	Stamp(time.Time) any
+}
+
+type adapterDB interface {
 	QueryRow(context.Context, string, ...any) interface{ Scan(...any) error }
 	Query(context.Context, string, ...any) (adapterTargetRows, error)
 	Exec(context.Context, string, ...any) (int64, error)
-	SQL(string, string) string
-	Stamp(time.Time) any
+	adapterDialect
 }
 
 type sqliteAdoptDB struct{ db sqlitegen.DBTX }
@@ -651,7 +530,7 @@ func (d pgAdoptDB) Exec(ctx context.Context, query string, args ...any) (int64, 
 func (pgAdoptDB) SQL(_, postgresQuery string) string { return postgresQuery }
 func (pgAdoptDB) Stamp(value time.Time) any          { return CanonTime(value) }
 
-func adoptAdapter(ctx context.Context, db adoptDB, chain domain.Scope, adoption AdapterAdoption) (AdapterAdoptionResult, error) {
+func adoptAdapter(ctx context.Context, db adapterDB, chain domain.Scope, adoption AdapterAdoption) (AdapterAdoptionResult, error) {
 	var adapterID, environmentID, origin, destinationKind, priorJob string
 	var destinationID, repositoryID, generation int64
 	var providerBusy int
@@ -743,12 +622,15 @@ type publishedAdapterTarget struct {
 	generation                              int64
 }
 
-func (r sqliteAdapters) EnqueuePublished(ctx context.Context, p authz.Proof, at time.Time) ([]AdapterEnqueueResult, error) {
+func (r adapterQueries) EnqueuePublished(ctx context.Context, p authz.Proof, at time.Time) ([]AdapterEnqueueResult, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersEnqueuePublished, r.tok)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,'') FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.state='active' ORDER BY t.id`, chain.Org, chain.Project, chain.Env)
+	query := r.db.SQL(
+		`SELECT t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,'') FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.org_id=? AND t.project_id=? AND t.environment_id=? AND t.state='active' ORDER BY t.id`,
+		`SELECT t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,'') FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.org_id=$1 AND t.project_id=$2 AND t.environment_id=$3 AND t.state='active' ORDER BY t.id FOR UPDATE OF t`)
+	rows, err := r.db.Query(ctx, query, chain.Org, chain.Project, chain.Env)
 	if err != nil {
 		return nil, err
 	}
@@ -756,43 +638,21 @@ func (r sqliteAdapters) EnqueuePublished(ctx context.Context, p authz.Proof, at 
 	for rows.Next() {
 		var target publishedAdapterTarget
 		if err := rows.Scan(&target.id, &target.environmentID, &target.authority, &target.generation, &target.activeJob); err != nil {
-			_ = rows.Close()
+			_ = closeAdapterRows(rows)
 			return nil, err
 		}
 		targets = append(targets, target)
 	}
-	if err := rows.Close(); err != nil {
+	if err := closeAdapterRows(rows); err != nil {
 		return nil, err
 	}
-	return enqueuePublishedTargets(ctx, sqliteAdoptDB{db: r.db}, chain, targets, at)
-}
-
-func (r pgAdapters) EnqueuePublished(ctx context.Context, p authz.Proof, at time.Time) ([]AdapterEnqueueResult, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersEnqueuePublished, r.tok)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,'') FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.org_id=$1 AND t.project_id=$2 AND t.environment_id=$3 AND t.state='active' ORDER BY t.id FOR UPDATE OF t`, chain.Org, chain.Project, chain.Env)
-	if err != nil {
-		return nil, err
-	}
-	var targets []publishedAdapterTarget
-	for rows.Next() {
-		var target publishedAdapterTarget
-		if err := rows.Scan(&target.id, &target.environmentID, &target.authority, &target.generation, &target.activeJob); err != nil {
-			rows.Close()
-			return nil, err
-		}
-		targets = append(targets, target)
-	}
-	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return enqueuePublishedTargets(ctx, pgAdoptDB{db: r.db}, chain, targets, at)
+	return enqueuePublishedTargets(ctx, r.db, chain, targets, at)
 }
 
-func enqueuePublishedTargets(ctx context.Context, db adoptDB, chain domain.Scope, targets []publishedAdapterTarget, at time.Time) ([]AdapterEnqueueResult, error) {
+func enqueuePublishedTargets(ctx context.Context, db adapterDB, chain domain.Scope, targets []publishedAdapterTarget, at time.Time) ([]AdapterEnqueueResult, error) {
 	stamp := db.Stamp(at)
 	out := make([]AdapterEnqueueResult, 0, len(targets))
 	for _, target := range targets {
@@ -853,7 +713,7 @@ func (r pgAdapters) EnqueueManual(ctx context.Context, p authz.Proof, targetID, 
 	return enqueueManualTarget(ctx, pgAdoptDB{db: r.db}, chain, targetID, authorityPrincipalID, at)
 }
 
-func enqueueManualTarget(ctx context.Context, db adoptDB, chain domain.Scope, targetID, authorityPrincipalID string, at time.Time) (AdapterEnqueueResult, error) {
+func enqueueManualTarget(ctx context.Context, db adapterDB, chain domain.Scope, targetID, authorityPrincipalID string, at time.Time) (AdapterEnqueueResult, error) {
 	if targetID == "" || authorityPrincipalID == "" {
 		return AdapterEnqueueResult{}, fmt.Errorf("%w: manual adapter sync requires target and authority", domain.ErrInvalid)
 	}
@@ -887,60 +747,48 @@ type adapterTeardownTarget struct {
 	orphaned                                                 []string
 }
 
-func (r sqliteAdapters) TeardownTarget(ctx context.Context, p authz.Proof, targetID string, keepRemote bool, at time.Time) (AdapterTeardownResult, error) {
+func (r adapterQueries) TeardownTarget(ctx context.Context, p authz.Proof, targetID string, keepRemote bool, at time.Time) (AdapterTeardownResult, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersTeardownTarget, r.tok)
 	if err != nil {
 		return AdapterTeardownResult{}, err
 	}
 	var target adapterTeardownTarget
-	err = r.db.QueryRowContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.state='active'`, adapterTimestamp(EngineSQLite, at), targetID, chain.Org, chain.Project).Scan(
+	query := r.db.SQL(
+		`SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=? AND t.org_id=? AND t.project_id=? AND t.state='active'`,
+		`SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>$1 THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.state='active' FOR UPDATE OF t`)
+	err = r.db.QueryRow(ctx, query, r.db.Stamp(at), targetID, chain.Org, chain.Project).Scan(
 		&target.adapterID, &target.targetID, &target.environmentID, &target.authority, &target.generation, &target.activeJob, &target.providerBusy)
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 		return AdapterTeardownResult{}, ErrNotFound
 	}
 	if err != nil {
 		return AdapterTeardownResult{}, err
 	}
-	target.orphaned, err = sqliteAdapterOrphans(ctx, r.db, chain, target.targetID, target.environmentID)
+	target.orphaned, err = adapterOrphans(ctx, r.db, chain, target.targetID, target.environmentID)
 	if err != nil {
 		return AdapterTeardownResult{}, err
 	}
-	return teardownAdapterTarget(ctx, sqliteAdoptDB{db: r.db}, chain, target, keepRemote, at)
+	return teardownAdapterTarget(ctx, r.db, chain, target, keepRemote, at)
 }
 
-func (r pgAdapters) TeardownTarget(ctx context.Context, p authz.Proof, targetID string, keepRemote bool, at time.Time) (AdapterTeardownResult, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersTeardownTarget, r.tok)
-	if err != nil {
-		return AdapterTeardownResult{}, err
-	}
-	var target adapterTeardownTarget
-	err = r.db.QueryRow(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>$1 THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.state='active' FOR UPDATE OF t`, CanonTime(at), targetID, chain.Org, chain.Project).Scan(
-		&target.adapterID, &target.targetID, &target.environmentID, &target.authority, &target.generation, &target.activeJob, &target.providerBusy)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return AdapterTeardownResult{}, ErrNotFound
-	}
-	if err != nil {
-		return AdapterTeardownResult{}, err
-	}
-	target.orphaned, err = pgAdapterOrphans(ctx, r.db, chain, target.targetID, target.environmentID)
-	if err != nil {
-		return AdapterTeardownResult{}, err
-	}
-	return teardownAdapterTarget(ctx, pgAdoptDB{db: r.db}, chain, target, keepRemote, at)
-}
-
-func (r sqliteAdapters) TeardownAdapter(ctx context.Context, p authz.Proof, adapterID string, keepRemote bool, at time.Time) (AdapterTeardownBatch, error) {
+func (r adapterQueries) TeardownAdapter(ctx context.Context, p authz.Proof, adapterID string, keepRemote bool, at time.Time) (AdapterTeardownBatch, error) {
 	chain, err := authz.Verify(p, authz.StoreAdaptersTeardownAdapter, r.tok)
 	if err != nil {
 		return AdapterTeardownBatch{}, err
 	}
+	authorityQuery := r.db.SQL(
+		`SELECT authority_principal_id FROM adapters WHERE id=? AND org_id=? AND project_id=? AND state='active'`,
+		`SELECT authority_principal_id FROM adapters WHERE id=$1 AND org_id=$2 AND project_id=$3 AND state='active' FOR UPDATE`)
 	var authority string
-	if err := r.db.QueryRowContext(ctx, `SELECT authority_principal_id FROM adapters WHERE id=? AND org_id=? AND project_id=? AND state='active'`, adapterID, chain.Org, chain.Project).Scan(&authority); errors.Is(err, sql.ErrNoRows) {
+	if err := r.db.QueryRow(ctx, authorityQuery, adapterID, chain.Org, chain.Project).Scan(&authority); errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 		return AdapterTeardownBatch{}, ErrNotFound
 	} else if err != nil {
 		return AdapterTeardownBatch{}, err
 	}
-	rows, err := r.db.QueryContext(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=? AND t.org_id=? AND t.project_id=? AND t.state='active' ORDER BY t.id`, adapterTimestamp(EngineSQLite, at), adapterID, chain.Org, chain.Project)
+	targetsQuery := r.db.SQL(
+		`SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>? THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=? AND t.org_id=? AND t.project_id=? AND t.state='active' ORDER BY t.id`,
+		`SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>$1 THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.state='active' ORDER BY t.id FOR UPDATE OF t`)
+	rows, err := r.db.Query(ctx, targetsQuery, r.db.Stamp(at), adapterID, chain.Org, chain.Project)
 	if err != nil {
 		return AdapterTeardownBatch{}, err
 	}
@@ -948,66 +796,35 @@ func (r sqliteAdapters) TeardownAdapter(ctx context.Context, p authz.Proof, adap
 	for rows.Next() {
 		var target adapterTeardownTarget
 		if err := rows.Scan(&target.adapterID, &target.targetID, &target.environmentID, &target.authority, &target.generation, &target.activeJob, &target.providerBusy); err != nil {
-			_ = rows.Close()
+			_ = closeAdapterRows(rows)
 			return AdapterTeardownBatch{}, err
 		}
 		targets = append(targets, target)
 	}
-	if err := rows.Close(); err != nil {
+	if err := closeAdapterRows(rows); err != nil {
 		return AdapterTeardownBatch{}, err
 	}
-	for i := range targets {
-		targets[i].orphaned, err = sqliteAdapterOrphans(ctx, r.db, chain, targets[i].targetID, targets[i].environmentID)
-		if err != nil {
-			return AdapterTeardownBatch{}, err
-		}
-	}
-	return teardownWholeAdapter(ctx, sqliteAdoptDB{db: r.db}, chain, adapterID, authority, targets, keepRemote, at)
-}
-
-func (r pgAdapters) TeardownAdapter(ctx context.Context, p authz.Proof, adapterID string, keepRemote bool, at time.Time) (AdapterTeardownBatch, error) {
-	chain, err := authz.Verify(p, authz.StoreAdaptersTeardownAdapter, r.tok)
-	if err != nil {
-		return AdapterTeardownBatch{}, err
-	}
-	var authority string
-	if err := r.db.QueryRow(ctx, `SELECT authority_principal_id FROM adapters WHERE id=$1 AND org_id=$2 AND project_id=$3 AND state='active' FOR UPDATE`, adapterID, chain.Org, chain.Project).Scan(&authority); errors.Is(err, pgx.ErrNoRows) {
-		return AdapterTeardownBatch{}, ErrNotFound
-	} else if err != nil {
-		return AdapterTeardownBatch{}, err
-	}
-	rows, err := r.db.Query(ctx, `SELECT t.adapter_id,t.id,t.environment_id,a.authority_principal_id,t.generation,COALESCE(t.active_job_id,''),CASE WHEN t.provider_lease_job_id IS NOT NULL AND t.provider_lease_expires_at>$1 THEN 1 ELSE 0 END FROM adapter_targets t JOIN adapters a ON a.id=t.adapter_id AND a.org_id=t.org_id AND a.project_id=t.project_id WHERE t.adapter_id=$2 AND t.org_id=$3 AND t.project_id=$4 AND t.state='active' ORDER BY t.id FOR UPDATE OF t`, CanonTime(at), adapterID, chain.Org, chain.Project)
-	if err != nil {
-		return AdapterTeardownBatch{}, err
-	}
-	var targets []adapterTeardownTarget
-	for rows.Next() {
-		var target adapterTeardownTarget
-		if err := rows.Scan(&target.adapterID, &target.targetID, &target.environmentID, &target.authority, &target.generation, &target.activeJob, &target.providerBusy); err != nil {
-			rows.Close()
-			return AdapterTeardownBatch{}, err
-		}
-		targets = append(targets, target)
-	}
-	rows.Close()
 	if err := rows.Err(); err != nil {
 		return AdapterTeardownBatch{}, err
 	}
 	for i := range targets {
-		targets[i].orphaned, err = pgAdapterOrphans(ctx, r.db, chain, targets[i].targetID, targets[i].environmentID)
+		targets[i].orphaned, err = adapterOrphans(ctx, r.db, chain, targets[i].targetID, targets[i].environmentID)
 		if err != nil {
 			return AdapterTeardownBatch{}, err
 		}
 	}
-	return teardownWholeAdapter(ctx, pgAdoptDB{db: r.db}, chain, adapterID, authority, targets, keepRemote, at)
+	return teardownWholeAdapter(ctx, r.db, chain, adapterID, authority, targets, keepRemote, at)
 }
 
-func sqliteAdapterOrphans(ctx context.Context, db sqlitegen.DBTX, chain domain.Scope, targetID, environmentID string) ([]string, error) {
-	rows, err := db.QueryContext(ctx, `SELECT surface,effective_name FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('owned','dispatched') ORDER BY surface,effective_name`, targetID, chain.Org, chain.Project, environmentID)
+func adapterOrphans(ctx context.Context, db adapterDB, chain domain.Scope, targetID, environmentID string) ([]string, error) {
+	query := db.SQL(
+		`SELECT surface,effective_name FROM adapter_ledger WHERE target_id=? AND org_id=? AND project_id=? AND environment_id=? AND state IN ('owned','dispatched') ORDER BY surface,effective_name`,
+		`SELECT surface,effective_name FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state IN ('owned','dispatched') ORDER BY surface,effective_name`)
+	rows, err := db.Query(ctx, query, targetID, chain.Org, chain.Project, environmentID)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer closeAdapterRows(rows)
 	var out []string
 	for rows.Next() {
 		var surface, name string
@@ -1019,24 +836,7 @@ func sqliteAdapterOrphans(ctx context.Context, db sqlitegen.DBTX, chain domain.S
 	return out, rows.Err()
 }
 
-func pgAdapterOrphans(ctx context.Context, db pggen.DBTX, chain domain.Scope, targetID, environmentID string) ([]string, error) {
-	rows, err := db.Query(ctx, `SELECT surface,effective_name FROM adapter_ledger WHERE target_id=$1 AND org_id=$2 AND project_id=$3 AND environment_id=$4 AND state IN ('owned','dispatched') ORDER BY surface,effective_name`, targetID, chain.Org, chain.Project, environmentID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var surface, name string
-		if err := rows.Scan(&surface, &name); err != nil {
-			return nil, err
-		}
-		out = append(out, surface+":"+name)
-	}
-	return out, rows.Err()
-}
-
-func teardownAdapterTarget(ctx context.Context, db adoptDB, chain domain.Scope, target adapterTeardownTarget, keepRemote bool, at time.Time) (AdapterTeardownResult, error) {
+func teardownAdapterTarget(ctx context.Context, db adapterDB, chain domain.Scope, target adapterTeardownTarget, keepRemote bool, at time.Time) (AdapterTeardownResult, error) {
 	if target.providerBusy == 1 {
 		return AdapterTeardownResult{}, adapter.ErrProviderBusy
 	}
@@ -1100,7 +900,7 @@ func teardownAdapterTarget(ctx context.Context, db adoptDB, chain domain.Scope, 
 	return result, nil
 }
 
-func teardownWholeAdapter(ctx context.Context, db adoptDB, chain domain.Scope, adapterID, authority string, targets []adapterTeardownTarget, keepRemote bool, at time.Time) (AdapterTeardownBatch, error) {
+func teardownWholeAdapter(ctx context.Context, db adapterDB, chain domain.Scope, adapterID, authority string, targets []adapterTeardownTarget, keepRemote bool, at time.Time) (AdapterTeardownBatch, error) {
 	results := make([]AdapterTeardownResult, 0, len(targets))
 	for _, target := range targets {
 		result, err := teardownAdapterTarget(ctx, db, chain, target, keepRemote, at)
@@ -1150,7 +950,7 @@ func (r pgAdapters) ReplaceCredential(ctx context.Context, p authz.Proof, mutati
 	return replaceAdapterCredential(ctx, pgAdoptDB{db: r.db}, chain, mutation)
 }
 
-func replaceAdapterCredential(ctx context.Context, db adoptDB, chain domain.Scope, mutation AdapterCredentialMutation) (AdapterCredentialResult, error) {
+func replaceAdapterCredential(ctx context.Context, db adapterDB, chain domain.Scope, mutation AdapterCredentialMutation) (AdapterCredentialResult, error) {
 	stamp := db.Stamp(mutation.At)
 	var previous string
 	var targetCount, providerBusy int
@@ -1206,7 +1006,7 @@ func (r pgAdapters) RevokeCredential(ctx context.Context, p authz.Proof, adapter
 	return revokeAdapterCredential(ctx, pgAdoptDB{db: r.db}, chain, adapterID, at)
 }
 
-func revokeAdapterCredential(ctx context.Context, db adoptDB, chain domain.Scope, adapterID string, at time.Time) (AdapterCredentialResult, error) {
+func revokeAdapterCredential(ctx context.Context, db adapterDB, chain domain.Scope, adapterID string, at time.Time) (AdapterCredentialResult, error) {
 	if adapterID == "" {
 		return AdapterCredentialResult{}, fmt.Errorf("%w: credential revocation requires adapter id", domain.ErrInvalid)
 	}

--- a/internal/store/repos_adapters_config.go
+++ b/internal/store/repos_adapters_config.go
@@ -773,7 +773,7 @@ func (r pgAdapters) UpdateTarget(ctx context.Context, p authz.Proof, m AdapterTa
 	return updateTargetConfig(ctx, pgAdoptDB{db: r.db}, chain, m, true)
 }
 
-func updateTargetConfig(ctx context.Context, db adoptDB, chain domain.Scope, m AdapterTargetUpdate, postgres bool) (AdapterTargetUpdateResult, error) {
+func updateTargetConfig(ctx context.Context, db adapterDB, chain domain.Scope, m AdapterTargetUpdate, postgres bool) (AdapterTargetUpdateResult, error) {
 	if err := validateTargetMutation(m.Target); err != nil {
 		return AdapterTargetUpdateResult{}, err
 	}

--- a/internal/store/repos_adapters_move.go
+++ b/internal/store/repos_adapters_move.go
@@ -122,7 +122,7 @@ func (r pgAdapters) ReplaceMoveOrigin(ctx context.Context, p authz.Proof, moveID
 	return replaceAdapterMoveOrigin(ctx, pgAdoptDB{db: r.db}, chain, moveID, origin, pendingCredential, authorityPrincipalID, at)
 }
 
-func readAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, moveID string, lock bool) (AdapterMove, error) {
+func readAdapterMove(ctx context.Context, db adapterDB, chain domain.Scope, moveID string, lock bool) (AdapterMove, error) {
 	var out AdapterMove
 	var keep bool
 	var created adapterStoredTime
@@ -198,7 +198,7 @@ func readAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, moveID
 	return out, nil
 }
 
-func cancelAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, moveID, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
+func cancelAdapterMove(ctx context.Context, db adapterDB, chain domain.Scope, moveID, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
 	if moveID == "" || authorityPrincipalID == "" || at.IsZero() {
 		return AdapterMove{}, fmt.Errorf("%w: move cancellation requires move, authority, and timestamp", domain.ErrInvalid)
 	}
@@ -262,7 +262,7 @@ func cancelAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, move
 	return out, nil
 }
 
-func replaceAdapterMoveTarget(ctx context.Context, db adoptDB, chain domain.Scope, moveID string, target AdapterTargetMutation, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
+func replaceAdapterMoveTarget(ctx context.Context, db adapterDB, chain domain.Scope, moveID string, target AdapterTargetMutation, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
 	if err := validatePendingTarget(target); err != nil {
 		return AdapterMove{}, err
 	}
@@ -317,7 +317,7 @@ func replaceAdapterMoveTarget(ctx context.Context, db adoptDB, chain domain.Scop
 	return out, nil
 }
 
-func replaceAdapterMoveOrigin(ctx context.Context, db adoptDB, chain domain.Scope, moveID, origin string, pendingCredential []byte, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
+func replaceAdapterMoveOrigin(ctx context.Context, db adapterDB, chain domain.Scope, moveID, origin string, pendingCredential []byte, authorityPrincipalID string, at time.Time) (AdapterMove, error) {
 	if moveID == "" || origin == "" || len(pendingCredential) == 0 || authorityPrincipalID == "" || at.IsZero() {
 		return AdapterMove{}, fmt.Errorf("%w: pending origin replacement requires move, origin, credential, authority, and timestamp", domain.ErrInvalid)
 	}
@@ -395,7 +395,7 @@ func replaceAdapterMoveOrigin(ctx context.Context, db adoptDB, chain domain.Scop
 	return out, nil
 }
 
-func resumeAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, move AdapterMove, authorityPrincipalID string, at time.Time) error {
+func resumeAdapterMove(ctx context.Context, db adapterDB, chain domain.Scope, move AdapterMove, authorityPrincipalID string, at time.Time) error {
 	stamp := db.Stamp(at)
 	activate := db.SQL(
 		`UPDATE adapter_route_moves SET state='activating',authority_principal_id=? WHERE id=? AND org_id=? AND project_id=? AND state='attention_required'`,
@@ -433,7 +433,7 @@ func resumeAdapterMove(ctx context.Context, db adoptDB, chain domain.Scope, move
 	return nil
 }
 
-func beginAdapterOriginMove(ctx context.Context, db adoptDB, chain domain.Scope, mutation AdapterOriginMoveMutation) (AdapterRouteMoveBatch, error) {
+func beginAdapterOriginMove(ctx context.Context, db adapterDB, chain domain.Scope, mutation AdapterOriginMoveMutation) (AdapterRouteMoveBatch, error) {
 	if mutation.AdapterID == "" || mutation.Origin == "" || len(mutation.PendingCredentialCiphertext) == 0 || mutation.AuthorityPrincipalID == "" || mutation.At.IsZero() {
 		return AdapterRouteMoveBatch{}, fmt.Errorf("%w: origin move requires adapter, origin, sealed credential, authority, and timestamp", domain.ErrInvalid)
 	}
@@ -665,7 +665,7 @@ func validatePendingTarget(m AdapterTargetMutation) error {
 	return nil
 }
 
-func beginAdapterTargetMove(ctx context.Context, db adoptDB, chain domain.Scope, mutation AdapterRouteMoveMutation) (AdapterRouteMoveResult, error) {
+func beginAdapterTargetMove(ctx context.Context, db adapterDB, chain domain.Scope, mutation AdapterRouteMoveMutation) (AdapterRouteMoveResult, error) {
 	if err := validatePendingTarget(mutation.Target); err != nil {
 		return AdapterRouteMoveResult{}, err
 	}
@@ -814,7 +814,7 @@ func beginAdapterTargetMove(ctx context.Context, db adoptDB, chain domain.Scope,
 	return result, nil
 }
 
-func reserveAdapterMoveClaims(ctx context.Context, db adoptDB, chain domain.Scope, moveID, origin string, target AdapterTargetMutation) error {
+func reserveAdapterMoveClaims(ctx context.Context, db adapterDB, chain domain.Scope, moveID, origin string, target AdapterTargetMutation) error {
 	keyQuery := db.SQL(
 		`SELECT id,name,classification FROM keys WHERE org_id=? AND project_id=? AND id IN (`+placeholders(len(target.KeyIDs), false, 3)+`) ORDER BY id`,
 		`SELECT id,name,classification FROM keys WHERE org_id=$1 AND project_id=$2 AND id IN (`+placeholders(len(target.KeyIDs), true, 3)+`) ORDER BY id`)


### PR DESCRIPTION
Closes #373

Depends on #408 / #352, the required dialect-ownership prerequisite.

## Contract

- Collapse the 13 hand-twinned SQLite/PostgreSQL repository operations behind one `adapterQueries` owner.
- Make `adapterDBTX` own SQL selection and timestamp conversion.
- Reuse one active-ledger orphan query across repository and runtime consumers.
- Preserve SQLite integer versus PostgreSQL boolean scans, PostgreSQL locking clauses, ordering, authorization, audit bytes, and failure behavior.

## Migration and generated outputs

- No schema migration.
- No generated outputs.

## Validation

- `TestAdapterTransactionOwnsDialectSelection` red-before-green compile seam
- Adapter-focused store tests: 30 passed
- `./internal/store ./internal/service`: 317 passed
- `go test -count=1 ./...`: 3605 passed in 61 packages
- Two-axis standards/spec review: CLEAN, 0 findings after fixes

Full handoff: `docs/handoff/373-adapter-query-ownership.md`.