### PR TITLE
fix(release): prove container serves SPA #197

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,15 +354,18 @@ jobs:
           dist image-root "$(git rev-parse HEAD)" .goreleaser.yaml
       - name: Smoke the exact candidate image
         run: |
+          image=hikyo-release-snapshot:${{ github.sha }}
           docker build --build-arg TARGETARCH=amd64 \
-            --tag hikyo-release-snapshot:${{ github.sha }} \
+            --tag "$image" \
             --file Dockerfile.release .
+          image_id=$(docker image inspect --format '{{.Id}}' "$image")
           expected=$(jq -r '.version' dist/metadata.json)
-          actual=$(docker run --rm hikyo-release-snapshot:${{ github.sha }} version)
+          actual=$(docker run --rm "$image_id" version)
           case "$actual" in
             "hikyo $expected ("*) ;;
             *) printf 'candidate image: version mismatch: %s\n' "$actual" >&2; exit 1 ;;
           esac
+          ./scripts/release/smoke-image-ui.sh "$image_id"
       # This fixture works on a temporary copy of dist. Keep it before upload:
       # failed archive/version/manifest checks must not leave a download behind.
       - name: Classify complete snapshot manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,12 @@ jobs:
             org.opencontainers.image.revision=${{ steps.candidate.outputs.commit }}
             org.opencontainers.image.version=${{ steps.candidate.outputs.version }}
 
