### PR TITLE
docs: reconcile multi-instance completion #71

### DIFF
--- a/docs/handoff/71-multi-instance-workspace.md
+++ b/docs/handoff/71-multi-instance-workspace.md
@@ -4,7 +4,9 @@ Issue [#71](https://github.com/Hikyo-Org/Hikyo/issues/71) was **reopened**: the
 directory tier and the handoff ceremony had landed, but the workspace tier was a
 bearer-backed liveness badge — the UI never routed Matrix, Values, history,
 reveal, edit or publish operations to the remote. A live workspace could not
-operate B's data. This run closes that gap.
+operate B's data. PR #259 closed that product gap. PRs #308 and #310 later
+landed and integrated the root session-epoch owner that deliberately kept the
+issue open. #71 is now complete.
 
 The whole change is **frontend**. The server was already complete for the entire
 workspace tier — both establishment and step-up — before this run:
@@ -91,14 +93,17 @@ disclosure retries over the now-elevated transport.
   ceiling, and the binding is authoritative (nothing the popup was handed
   decides the elevation's scope). Mirrors the cli-reauth transaction read.
 
-## Deferred / blockers, by name
+## Closure evidence
 
-- **Epoch-tracker blocker (do NOT close #71 on merge).** The reopen states:
-  "Integrate the private session-epoch tracker before closing; remote-client
-  work can proceed in parallel." The remote-client work is done; the tracker
-  integration is a separate item. No `close #71` in the PR until Marc confirms
-  it. The workspace context already carries the pieces (origin, bearer, live API
-  revision) the tracker would hang off.
+- **Session-epoch integration — RESOLVED.** PR #308 made `AuthProvider` the
+  root browser session-epoch owner. PR #310 connected every workspace aggregate
+  to that owner through `transitionWorkspaceOwner`: login replacement, logout,
+  expiry, and cross-tab replacement clear workspace state before the next root
+  epoch renders; same-session assurance refresh preserves it. Deferred probes
+  and transport responses compare a local workspace epoch before they can
+  mutate or evict a replacement session. Coverage lives in
+  `web/src/app/AuthProvider.test.tsx`, `web/src/api/workspace.test.ts`, and
+  `web/src/api/workspaceClient.test.ts`.
 - **Reveal / protected-publish e2e over the TOTP-in-popup path.** B is an IP
   literal, so a workspace step-up on B must use the TOTP path (no passkey RP).
   The unit tests cover the step-up prepare/elevate client logic; the full
@@ -109,6 +114,10 @@ disclosure retries over the now-elevated transport.
   threading, the unit tests (the generated-SDK-through-workspace-client test
   exercises the value PUT path), and the same tripwire (a leaked edit to A
   would fail it) — but no edit is driven through the matrix UI in the browser.
+- **M6 status — COMPLETE.** The remaining TOTP browser permutation above is a
+  recorded test-shape limitation, not an unimplemented M6 behavior. Server
+  step-up coverage exercises both engines; browser coverage proves the popup,
+  direct remote transport, kill switch, version gate, and no-proxy tripwire.
 - ~~URL length ceiling on step-up `key` params~~ — **RESOLVED** by the
   transaction-read endpoint above (the ceiling that a large reveal-all's key set
   would have hit no longer exists; the URL carries only `state`).

--- a/docs/handoff/71-multi-instance.md
+++ b/docs/handoff/71-multi-instance.md
@@ -3,21 +3,18 @@
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/71. ADR: `.xreview/multi-instance-adr.md`
 (locked 2026-08-06). MVP gate: M6 in `.xreview/mvp-boundary.md`.
 
-Status: **IN PROGRESS.** Foundation, store, service, audit, API, CORS/CSP, CLI,
-the Go E2E lifecycle and the two-instance harness are done and green on BOTH
-engines. Criteria 1, 2, 4, 5 and 6 are met; 3 is partly met with two named
-blockers. **What remains: the
-web UI + Playwright flows, and the two-instance E2E harness** — plus two named
-gaps (the workspace session's assurance record, and the step-up elevation path)
-that need Marc. See "Session 2 progress", "Session 2, second half" and
-"STILL NOT DONE".
+Status: **COMPLETE on current main.** Foundation, store, service, audit, API,
+CORS/CSP, CLI, the Go E2E lifecycle, and the two-instance harness landed in
+PR #115. PR #259 completed the browser-to-remote workspace data path and remote
+step-up flow. PRs #308 and #310 then supplied and integrated the root browser
+session-epoch owner that had kept #71 open. All six M6 criteria now have
+executable coverage. See `71-multi-instance-workspace.md` for the final browser
+slice and session-epoch closure evidence.
 
-**Read first if you are resuming:** "STILL NOT DONE" (what is left and why the
-UI is atomic), then "Repo facts", then BOTH trap lists ("Traps hit while
-building this" from session 1 and "More traps hit (session 2)"). Those are the
-parts that cost real time and that no amount of reading the ADR would have told
-you. The decision list runs 1-15 across both sessions and is the review
-surface.
+**Historical note:** sections below preserve the implementation-time progress
+log and therefore describe work as unfinished. For current status, use the
+paragraph above and `71-multi-instance-workspace.md`. The two trap lists remain
+useful when changing this subsystem.
 
 ## Plan (as designed, before code)
 


### PR DESCRIPTION
Closes #71.

## Summary
- reconcile the original #71 handoff with the workspace data path merged in PR #259
- record root session-epoch ownership from PR #308 and workspace integration from PR #310
- mark M6 complete while retaining historical implementation notes and the documented TOTP browser-test limitation

## Contract and generated outputs
- documentation only; no runtime, API, database, or generated output changes

## Validation
- `git diff --check`: passed
- full local validation deferred until host memory pressure subsides, as requested; CI started on this head