### PR TITLE
Fix nightly native package publication

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Build tested embedded WebUI
         if: steps.identity.outputs.skip != 'true'
         run: ./scripts/ci/build-spa.sh
-      - name: Build six nightly archives
+      - name: Build six nightly archives and eight native packages
         if: steps.identity.outputs.skip != 'true'
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         env:
@@ -147,7 +147,7 @@ jobs:
           distribution: goreleaser
           version: v2.17.1
           args: release --snapshot --clean --skip=publish
-      - name: Verify nightly archive identity
+      - name: Verify nightly archive and package identity
         if: steps.identity.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.identity.outputs.version }}
@@ -170,6 +170,7 @@ jobs:
             "Version: $VERSION" \
             "Source commit: $COMMIT" \
             'Built automatically from an exact main commit with successful CI.' \
+            'Includes six archives and eight native Linux packages.' \
             'Use the stable channel for recovery-signed production releases.' \
             >dist/NIGHTLY-BUILD.txt
           cp dist/NIGHTLY-BUILD.txt "$RUNNER_TEMP/nightly-notes.md"
@@ -203,6 +204,10 @@ jobs:
             dist/hikyo_*_Darwin_*.tar.gz \
             dist/hikyo_*_Linux_*.tar.gz \
             dist/hikyo_*_Windows_*.zip \
+            dist/hikyo_*.deb \
+            dist/hikyo-*.rpm \
+            dist/hikyo_*.apk \
+            dist/hikyo-*.pkg.tar.zst \
             dist/checksums.txt \
             dist/binary-provenance.json \
             dist/NIGHTLY-BUILD.txt \

--- a/docs/handoff/package-manager-releases.md
+++ b/docs/handoff/package-manager-releases.md
@@ -76,3 +76,7 @@ awaits the human merge gate.
 Hosted apt, RPM, APK, and pacman repositories remain out of scope; local
 package files use the signed Hikyo bundle instead of repository-native package
 signatures.
+
+Unsigned nightlies publish the same eight package formats as convenience
+artifacts after snapshot verification. They do not enter the offline signing
+ceremony and do not carry the pinned-root guarantee.

--- a/docs/release/signing.md
+++ b/docs/release/signing.md
@@ -198,6 +198,9 @@ Nightly builds do not use either offline signing key. An organization-owned
 GitHub App named `Hikyo Nightly Release`, installed only on this repository,
 owns nightly tag and prerelease publication. It has only repository
 `Contents: read and write`, no webhook, and no event subscriptions.
+Each nightly publishes the six platform archives and all eight native Linux
+packages produced by the same verified GoReleaser snapshot. They remain
+explicitly unsigned development artifacts, not pinned-root releases.
 
 The workflow stores the app client ID in the
 `NIGHTLY_RELEASE_APP_CLIENT_ID` repository variable and its private key in the

--- a/scripts/ci/check-nightly-release_test.sh
+++ b/scripts/ci/check-nightly-release_test.sh
@@ -53,6 +53,11 @@ grep -F -- '--prerelease' "$workflow" >/dev/null || fail 'nightly is not marked 
 grep -F 'dist/hikyo_*_Darwin_*.tar.gz' "$workflow" >/dev/null || fail 'macOS assets are missing'
 grep -F 'dist/hikyo_*_Linux_*.tar.gz' "$workflow" >/dev/null || fail 'Linux assets are missing'
 grep -F 'dist/hikyo_*_Windows_*.zip' "$workflow" >/dev/null || fail 'Windows assets are missing'
+grep -F 'dist/hikyo_*.deb' "$workflow" >/dev/null || fail 'Debian package assets are missing'
+grep -F 'dist/hikyo-*.rpm' "$workflow" >/dev/null || fail 'RPM package assets are missing'
+grep -F 'dist/hikyo_*.apk' "$workflow" >/dev/null || fail 'APK package assets are missing'
+grep -F 'dist/hikyo-*.pkg.tar.zst' "$workflow" >/dev/null || fail 'Arch package assets are missing'
+grep -F 'Includes six archives and eight native Linux packages.' "$workflow" >/dev/null || fail 'nightly package warning is missing'
 grep -F '"!v*-nightly.*"' "$official" >/dev/null || fail 'official ceremony still accepts nightly tags'
 grep -F 'index .Env "HIKYO_RELEASE_VERSION"' "$goreleaser" >/dev/null || fail 'snapshot archive version is not injectable'
 grep -F 'release/repository/nightly-tag-creation.json' "$repo_root/scripts/release/configure-repository.sh" >/dev/null || fail 'nightly tag creation policy is not applied'
@@ -80,4 +85,4 @@ fi
 "$repo_root/scripts/release/latest-nightly-tag_test.sh"
 "$repo_root/scripts/release/nightly-run-tag_test.sh"
 "$repo_root/scripts/release/require-green-main_test.sh"
-printf 'nightly release fixture: CI-gated six-platform prereleases stay outside official signing\n'
+printf 'nightly release fixture: CI-gated archives and native packages stay outside official signing\n'


### PR DESCRIPTION
## Cause

GoReleaser produced all eight native packages, but the nightly gh release create allowlist uploaded only the six platform archives and metadata. The immutable nightly release therefore exposed zero package assets.

## Fix

- Upload Debian, RPM, APK, and Arch package globs alongside the six archives.
- Keep nightlies explicitly outside the offline signing ceremony and pinned-root guarantee.
- Add a regression fixture requiring every package format in the publication allowlist.

## Verification

- Reproduced against v0.0.1-nightly.20260824.6.gc43d6f94: 0 package assets.
- Tagged workflow logs prove GoReleaser created all eight package files.
- Regression fixture failed before the workflow change and passes afterward.
- actionlint, shellcheck, documentation, OSS-policy, PWA, and live-doc gates pass.

Follow-up to #435.