### PR TITLE
fix: publish nightlies with scoped GitHub App

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,24 +44,54 @@ jobs:
           INITIAL_NIGHTLY_VERSION: 0.0.1
         run: |
           set -o pipefail
-          latest_tag=$(gh api --paginate --slurp \
-            "repos/$REPOSITORY/releases?per_page=100" | \
-            ./scripts/release/latest-nightly-tag.sh)
-          latest_commit=
-          if [ -n "$latest_tag" ]; then
-            latest_commit=$(gh api "repos/$REPOSITORY/git/ref/tags/$latest_tag" \
-              --jq '.object.sha')
-          fi
-          if [ "$latest_commit" = "$COMMIT" ]; then
-            printf 'skip=true\n' >>"$GITHUB_OUTPUT"
-            printf 'nightly: commit %s already published\n' "$COMMIT"
-            exit 0
-          fi
           tag=$(gh api --paginate --slurp \
             "repos/$REPOSITORY/git/matching-refs/tags/v" | \
             ./scripts/release/nightly-run-tag.sh "$RUN_NUMBER")
-          tag_exists=true
-          if [ -z "$tag" ]; then
+          tag_exists=false
+          if [ -n "$tag" ]; then
+            tag_lookup_error="$RUNNER_TEMP/nightly-tag-lookup.err"
+            if ! existing_tag_sha=$(gh api "repos/$REPOSITORY/git/ref/tags/$tag" \
+              --jq '.object.sha' 2>"$tag_lookup_error"); then
+              cat "$tag_lookup_error" >&2
+              exit 1
+            fi
+            if [ "$existing_tag_sha" != "$COMMIT" ]; then
+              printf 'nightly: run %s tag %s resolves to %s, expected %s\n' \
+                "$RUN_NUMBER" "$tag" "$existing_tag_sha" "$COMMIT" >&2
+              exit 1
+            fi
+            release_lookup_error="$RUNNER_TEMP/nightly-release-lookup.err"
+            if release_state=$(gh api "repos/$REPOSITORY/releases/tags/$tag" \
+              --jq '"\(.draft):\(.prerelease)"' 2>"$release_lookup_error"); then
+              if [ "$release_state" != 'false:true' ]; then
+                printf 'nightly: existing release %s has unexpected state %s\n' \
+                  "$tag" "$release_state" >&2
+                exit 1
+              fi
+              printf 'skip=true\n' >>"$GITHUB_OUTPUT"
+              printf 'nightly: workflow run %s already published as %s\n' \
+                "$RUN_NUMBER" "$tag"
+              exit 0
+            elif ! grep -F '(HTTP 404)' "$release_lookup_error" >/dev/null; then
+              cat "$release_lookup_error" >&2
+              exit 1
+            fi
+            version=${tag#v}
+            tag_exists=true
+          else
+            latest_tag=$(gh api --paginate --slurp \
+              "repos/$REPOSITORY/releases?per_page=100" | \
+              ./scripts/release/latest-nightly-tag.sh)
+            latest_commit=
+            if [ -n "$latest_tag" ]; then
+              latest_commit=$(gh api "repos/$REPOSITORY/git/ref/tags/$latest_tag" \
+                --jq '.object.sha')
+            fi
+            if [ "$latest_commit" = "$COMMIT" ]; then
+              printf 'skip=true\n' >>"$GITHUB_OUTPUT"
+              printf 'nightly: commit %s already published\n' "$COMMIT"
+              exit 0
+            fi
             stable_tag=$(gh api --paginate --slurp \
               "repos/$REPOSITORY/releases?per_page=100" | \
               ./scripts/release/latest-stable-version.sh)
@@ -74,27 +104,21 @@ jobs:
                 "$release_date" "$RUN_NUMBER" "$COMMIT")
             fi
             tag="v$version"
