### PR TITLE
Redirect after successful project deletion #445

### DIFF
--- a/docs/handoff/445-project-delete-redirect.md
+++ b/docs/handoff/445-project-delete-redirect.md
@@ -1,0 +1,25 @@
+# #445 — Project-delete redirect
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/445. Pull request:
+https://github.com/Hikyo-Org/Hikyo/pull/469.
+
+## Contract
+
+- A successful project delete navigates to the canonical `/projects` surface.
+- Navigation is the mutation hook's success callback, so it runs before the
+  session refresh invalidates the deleted project's query.
+- Delete refusals remain inline on the project settings page.
+
+## Regression evidence
+
+- The routed `ProjectSettings` test submits a real mocked `204` delete.
+- Its mocked session refresh never settles; reaching `/projects` therefore
+  proves navigation does not wait for refresh or a deleted-resource refetch.
+- The destination cannot render the stale project-read refusal.
+
+## Validation
+
+- `git diff --check` passed.
+- Standards and issue-spec review both returned `CLEAN` after the callback
+  ordering was corrected.
+- Exact-head local and CI results are recorded on PR #469.

--- a/docs/handoff/445-project-delete-redirect.md
+++ b/docs/handoff/445-project-delete-redirect.md
@@ -16,6 +16,8 @@ https://github.com/Hikyo-Org/Hikyo/pull/469.
 - Its mocked session refresh never settles; reaching `/projects` therefore
   proves navigation does not wait for refresh or a deleted-resource refetch.
 - The destination cannot render the stale project-read refusal.
+- The existing browser deletion flow now proves the `/projects` destination
+  and absence of the deleted-project alert on desktop and mobile.
 
 ## Validation
 

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -658,7 +658,11 @@ test.describe('project settings', () => {
     const again = page.locator('#project-danger');
     await again.getByLabel('Delete this project').fill(drillName);
     await again.getByRole('button', { name: 'Delete project' }).click();
-    await expect(page.locator('.notice').filter({ hasText: 'Project deleted' })).toBeVisible();
+    await expect(page).toHaveURL(/\/projects$/);
+    await expect(page.getByRole('heading', { name: 'Projects', level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'This project could not be read' }),
+    ).toHaveCount(0);
     drillProject = '';
   });
 

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -430,11 +430,12 @@ export function useRenameProject(org: string) {
   });
 }
 
