### PR TITLE
Add environment lifecycle controls #446

### DIFF
--- a/docs/handoff/446-environment-lifecycle-ui.md
+++ b/docs/handoff/446-environment-lifecycle-ui.md
@@ -1,0 +1,42 @@
+# Issue #446 — environment lifecycle UI
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/446
+
+**State: implemented; verification running.** Project settings now exposes the
+four existing environment lifecycle operations: rename, delete, whole-set
+reorder, and atomic clone-at-creation.
+
+## Contract
+
+- Each environment row owns rename, move up/down, clone, and typed-name delete
+  controls under one `Manage environment` disclosure.
+- Reorder sends every current environment id exactly once.
+- Clone reports both copied values and secrets the source-material gate omitted.
+- Lifecycle refusals preserve caller-safe details and keep uniform 403/404
+  responses indistinguishable.
+- Successful mutations invalidate the environment list plus every project
+  matrix cache family affected by topology changes.
+- Environment deletion is destructive by backend contract: it removes the
+  environment and its values, drafts, revision history, pins, and snapshots.
+  The UI states this before enabling typed-name confirmation.
+
+## Migration and generated outputs
+
+No schema migration or generated output is needed. The SPA consumes the four
+operations already present in the generated TypeScript client.
+
+## Validation
+
+Focused Vitest coverage exercises all four requests, refusal mapping, and the
+rename/delete confirmation flow. The settings Playwright flow proves create,
+rename, delete, then project delete through the SPA. Local execution is delayed
+until host memory pressure subsides; exact commands and results will replace
+this paragraph before merge.
+
+## Review disposition
+
+First two-axis review found four issues: centralize matrix cache prefixes,
+remove a new type assertion, deduplicate lifecycle refusal mapping, and add
+this handoff. The spec review then found missing matrix-key invalidation and a
+delete-success callback that could be lost when invalidation unmounted its row.
+Both were fixed. Final standards and issue-spec rechecks returned `CLEAN`.

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -642,7 +642,7 @@ test.describe('project settings', () => {
     }
   });
 