+      - name: Smoke the published candidate image
+        env:
+          IMAGE: ${{ steps.identity.outputs.image }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: ./scripts/release/smoke-image-ui.sh "$IMAGE@$IMAGE_DIGEST"
+
       - name: Published image SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:

--- a/docs/handoff/197-release-container-spa.md
+++ b/docs/handoff/197-release-container-spa.md
@@ -1,0 +1,43 @@
+# Issue #197: release container SPA proof
+
+## State
+
+Implemented. Release archives and OCI inputs already share the `hikyo`
+GoReleaser build, whose `.goreleaser.yaml` flags include `-tags=ui` for both
+Linux architectures. This slice closes the remaining packaging gap by booting
+the exact candidate image and proving its embedded browser surface.
+
+## Contract
+
+- CI resolves the locally built image to its immutable image ID before any
+  assertion.
+- The release workflow pulls and runs the published multi-architecture image
+  by the digest returned from `docker/build-push-action`.
+- `scripts/release/smoke-image-ui.sh` boots that reference with isolated SQLite
+  and state paths, update checks disabled, a read-only root filesystem, and a
+  private host port.
+- The smoke requires `/` to return `200` SPA HTML with `text/html`, extracts a
+  content-hashed JavaScript reference, then requires that exact asset to be
+  non-empty and served as `text/javascript`.
+- Untagged development builds keep their existing API-only `404` contract;
+  `TestNoEmbeddedUIStillServesTheAPI` remains the direct public-router proof.
+
+## Files
+
+- `.github/workflows/ci.yml`: immutable local candidate smoke.
+- `.github/workflows/release.yml`: published digest smoke before SBOM and chart
+  publication.
+- `scripts/release/smoke-image-ui.sh`: shared image-level HTTP probe.
+- `scripts/ci/check-release-binary-reuse_test.sh`: fail-closed workflow and
+  smoke-contract fixture.
+
+## Validation
+
+- `./scripts/ci/check-release-binary-reuse_test.sh`
+- `./scripts/release/prepare-image-root_test.sh`
+- `shellcheck scripts/release/smoke-image-ui.sh scripts/ci/check-release-binary-reuse_test.sh`
+- `./scripts/ci/run-go-tool.sh actionlint`
+- `go test -count=1 ./internal/server -run '^TestNoEmbeddedUIStillServesTheAPI$'`
+- `go test -count=1 -tags ui ./internal/server/... ./internal/webui/...`
+- Local Linux/arm64 `-tags=ui` image booted by immutable image ID; `/` served
+  the Hikyo shell and `/assets/index-c5rIZ486.js` as `text/javascript`.

--- a/scripts/ci/check-release-binary-reuse_test.sh
+++ b/scripts/ci/check-release-binary-reuse_test.sh
@@ -8,6 +8,7 @@ repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
 ci_workflow="$repo_root/.github/workflows/ci.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
 dockerfile="$repo_root/Dockerfile.release"
+smoke_script="$repo_root/scripts/release/smoke-image-ui.sh"
 
 fail() {
 	printf 'release binary reuse fixture failed: %s\n' "$1" >&2
@@ -21,8 +22,10 @@ require_text() {
 }
 
 release_block=$(sed -n '/args: release --clean --skip=publish/,/uses: docker\/setup-buildx-action/p' "$release_workflow")
+release_image_block=$(sed -n '/name: Publish unsigned multi-arch image/,/name: Published image SBOM/p' "$release_workflow")
 snapshot_block=$(sed -n '/^  release-snapshot:/,/^  generated:/p' "$ci_workflow")
 [ -n "$release_block" ] || fail 'release packaging block is missing'
+[ -n "$release_image_block" ] || fail 'release image block is missing'
 [ -n "$snapshot_block" ] || fail 'release snapshot job is missing'
 
 require_text "$release_block" 'args: release --clean --skip=publish'
@@ -36,7 +39,14 @@ fi
 
 require_text "$snapshot_block" './scripts/release/prepare-image-root.sh'
 require_text "$snapshot_block" 'name: Smoke the exact candidate image'
-require_text "$snapshot_block" 'docker run --rm hikyo-release-snapshot:${{ github.sha }} version'
+require_text "$snapshot_block" 'image_id=$(docker image inspect --format '\''{{.Id}}'\'' "$image")'
+require_text "$snapshot_block" 'docker run --rm "$image_id" version'
+require_text "$snapshot_block" './scripts/release/smoke-image-ui.sh "$image_id"'
+require_text "$release_image_block" 'name: Smoke the published candidate image'
+require_text "$release_image_block" './scripts/release/smoke-image-ui.sh "$IMAGE@$IMAGE_DIGEST"'
 require_text "$(cat "$dockerfile")" 'image-root/${TARGETARCH}/hikyo'
+require_text "$(cat "$smoke_script")" 'Accept: text/html'
+require_text "$(cat "$smoke_script")" '^/assets/[^/?#]+-[A-Za-z0-9_-]{8,}\.js$'
+require_text "$(cat "$smoke_script")" '^content-type: text/javascript'
 
-printf 'release binary reuse fixture: archives and OCI images share GoReleaser outputs\n'
+printf 'release binary reuse fixture: archives and OCI images share GoReleaser outputs; candidate images serve the SPA\n'

--- a/scripts/release/smoke-image-ui.sh
+++ b/scripts/release/smoke-image-ui.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	printf 'usage: %s IMAGE\n' "$0" >&2
+	exit 2
+fi
+
+for command in docker curl grep sed tr; do
+	command -v "$command" >/dev/null || {
+		printf 'candidate image UI smoke: %s is required\n' "$command" >&2
+		exit 2
+	}
+done
+
+image=$1
+work=$(mktemp -d "${TMPDIR:-/tmp}/hikyo-image-ui-smoke.XXXXXX")
+container=
+cleanup() {
+	if [ -n "$container" ]; then
+		docker rm --force "$container" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+	printf 'candidate image UI smoke: %s\n' "$1" >&2
+	if [ -n "$container" ]; then
+		docker logs "$container" >&2 || true
+	fi
+	exit 1
+}
+
+# Boot the candidate itself with an isolated, zero-authority fixture. The
+# update channel is disabled so this packaging proof cannot make outbound
+# release checks; only the host-bound HTTP port is exposed.
+container=$(docker run --detach --rm \
+	--read-only \
+	--tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+	--env HIKYO_DB=sqlite:/tmp/hikyo-release-smoke.db \
+	--env HIKYO_STATE_DIR=/tmp/hikyo-release-smoke-state \
+	--env HIKYO_TRUSTED_PROXY_CIDRS=127.0.0.1/32 \
+	--env HIKYO_UPDATE_CHANNEL=off \
+	--publish 127.0.0.1::8080 \
+	"$image" server --dev --listen=0.0.0.0:8080 --operational-listen=0.0.0.0:8081)
+
+published=$(docker port "$container" 8080/tcp) || fail 'public port was not published'
+port=${published##*:}
+case "$port" in
+	'' | *[!0-9]*) fail "invalid published port: $published" ;;
+esac
+origin=http://127.0.0.1:$port
+html=$work/index.html
+html_headers=$work/index.headers
+
+status=
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+	attempt=$((attempt + 1))
+	if status=$(curl --silent --show-error --connect-timeout 1 --max-time 2 \
+		--header 'Accept: text/html' --dump-header "$html_headers" \
+		--output "$html" --write-out '%{http_code}' "$origin/" 2>/dev/null); then
+		[ "$status" = 200 ] && break
+	fi
+	if [ "$(docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null || true)" != true ]; then
+		fail 'container exited before serving the SPA'
+	fi
+	sleep 0.5
+done
+[ "$status" = 200 ] || fail "GET / returned ${status:-no response}, want 200"
+
+tr -d '\r' <"$html_headers" | grep -Eiq '^content-type: text/html(;|$)' ||
+	fail 'GET / did not return text/html'
+grep -F '<div id="root"></div>' "$html" >/dev/null ||
+	fail 'GET / did not return the SPA HTML shell'
+
+asset=$(grep -Eo 'src="/assets/[^"]+\.js"' "$html" |
+	sed -n '1{s/^src="//;s/"$//;p;}')
+[ -n "$asset" ] || fail 'SPA HTML did not reference a JavaScript asset'
+printf '%s\n' "$asset" | grep -Eq '^/assets/[^/?#]+-[A-Za-z0-9_-]{8,}\.js$' ||
+	fail "SPA JavaScript asset is not content hashed: $asset"
+
+asset_headers=$work/asset.headers
+asset_body=$work/asset.js
+curl --fail --silent --show-error --dump-header "$asset_headers" \
+	--output "$asset_body" "$origin$asset" || fail "GET $asset failed"
+[ -s "$asset_body" ] || fail "GET $asset returned an empty body"
+tr -d '\r' <"$asset_headers" | grep -Eiq '^content-type: text/javascript(;|$)' ||
+	fail "GET $asset did not return text/javascript"
+
+printf 'candidate image UI smoke: %s serves SPA HTML and %s as text/javascript\n' \
+	"$image" "$asset"


### PR DESCRIPTION
Closes #197

## Summary

- reuse the canonical GoReleaser UI-tagged binaries for OCI images
- smoke local candidates by immutable image ID
- smoke published multi-architecture releases by registry digest
- require SPA HTML plus a content-hashed JavaScript asset and content type

## Local validation

- release binary reuse fixture
- canonical image-root fixture
- ShellCheck and actionlint
- no-UI API-only router test
- UI-tagged server/webui tests
- real Linux/arm64 candidate image HTTP smoke