-export function useDeleteProject(org: string) {
+export function useDeleteProject(org: string, onDeleted?: () => void) {
   const auth = useAuth();
   return useMutation({
     mutationFn: (input: { project: string }) =>
       ok(deleteProjectOp, { path: { org, project: input.project } }),
+    onSuccess: onDeleted,
     onSettled: () => auth.refreshSession(),
   });
 }

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -1,12 +1,96 @@
 // @vitest-environment happy-dom
 import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { created, renderForm, settle, typeInto } from '../testkit/renderForm.tsx';
-import { NewEnvironmentForm } from './ProjectSettings.tsx';
+import { created, renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { NewEnvironmentForm, ProjectSettings } from './ProjectSettings.tsx';
+
+const mocks = vi.hoisted(() => ({
+  refreshSession: vi.fn(),
+}));
+
+vi.mock('../app/AuthProvider.tsx', () => ({
+  useAuth: () => ({ refreshSession: mocks.refreshSession }),
+}));
+
+vi.mock('../api/definitions.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/definitions.ts')>();
+  return {
+    ...actual,
+    useDefinitionsSettings: () => ({ data: undefined, isError: false, isPending: true }),
+    useSetDefinitionsSettings: () => ({ isPending: false, mutate: vi.fn() }),
+  };
+});
+
+vi.mock('../api/settings.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/settings.ts')>();
+  return {
+    ...actual,
+    useEnvironments: () => ({ data: undefined, isError: false, isPending: true }),
+    useEnvironmentSettings: () => new Map(),
+    useOrgRetention: () => ({ data: undefined, isError: false, isPending: true }),
+    useProject: () => ({
+      data: {
+        id: 'project_1',
+        org_id: 'org_1',
+        name: 'Payments',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      isError: false,
+    }),
+    useProjectRetention: () => ({ data: undefined, isError: false }),
+    useRenameProject: () => ({ isPending: false, mutate: vi.fn() }),
+  };
+});
 
 afterEach(() => {
+  mocks.refreshSession.mockReset();
   vi.unstubAllGlobals();
+});
+
+describe('ProjectSettings', () => {
+  it('navigates to the project list after deleting the current project', async () => {
+    const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) =>
+      Promise.resolve(new Response(null, { status: 204 })),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container, unmount } = await renderForm(
+      <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
+        <Routes>
+          <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
+          <Route path="/projects" element={<p>Project list</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const input = container.querySelector<HTMLInputElement>('.danger-zone input');
+    if (input === null) {
+      throw new Error('the project delete confirmation input is missing');
+    }
+    const deleteButton = [...container.querySelectorAll('button')].find(
+      (candidate) => candidate.textContent === 'Delete project',
+    );
+    if (deleteButton === undefined) {
+      throw new Error('the project delete button is missing');
+    }
+
+    await act(async () => typeInto(input, 'Payments'));
+    await act(async () => deleteButton.click());
+    await settleTask();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = fetchMock.mock.calls[0]?.[0];
+    if (!(request instanceof Request)) {
+      throw new Error('fetch was not called with a Request');
+    }
+    expect(request.method).toBe('DELETE');
+    expect(new URL(request.url).pathname).toBe('/api/v1/orgs/org_1/projects/project_1');
+    expect(container.textContent).toContain('Project list');
+    expect(container.textContent).not.toContain('This project could not be read.');
+
+    await unmount();
+  });
 });
 
 describe('NewEnvironmentForm', () => {

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -51,6 +51,9 @@ afterEach(() => {
 
 describe('ProjectSettings', () => {
   it('navigates to the project list after deleting the current project', async () => {
+    // The redirect must not wait for session refresh: refresh immediately
+    // invalidates the deleted project's query in the real provider.
+    mocks.refreshSession.mockReturnValue(new Promise<void>(() => {}));
     const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) =>
       Promise.resolve(new Response(null, { status: 204 })),
     );

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -64,7 +64,7 @@ export function ProjectSettings() {
   const definitionsSettings = useDefinitionsSettings(org, project);
   const setDefinitionsSettings = useSetDefinitionsSettings(org, project);
   const rename = useRenameProject(org);
-  const remove = useDeleteProject(org);
+  const remove = useDeleteProject(org, () => navigate(surfaceById('projects').path));
   const nameId = useId();
 
   const [name, setName] = useState('');
@@ -258,7 +258,6 @@ export function ProjectSettings() {
             remove.mutate(
               { project },
               {
-                onSuccess: () => navigate(surfaceById('projects').path),
                 onError: (error) => report('delete-project', error),
               },
             )

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState, type FormEvent } from 'react';
-import { generatePath, Link, useParams } from 'react-router';
+import { generatePath, Link, useNavigate, useParams } from 'react-router';
 
 import {
   GIT_DEFINITIONS_NOTICE,
@@ -53,6 +53,7 @@ import { useFeedback } from './useModalDialog.ts';
  * values, never definitions.
  */
 export function ProjectSettings() {
+  const navigate = useNavigate();
   const params = useParams();
   const org = params.org === undefined ? '' : params.org;
   const project = params.project === undefined ? '' : params.project;
@@ -257,7 +258,7 @@ export function ProjectSettings() {
             remove.mutate(
               { project },
               {
-                onSuccess: () => feedback.ok('Project deleted.'),
+                onSuccess: () => navigate(surfaceById('projects').path),
                 onError: (error) => report('delete-project', error),
               },
             )


### PR DESCRIPTION
Closes #445

## Summary
- redirect successful project deletion to the project list before session refresh invalidates queries
- cover the route transition with a real mocked 204 delete mutation
- keep refresh unresolved in the regression to prove navigation is independent of refetch completion
- update the desktop/mobile browser flow to assert `/projects` and no dead-project alert

## Validation
- focused `ProjectSettings.test.tsx`: 2/2 passed
- merged-tree `pnpm run typecheck`: passed
- merged-tree full web Vitest suite: 46 files, 344/344 tests passed
- browser flow on pre-sync head: desktop + mobile passed
- `git diff --check`: passed
- three-round two-axis Standards + issue-spec review: CLEAN/CLEAN