-            tag_exists=false
-          else
-            version=${tag#v}
-          fi
-          tag_lookup_error="$RUNNER_TEMP/nightly-tag-lookup.err"
-          if existing_tag_sha=$(gh api "repos/$REPOSITORY/git/ref/tags/$tag" \
-            --jq '.object.sha' 2>"$tag_lookup_error"); then
-            if [ "$existing_tag_sha" != "$COMMIT" ]; then
-              printf 'nightly: tag %s resolves to %s, expected %s\n' \
-                "$tag" "$existing_tag_sha" "$COMMIT" >&2
+            tag_lookup_error="$RUNNER_TEMP/nightly-tag-lookup.err"
+            if existing_tag_sha=$(gh api "repos/$REPOSITORY/git/ref/tags/$tag" \
+              --jq '.object.sha' 2>"$tag_lookup_error"); then
+              if [ "$existing_tag_sha" != "$COMMIT" ]; then
+                printf 'nightly: tag %s resolves to %s, expected %s\n' \
+                  "$tag" "$existing_tag_sha" "$COMMIT" >&2
+                exit 1
+              fi
+              printf 'nightly: tag %s already resolves to %s; resuming publication\n' \
+                "$tag" "$COMMIT"
+              tag_exists=true
+            elif ! grep -F '(HTTP 404)' "$tag_lookup_error" >/dev/null; then
+              cat "$tag_lookup_error" >&2
               exit 1
             fi
-            printf 'nightly: tag %s already resolves to %s; resuming publication\n' \
-              "$tag" "$COMMIT"
-            tag_exists=true
-          elif [ "$tag_exists" = true ]; then
-            cat "$tag_lookup_error" >&2
-            exit 1
-          elif ! grep -F '(HTTP 404)' "$tag_lookup_error" >/dev/null; then
-            cat "$tag_lookup_error" >&2
-            exit 1
           fi
           printf 'skip=false\nversion=%s\ntag=%s\ntag_exists=%s\n' \
             "$version" "$tag" "$tag_exists" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
   group: nightly-release
@@ -65,11 +65,34 @@ jobs:
               "$release_date" "$RUN_NUMBER" "$COMMIT")
           fi
           tag="v$version"
-          if gh api "repos/$REPOSITORY/git/ref/tags/$tag" >/dev/null 2>&1; then
-            printf 'nightly: tag %s already exists\n' "$tag" >&2
+          tag_exists=false
+          tag_lookup_error="$RUNNER_TEMP/nightly-tag-lookup.err"
+          if existing_tag_sha=$(gh api "repos/$REPOSITORY/git/ref/tags/$tag" \
+            --jq '.object.sha' 2>"$tag_lookup_error"); then
+            if [ "$existing_tag_sha" != "$COMMIT" ]; then
+              printf 'nightly: tag %s resolves to %s, expected %s\n' \
+                "$tag" "$existing_tag_sha" "$COMMIT" >&2
+              exit 1
+            fi
+            printf 'nightly: tag %s already resolves to %s; resuming publication\n' \
+              "$tag" "$COMMIT"
+            tag_exists=true
+          elif ! grep -F '(HTTP 404)' "$tag_lookup_error" >/dev/null; then
+            cat "$tag_lookup_error" >&2
             exit 1
           fi
-          printf 'skip=false\nversion=%s\ntag=%s\n' "$version" "$tag" >>"$GITHUB_OUTPUT"
+          printf 'skip=false\nversion=%s\ntag=%s\ntag_exists=%s\n' \
+            "$version" "$tag" "$tag_exists" >>"$GITHUB_OUTPUT"
+      - name: Mint scoped nightly release app token
+        id: release_app
+        if: steps.identity.outputs.skip != 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.NIGHTLY_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NIGHTLY_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         if: steps.identity.outputs.skip != 'true'
         with:
@@ -121,12 +144,21 @@ jobs:
             'Use the stable channel for recovery-signed production releases.' \
             >dist/NIGHTLY-BUILD.txt
           cp dist/NIGHTLY-BUILD.txt "$RUNNER_TEMP/nightly-notes.md"
+      - name: Create immutable nightly tag
+        if: steps.identity.outputs.skip != 'true' && steps.identity.outputs.tag_exists != 'true'
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.identity.outputs.tag }}
+          COMMIT: ${{ steps.source.outputs.commit }}
+        run: |
+          gh api --method POST "repos/$REPOSITORY/git/refs" \
+            -f ref="refs/tags/$TAG" -f sha="$COMMIT" >/dev/null
       - name: Publish immutable GitHub prerelease
         if: steps.identity.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
           TAG: ${{ steps.identity.outputs.tag }}
-          COMMIT: ${{ steps.source.outputs.commit }}
         run: |
           gh release create "$TAG" \
             dist/hikyo_*_Darwin_*.tar.gz \
@@ -136,7 +168,7 @@ jobs:
             dist/binary-provenance.json \
             dist/NIGHTLY-BUILD.txt \
             --repo "$GITHUB_REPOSITORY" \
-            --target "$COMMIT" \
+            --verify-tag \
             --title "$TAG" \
             --notes-file "$RUNNER_TEMP/nightly-notes.md" \
             --prerelease

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,28 +44,40 @@ jobs:
           INITIAL_NIGHTLY_VERSION: 0.0.1
         run: |
           set -o pipefail
