### PR TITLE
Fix first nightly release bootstrap

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           COMMIT: ${{ steps.source.outputs.commit }}
           RUN_NUMBER: ${{ github.run_number }}
+          INITIAL_NIGHTLY_VERSION: 0.0.1
         run: |
+          set -o pipefail
           latest_target=$(gh api "repos/$REPOSITORY/releases?per_page=100" --jq '
             map(select(.draft == false and .prerelease == true and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\.")))) |
             .[0].target_commitish // ""
@@ -51,9 +53,17 @@ jobs:
             printf 'nightly: commit %s already published\n' "$COMMIT"
             exit 0
           fi
-          stable_tag=$(gh api "repos/$REPOSITORY/releases/latest" --jq .tag_name)
-          version=$(./scripts/release/next-nightly-version.sh \
-            "$stable_tag" "$(date -u +%Y%m%d)" "$RUN_NUMBER" "$COMMIT")
+          stable_tag=$(gh api --paginate --slurp \
+            "repos/$REPOSITORY/releases?per_page=100" | \
+            ./scripts/release/latest-stable-version.sh)
+          release_date=$(date -u +%Y%m%d)
+          if [ -n "$stable_tag" ]; then
+            version=$(./scripts/release/next-nightly-version.sh \
+              "$stable_tag" "$release_date" "$RUN_NUMBER" "$COMMIT")
+          else
+            version=$(./scripts/release/nightly-version.sh "$INITIAL_NIGHTLY_VERSION" \
+              "$release_date" "$RUN_NUMBER" "$COMMIT")
+          fi
           tag="v$version"
           if gh api "repos/$REPOSITORY/git/ref/tags/$tag" >/dev/null 2>&1; then
             printf 'nightly: tag %s already exists\n' "$tag" >&2

--- a/docs/handoff/nightly-bootstrap.md
+++ b/docs/handoff/nightly-bootstrap.md
@@ -1,0 +1,23 @@
+# Handoff: first nightly before a stable release
+
+Failure: https://github.com/Hikyo-Org/Hikyo/actions/runs/32702294800/job/97356242963.
+Implementation base: `9cf0fecb156e7ac60520e77b2d94c790222e9a83`.
+
+## Contract
+
+- With no published stable release, the nightly identity starts at
+  `0.0.1-nightly.<date>.<run>.g<sha>`.
+- After a stable release exists, nightlies continue on the next minor line. A
+  stable `1.0.0` therefore produces `1.1.0-nightly...`.
+- Stable discovery walks every GitHub Releases page. Daily prereleases cannot
+  push the latest stable beyond a first-page query.
+- GitHub API, malformed stable tag, date, run-number, and commit failures remain
+  fatal. Only a successful empty stable-release set activates bootstrap.
+
+## Regression evidence
+
+The nightly workflow fixture failed before implementation because the initial
+version and empty-release path were absent. The shared formatter now pins exact
+initial and next-minor identities while preserving all invalid-input refusals.
+The release-page fixture covers empty, nightly-only, multi-page stable,
+malformed JSON, wrong-shape, and malformed-tag inputs.

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -15,6 +15,10 @@ prereleases built from the newest green, changed `main` commit. A stable
 `1.1.0`, it advances to `1.2.0-nightly...`. Nightlies are evaluation artifacts,
 not production releases.
 
+Before any stable release exists, the first line is
+`0.0.1-nightly.<date>.<run>.g<sha>`. Release discovery is paginated; a long
+nightly history cannot hide the latest published stable release.
+
 Checks remain notification-only unless the instance operator configures the
 separately privileged local updater helper. Remote apply admits stable releases
 only; nightlies can never cross that boundary.

--- a/scripts/ci/check-nightly-release_test.sh
+++ b/scripts/ci/check-nightly-release_test.sh
@@ -7,6 +7,7 @@ repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
 workflow="$repo_root/.github/workflows/nightly.yml"
 official="$repo_root/.github/workflows/release.yml"
 goreleaser="$repo_root/.goreleaser.yaml"
+stable_resolver="$repo_root/scripts/release/latest-stable-version.sh"
 
 fail() {
 	printf 'nightly release fixture failed: %s\n' "$1" >&2
@@ -19,6 +20,14 @@ grep -F 'ref: refs/heads/main' "$workflow" >/dev/null || fail 'nightly checkout 
 grep -F 'COMMIT: ${{ steps.source.outputs.commit }}' "$workflow" >/dev/null || fail 'nightly does not use the checked-out main SHA'
 grep -F 'select(.draft == false and .prerelease == true' "$workflow" >/dev/null || fail 'draft nightlies can suppress publication'
 grep -F './scripts/release/require-green-main.sh "$REPOSITORY" "$COMMIT"' "$workflow" >/dev/null || fail 'nightly does not require exact-head green main CI'
+grep -F 'INITIAL_NIGHTLY_VERSION: 0.0.1' "$workflow" >/dev/null || fail 'first nightly version is not explicit'
+grep -F 'set -o pipefail' "$workflow" >/dev/null || fail 'paginated release discovery can hide API failures'
+grep -F './scripts/release/latest-stable-version.sh' "$workflow" >/dev/null || fail 'stable release discovery is missing'
+grep -F 'select(.draft == false and .prerelease == false' "$stable_resolver" >/dev/null || fail 'stable resolver admits prereleases'
+grep -F './scripts/release/nightly-version.sh "$INITIAL_NIGHTLY_VERSION"' "$workflow" >/dev/null || fail 'first nightly does not use the initial version'
+if grep -F 'releases/latest' "$workflow" >/dev/null; then
+	fail 'no-release bootstrap still depends on the latest-release endpoint'
+fi
 grep -F 'HIKYO_RELEASE_VERSION: ${{ steps.identity.outputs.version }}' "$workflow" >/dev/null || fail 'GoReleaser does not receive nightly version'
 grep -F 'gh release create "$TAG"' "$workflow" >/dev/null || fail 'nightly prerelease publication is missing'
 grep -F -- '--prerelease' "$workflow" >/dev/null || fail 'nightly is not marked prerelease'
@@ -40,5 +49,6 @@ if grep -E 'sign-bundle|bind-manifest|ceremony\.sh|COSIGN_PASSWORD|\.key\.age' "
 fi
 
 "$repo_root/scripts/release/next-nightly-version_test.sh"
+"$repo_root/scripts/release/latest-stable-version_test.sh"
 "$repo_root/scripts/release/require-green-main_test.sh"
 printf 'nightly release fixture: CI-gated six-platform prereleases stay outside official signing\n'

--- a/scripts/release/latest-stable-version.sh
+++ b/scripts/release/latest-stable-version.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$script_dir/../lib/release.sh"
+
+[ "$#" -eq 0 ] || {
+	printf 'usage: GitHub release pages JSON | %s\n' "$0" >&2
+	exit 2
+}
+
+stable=$(jq -r '
+  if type != "array" or any(.[]; type != "array") then
+    error("expected an array of GitHub release pages")
+  else
+    [.[][] | select(.draft == false and .prerelease == false)] |
+    if length == 0 then
+      ""
+    elif (.[0].tag_name | type) == "string" then
+      .[0].tag_name
+    else
+      error("stable release has no tag_name")
+    end
+  end
+')
+
+if [ -n "$stable" ]; then
+	version=${stable#v}
+	if ! is_semver "$version" || [ "${version%%[-+]*}" != "$version" ]; then
+		printf 'latest stable version: invalid stable release tag %s\n' "$stable" >&2
+		exit 2
+	fi
+fi
+printf '%s\n' "$stable"

--- a/scripts/release/latest-stable-version_test.sh
+++ b/scripts/release/latest-stable-version_test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+script=$(dirname "$0")/latest-stable-version.sh
+
+[ -z "$(printf '[]' | "$script")" ]
+[ -z "$(printf '[[{"tag_name":"v0.0.1-nightly.20260824.1.g12345678","draft":false,"prerelease":true}]]' | "$script")" ]
+
+pages='[
+  [{"tag_name":"v2.0.0-nightly.20260824.2.g12345678","draft":false,"prerelease":true}],
+  [{"tag_name":"v1.4.2","draft":false,"prerelease":false}]
+]'
+[ "$(printf '%s\n' "$pages" | "$script")" = 'v1.4.2' ]
+
+expect_reject() {
+	label=$1
+	payload=$2
+	if printf '%s\n' "$payload" | "$script" >/dev/null 2>&1; then
+		printf 'latest stable version fixture failed: %s accepted\n' "$label" >&2
+		exit 1
+	fi
+}
+
+expect_reject malformed-json '{'
+expect_reject wrong-shape '{}'
+expect_reject malformed-stable-tag '[[{"tag_name":"latest","draft":false,"prerelease":false}]]'
+
+printf 'latest stable version fixture: empty and paginated release histories are deterministic\n'

--- a/scripts/release/next-nightly-version.sh
+++ b/scripts/release/next-nightly-version.sh
@@ -19,23 +19,9 @@ if ! is_semver "$stable" || [ "${stable%%[-+]*}" != "$stable" ]; then
 	printf 'next nightly version: %s is not a stable SemVer version\n' "$1" >&2
 	exit 2
 fi
-if ! printf '%s\n' "$date" | grep -Eq '^[0-9]{8}$'; then
-	printf 'next nightly version: date must be YYYYMMDD\n' >&2
-	exit 2
-fi
-if ! printf '%s\n' "$run" | grep -Eq '^[1-9][0-9]*$'; then
-	printf 'next nightly version: run number must be a positive integer\n' >&2
-	exit 2
-fi
-if ! printf '%s\n' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
-	printf 'next nightly version: commit must be a full lowercase SHA-1\n' >&2
-	exit 2
-fi
-
 major=${stable%%.*}
 remainder=${stable#*.}
 minor=${remainder%%.*}
 next_minor=$((minor + 1))
-short_commit=$(printf '%s' "$commit" | cut -c1-8)
-printf '%s.%s.0-nightly.%s.%s.g%s\n' \
-	"$major" "$next_minor" "$date" "$run" "$short_commit"
+exec "$script_dir/nightly-version.sh" \
+	"$major.$next_minor.0" "$date" "$run" "$commit"

--- a/scripts/release/next-nightly-version_test.sh
+++ b/scripts/release/next-nightly-version_test.sh
@@ -2,8 +2,11 @@
 set -eu
 
 script=$(dirname "$0")/next-nightly-version.sh
+nightly_script=$(dirname "$0")/nightly-version.sh
 commit=176e6e67379d0675e6211f0491dc965cee4f1c5c
 
+[ "$("$nightly_script" 0.0.1 20260824 1 "$commit")" = \
+	'0.0.1-nightly.20260824.1.g176e6e67' ]
 [ "$("$script" 1.0.0 20260824 42 "$commit")" = \
 	'1.1.0-nightly.20260824.42.g176e6e67' ]
 [ "$("$script" v1.0.9 20261231 7 "$commit")" = \
@@ -25,4 +28,9 @@ expect_reject invalid-date 1.0.0 2026824 42 "$commit"
 expect_reject invalid-run 1.0.0 20260824 run-42 "$commit"
 expect_reject short-commit 1.0.0 20260824 42 deadbeef
 
-printf 'next nightly version fixture: stable next-minor tags are deterministic\n'
+if "$nightly_script" 0.0.1-rc.1 20260824 1 "$commit" >/dev/null 2>&1; then
+	printf 'next nightly version fixture failed: prerelease initial version accepted\n' >&2
+	exit 1
+fi
+
+printf 'next nightly version fixture: initial and stable next-minor tags are deterministic\n'

--- a/scripts/release/nightly-version.sh
+++ b/scripts/release/nightly-version.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$script_dir/../lib/release.sh"
+
+[ "$#" -eq 4 ] || {
+	printf 'usage: %s VERSION YYYYMMDD RUN_NUMBER COMMIT\n' "$0" >&2
+	exit 2
+}
+
+version=${1#v}
+date=$2
+run=$3
+commit=$4
+
+if ! is_semver "$version" || [ "${version%%[-+]*}" != "$version" ]; then
+	printf 'nightly version: %s is not a stable SemVer version\n' "$1" >&2
+	exit 2
+fi
+if ! printf '%s\n' "$date" | grep -Eq '^[0-9]{8}$'; then
+	printf 'nightly version: date must be YYYYMMDD\n' >&2
+	exit 2
+fi
+if ! printf '%s\n' "$run" | grep -Eq '^[1-9][0-9]*$'; then
+	printf 'nightly version: run number must be a positive integer\n' >&2
+	exit 2
+fi
+if ! printf '%s\n' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
+	printf 'nightly version: commit must be a full lowercase SHA-1\n' >&2
+	exit 2
+fi
+
+short_commit=$(printf '%s' "$commit" | cut -c1-8)
+printf '%s-nightly.%s.%s.g%s\n' "$version" "$date" "$run" "$short_commit"


### PR DESCRIPTION
## Summary

- start the first nightly at `0.0.1-nightly.<date>.<run>.g<sha>` when no stable release exists
- preserve next-minor nightly lines after a stable release, such as `1.1.0-nightly...` after `1.0.0`
- discover stable releases across every GitHub Releases page without treating prereleases as stable
- keep GitHub API failures, malformed release data, and invalid version inputs fatal

## Failure

Nightly run 32702294800 failed in Resolve next-minor nightly identity because `/releases/latest` returns HTTP 404 before the first published stable release.

## Validation

- reproduced the empty-release response against the live repository
- live empty-release resolution produced `0.0.1-nightly.20260824.3.g9cf0fecb`
- nightly workflow and release fixtures passed
- actionlint and shellcheck passed
- full docs verification, build, PWA, and policy gates passed
