### PR TITLE
Potential fix for code scanning alert no. 40: Size computation for allocation may overflow

### DIFF
--- a/internal/samlsp/nameid.go
+++ b/internal/samlsp/nameid.go
@@ -10,7 +10,10 @@ import (
 	"math"
 )
 
-var ErrEmptyNameID = errors.New("samlsp: NameID value is empty")
+var (
+	ErrEmptyNameID    = errors.New("samlsp: NameID value is empty")
+	ErrNameIDTooLarge = errors.New("samlsp: NameID value is too large")
+)
 
 // NameID is the byte-exact identity material extracted from a verified SAML
 // Assertion. Pointers preserve the difference between an absent XML attribute
@@ -29,8 +32,12 @@ func EncodeNameID(id NameID) ([]byte, error) {
 	if len(id.Value) == 0 {
 		return nil, ErrEmptyNameID
 	}
+	if len(id.Value) > math.MaxInt-20 {
+		return nil, ErrNameIDTooLarge
+	}
 
-	encoded := make([]byte, 0, len(id.Value)+20)
+	capHint := len(id.Value) + 20
+	encoded := make([]byte, 0, capHint)
 	encoded = appendPresentField(encoded, id.Value)
 	encoded = appendOptionalField(encoded, id.Format)
 	encoded = appendOptionalField(encoded, id.NameQualifier)


### PR DESCRIPTION
Potential fix for [https://github.com/Hikyo-Org/Hikyo/security/code-scanning/40](https://github.com/Hikyo-Org/Hikyo/security/code-scanning/40)

To fix this safely without changing intended behavior, add an explicit overflow guard before `make([]byte, 0, len(id.Value)+20)` in `internal/samlsp/nameid.go`.

Best approach:
- Keep existing semantics (`ErrEmptyNameID` for empty value).
- Before computing capacity, ensure `len(id.Value) <= math.MaxInt-20`.
- If it exceeds, fail closed with an error (not panic), because this is input-derived and should be handled as a refusal.
- Then allocate using a precomputed safe `capHint`.

This is a minimal, targeted change in `EncodeNameID` only. It requires:
- One new exported/package error variable for oversize input (using existing `errors` import).
- One guard and one local variable in `EncodeNameID`.
- No new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