-  test('refuses to delete a project that still holds an environment, then deletes it', async () => {
+  test('creates, renames, and deletes an environment before deleting its empty project', async () => {
     await page.goto(`/orgs/${seed.org}/projects/${drillProject}/settings`);
     const danger = page.locator('#project-danger');
     await danger.getByLabel('Delete this project').fill(drillName);
@@ -651,9 +651,39 @@ test.describe('project settings', () => {
     const refusal = page.getByRole('alert').filter({ hasText: 'never cascades' });
     await expect(refusal).toBeVisible();
 
+    // Clear the setup environment, then prove the whole documented lifecycle
+    // through the SPA rather than preparing the desired state through the API.
     await browserApi(page, 'DELETE', `${base()}/environments/${drillEnv}`, z.null());
     drillEnv = '';
     await page.reload();
+    const policy = page.locator('#project-policy');
+    await policy.getByLabel('Environment name').fill('lifecycle');
+    const createdResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === `${base()}/environments`,
+    );
+    await policy.getByRole('button', { name: 'Create environment' }).click();
+    drillEnv = zEnvironment.parse(await (await createdResponse).json()).id;
+    await expect(policy.getByRole('status').filter({ hasText: 'Environment lifecycle created' })).toBeVisible();
+
+    let row = policy.locator('.envpolicy__row').filter({ hasText: 'lifecycle' });
+    await row.getByText('Manage environment', { exact: true }).click();
+    await row.getByLabel('New name for lifecycle').fill('lifecycle-renamed');
+    await row.getByRole('button', { name: 'Rename environment' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: 'Environment lifecycle renamed to lifecycle-renamed' }),
+    ).toBeVisible();
+
+    row = policy.locator('.envpolicy__row').filter({ hasText: 'lifecycle-renamed' });
+    await row.getByLabel('Delete lifecycle-renamed').fill('lifecycle-renamed');
+    await expect(row.getByRole('status').filter({ hasText: 'The name matches' })).toBeVisible();
+    await row.getByRole('button', { name: 'Delete environment' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: 'Environment lifecycle-renamed deleted' }),
+    ).toBeVisible();
+    drillEnv = '';
+
     await expect(page.getByLabel('Name', { exact: true })).toHaveValue(drillName);
     const again = page.locator('#project-danger');
     await again.getByLabel('Delete this project').fill(drillName);

--- a/web/src/api/keys.ts
+++ b/web/src/api/keys.ts
@@ -26,6 +26,20 @@ export const signalsKey = (ref: MatrixRef, environment: string) =>
 export const pendingDraftsKey = (ref: MatrixRef, environment: string) =>
   ['matrix-pending', ref.org, ref.project, environment] as const;
 
+/** Project-wide cache prefixes affected when its environment topology changes. */
+export function environmentTopologyQueryPrefixes(ref: MatrixRef) {
+  return [
+    ['values', ref.org, ref.project],
+    ['reveal-window', ref.org, ref.project],
+    ['revisions', ref.org, ref.project],
+    ['revision-detail', ref.org, ref.project],
+    ['revision-pins', ref.org, ref.project],
+    ['matrix-keys', ref.org, ref.project],
+    ['matrix-signals', ref.org, ref.project],
+    ['matrix-pending', ref.org, ref.project],
+  ];
+}
+
 /** Every cache whose destination-owned state changes after a successful copy. */
 export function copyInvalidationKeys(
   ref: MatrixRef,

--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import { ApiError } from './client.ts';
 import {
+  cloneEnvironmentRefusalText,
   createEnvironmentRefusalText,
   createProjectRefusalText,
   DAY_SECONDS,
+  deleteEnvironmentRefusalText,
   environmentSettingsReadState,
   formatRetentionAge,
   orgTopologyReadiness,
   projectRetentionInherited,
+  renameEnvironmentRefusalText,
+  reorderEnvironmentsRefusalText,
   retentionBoundsPayload,
   retentionDayState,
   retentionSentence,
@@ -303,6 +307,39 @@ describe('authoring refusals', () => {
     );
     expect(createEnvironmentRefusalText(new Error('network'))).toContain(
       'whether the environment was created is unknown',
+    );
+  });
+
+  it('maps every environment lifecycle refusal without leaking uniform not-found state', () => {
+    expect(renameEnvironmentRefusalText(new ApiError(400, 'x'))).toContain(
+      'environment name is invalid',
+    );
+    expect(renameEnvironmentRefusalText(new ApiError(404, 'x'))).toBe(
+      renameEnvironmentRefusalText(new ApiError(403, 'x')),
+    );
+    expect(deleteEnvironmentRefusalText(new ApiError(409, 'x'))).toContain(
+      'current environment state refused deletion',
+    );
+    expect(reorderEnvironmentsRefusalText(new ApiError(400, 'x'))).toContain(
+      'complete environment order',
+    );
+    expect(cloneEnvironmentRefusalText(new ApiError(409, 'x', 'required secret missing'))).toBe(
+      'required secret missing',
+    );
+  });
+
+  it('states uncertain lifecycle outcomes instead of claiming failure', () => {
+    expect(renameEnvironmentRefusalText(new Error('network'))).toContain(
+      'whether the environment was renamed is unknown',
+    );
+    expect(deleteEnvironmentRefusalText(new ApiError(500, 'x'))).toContain(
+      'whether the environment was deleted is unknown',
+    );
+    expect(reorderEnvironmentsRefusalText(new Error('network'))).toContain(
+      'whether the order changed is unknown',
+    );
+    expect(cloneEnvironmentRefusalText(new ApiError(500, 'x'))).toContain(
+      'whether the environment was cloned is unknown',
     );
   });
 });

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -1,7 +1,9 @@
 import {
+  cloneEnvironmentOp,
   createEnvironmentOp,
   createOrgOp,
   createProjectOp,
+  deleteEnvironmentOp,
   deleteOrgOp,
   deleteProjectOp,
   getEnvironmentSettingsOp,
@@ -12,8 +14,10 @@ import {
   listEnvironmentsOp,
   listOrgsOp,
   listProjectsOp,
+  renameEnvironmentOp,
   renameOrgOp,
   renameProjectOp,
+  reorderEnvironmentsOp,
   rotateTokenKeyOp,
   setEnvironmentSettingsOp,
   setOrgRetentionOp,
@@ -34,6 +38,7 @@ import {
   useQueries,
   useQuery,
   useQueryClient,
+  type QueryClient,
   type UseQueryResult,
 } from '@tanstack/react-query';
 import type { Client } from '@hikyo/runtime-core';
@@ -41,6 +46,7 @@ import type { z } from 'zod';
 
 import { useAuth } from '../app/AuthProvider.tsx';
 import { ApiError, ok, parsed } from './client.ts';
+import { environmentTopologyQueryPrefixes } from './keys.ts';
 import type { EnvironmentNode, ProjectNode } from './access.ts';
 import { useTransport } from './transport.tsx';
 
@@ -473,6 +479,80 @@ export function useCreateEnvironment(org: string, project: string) {
   });
 }
 
+function invalidateEnvironmentTopology(
+  queries: QueryClient,
+  org: string,
+  project: string,
+) {
+  const queryKeys = [
+    environmentsKey(org, project),
+    ['environment-settings', org, project],
+    ...environmentTopologyQueryPrefixes({ org, project }),
+  ];
+  return Promise.all(
+    queryKeys.map((queryKey) => queries.invalidateQueries({ queryKey })),
+  );
+}
+
+/** Rename one environment and refresh every project view keyed by its topology. */
+export function useRenameEnvironment(org: string, project: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environment: string; name: string }) =>
+      parsed(renameEnvironmentOp, {
+        path: { org, project, environment: input.environment },
+        body: { name: input.name },
+      }),
+    onSuccess: () => invalidateEnvironmentTopology(queries, org, project),
+  });
+}
+
+/** Delete one environment and refresh every cache for the topology it removes. */
+export function useDeleteEnvironment(
+  org: string,
+  project: string,
+  onDeleted?: () => void,
+) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environment: string }) =>
+      ok(deleteEnvironmentOp, { path: { org, project, environment: input.environment } }),
+    // The list invalidation unmounts the deleted row. Run its durable parent
+    // feedback callback first; per-call callbacks are not guaranteed to
+    // survive that unmount.
+    onSuccess: async () => {
+      onDeleted?.();
+      await invalidateEnvironmentTopology(queries, org, project);
+    },
+  });
+}
+
+/** Replace display order with the complete environment id set in one transaction. */
+export function useReorderEnvironments(org: string, project: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environmentIds: readonly string[] }) =>
+      parsed(reorderEnvironmentsOp, {
+        path: { org, project },
+        body: { environment_ids: [...input.environmentIds] },
+      }),
+    onSuccess: () => invalidateEnvironmentTopology(queries, org, project),
+  });
+}
+
+/** Clone an environment and expose the server's copied/omitted value accounting. */
+export function useCloneEnvironment(org: string, project: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { sourceEnvironment: string; name: string }) =>
+      parsed(cloneEnvironmentOp, {
+        path: { org, project },
+        body: { source_environment_id: input.sourceEnvironment, name: input.name },
+      }),
+    onSuccess: () => invalidateEnvironmentTopology(queries, org, project),
+  });
+}
+
 /**
  * createProjectRefusalText names the capability the act needs.
  *
@@ -525,6 +605,82 @@ export function createEnvironmentRefusalText(error: unknown): string {
     }
   }
   return 'The server failed; whether the environment was created is unknown — reload to check.';
+}
+
+function environmentLifecyclePermission(action: string): string {
+  return `You are not permitted to ${action} — that needs definitions-edit on the project.`;
+}
+
+type EnvironmentLifecycleRefusal = {
+  readonly action: string;
+  readonly invalid: string;
+  readonly conflict: string;
+  readonly uncertain: string;
+};
+
+function environmentLifecycleRefusalText(
+  error: unknown,
+  refusal: EnvironmentLifecycleRefusal,
+): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return error.detail ?? refusal.invalid;
+      case 401:
+        return 'Your session ended. Sign in again to continue.';
+      case 403:
+      case 404:
+        return environmentLifecyclePermission(refusal.action);
+      case 409:
+        return error.detail ?? refusal.conflict;
+      case 429:
+        return 'Too many attempts right now. Wait a moment and try again.';
+    }
+  }
+  return refusal.uncertain;
+}
+
+/** Refusal text for environment rename, including uncertain network outcomes. */
+export function renameEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'rename this environment',
+    invalid: 'The environment name is invalid.',
+    conflict: 'This environment name is already in use.',
+    uncertain:
+      'The server failed; whether the environment was renamed is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for deliberate environment deletion. */
+export function deleteEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'delete this environment',
+    invalid: 'The environment cannot be deleted from this request.',
+    conflict: 'The current environment state refused deletion. Reload before retrying.',
+    uncertain:
+      'The server failed; whether the environment was deleted is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for a complete-set environment reorder. */
+export function reorderEnvironmentsRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'reorder these environments',
+    invalid: 'The complete environment order is invalid. Reload before retrying.',
+    conflict: 'The current environment state refused reordering. Reload before retrying.',
+    uncertain: 'The server failed; whether the order changed is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for atomic clone-at-creation. */
+export function cloneEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'clone this environment',
+    invalid: 'The cloned environment name or source is invalid.',
+    conflict: 'The clone conflicts with the current environment state.',
+    uncertain:
+      'The server failed; whether the environment was cloned is unknown — reload to check.',
+  });
 }
 
 /**

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
-import { act } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { act, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { created, renderForm, settle, typeInto } from '../testkit/renderForm.tsx';
-import { NewEnvironmentForm } from './ProjectSettings.tsx';
+import { created, renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { EnvironmentLifecycleActions, NewEnvironmentForm } from './ProjectSettings.tsx';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -25,7 +26,7 @@ describe('NewEnvironmentForm', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    const { container } = await renderForm(
+    const { container, client } = await renderForm(
       <NewEnvironmentForm org="org_1" project="project_1" />,
     );
     const input = container.querySelector('input');
@@ -58,5 +59,248 @@ describe('NewEnvironmentForm', () => {
 
     const status = container.querySelector('[role="status"]');
     expect(status?.textContent).toContain('Environment staging created.');
+  });
+});
+
+const DEV = {
+  id: 'env_123e4567-e89b-12d3-a456-426614174010',
+  name: 'dev',
+};
+const PROD = {
+  id: 'env_123e4567-e89b-12d3-a456-426614174011',
+  name: 'prod',
+};
+
+function environment(id: string, name: string, displayOrder: number) {
+  return {
+    id,
+    org_id: 'org_123e4567-e89b-12d3-a456-426614174001',
+    project_id: 'prj_123e4567-e89b-12d3-a456-426614174002',
+    name,
+    display_order: displayOrder,
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function requestFromCall(call: Parameters<typeof fetch> | undefined): Request {
+  const request = call?.[0];
+  if (!(request instanceof Request)) {
+    throw new Error('fetch was not called with a Request');
+  }
+  return request;
+}
+
+function DeleteFeedbackHarness({ onDone }: { readonly onDone: (text: string) => void }) {
+  const [done, setDone] = useState('');
+  const environments = useQuery({
+    queryKey: ['environments', 'org_1', 'project_1'],
+    queryFn: () => Promise.resolve({ items: [], count: 0 }),
+    initialData: { items: [DEV], count: 1 },
+    staleTime: Infinity,
+  });
+  const current = environments.data.items[0];
+
+  return (
+    <>
+      {current === undefined ? null : (
+        <EnvironmentLifecycleActions
+          org="org_1"
+          project="project_1"
+          environment={current}
+          environments={environments.data.items}
+          onDone={(text) => {
+            setDone(text);
+            onDone(text);
+          }}
+        />
+      )}
+      <p role="status">{done}</p>
+    </>
+  );
+}
+
+describe('EnvironmentLifecycleActions', () => {
+  it('keeps deletion feedback after invalidation unmounts the deleted row', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    const done = vi.fn();
+    const { container } = await renderForm(<DeleteFeedbackHarness onDone={done} />);
+    const confirmInput = container.querySelector(`input[placeholder="${DEV.name}"]`);
+    if (!(confirmInput instanceof HTMLInputElement)) {
+      throw new Error('delete confirmation input is missing');
+    }
+    await act(async () => typeInto(confirmInput, DEV.name));
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Delete environment',
+    );
+    if (deleteButton === undefined) {
+      throw new Error('delete button is missing');
+    }
+    await act(async () => deleteButton.click());
+    await settleTask();
+
+    expect(container.querySelector('input[name="rename-environment"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Environment dev deleted.',
+    );
+    expect(done).toHaveBeenCalledWith('Environment dev deleted.');
+  });
+
+  it('renames and deletes through deliberate user controls', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const request = requestFromCall(args);
+      if (request.method === 'PATCH') {
+        return Promise.resolve(
+          new Response(JSON.stringify(environment(DEV.id, 'development', 0)), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (request.method === 'DELETE') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      throw new Error(`unexpected ${request.method} ${request.url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const done = vi.fn();
+    const { container } = await renderForm(
+      <EnvironmentLifecycleActions
+        org="org_1"
+        project="project_1"
+        environment={DEV}
+        environments={[DEV, PROD]}
+        onDone={done}
+      />,
+    );
+    const renameInput = container.querySelector('input[name="rename-environment"]');
+    if (!(renameInput instanceof HTMLInputElement)) {
+      throw new Error('rename input is missing');
+    }
+    await act(async () => typeInto(renameInput, 'development'));
+    const renameButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Rename environment',
+    );
+    if (renameButton === undefined) {
+      throw new Error('rename button is missing');
+    }
+    await act(async () => renameButton.click());
+    await settleTask();
+
+    const renameRequest = requestFromCall(fetchMock.mock.calls[0]);
+    expect(renameRequest.method).toBe('PATCH');
+    expect(new URL(renameRequest.url).pathname).toBe(
+      `/api/v1/orgs/org_1/projects/project_1/environments/${DEV.id}`,
+    );
+    expect(await renameRequest.json()).toEqual({ name: 'development' });
+    expect(done).toHaveBeenCalledWith('Environment dev renamed to development.');
+
+    const confirmInput = container.querySelector(`input[placeholder="${DEV.name}"]`);
+    if (!(confirmInput instanceof HTMLInputElement)) {
+      throw new Error('delete confirmation input is missing');
+    }
+    await act(async () => typeInto(confirmInput, DEV.name));
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Delete environment',
+    );
+    if (deleteButton === undefined) {
+      throw new Error('delete button is missing');
+    }
+    expect(deleteButton.disabled).toBe(false);
+    await act(async () => deleteButton.click());
+    await settleTask();
+
+    const deleteRequest = requestFromCall(fetchMock.mock.calls[1]);
+    expect(deleteRequest.method).toBe('DELETE');
+    expect(new URL(deleteRequest.url).pathname).toBe(
+      `/api/v1/orgs/org_1/projects/project_1/environments/${DEV.id}`,
+    );
+    expect(done).toHaveBeenCalledWith('Environment dev deleted.');
+  });
+
+  it('moves with the complete ordered set and clones into a named environment', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const request = requestFromCall(args);
+      if (request.method === 'PUT') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              items: [environment(PROD.id, PROD.name, 0), environment(DEV.id, DEV.name, 1)],
+              count: 2,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }
+      if (request.method === 'POST') {
+        return Promise.resolve(
+          created({
+            environment: environment(
+              'env_123e4567-e89b-12d3-a456-426614174012',
+              'staging',
+              2,
+            ),
+            copied: ['API_URL'],
+            uncopied_secrets: ['TOKEN'],
+          }),
+        );
+      }
+      throw new Error(`unexpected ${request.method} ${request.url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const done = vi.fn();
+    const { container, client } = await renderForm(
+      <EnvironmentLifecycleActions
+        org="org_1"
+        project="project_1"
+        environment={DEV}
+        environments={[DEV, PROD]}
+        onDone={done}
+      />,
+    );
+    const environmentsKey = ['environments', 'org_1', 'project_1'];
+    const matrixKeysKey = ['matrix-keys', 'org_1', 'project_1'];
+    client.setQueryData(environmentsKey, { items: [DEV, PROD], count: 2 });
+    client.setQueryData(matrixKeysKey, { items: [], count: 0 });
+
+    const moveDown = container.querySelector('button[aria-label="Move dev down"]');
+    if (!(moveDown instanceof HTMLButtonElement)) {
+      throw new Error('move-down button is missing');
+    }
+    await act(async () => moveDown.click());
+    await settleTask();
+    const reorderRequest = requestFromCall(fetchMock.mock.calls[0]);
+    expect(reorderRequest.method).toBe('PUT');
+    expect(new URL(reorderRequest.url).pathname).toBe(
+      '/api/v1/orgs/org_1/projects/project_1/environments/order',
+    );
+    expect(await reorderRequest.json()).toEqual({ environment_ids: [PROD.id, DEV.id] });
+    expect(client.getQueryState(environmentsKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(matrixKeysKey)?.isInvalidated).toBe(true);
+
+    const cloneInput = container.querySelector('input[name="clone-environment"]');
+    if (!(cloneInput instanceof HTMLInputElement)) {
+      throw new Error('clone input is missing');
+    }
+    await act(async () => typeInto(cloneInput, 'staging'));
+    const cloneButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Clone environment',
+    );
+    if (cloneButton === undefined) {
+      throw new Error('clone button is missing');
+    }
+    await act(async () => cloneButton.click());
+    await settleTask();
+    const cloneRequest = requestFromCall(fetchMock.mock.calls[1]);
+    expect(cloneRequest.method).toBe('POST');
+    expect(new URL(cloneRequest.url).pathname).toBe(
+      '/api/v1/orgs/org_1/projects/project_1/environments/clone',
+    );
+    expect(await cloneRequest.json()).toEqual({
+      name: 'staging',
+      source_environment_id: DEV.id,
+    });
+    expect(done).toHaveBeenCalledWith(
+      'Environment dev cloned to staging. Copied 1 value; 1 secret could not be copied.',
+    );
   });
 });

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState, type FormEvent } from 'react';
+import { useEffect, useId, useState, type FormEvent, type ReactNode } from 'react';
 import { generatePath, Link, useParams } from 'react-router';
 
 import {
@@ -9,21 +9,29 @@ import {
   type DefinitionsSettings,
 } from '../api/definitions.ts';
 import {
+  cloneEnvironmentRefusalText,
   createEnvironmentRefusalText,
+  deleteEnvironmentRefusalText,
   projectRetentionInherited,
   retentionBoundsPayload,
   retentionDayState,
   retentionSentence,
+  renameEnvironmentRefusalText,
+  reorderEnvironmentsRefusalText,
   settingsFailureText,
   settingsOperationFailure,
+  useCloneEnvironment,
   useCreateEnvironment,
+  useDeleteEnvironment,
   useDeleteProject,
   useEnvironmentSettings,
   useEnvironments,
   useOrgRetention,
   useProject,
   useProjectRetention,
+  useRenameEnvironment,
   useRenameProject,
+  useReorderEnvironments,
   useSetEnvironmentSettings,
   useSetProjectRetention,
   type EnvironmentSettingsReadState,
@@ -441,9 +449,13 @@ function EnvironmentPolicy({
       {environments.map((environment) => (
         <EnvironmentPolicyItem
           key={environment.id}
+          org={org}
+          project={project}
           environment={environment}
+          environments={environments}
           state={protection.get(environment.id)}
           busy={save.isPending}
+          onDone={onDone}
           onSave={(next) =>
             save.mutate(
               { environment: environment.id, ...next },
@@ -465,20 +477,38 @@ function EnvironmentPolicy({
 }
 
 function EnvironmentPolicyItem({
+  org,
+  project,
   environment,
+  environments,
   state,
   busy,
+  onDone,
   onSave,
 }: {
+  org: string;
+  project: string;
   environment: { id: string; name: string };
+  environments: readonly { id: string; name: string }[];
   state: EnvironmentSettingsReadState | undefined;
   busy: boolean;
+  onDone: (text: string) => void;
   onSave: (next: { protectedFlag: boolean; reauthWindowSeconds: number | null }) => void;
 }) {
   if (state === undefined) {
     throw new Error(`environment ${environment.id} has no settings read state`);
   }
-  return <EnvironmentRow environment={environment} state={state} busy={busy} onSave={onSave} />;
+  return (
+    <EnvironmentRow environment={environment} state={state} busy={busy} onSave={onSave}>
+      <EnvironmentLifecycleActions
+        org={org}
+        project={project}
+        environment={environment}
+        environments={environments}
+        onDone={onDone}
+      />
+    </EnvironmentRow>
+  );
 }
 
 function EnvironmentRow({
@@ -486,11 +516,13 @@ function EnvironmentRow({
   state,
   busy,
   onSave,
+  children,
 }: {
   environment: { id: string; name: string };
   state: EnvironmentSettingsReadState;
   busy: boolean;
   onSave: (next: { protectedFlag: boolean; reauthWindowSeconds: number | null }) => void;
+  children: ReactNode;
 }) {
   const protectedId = useId();
   const windowId = useId();
@@ -595,7 +627,201 @@ function EnvironmentRow({
           Save policy
         </button>
       </div>
+      {children}
     </li>
+  );
+}
+
+/** All project-scoped environment topology mutations, kept with the row they affect. */
+export function EnvironmentLifecycleActions({
+  org,
+  project,
+  environment,
+  environments,
+  onDone,
+}: {
+  readonly org: string;
+  readonly project: string;
+  readonly environment: { readonly id: string; readonly name: string };
+  readonly environments: readonly { readonly id: string; readonly name: string }[];
+  readonly onDone: (text: string) => void;
+}) {
+  const rename = useRenameEnvironment(org, project);
+  const remove = useDeleteEnvironment(org, project, () =>
+    onDone(`Environment ${environment.name} deleted.`),
+  );
+  const reorder = useReorderEnvironments(org, project);
+  const clone = useCloneEnvironment(org, project);
+  const renameId = useId();
+  const cloneId = useId();
+  const [renameName, setRenameName] = useState('');
+  const [cloneName, setCloneName] = useState('');
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const index = environments.findIndex((candidate) => candidate.id === environment.id);
+  if (index === -1) {
+    throw new Error(`environment ${environment.id} is missing from its project order`);
+  }
+
+  const busy = rename.isPending || remove.isPending || reorder.isPending || clone.isPending;
+  const move = (offset: -1 | 1) => {
+    const target = environments[index + offset];
+    if (target === undefined) {
+      return;
+    }
+    setFailure(null);
+    reorder.mutate(
+      {
+        environmentIds: environments.map((candidate) => {
+          if (candidate.id === environment.id) {
+            return target.id;
+          }
+          if (candidate.id === target.id) {
+            return environment.id;
+          }
+          return candidate.id;
+        }),
+      },
+      {
+        onSuccess: () => onDone(`Environment ${environment.name} moved ${offset === -1 ? 'up' : 'down'}.`),
+        onError: (error) => setFailure(reorderEnvironmentsRefusalText(error)),
+      },
+    );
+  };
+
+  return (
+    <details className="environment-lifecycle">
+      <summary>Manage environment</summary>
+      {failure === null ? null : <Alert>{failure}</Alert>}
+      <form
+        className="environment-lifecycle__action"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const name = renameName.trim();
+          if (name === '' || name === environment.name) {
+            return;
+          }
+          setFailure(null);
+          rename.mutate(
+            { environment: environment.id, name },
+            {
+              onSuccess: (renamed) => {
+                setRenameName('');
+                onDone(`Environment ${environment.name} renamed to ${renamed.name}.`);
+              },
+              onError: (error) => setFailure(renameEnvironmentRefusalText(error)),
+            },
+          );
+        }}
+      >
+        <div className="field">
+          <label htmlFor={renameId}>New name for {environment.name}</label>
+          <input
+            id={renameId}
+            name="rename-environment"
+            value={renameName}
+            disabled={busy}
+            onChange={(event) => setRenameName(event.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          className="btn"
+          disabled={busy || renameName.trim() === '' || renameName.trim() === environment.name}
+        >
+          Rename environment
+        </button>
+      </form>
+
+      <div className="environment-lifecycle__action">
+        <p className="field__hint">Move sends the complete project order as one atomic change.</p>
+        <div className="panel__actions">
+          <button
+            type="button"
+            className="btn"
+            aria-label={`Move ${environment.name} up`}
+            disabled={busy || index === 0}
+            onClick={() => move(-1)}
+          >
+            Move up
+          </button>
+          <button
+            type="button"
+            className="btn"
+            aria-label={`Move ${environment.name} down`}
+            disabled={busy || index === environments.length - 1}
+            onClick={() => move(1)}
+          >
+            Move down
+          </button>
+        </div>
+      </div>
+
+      <form
+        className="environment-lifecycle__action"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const name = cloneName.trim();
+          if (name === '') {
+            return;
+          }
+          setFailure(null);
+          clone.mutate(
+            { sourceEnvironment: environment.id, name },
+            {
+              onSuccess: (result) => {
+                setCloneName('');
+                const copied = result.copied.length;
+                const omitted = result.uncopied_secrets.length;
+                onDone(
+                  `Environment ${environment.name} cloned to ${result.environment.name}. Copied ${copied} ${copied === 1 ? 'value' : 'values'}; ${omitted} ${omitted === 1 ? 'secret' : 'secrets'} could not be copied.`,
+                );
+              },
+              onError: (error) => setFailure(cloneEnvironmentRefusalText(error)),
+            },
+          );
+        }}
+      >
+        <div className="field">
+          <label htmlFor={cloneId}>Clone {environment.name} into</label>
+          <input
+            id={cloneId}
+            name="clone-environment"
+            value={cloneName}
+            disabled={busy}
+            onChange={(event) => setCloneName(event.target.value)}
+          />
+        </div>
+        <button type="submit" className="btn" disabled={busy || cloneName.trim() === ''}>
+          Clone environment
+        </button>
+      </form>
+
+      <div className="environment-lifecycle__action environment-lifecycle__danger">
+        <TypedNameConfirm
+          key={environment.id}
+          label={`Delete ${environment.name}`}
+          expect={environment.name}
+          action="Delete environment"
+          busy={busy}
+          hint={
+            <>
+              This permanently deletes the environment and its values, drafts, revision history,
+              pins, and snapshots. Type its name exactly to continue.
+            </>
+          }
+          onConfirm={() => {
+            setFailure(null);
+            remove.mutate(
+              { environment: environment.id },
+              {
+                onError: (error) => setFailure(deleteEnvironmentRefusalText(error)),
+              },
+            );
+          }}
+        />
+      </div>
+    </details>
   );
 }
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3046,6 +3046,9 @@ select {
 }
 
 .environment-lifecycle > summary {
+  display: flex;
+  align-items: center;
+  min-height: var(--touch);
   cursor: pointer;
   font-weight: 650;
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3040,6 +3040,34 @@ select {
   background: var(--bg);
 }
 
+.environment-lifecycle {
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.environment-lifecycle > summary {
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.environment-lifecycle__action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.environment-lifecycle__action .field {
+  width: min(100%, 420px);
+}
+
+.environment-lifecycle__danger {
+  width: 100%;
+}
+
 .project-retention-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #446

## Summary
- add per-environment rename, typed-name delete, whole-set reorder, and clone controls
- invalidate environment and matrix caches after topology changes
- add focused hook/component coverage plus the full SPA lifecycle Playwright flow
- document destructive environment-delete semantics and delivery handoff

## Review
- standards: CLEAN
- issue spec: CLEAN

## Validation
- local execution deferred while host memory pressure is high, per request
- CI is running on the committed head