### PR TITLE
fix(web): keep account security failures visible inline #443

### DIFF
--- a/web/e2e/flows/account.spec.ts
+++ b/web/e2e/flows/account.spec.ts
@@ -119,13 +119,19 @@ test.describe('account and security', () => {
     await dialog.getByLabel('Password').fill(`${ADMIN.password}-wrong`);
     await dialog.getByRole('button', { name: 'Confirm' }).click();
 
-    const alert = page.getByRole('alert').filter({ hasText: 'did not authorise the change' });
-    await expect(alert).toContainText('did not authorise the change');
-    await expect(alert).toBeInViewport();
+    const inlineAlert = page
+      .locator('#content')
+      .getByRole('alert')
+      .filter({ hasText: 'did not authorise the change' });
+    await expect(inlineAlert).toContainText('did not authorise the change');
+    const toastAlert = page
+      .locator('.toast[role="alert"]')
+      .filter({ hasText: 'did not authorise the change' });
+    await expect(toastAlert).toBeInViewport();
     // Never presented as a bare "wrong password": a 401 here is either a
     // refused proof or an ended session, and the sentence covers both without
     // guessing which.
-    await expect(alert).toContainText('or this session has ended');
+    await expect(inlineAlert).toContainText('or this session has ended');
   });
 
   test('keeps the theme choice explicit and local', async ({ page }) => {

--- a/web/src/routes/AccountSecurity.test.tsx
+++ b/web/src/routes/AccountSecurity.test.tsx
@@ -75,7 +75,7 @@ vi.mock('../api/remotes.ts', () => ({
     isPending: false,
     mutate: (
       _session: string,
-      callbacks: { readonly onError: (error: unknown) => void },
+      callbacks: { readonly onError: (error: Error) => void },
     ) => callbacks.onError(new Error('revoke failed')),
   }),
 }));

--- a/web/src/routes/AccountSecurity.test.tsx
+++ b/web/src/routes/AccountSecurity.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearNotification, notifyFailure, ToastViewport } from '../app/notifications.tsx';
+import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { AccountSecurity } from './AccountSecurity.tsx';
+
+vi.mock('../app/AuthProvider.tsx', () => ({
+  useAuth: () => ({
+    identity: {
+      principal: { id: 'usr_alice', display_name: 'Alice' },
+      session: { assurance: { factors: ['password'] } },
+    },
+    refreshSession: vi.fn(),
+  }),
+}));
+
+vi.mock('../api/account.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/account.ts')>();
+  const mutation = () => ({ isPending: false, mutate: vi.fn() });
+  return {
+    ...actual,
+    useAuthMethods: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      data: { providers: [] },
+    }),
+    useConfirmTotp: mutation,
+    useEnrolPasskey: mutation,
+    useEnrolTotpStart: mutation,
+    useIdentities: () => ({
+      isError: false,
+      isSuccess: true,
+      data: { identities: [] },
+    }),
+    useLinkIdentity: mutation,
+    usePasskeys: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      data: { passkeys: [] },
+    }),
+    useRegenerateRecoveryCodes: mutation,
+    useRemovePasskey: mutation,
+    useRemoveTotp: mutation,
+    useTotpStatus: () => ({
+      isPending: false,
+      isFetching: false,
+      isError: false,
+      isSuccess: true,
+      data: { confirmed: false, pending: false },
+    }),
+    useUnlinkIdentity: mutation,
+  };
+});
+
+vi.mock('../api/remotes.ts', () => ({
+  useSessions: () => ({
+    isError: false,
+    isSuccess: true,
+    data: {
+      items: [
+        {
+          id: 'sess_1',
+          artifact: 'browser',
+          auth_method: 'password',
+          last_seen_at: '2026-08-24T12:00:00Z',
+        },
+      ],
+    },
+  }),
+  useRevokeSession: () => ({
+    isPending: false,
+    mutate: (
+      _session: string,
+      callbacks: { readonly onError: (error: unknown) => void },
+    ) => callbacks.onError(new Error('revoke failed')),
+  }),
+}));
+
+let unmount: (() => Promise<void>) | undefined;
+
+beforeEach(() => {
+  clearNotification();
+});
+
+afterEach(async () => {
+  await unmount?.();
+  unmount = undefined;
+  clearNotification();
+  document.body.replaceChildren();
+});
+
+describe('AccountSecurity mutation feedback', () => {
+  it('keeps a failed security mutation visible inline when a later toast replaces its toast', async () => {
+    const rendered = await renderForm(
+      <>
+        <AccountSecurity />
+        <ToastViewport />
+      </>,
+    );
+    unmount = rendered.unmount;
+
+    const revoke = rendered.container.querySelector(
+      'button[aria-label="Revoke the browser session sess_1"]',
+    );
+    if (!(revoke instanceof HTMLButtonElement)) {
+      throw new Error('the session has no revoke button');
+    }
+
+    await act(async () => revoke.click());
+    await settle();
+
+    const inlineFailure = rendered.container.querySelector('.page > .alert[role="alert"]');
+    expect(inlineFailure?.textContent).toContain(
+      'The account surface could not be reached, or it answered something this client does not understand.',
+    );
+    expect(rendered.container.querySelector('.toast')?.textContent).toContain(
+      'The account surface could not be reached',
+    );
+
+    await act(async () => notifyFailure('A later security failure.'));
+
+    expect(inlineFailure?.textContent).toContain('The account surface could not be reached');
+    expect(rendered.container.querySelector('.toast')?.textContent).toContain(
+      'A later security failure.',
+    );
+  });
+});

--- a/web/src/routes/AccountSecurity.tsx
+++ b/web/src/routes/AccountSecurity.tsx
@@ -70,7 +70,7 @@ export function AccountSecurity() {
   const link = useLinkIdentity();
 
   const [proof, setProof] = useState<ProofRequest | null>(null);
-  const { done, report: recordFailure, ok: recordSuccess } = useFeedback(accountFailureText);
+  const { done, failure, report: recordFailure, ok: recordSuccess } = useFeedback(accountFailureText);
   const report = (error: unknown) => {
     notifyFailure(accountFailureText(error));
     recordFailure(error);
@@ -199,6 +199,7 @@ export function AccountSecurity() {
       />
 
       {done !== null ? <Done>{done}</Done> : null}
+      {failure !== null ? <Alert>{failure}</Alert> : null}
 
       <Panel id="account-profile" title="Profile">
         <dl className="kv">


### PR DESCRIPTION
Closes #443

Account security mutation failures now remain visible inline even when a later notification replaces the toast.

Validation is pending lower local memory pressure; CI starts immediately.