-          latest_target=$(gh api "repos/$REPOSITORY/releases?per_page=100" --jq '
-            map(select(.draft == false and .prerelease == true and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\.")))) |
-            .[0].target_commitish // ""
-          ')
-          if [ "$latest_target" = "$COMMIT" ]; then
+          latest_tag=$(gh api --paginate --slurp \
+            "repos/$REPOSITORY/releases?per_page=100" | \
+            ./scripts/release/latest-nightly-tag.sh)
+          latest_commit=
+          if [ -n "$latest_tag" ]; then
+            latest_commit=$(gh api "repos/$REPOSITORY/git/ref/tags/$latest_tag" \
+              --jq '.object.sha')
+          fi
+          if [ "$latest_commit" = "$COMMIT" ]; then
             printf 'skip=true\n' >>"$GITHUB_OUTPUT"
             printf 'nightly: commit %s already published\n' "$COMMIT"
             exit 0
           fi
-          stable_tag=$(gh api --paginate --slurp \
-            "repos/$REPOSITORY/releases?per_page=100" | \
-            ./scripts/release/latest-stable-version.sh)
-          release_date=$(date -u +%Y%m%d)
-          if [ -n "$stable_tag" ]; then
-            version=$(./scripts/release/next-nightly-version.sh \
-              "$stable_tag" "$release_date" "$RUN_NUMBER" "$COMMIT")
+          tag=$(gh api --paginate --slurp \
+            "repos/$REPOSITORY/git/matching-refs/tags/v" | \
+            ./scripts/release/nightly-run-tag.sh "$RUN_NUMBER")
+          tag_exists=true
+          if [ -z "$tag" ]; then
+            stable_tag=$(gh api --paginate --slurp \
+              "repos/$REPOSITORY/releases?per_page=100" | \
+              ./scripts/release/latest-stable-version.sh)
+            release_date=$(date -u +%Y%m%d)
+            if [ -n "$stable_tag" ]; then
+              version=$(./scripts/release/next-nightly-version.sh \
+                "$stable_tag" "$release_date" "$RUN_NUMBER" "$COMMIT")
+            else
+              version=$(./scripts/release/nightly-version.sh "$INITIAL_NIGHTLY_VERSION" \
+                "$release_date" "$RUN_NUMBER" "$COMMIT")
+            fi
+            tag="v$version"
+            tag_exists=false
           else
-            version=$(./scripts/release/nightly-version.sh "$INITIAL_NIGHTLY_VERSION" \
-              "$release_date" "$RUN_NUMBER" "$COMMIT")
+            version=${tag#v}
           fi
-          tag="v$version"
-          tag_exists=false
           tag_lookup_error="$RUNNER_TEMP/nightly-tag-lookup.err"
           if existing_tag_sha=$(gh api "repos/$REPOSITORY/git/ref/tags/$tag" \
             --jq '.object.sha' 2>"$tag_lookup_error"); then
@@ -77,22 +89,15 @@ jobs:
             printf 'nightly: tag %s already resolves to %s; resuming publication\n' \
               "$tag" "$COMMIT"
             tag_exists=true
+          elif [ "$tag_exists" = true ]; then
+            cat "$tag_lookup_error" >&2
+            exit 1
           elif ! grep -F '(HTTP 404)' "$tag_lookup_error" >/dev/null; then
             cat "$tag_lookup_error" >&2
             exit 1
           fi
           printf 'skip=false\nversion=%s\ntag=%s\ntag_exists=%s\n' \
             "$version" "$tag" "$tag_exists" >>"$GITHUB_OUTPUT"
-      - name: Mint scoped nightly release app token
-        id: release_app
-        if: steps.identity.outputs.skip != 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.NIGHTLY_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.NIGHTLY_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         if: steps.identity.outputs.skip != 'true'
         with:
@@ -144,6 +149,16 @@ jobs:
             'Use the stable channel for recovery-signed production releases.' \
             >dist/NIGHTLY-BUILD.txt
           cp dist/NIGHTLY-BUILD.txt "$RUNNER_TEMP/nightly-notes.md"
+      - name: Mint scoped nightly release app token
+        id: release_app
+        if: steps.identity.outputs.skip != 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.NIGHTLY_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NIGHTLY_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
       - name: Create immutable nightly tag
         if: steps.identity.outputs.skip != 'true' && steps.identity.outputs.tag_exists != 'true'
         env:

--- a/docs/handoff/nightly-github-app.md
+++ b/docs/handoff/nightly-github-app.md
@@ -27,9 +27,10 @@ exact checked-out main commit. The workflow run number is the durable retry
 identity, so a rerun finds its tag even after midnight or a new stable release.
 Any different object or multiple tags for one run is fatal. If tag creation
 succeeds but release creation fails, rerunning the same workflow run resumes
-publication without moving or replacing the immutable tag. Published commit
-deduplication resolves the latest nightly tag itself instead of trusting the
-release API's `target_commitish`, which is not the tag target.
+publication without moving or replacing the immutable tag. A rerun of an
+already-published run exits successfully without recreating the release.
+Published commit deduplication resolves the latest nightly tag itself instead
+of trusting the release API's `target_commitish`, which is not the tag target.
 
 ## Adjacent repository-policy repair
 

--- a/docs/handoff/nightly-github-app.md
+++ b/docs/handoff/nightly-github-app.md
@@ -1,0 +1,35 @@
+# Handoff: nightly publication GitHub App
+
+Failed run:
+https://github.com/Hikyo-Org/Hikyo/actions/runs/32705690965/job/97366200119.
+Implementation base: `cf4bb563b3f98d1cde4856470afe02d408d7761a`.
+
+## Failure and boundary
+
+All six archives built and passed the independent version/commit identity
+check. Publication then failed because the built-in `GITHUB_TOKEN` could not
+create `v0.0.1-nightly.20260824.3.gcf4bb563` through the protected `v*` tag
+ruleset. GitHub also rejects the built-in GitHub Actions integration as a
+repository-ruleset bypass actor when that integration is not installed on the
+organization.
+
+Nightly publication now uses an organization-owned GitHub App installed only
+on `Hikyo`. The app has repository `Contents: read and write`, no webhook, and
+no event subscriptions. The workflow requests that one permission in a
+short-lived installation token, creates the lightweight tag only after archive
+identity passes, and creates the prerelease with `--verify-tag`. The built-in
+workflow token is read-only.
+
+## Recovery behavior
+
+A retry accepts an existing nightly tag only when it still resolves to the
+exact checked-out main commit. Any different object is fatal. If tag creation
+succeeds but release creation fails, rerunning the same workflow run therefore
+resumes publication without moving or replacing the immutable tag.
+
+## Adjacent repository-policy repair
+
+`configure-repository.sh` previously tried to broaden repository Actions to
+`allowed_actions=all`. That conflicts with Hikyo-Org's selected-actions policy.
+Repository configuration now preserves the organization-approved mode while
+continuing to assert SHA pinning.

--- a/docs/handoff/nightly-github-app.md
+++ b/docs/handoff/nightly-github-app.md
@@ -23,9 +23,13 @@ workflow token is read-only.
 ## Recovery behavior
 
 A retry accepts an existing nightly tag only when it still resolves to the
-exact checked-out main commit. Any different object is fatal. If tag creation
-succeeds but release creation fails, rerunning the same workflow run therefore
-resumes publication without moving or replacing the immutable tag.
+exact checked-out main commit. The workflow run number is the durable retry
+identity, so a rerun finds its tag even after midnight or a new stable release.
+Any different object or multiple tags for one run is fatal. If tag creation
+succeeds but release creation fails, rerunning the same workflow run resumes
+publication without moving or replacing the immutable tag. Published commit
+deduplication resolves the latest nightly tag itself instead of trusting the
+release API's `target_commitish`, which is not the tag target.
 
 ## Adjacent repository-policy repair
 

--- a/docs/release/signing.md
+++ b/docs/release/signing.md
@@ -175,6 +175,21 @@ SBOMs, installer, chart, digest files, and OCI payloads.
 Hash agreement proves asset consistency, not an honest CI build. Reproducible
 build comparison is the named future control for compromised-CI risk.
 
+## Automated nightly publication identity
+
+Nightly builds do not use either offline signing key. An organization-owned
+GitHub App named `Hikyo Nightly Release`, installed only on this repository,
+owns nightly tag and prerelease publication. It has only repository
+`Contents: read and write`, no webhook, and no event subscriptions.
+
+The workflow stores the app client ID in the
+`NIGHTLY_RELEASE_APP_CLIENT_ID` repository variable and its private key in the
+`NIGHTLY_RELEASE_APP_PRIVATE_KEY` Actions secret. Each run mints a short-lived,
+current-repository-only token and requests only `contents: write`. The built-in
+workflow token remains read-only. `configure-repository.sh` applies the
+dedicated app as the sole bypass actor for creation of `v*-nightly.*`; stable
+tag creation remains admin-only and every `v*` tag remains immutable.
+
 ## Rotation, revocation, and loss
 
 - Rotation: recovery-sign metadata that closes the old primary at a named

--- a/internal/app/keyring_test.go
+++ b/internal/app/keyring_test.go
@@ -61,7 +61,10 @@ func TestBootWithRootKeyFileAndWrongKeyRefused(t *testing.T) {
 	if err := os.WriteFile(keyPath, []byte(crypto.EncodeRootKey(key)+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	env := map[string]string{"HIKYO_DB": "sqlite:" + filepath.Join(dir, "hikyo.db")}
+	env := map[string]string{
+		"HIKYO_DB":                 "sqlite:" + filepath.Join(dir, "hikyo.db"),
+		"HIKYO_OPERATIONAL_LISTEN": "localhost:0",
+	}
 	cfg, _, err := config.Load("server", []string{"--listen", "127.0.0.1:0", "--root-key-file", keyPath},
 		func(k string) string { return env[k] }, nil)
 	if err != nil {

--- a/release/repository/nightly-tag-creation.json
+++ b/release/repository/nightly-tag-creation.json
@@ -1,10 +1,10 @@
 {
-  "name": "nightly tags require GitHub Actions",
+  "name": "nightly tags require Hikyo release app",
   "target": "tag",
   "enforcement": "active",
   "bypass_actors": [
     {
-      "actor_id": 15368,
+      "actor_id": 4700019,
       "actor_type": "Integration",
       "bypass_mode": "always"
     }

--- a/scripts/ci/check-nightly-release_test.sh
+++ b/scripts/ci/check-nightly-release_test.sh
@@ -22,6 +22,11 @@ grep -F './scripts/release/latest-nightly-tag.sh' "$workflow" >/dev/null || fail
 grep -F 'git/ref/tags/$latest_tag' "$workflow" >/dev/null || fail 'nightly deduplication trusts target_commitish instead of resolving the tag'
 grep -F './scripts/release/nightly-run-tag.sh "$RUN_NUMBER"' "$workflow" >/dev/null || fail 'reruns do not recover their durable tag identity'
 grep -F 'multiple nightly tags exist for workflow run' "$repo_root/scripts/release/nightly-run-tag.sh" >/dev/null || fail 'ambiguous rerun tag identity is accepted'
+grep -F 'repos/$REPOSITORY/releases/tags/$tag' "$workflow" >/dev/null || fail 'successful reruns attempt to recreate an existing release'
+grep -F 'workflow run %s already published as %s' "$workflow" >/dev/null || fail 'successful reruns are not skipped'
+run_tag_line=$(grep -nF './scripts/release/nightly-run-tag.sh "$RUN_NUMBER"' "$workflow" | cut -d: -f1)
+latest_tag_line=$(grep -nF './scripts/release/latest-nightly-tag.sh' "$workflow" | cut -d: -f1)
+[ "$run_tag_line" -lt "$latest_tag_line" ] || fail 'latest-release deduplication bypasses run-tag mismatch validation'
 if grep -F 'target_commitish' "$workflow" >/dev/null; then
 	fail 'nightly deduplication trusts mutable release metadata'
 fi

--- a/scripts/ci/check-nightly-release_test.sh
+++ b/scripts/ci/check-nightly-release_test.sh
@@ -29,7 +29,15 @@ if grep -F 'releases/latest' "$workflow" >/dev/null; then
 	fail 'no-release bootstrap still depends on the latest-release endpoint'
 fi
 grep -F 'HIKYO_RELEASE_VERSION: ${{ steps.identity.outputs.version }}' "$workflow" >/dev/null || fail 'GoReleaser does not receive nightly version'
+grep -F 'contents: read' "$workflow" >/dev/null || fail 'built-in workflow token retains repository write permission'
+grep -F 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' "$workflow" >/dev/null || fail 'nightly app token action is missing or unpinned'
+grep -F 'client-id: ${{ vars.NIGHTLY_RELEASE_APP_CLIENT_ID }}' "$workflow" >/dev/null || fail 'nightly release app client ID variable is missing'
+grep -F 'private-key: ${{ secrets.NIGHTLY_RELEASE_APP_PRIVATE_KEY }}' "$workflow" >/dev/null || fail 'nightly release app private key secret is missing'
+grep -F 'permission-contents: write' "$workflow" >/dev/null || fail 'nightly release app token does not request exact contents permission'
+grep -F 'GH_TOKEN: ${{ steps.release_app.outputs.token }}' "$workflow" >/dev/null || fail 'nightly publication does not use the short-lived app token'
+grep -F 'gh api --method POST "repos/$REPOSITORY/git/refs"' "$workflow" >/dev/null || fail 'nightly app does not create the immutable tag'
 grep -F 'gh release create "$TAG"' "$workflow" >/dev/null || fail 'nightly prerelease publication is missing'
+grep -F -- '--verify-tag' "$workflow" >/dev/null || fail 'nightly release can create an unverified tag through GITHUB_TOKEN'
 grep -F -- '--prerelease' "$workflow" >/dev/null || fail 'nightly is not marked prerelease'
 grep -F 'dist/hikyo_*_Darwin_*.tar.gz' "$workflow" >/dev/null || fail 'macOS assets are missing'
 grep -F 'dist/hikyo_*_Linux_*.tar.gz' "$workflow" >/dev/null || fail 'Linux assets are missing'
@@ -37,10 +45,18 @@ grep -F 'dist/hikyo_*_Windows_*.zip' "$workflow" >/dev/null || fail 'Windows ass
 grep -F '"!v*-nightly.*"' "$official" >/dev/null || fail 'official ceremony still accepts nightly tags'
 grep -F 'index .Env "HIKYO_RELEASE_VERSION"' "$goreleaser" >/dev/null || fail 'snapshot archive version is not injectable'
 grep -F 'release/repository/nightly-tag-creation.json' "$repo_root/scripts/release/configure-repository.sh" >/dev/null || fail 'nightly tag creation policy is not applied'
+if grep -F 'allowed_actions=all' "$repo_root/scripts/release/configure-repository.sh" >/dev/null; then
+	fail 'repository configuration broadens organization Actions policy'
+fi
+grep -F 'allowed_actions="$allowed_actions"' "$repo_root/scripts/release/configure-repository.sh" >/dev/null || fail 'repository configuration does not preserve organization Actions policy'
 jq -e '
 	.conditions.ref_name.include == ["refs/tags/v*-nightly.*"] and
-	.bypass_actors == [{actor_id: 15368, actor_type: "Integration", bypass_mode: "always"}]
-' "$repo_root/release/repository/nightly-tag-creation.json" >/dev/null || fail 'nightly tag creation is not restricted to GitHub Actions'
+	(.bypass_actors | length) == 1 and
+	.bypass_actors[0].actor_type == "Integration" and
+	.bypass_actors[0].bypass_mode == "always" and
+	(.bypass_actors[0].actor_id | type) == "number" and
+	.bypass_actors[0].actor_id == 4700019
+' "$repo_root/release/repository/nightly-tag-creation.json" >/dev/null || fail 'nightly tag creation is not restricted to the dedicated GitHub App'
 jq -e '.conditions.ref_name.exclude == ["refs/tags/v*-nightly.*"]' \
 	"$repo_root/release/repository/release-tag-creation.json" >/dev/null || fail 'stable creation policy still captures nightlies'
 

--- a/scripts/ci/check-nightly-release_test.sh
+++ b/scripts/ci/check-nightly-release_test.sh
@@ -18,7 +18,13 @@ fail() {
 grep -F 'cron: "0 2 * * *"' "$workflow" >/dev/null || fail '02:00 UTC schedule is missing'
 grep -F 'ref: refs/heads/main' "$workflow" >/dev/null || fail 'nightly checkout is not pinned to main'
 grep -F 'COMMIT: ${{ steps.source.outputs.commit }}' "$workflow" >/dev/null || fail 'nightly does not use the checked-out main SHA'
-grep -F 'select(.draft == false and .prerelease == true' "$workflow" >/dev/null || fail 'draft nightlies can suppress publication'
+grep -F './scripts/release/latest-nightly-tag.sh' "$workflow" >/dev/null || fail 'published nightly discovery is missing'
+grep -F 'git/ref/tags/$latest_tag' "$workflow" >/dev/null || fail 'nightly deduplication trusts target_commitish instead of resolving the tag'
+grep -F './scripts/release/nightly-run-tag.sh "$RUN_NUMBER"' "$workflow" >/dev/null || fail 'reruns do not recover their durable tag identity'
+grep -F 'multiple nightly tags exist for workflow run' "$repo_root/scripts/release/nightly-run-tag.sh" >/dev/null || fail 'ambiguous rerun tag identity is accepted'
+if grep -F 'target_commitish' "$workflow" >/dev/null; then
+	fail 'nightly deduplication trusts mutable release metadata'
+fi
 grep -F './scripts/release/require-green-main.sh "$REPOSITORY" "$COMMIT"' "$workflow" >/dev/null || fail 'nightly does not require exact-head green main CI'
 grep -F 'INITIAL_NIGHTLY_VERSION: 0.0.1' "$workflow" >/dev/null || fail 'first nightly version is not explicit'
 grep -F 'set -o pipefail' "$workflow" >/dev/null || fail 'paginated release discovery can hide API failures'
@@ -66,5 +72,7 @@ fi
 
 "$repo_root/scripts/release/next-nightly-version_test.sh"
 "$repo_root/scripts/release/latest-stable-version_test.sh"
+"$repo_root/scripts/release/latest-nightly-tag_test.sh"
+"$repo_root/scripts/release/nightly-run-tag_test.sh"
 "$repo_root/scripts/release/require-green-main_test.sh"
 printf 'nightly release fixture: CI-gated six-platform prereleases stay outside official signing\n'

--- a/scripts/release/configure-repository.sh
+++ b/scripts/release/configure-repository.sh
@@ -18,6 +18,9 @@ upsert_ruleset() {
 	if [ -z "$id" ] && [ "$name" = 'release tags require admin role' ]; then
 		id=$($GH_BIN api "repos/$repository/rulesets" \
 			--jq '.[] | select(.name == "release tags require maintainer role") | .id')
+	elif [ -z "$id" ] && [ "$name" = 'nightly tags require Hikyo release app' ]; then
+		id=$($GH_BIN api "repos/$repository/rulesets" \
+			--jq '.[] | select(.name == "nightly tags require GitHub Actions") | .id')
 	fi
 	if [ -n "$id" ]; then
 		$GH_BIN api --method PUT "repos/$repository/rulesets/$id" --input "$payload" >/dev/null
@@ -40,8 +43,9 @@ $GH_BIN api --method PUT "repos/$repository/immutable-releases" >/dev/null
 $GH_BIN api --method PATCH "repos/$repository/code-scanning/default-setup" \
 	-f state=configured -f query_suite=default \
 	-f 'languages[]=actions' -f 'languages[]=go' -f 'languages[]=javascript-typescript' >/dev/null
+allowed_actions=$($GH_BIN api "repos/$repository/actions/permissions" --jq '.allowed_actions')
 $GH_BIN api --method PUT "repos/$repository/actions/permissions" \
-	-F enabled=true -f allowed_actions=all -F sha_pinning_required=true >/dev/null
+	-F enabled=true -f allowed_actions="$allowed_actions" -F sha_pinning_required=true >/dev/null
 
 rulesets=$($GH_BIN api "repos/$repository/rulesets")
 printf '%s\n' "$rulesets" | jq -e '
@@ -51,7 +55,7 @@ printf '%s\n' "$rulesets" | jq -e '
 	[.[] | select(.name == "release tags require admin role" and .enforcement == "active")] | length == 1
 ' >/dev/null
 printf '%s\n' "$rulesets" | jq -e '
-	[.[] | select(.name == "nightly tags require GitHub Actions" and .enforcement == "active")] | length == 1
+	[.[] | select(.name == "nightly tags require Hikyo release app" and .enforcement == "active")] | length == 1
 ' >/dev/null
 printf '%s\n' "$rulesets" | jq -e '
 	[.[] | select(.name == "main requires PR and release CI" and .enforcement == "active")] | length == 1
@@ -79,11 +83,11 @@ printf '%s\n' "$creation" | jq -e '
 	.conditions.ref_name.include == ["refs/tags/v*"] and
 	.conditions.ref_name.exclude == ["refs/tags/v*-nightly.*"]
 ' >/dev/null
-nightly_id=$(printf '%s\n' "$rulesets" | jq -r '.[] | select(.name == "nightly tags require GitHub Actions") | .id')
+nightly_id=$(printf '%s\n' "$rulesets" | jq -r '.[] | select(.name == "nightly tags require Hikyo release app") | .id')
 nightly=$($GH_BIN api "repos/$repository/rulesets/$nightly_id")
 printf '%s\n' "$nightly" | jq -e '
 	.bypass_actors == [{
-		actor_id: 15368,
+		actor_id: 4700019,
 		actor_type: "Integration",
 		bypass_mode: "always"
 	}] and

--- a/scripts/release/latest-nightly-tag.sh
+++ b/scripts/release/latest-nightly-tag.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+[ "$#" -eq 0 ] || {
+	printf 'usage: GitHub release pages JSON | %s\n' "$0" >&2
+	exit 2
+}
+
+jq -r '
+  if type != "array" or any(.[]; type != "array") then
+    error("expected an array of GitHub release pages")
+  else
+    [.[][] | select(
+      .draft == false and
+      .prerelease == true and
+      (.tag_name | type) == "string" and
+      (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\."))
+    )] |
+    if length == 0 then
+      ""
+    else
+      .[0].tag_name
+    end
+  end
+'

--- a/scripts/release/latest-nightly-tag_test.sh
+++ b/scripts/release/latest-nightly-tag_test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+script=$(dirname "$0")/latest-nightly-tag.sh
+
+[ -z "$(printf '[]' | "$script")" ]
+[ -z "$(printf '[[{"tag_name":"v1.0.0","draft":false,"prerelease":false}]]' | "$script")" ]
+
+pages='[
+  [{"tag_name":"v0.0.1-nightly.20260824.3.gcf4bb563","draft":false,"prerelease":true}],
+  [{"tag_name":"v0.0.1-nightly.20260823.2.g12345678","draft":false,"prerelease":true}]
+]'
+[ "$(printf '%s\n' "$pages" | "$script")" = 'v0.0.1-nightly.20260824.3.gcf4bb563' ]
+
+mixed='[[
+  {"tag_name":"v0.0.1-nightly.20260824.4.gaaaaaaaa","draft":true,"prerelease":true},
+  {"tag_name":"invalid-nightly","draft":false,"prerelease":true},
+  {"tag_name":"v0.0.1-nightly.20260824.3.gcf4bb563","draft":false,"prerelease":true}
+]]'
+[ "$(printf '%s\n' "$mixed" | "$script")" = 'v0.0.1-nightly.20260824.3.gcf4bb563' ]
+
+expect_reject() {
+	label=$1
+	payload=$2
+	if printf '%s\n' "$payload" | "$script" >/dev/null 2>&1; then
+		printf 'latest nightly tag fixture failed: %s accepted\n' "$label" >&2
+		exit 1
+	fi
+}
+
+expect_reject malformed-json '{'
+expect_reject wrong-shape '{}'
+
+printf 'latest nightly tag fixture: published prerelease selection is deterministic\n'

--- a/scripts/release/nightly-run-tag.sh
+++ b/scripts/release/nightly-run-tag.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ] || ! printf '%s\n' "$1" | grep -Eq '^[1-9][0-9]*$'; then
+	printf 'usage: GitHub matching-refs pages JSON | %s RUN_NUMBER\n' "$0" >&2
+	exit 2
+fi
+
+run_number=$1
+jq -r --arg run "$run_number" '
+  if type != "array" or any(.[]; type != "array") then
+    error("expected an array of GitHub matching-refs pages")
+  else
+    [.[][] | select(
+      (.ref | type) == "string" and
+      (.ref | test(
+        "^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\.[0-9]{8}\\." +
+        $run + "\\.g[0-9a-f]{8}$"
+      ))
+    ) | .ref | sub("^refs/tags/"; "")] |
+    if length == 0 then
+      ""
+    elif length == 1 then
+      .[0]
+    else
+      error("multiple nightly tags exist for workflow run " + $run)
+    end
+  end
+'

--- a/scripts/release/nightly-run-tag_test.sh
+++ b/scripts/release/nightly-run-tag_test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+script=$(dirname "$0")/nightly-run-tag.sh
+
+[ -z "$(printf '[]' | "$script" 3)" ]
+
+refs='[[
+  {"ref":"refs/tags/v0.0.1-nightly.20260824.3.gcf4bb563"},
+  {"ref":"refs/tags/v1.1.0-nightly.20260825.4.g12345678"},
+  {"ref":"refs/tags/v1.0.0"}
+]]'
+[ "$(printf '%s\n' "$refs" | "$script" 3)" = 'v0.0.1-nightly.20260824.3.gcf4bb563' ]
+
+changed_date_and_version='[[
+  {"ref":"refs/tags/v1.1.0-nightly.20260825.3.gcf4bb563"}
+]]'
+[ "$(printf '%s\n' "$changed_date_and_version" | "$script" 3)" = \
+	'v1.1.0-nightly.20260825.3.gcf4bb563' ]
+
+expect_reject() {
+	label=$1
+	run=$2
+	payload=$3
+	if printf '%s\n' "$payload" | "$script" "$run" >/dev/null 2>&1; then
+		printf 'nightly run tag fixture failed: %s accepted\n' "$label" >&2
+		exit 1
+	fi
+}
+
+expect_reject invalid-run 0 '[]'
+expect_reject malformed-json 3 '{'
+expect_reject wrong-shape 3 '{}'
+expect_reject duplicate-run 3 '[[
+  {"ref":"refs/tags/v0.0.1-nightly.20260824.3.gcf4bb563"},
+  {"ref":"refs/tags/v1.1.0-nightly.20260825.3.g12345678"}
+]]'
+
+printf 'nightly run tag fixture: reruns reuse one durable tag identity\n'


### PR DESCRIPTION
## Summary

- keep the built-in workflow token read-only and mint a repository-scoped GitHub App token only for publication
- create the protected nightly tag explicitly after archive verification, then publish with `--verify-tag`
- make retries fail closed by binding each workflow run to one immutable tag and resolving Git refs instead of `target_commitish`
- preserve the organization selected-actions policy when applying repository configuration

## Failure repaired

The six archives passed in run 32705690965, but GitHub rejected tag creation with HTTP 422 because the built-in Actions integration could not bypass the protected nightly-tag ruleset.

## Validation

- Go: 3978 tests passed in 65 packages
- nightly release fixtures passed
- actionlint passed with the repository-pinned tool
- shellcheck passed for changed shell fixtures and helpers
- release fixtures passed with checksum-verified cosign v3.0.6
- docs verification, Astro checks, build, PWA/offline, OSS policy, live docs, and fallback-channel gates passed
- live repository configuration probe passed with the dedicated app as the sole nightly-tag creation bypass
- two-axis standards/spec review: no remaining findings

## Security boundary

The GitHub App is installed only on Hikyo and has only Contents read/write. The workflow requests only contents write in a short-lived current-repository token. Stable tag creation remains admin-only and all v* tags remain immutable.