### PR TITLE
Unify the workspace handoff launcher #438

### DIFF
--- a/docs/handoff/438-workspace-handoff-hook.md
+++ b/docs/handoff/438-workspace-handoff-hook.md
@@ -1,0 +1,25 @@
+# Issue #438 — shared workspace handoff launcher
+
+## Outcome
+
+- `useWorkspaceHandoff` owns establishment, step-up, unavailable, contacting,
+  ready, authorising, failure, retry, and unmount-safe completion state.
+- `WorkspaceStepUp`, `RemoteCard`, and `Reconnect` use the shared controller and
+  shared button-state mapper.
+- Popup launch remains synchronous to the ready action's click; authorising
+  launchers stay disabled until completion.
+- Failed preparation renders `Try again`; `Contacting…` is rendered only while
+  `prepareWorkspace` is running.
+
+## Validation
+
+- `pnpm exec vitest run src/routes/useWorkspaceHandoff.test.tsx src/routes/WorkspaceHandoffConsumers.test.tsx` — 2 files, 8 tests passed.
+- `pnpm run typecheck` — passed with TypeScript 7.0.2 on Node 26.7.0.
+- `pnpm test` — 44 files, 339 tests passed.
+- `pnpm run build` — production Vite build passed.
+
+## Delivery guard
+
+Before any branch refresh or merge, re-query open non-draft pull requests and
+proceed only when this pull request has the lowest number. Stop after GitHub
+reports the exact reviewed head merged; post-merge CI is outside this task.

--- a/docs/handoff/71-multi-instance.md
+++ b/docs/handoff/71-multi-instance.md
@@ -1057,13 +1057,12 @@ it, so surface + route + flow landed together):
 
 **Two UI decisions worth review:**
 
-1. **The ceremony is TWO clicks and the platform forces it.** `window.open`
-   only survives the popup blocker inside the task of a real user gesture, and
-   the handoff transaction cannot be opened without a network round trip first.
-   So click one prepares (`prepareWorkspace`: live meta read + transaction) and
-   click two opens (`openPrepared`, whose first statement is the `window.open`).
-   It buys something worth having anyway: the human reads which origin they are
-   about to be sent to before a window appears.
+1. **The ceremony prepares eagerly before its popup-launch click.** `window.open`
+   only survives the popup blocker inside the task of a real user gesture, while
+   the handoff transaction needs a network round trip first. The launcher stays
+   disabled and says `Contacting…` until `prepareWorkspace` completes; its
+   enabled, origin-labelled action then calls `openPrepared` synchronously. The
+   human still reads which origin they are about to visit before a window opens.
 2. **A liveness poll, and it is how both kill switches become visible.**
    `probeWorkspace` GETs the remote's `/api/v1/me/sessions` with the bearer
    every 5s. A 401/403 drops it. An OPAQUE failure counts a strike and two

--- a/web/e2e/flows/workspace.spec.ts
+++ b/web/e2e/flows/workspace.spec.ts
@@ -24,7 +24,7 @@ import { surfacesForFlow } from '../registry.ts';
  *      listing it holds.
  *   2. The serving instance's administrator allowlists the viewing origin
  *      THROUGH THE UI — the consent surface, exercised rather than seeded.
- *   3. "Open workspace" opens a popup ON THE REMOTE'S ORIGIN, the human
+ *   3. The origin-labelled workspace action opens a popup ON THE REMOTE'S ORIGIN, the human
  *      authorizes there, the code returns through this origin's own callback
  *      page over a BroadcastChannel, and the shell redeems it cross-origin.
  *      There is no server in the middle at any point.
@@ -119,10 +119,8 @@ test.describe('multi-instance', () => {
     // --- the ceremony -------------------------------------------------------
     await page.goto('/remotes');
     const entry = card(page);
-    await entry.getByRole('button', { name: 'Open workspace' }).click();
-    // Two clicks, and the second is the one that opens the window: a popup
-    // opened after an await has lost its user gesture and the browser blocks
-    // it. The interstitial names the origin the human is about to sign in at.
+    // Preparation is eager; the enabled action proves the network work has
+    // completed before the click that must synchronously open the popup.
     const proceed = entry.getByRole('button', { name: /^Continue to / });
     await expect(proceed).toBeVisible({ timeout: 30_000 });
     const popupOpened = context.waitForEvent('page');
@@ -135,6 +133,7 @@ test.describe('multi-instance', () => {
     );
     const liveness = page.waitForRequest((r) => r.url().includes('/api/v1/me/sessions'));
     await proceed.click();
+    await expect(entry.getByRole('button', { name: 'Waiting for sign-in…' })).toBeDisabled();
 
     const popup = await popupOpened;
     await popup.waitForLoadState();
@@ -237,13 +236,14 @@ test.describe('multi-instance', () => {
 
     // And the shell notices, on its own, within one liveness poll.
     await expect(entry.getByText('Workspace session ended')).toBeVisible({ timeout: 30_000 });
-    await expect(entry.getByRole('button', { name: 'Open workspace' })).toBeVisible();
+    await expect(entry.getByRole('button', { name: /^Continue to / })).toBeVisible({
+      timeout: 30_000,
+    });
 
     // --- kill switch 2: revoked from the remote's active-session list -------
     await onB(b, '/remotes');
     await allowOrigin(b);
 
-    await entry.getByRole('button', { name: 'Open workspace' }).click();
     const proceedAgain = entry.getByRole('button', { name: /^Continue to / });
     await expect(proceedAgain).toBeVisible({ timeout: 30_000 });
     const second = context.waitForEvent('page');
@@ -289,7 +289,6 @@ test.describe('multi-instance', () => {
     // Open the workspace with the popup ceremony.
     await page.goto('/remotes');
     const entry = card(page);
-    await entry.getByRole('button', { name: 'Open workspace' }).click();
     const proceed = entry.getByRole('button', { name: /^Continue to / });
     await expect(proceed).toBeVisible({ timeout: 30_000 });
     const popupOpened = context.waitForEvent('page');
@@ -388,7 +387,6 @@ test.describe('multi-instance', () => {
 
     await page.goto('/remotes');
     const entry = card(page);
-    await entry.getByRole('button', { name: 'Open workspace' }).click();
     const proceed = entry.getByRole('button', { name: /^Continue to / });
     await expect(proceed).toBeVisible({ timeout: 30_000 });
     const popupOpened = context.waitForEvent('page');

--- a/web/e2e/flows/workspace.spec.ts
+++ b/web/e2e/flows/workspace.spec.ts
@@ -236,14 +236,15 @@ test.describe('multi-instance', () => {
 
     // And the shell notices, on its own, within one liveness poll.
     await expect(entry.getByText('Workspace session ended')).toBeVisible({ timeout: 30_000 });
-    await expect(entry.getByRole('button', { name: /^Continue to / })).toBeVisible({
-      timeout: 30_000,
-    });
+    // Eager preparation correctly fails while this origin is no longer
+    // allowlisted; the launcher must expose a truthful retry, not claim ready.
+    await expect(entry.getByRole('button', { name: 'Try again' })).toBeVisible({ timeout: 30_000 });
 
     // --- kill switch 2: revoked from the remote's active-session list -------
     await onB(b, '/remotes');
     await allowOrigin(b);
 
+    await entry.getByRole('button', { name: 'Try again' }).click();
     const proceedAgain = entry.getByRole('button', { name: /^Continue to / });
     await expect(proceedAgain).toBeVisible({ timeout: 30_000 });
     const second = context.waitForEvent('page');

--- a/web/src/api/workspace.ts
+++ b/web/src/api/workspace.ts
@@ -421,13 +421,12 @@ const CEREMONY_TIMEOUT_MS = 5 * 60_000;
  * PreparedWorkspace is a handoff transaction that exists but has not been shown
  * to the human yet.
  *
- * The ceremony is TWO clicks and that is forced by the platform, not chosen:
- * `window.open` only survives the popup blocker inside the task of a real user
- * gesture, and the transaction cannot be opened without a network round trip
- * first. Preparing on the first click and opening on the second keeps the open
- * synchronous — and it buys something worth having anyway, since the human sees
- * exactly which origin they are about to be sent to sign in at before a window
- * appears, which is the one anti-phishing check a popup ceremony can offer.
+ * The ceremony prepares eagerly because `window.open` only survives the popup
+ * blocker inside the task of a real user gesture, while the transaction needs a
+ * network round trip first. The enabled, origin-labelled action therefore means
+ * preparation has completed and its click can open synchronously — while still
+ * giving the human the anti-phishing check of seeing the exact destination
+ * before a window appears.
  */
 export type PreparedWorkspace = {
   readonly origin: string;

--- a/web/src/routes/Ceremony.tsx
+++ b/web/src/routes/Ceremony.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useRef, useState, type FormEvent } from 'react';
 
 import { useWorkspaceContext } from '../api/transport.tsx';
 import { useSessionOIDCProvider } from '../api/account.ts';
@@ -11,13 +11,11 @@ import {
   type RevealWindow,
 } from '../api/values.ts';
 import {
-  openPrepared,
-  prepareWorkspace,
   workspaceBearer,
   WorkspaceError,
-  type PreparedWorkspace,
 } from '../api/workspace.ts';
 import { useModalDialog } from './useModalDialog.ts';
+import { useWorkspaceHandoff, workspaceHandoffAction } from './useWorkspaceHandoff.ts';
 
 /**
  * The purpose-bound ceremony modal (#58, locked prototype #21 iteration 6,
@@ -310,7 +308,7 @@ export function Ceremony({
  * the same session id), `openPrepared` installs it, and the caller resumes the
  * disclosure over the now-elevated transport.
  */
-function WorkspaceStepUp({
+export function WorkspaceStepUp({
   origin,
   operation,
   environmentId,
@@ -327,10 +325,6 @@ function WorkspaceStepUp({
   onAuthorised: () => void;
   onCancel: () => void;
 }) {
-  const [prepared, setPrepared] = useState<PreparedWorkspace | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [failure, setFailure] = useState<string | null>(null);
-
   // The decision's key set as a STABLE dependency. `keyIds` is a fresh array on
   // every parent render — Ceremony rebuilds it from `request.keys.map(...)`, and
   // the matrix behind it re-renders every couple of seconds as signals poll — so
@@ -338,62 +332,47 @@ function WorkspaceStepUp({
   // the remote on every one of those renders and rate-limit the human out of
   // their own ceremony. The content, joined, changes only when the target does.
   const keySetKey = keyIds.join(',');
-  useEffect(() => {
-    const bearer = workspaceBearer(origin);
-    if (bearer === undefined) {
-      setFailure('This workspace is no longer connected. Reconnect to the remote and try again.');
-      return;
-    }
-    let live = true;
-    prepareWorkspace(origin, {
-      session: bearer.session,
-      operation,
-      environment: environmentId,
-      keySet: keySetKey === '' ? [] : keySetKey.split(','),
-    })
-      .then((ready) => {
-        if (live) setPrepared(ready);
-      })
-      .catch((error: unknown) => {
-        if (live)
-          setFailure(
-            error instanceof WorkspaceError
-              ? error.message
-              : 'The remote could not be reached to authorise this disclosure.',
-          );
-      });
-    return () => {
-      live = false;
-    };
-    // Bound to the exact decision by content, not array identity: a re-prepare
-    // is warranted only if the target itself changes, which stages a new modal.
-  }, [origin, operation, environmentId, keySetKey]);
-
-  // Must stay synchronous to the click: the popup inside openPrepared only
-  // survives the blocker on a live user gesture.
-  const go = (ready: PreparedWorkspace) => {
-    setBusy(true);
-    setFailure(null);
-    openPrepared(ready)
-      .then(() => onAuthorised())
-      .catch((error: unknown) => {
-        setBusy(false);
-        setFailure(
-          error instanceof WorkspaceError
-            ? error.message
-            : 'The authorisation did not complete. Nothing was disclosed.',
-        );
-      });
-  };
+  const bearer = workspaceBearer(origin);
+  const handoff = useWorkspaceHandoff(origin, {
+    preparation:
+      bearer === undefined
+        ? {
+            kind: 'unavailable',
+            message:
+              'This workspace is no longer connected. Reconnect to the remote and try again.',
+          }
+        : {
+            kind: 'step-up',
+            params: {
+              session: bearer.session,
+              operation,
+              environment: environmentId,
+              keySet: keySetKey === '' ? [] : keySetKey.split(','),
+            },
+          },
+    onFailMessage: (error, stage) =>
+      error instanceof WorkspaceError
+        ? error.message
+        : stage === 'prepare'
+          ? 'The remote could not be reached to authorise this disclosure.'
+          : 'The authorisation did not complete. Nothing was disclosed.',
+    onAuthorised,
+  });
+  const { phase } = handoff;
+  const authorising = phase.kind === 'authorising';
+  const action = workspaceHandoffAction(handoff, {
+    ready: `Continue to ${origin} to authorise`,
+    authorising: 'Authorising…',
+  });
 
   return (
     <>
-      {failure === null ? null : (
+      {phase.kind !== 'failed' ? null : (
         <p className="alert" role="alert">
           <span className="alert__glyph" aria-hidden="true">
             !
           </span>
-          <span>{failure}</span>
+          <span>{phase.message}</span>
         </p>
       )}
       <div className="ceremony__actions">
@@ -401,16 +380,12 @@ function WorkspaceStepUp({
           className="btn btn--primary"
           type="button"
           ref={firstRef}
-          onClick={() => (prepared === null ? undefined : go(prepared))}
-          disabled={busy || prepared === null}
+          onClick={action.onClick}
+          disabled={action.disabled}
         >
-          {busy
-            ? 'Authorising…'
-            : prepared === null
-              ? 'Contacting…'
-              : `Continue to ${origin} to authorise`}
+          {action.label}
         </button>
-        <button className="btn" type="button" onClick={onCancel} disabled={busy}>
+        <button className="btn" type="button" onClick={onCancel} disabled={authorising}>
           Cancel
         </button>
       </div>

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -27,17 +27,15 @@ import {
 import {
   forgetWorkspace,
   livenessPollMs,
-  openPrepared,
-  prepareWorkspace,
   probeWorkspace,
   useWorkspaces,
   WorkspaceError,
-  type PreparedWorkspace,
   type WorkspaceBearer,
 } from '../api/workspace.ts';
 import { createWorkspaceClient } from '../api/workspaceClient.ts';
 import { makeQueryClient } from '../app/queryClient.ts';
 import { surfaceById } from '../app/navigation.ts';
+import { useWorkspaceHandoff, workspaceHandoffAction } from './useWorkspaceHandoff.ts';
 
 /**
  * The multi-instance surface (registry surface `remotes`).
@@ -106,11 +104,20 @@ function RemoteCard({ remote }: { remote: Remote }) {
   const remove = useRemoveRemote();
   const workspaces = useWorkspaces();
   const [failure, setFailure] = useState<string | null>(null);
-  const [opening, setOpening] = useState(false);
   const [ended, setEnded] = useState(false);
-  const [prepared, setPrepared] = useState<PreparedWorkspace | null>(null);
   const origin = safeOrigin(remote.url);
   const live = workspaces.find((w) => w.origin === origin);
+  const handoff = useWorkspaceHandoff(origin, {
+    // A live card hides the launcher and must not stage an unused transaction.
+    preparation:
+      live === undefined
+        ? { kind: 'establishment' }
+        : { kind: 'unavailable', message: 'This workspace is already open.' },
+    onFailMessage: (error) =>
+      error instanceof WorkspaceError
+        ? error.message
+        : 'The workspace could not be opened. Check that this instance allowlists this origin.',
+  });
   const updateStatuses = useRemoteUpdateStatuses(live === undefined ? [] : [live]);
   const updateProbe = updateStatuses[0];
   const update = updateProbe?.status;
@@ -119,36 +126,17 @@ function RemoteCard({ remote }: { remote: Remote }) {
   const updateJob = useRemoteUpdateJob(origin, updateJobID);
   const staleness = stalenessText(remote);
   useWorkspaceLiveness(live, () => setEnded(true));
-
-  const fail = (error: unknown) =>
-    setFailure(
-      error instanceof WorkspaceError
-        ? error.message
-        : 'The workspace could not be opened. Check that this instance allowlists this origin.',
-    );
-
-  // Step one: the live compatibility check and the handoff transaction. No
-  // window is touched here.
-  const prepare = async () => {
-    setFailure(null);
-    setEnded(false);
-    setOpening(true);
-    try {
-      setPrepared(await prepareWorkspace(origin));
-    } catch (error) {
-      fail(error);
-    } finally {
-      setOpening(false);
-    }
-  };
-
-  // Step two, and it must stay SYNCHRONOUS up to the `window.open` inside
-  // `openPrepared`: a popup opened after an await has lost the user gesture and
-  // the browser blocks it.
-  const go = (ready: PreparedWorkspace) => {
-    setPrepared(null);
-    openPrepared(ready).catch(fail);
-  };
+  const handoffAction = workspaceHandoffAction(
+    handoff,
+    {
+      ready: `Continue to ${origin} to sign in`,
+      authorising: 'Waiting for sign-in…',
+    },
+    () => {
+      setEnded(false);
+      handoff.retry();
+    },
+  );
 
   const applyUpdate = async () => {
     if (update?.latest_version === undefined) {
@@ -228,6 +216,15 @@ function RemoteCard({ remote }: { remote: Remote }) {
         </p>
       )}
 
+      {live !== undefined || handoff.phase.kind !== 'failed' ? null : (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{handoff.phase.message}</span>
+        </p>
+      )}
+
       {updateProbe?.error === null || updateProbe?.error === undefined ? null : (
         <p className="alert" role="alert">
           <span className="alert__glyph" aria-hidden="true">!</span>
@@ -290,14 +287,14 @@ function RemoteCard({ remote }: { remote: Remote }) {
       ) : null}
 
       <div className="remote__actions">
-        {live === undefined && prepared !== null ? (
-          <button className="btn btn--primary" type="button" onClick={() => go(prepared)}>
-            Continue to {origin} to sign in
-          </button>
-        ) : null}
-        {live === undefined && prepared === null ? (
-          <button className="btn btn--primary" type="button" onClick={prepare} disabled={opening}>
-            {opening ? 'Contacting…' : 'Open workspace'}
+        {live === undefined ? (
+          <button
+            className="btn btn--primary"
+            type="button"
+            onClick={handoffAction.onClick}
+            disabled={handoffAction.disabled}
+          >
+            {handoffAction.label}
           </button>
         ) : null}
         {live === undefined ? null : (

--- a/web/src/routes/WorkspaceHandoffConsumers.test.tsx
+++ b/web/src/routes/WorkspaceHandoffConsumers.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { act, createRef, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  PreparedWorkspace,
+  StepUpParams,
+  WorkspaceBearer,
+} from '../api/workspace.ts';
+import { WorkspaceStepUp } from './Ceremony.tsx';
+import { Reconnect } from './WorkspaceScope.tsx';
+
+const workspace = vi.hoisted(() => ({
+  workspaceBearer: vi.fn<(origin: string) => WorkspaceBearer | undefined>(),
+  prepareWorkspace:
+    vi.fn<(origin: string, stepUp?: StepUpParams) => Promise<PreparedWorkspace>>(),
+  openPrepared: vi.fn<(prepared: PreparedWorkspace) => Promise<void>>(),
+}));
+
+vi.mock('../api/workspace.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/workspace.ts')>();
+  return {
+    ...actual,
+    workspaceBearer: workspace.workspaceBearer,
+    prepareWorkspace: workspace.prepareWorkspace,
+    openPrepared: workspace.openPrepared,
+  };
+});
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const origin = 'https://remote.example';
+const prepared: PreparedWorkspace = {
+  origin,
+  state: 'state-1',
+  verifier: 'verifier-1',
+  approveURL: `${origin}/workspace/approve?state=state-1`,
+};
+const bearer: WorkspaceBearer = {
+  origin,
+  value: 'bearer-1',
+  session: 'session-1',
+  idleExpiresAt: '2026-08-24T15:00:00Z',
+  absoluteExpiresAt: '2026-08-24T16:00:00Z',
+};
+
+afterEach(() => {
+  workspace.workspaceBearer.mockReset();
+  workspace.prepareWorkspace.mockReset();
+  workspace.openPrepared.mockReset();
+  document.body.replaceChildren();
+});
+
+describe('workspace handoff consumers', () => {
+  it('gives Ceremony a reachable retry after preparation fails', async () => {
+    const retry = deferred<PreparedWorkspace>();
+    workspace.workspaceBearer.mockReturnValue(bearer);
+    workspace.prepareWorkspace
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockReturnValueOnce(retry.promise);
+
+    const mounted = await render(
+      <WorkspaceStepUp
+        origin={origin}
+        operation="reveal"
+        environmentId="environment-1"
+        keyIds={['key-1']}
+        firstRef={createRef<HTMLButtonElement>()}
+        onAuthorised={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await settle();
+
+    expect(mounted.container.querySelector('[role="alert"]')?.textContent).toContain(
+      'The remote could not be reached to authorise this disclosure.',
+    );
+    expect(buttonNamed(mounted.container, 'Try again')).toMatchObject({ disabled: false });
+    expect(mounted.container.textContent).not.toContain('Contacting…');
+
+    act(() => buttonNamed(mounted.container, 'Try again').click());
+    expect(buttonNamed(mounted.container, 'Contacting…')).toMatchObject({ disabled: true });
+    await act(async () => retry.resolve(prepared));
+    expect(buttonNamed(mounted.container, `Continue to ${origin} to authorise`)).toMatchObject({
+      disabled: false,
+    });
+    await unmount(mounted.root);
+  });
+
+  it('keeps WorkspaceScope disabled while sign-in is pending without preparing twice', async () => {
+    const authorisation = deferred<void>();
+    workspace.prepareWorkspace.mockResolvedValue(prepared);
+    workspace.openPrepared.mockReturnValue(authorisation.promise);
+
+    const mounted = await render(<Reconnect origin={origin} name="remote" />);
+    await settle();
+    const proceed = buttonNamed(mounted.container, `Continue to ${origin} to sign in`);
+
+    act(() => proceed.click());
+    const waiting = buttonNamed(mounted.container, 'Waiting for sign-in…');
+    expect(waiting).toMatchObject({ disabled: true });
+    waiting.click();
+    expect(workspace.prepareWorkspace).toHaveBeenCalledOnce();
+    expect(workspace.openPrepared).toHaveBeenCalledOnce();
+
+    await act(async () => authorisation.resolve(undefined));
+    await unmount(mounted.root);
+  });
+});
+
+async function render(element: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => root.render(element));
+  return { container, root };
+}
+
+function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent === name,
+  );
+  if (button === undefined) throw new Error(`button not found: ${name}`);
+  return button;
+}
+
+async function settle(): Promise<void> {
+  await act(async () => Promise.resolve());
+}
+
+async function unmount(root: Root): Promise<void> {
+  await act(async () => root.unmount());
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => {
+      if (resolvePromise === undefined) throw new Error('deferred promise was not initialised');
+      resolvePromise(value);
+    },
+  };
+}

--- a/web/src/routes/WorkspaceScope.tsx
+++ b/web/src/routes/WorkspaceScope.tsx
@@ -8,15 +8,13 @@ import {
   assertCompatible,
   forgetWorkspace,
   livenessPollMs,
-  openPrepared,
-  prepareWorkspace,
   probeWorkspace,
   useWorkspaces,
   WorkspaceError,
-  type PreparedWorkspace,
 } from '../api/workspace.ts';
 import { createWorkspaceClient } from '../api/workspaceClient.ts';
 import { makeQueryClient } from '../app/queryClient.ts';
+import { useWorkspaceHandoff, workspaceHandoffAction } from './useWorkspaceHandoff.ts';
 
 /**
  * WorkspaceScope is the boundary between operating THIS instance and operating a
@@ -243,40 +241,22 @@ function WorkspaceBanner({ origin }: { origin: string }) {
 /**
  * Reconnect is the state a deep-linked workspace URL lands in when the bearer
  * is gone — which is EVERY reload, because the bearer lives in memory only, and
- * also the moment a kill switch fires. It is the same two-click ceremony the
- * remotes card uses: prepare (a network round trip that names the origin the
- * human is about to sign in at), then a synchronous open on the gesture.
+ * also the moment a kill switch fires. It is the same eager preparation the
+ * remotes card uses: finish the network round trip first, then synchronously
+ * open the popup from the origin-labelled action's user gesture.
  */
-function Reconnect({ origin, name }: { origin: string; name: string }) {
-  const [prepared, setPrepared] = useState<PreparedWorkspace | null>(null);
-  const [opening, setOpening] = useState(false);
-  const [failure, setFailure] = useState<string | null>(null);
-
-  const fail = (error: unknown) =>
-    setFailure(
+export function Reconnect({ origin, name }: { origin: string; name: string }) {
+  const handoff = useWorkspaceHandoff(origin, {
+    preparation: { kind: 'establishment' },
+    onFailMessage: (error) =>
       error instanceof WorkspaceError
         ? error.message
         : 'The workspace could not be reconnected. Check that this instance allowlists this origin.',
-    );
-
-  const prepare = async () => {
-    setFailure(null);
-    setOpening(true);
-    try {
-      setPrepared(await prepareWorkspace(origin));
-    } catch (error) {
-      fail(error);
-    } finally {
-      setOpening(false);
-    }
-  };
-
-  // Must stay synchronous to the gesture: a popup opened after an await has lost
-  // the user activation and the browser blocks it.
-  const go = (ready: PreparedWorkspace) => {
-    setPrepared(null);
-    openPrepared(ready).catch(fail);
-  };
+  });
+  const action = workspaceHandoffAction(handoff, {
+    ready: `Continue to ${origin} to sign in`,
+    authorising: 'Waiting for sign-in…',
+  });
 
   return (
     <section className="card" aria-labelledby="workspace-reconnect">
@@ -285,23 +265,22 @@ function Reconnect({ origin, name }: { origin: string; name: string }) {
         Your workspace on <span className="mono">{origin}</span> is not open. Reconnect to operate
         it — you will sign in on that instance&apos;s own origin, in a popup.
       </p>
-      {failure === null ? null : (
+      {handoff.phase.kind !== 'failed' ? null : (
         <p className="alert" role="alert">
           <span className="alert__glyph" aria-hidden="true">
             !
           </span>
-          <span>{failure}</span>
+          <span>{handoff.phase.message}</span>
         </p>
       )}
-      {prepared === null ? (
-        <button className="btn btn--primary" type="button" onClick={prepare} disabled={opening}>
-          {opening ? 'Contacting…' : 'Reconnect workspace'}
-        </button>
-      ) : (
-        <button className="btn btn--primary" type="button" onClick={() => go(prepared)}>
-          Continue to {origin} to sign in
-        </button>
-      )}
+      <button
+        className="btn btn--primary"
+        type="button"
+        onClick={action.onClick}
+        disabled={action.disabled}
+      >
+        {action.label}
+      </button>
     </section>
   );
 }

--- a/web/src/routes/useWorkspaceHandoff.test.tsx
+++ b/web/src/routes/useWorkspaceHandoff.test.tsx
@@ -1,0 +1,275 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PreparedWorkspace, StepUpParams } from '../api/workspace.ts';
+import {
+  useWorkspaceHandoff,
+  workspaceHandoffAction,
+  type WorkspaceHandoffPreparation,
+} from './useWorkspaceHandoff.ts';
+
+const workspace = vi.hoisted(() => ({
+  prepareWorkspace:
+    vi.fn<(origin: string, stepUp?: StepUpParams) => Promise<PreparedWorkspace>>(),
+  openPrepared: vi.fn<(prepared: PreparedWorkspace) => Promise<void>>(),
+}));
+
+vi.mock('../api/workspace.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/workspace.ts')>();
+  return {
+    ...actual,
+    prepareWorkspace: workspace.prepareWorkspace,
+    openPrepared: workspace.openPrepared,
+  };
+});
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const origin = 'https://remote.example';
+const prepared: PreparedWorkspace = {
+  origin,
+  state: 'state-1',
+  verifier: 'verifier-1',
+  approveURL: `${origin}/workspace/approve?state=state-1`,
+};
+
+afterEach(() => {
+  workspace.prepareWorkspace.mockReset();
+  workspace.openPrepared.mockReset();
+  document.body.replaceChildren();
+});
+
+describe('useWorkspaceHandoff', () => {
+  it('moves from contacting through authorising to success without re-arming', async () => {
+    const preparation = deferred<PreparedWorkspace>();
+    const authorisation = deferred<void>();
+    const authorised = vi.fn();
+    workspace.prepareWorkspace.mockReturnValue(preparation.promise);
+    workspace.openPrepared.mockReturnValue(authorisation.promise);
+
+    const mounted = await renderHandoff(authorised);
+    expect(action(mounted.container)).toMatchObject({ disabled: true, textContent: 'Contacting…' });
+
+    await act(async () => preparation.resolve(prepared));
+    expect(action(mounted.container)).toMatchObject({
+      disabled: false,
+      textContent: `Continue to ${origin} to sign in`,
+    });
+
+    act(() => action(mounted.container).click());
+    expect(workspace.openPrepared).toHaveBeenCalledOnce();
+    expect(action(mounted.container)).toMatchObject({
+      disabled: true,
+      textContent: 'Waiting for sign-in…',
+    });
+    action(mounted.container).click();
+    expect(workspace.openPrepared).toHaveBeenCalledOnce();
+
+    await act(async () => authorisation.resolve(undefined));
+    expect(authorised).toHaveBeenCalledOnce();
+    await unmount(mounted.root);
+  });
+
+  it('exposes retry after preparation fails and leaves no false contacting state', async () => {
+    const retry = deferred<PreparedWorkspace>();
+    workspace.prepareWorkspace
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockReturnValueOnce(retry.promise);
+
+    const mounted = await renderHandoff(vi.fn());
+    await settle();
+
+    expect(mounted.container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Could not contact remote.',
+    );
+    expect(action(mounted.container)).toMatchObject({ disabled: false, textContent: 'Try again' });
+
+    act(() => action(mounted.container).click());
+    expect(action(mounted.container)).toMatchObject({ disabled: true, textContent: 'Contacting…' });
+    expect(workspace.prepareWorkspace).toHaveBeenCalledTimes(2);
+
+    await act(async () => retry.resolve(prepared));
+    expect(action(mounted.container)).toMatchObject({
+      disabled: false,
+      textContent: `Continue to ${origin} to sign in`,
+    });
+    await unmount(mounted.root);
+  });
+
+  it('does not report a completed handoff after its consumer unmounts', async () => {
+    const authorisation = deferred<void>();
+    const authorised = vi.fn();
+    workspace.prepareWorkspace.mockResolvedValue(prepared);
+    workspace.openPrepared.mockReturnValue(authorisation.promise);
+
+    const mounted = await renderHandoff(authorised);
+    await settle();
+    act(() => action(mounted.container).click());
+    await unmount(mounted.root);
+    await act(async () => authorisation.resolve(undefined));
+
+    expect(authorised).not.toHaveBeenCalled();
+  });
+
+  it('fails with a retry affordance when a step-up bearer is unavailable', async () => {
+    const mounted = await renderHandoff(vi.fn(), {
+      preparation: {
+        kind: 'unavailable',
+        message: 'This workspace is no longer connected.',
+      },
+    });
+
+    expect(workspace.prepareWorkspace).not.toHaveBeenCalled();
+    expect(mounted.container.querySelector('[role="alert"]')?.textContent).toBe(
+      'This workspace is no longer connected.',
+    );
+    expect(action(mounted.container)).toMatchObject({ disabled: false, textContent: 'Try again' });
+    await unmount(mounted.root);
+  });
+
+  it('replaces an in-flight contacting state immediately when preparation becomes unavailable', async () => {
+    workspace.prepareWorkspace.mockReturnValue(deferred<PreparedWorkspace>().promise);
+    const mounted = await renderHandoff(vi.fn());
+    expect(action(mounted.container).textContent).toBe('Contacting…');
+
+    await act(async () =>
+      mounted.root.render(
+        <HandoffHarness
+          onAuthorised={vi.fn()}
+          preparation={{ kind: 'unavailable', message: 'Workspace disconnected.' }}
+        />,
+      ),
+    );
+
+    expect(mounted.container.textContent).not.toContain('Contacting…');
+    expect(mounted.container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Workspace disconnected.',
+    );
+    expect(action(mounted.container).textContent).toBe('Try again');
+    await unmount(mounted.root);
+  });
+
+  it('prepares once for stable step-up content and again when the target changes', async () => {
+    workspace.prepareWorkspace.mockResolvedValue(prepared);
+    const prepareArgs: StepUpParams = {
+      session: 'session-1',
+      operation: 'reveal',
+      environment: 'environment-1',
+      keySet: ['key-1'],
+    };
+    const mounted = await renderHandoff(vi.fn(), {
+      preparation: { kind: 'step-up', params: prepareArgs },
+    });
+    await settle();
+
+    await act(async () =>
+      mounted.root.render(
+        <HandoffHarness
+          onAuthorised={vi.fn()}
+          preparation={{
+            kind: 'step-up',
+            params: { ...prepareArgs, keySet: ['key-1'] },
+          }}
+        />,
+      ),
+    );
+    expect(workspace.prepareWorkspace).toHaveBeenCalledOnce();
+
+    await act(async () =>
+      mounted.root.render(
+        <HandoffHarness
+          onAuthorised={vi.fn()}
+          preparation={{
+            kind: 'step-up',
+            params: { ...prepareArgs, keySet: ['key-2'] },
+          }}
+        />,
+      ),
+    );
+    expect(workspace.prepareWorkspace).toHaveBeenCalledTimes(2);
+    await unmount(mounted.root);
+  });
+});
+
+function HandoffHarness({
+  onAuthorised,
+  preparation = { kind: 'establishment' },
+}: {
+  onAuthorised: () => void;
+  preparation?: WorkspaceHandoffPreparation;
+}) {
+  const handoff = useWorkspaceHandoff(origin, {
+    preparation,
+    onFailMessage: (_error, stage) =>
+      stage === 'prepare' ? 'Could not contact remote.' : 'Sign-in did not complete.',
+    onAuthorised,
+  });
+  const button = workspaceHandoffAction(handoff, {
+    ready: `Continue to ${origin} to sign in`,
+    authorising: 'Waiting for sign-in…',
+  });
+
+  return (
+    <>
+      {handoff.phase.kind === 'failed' ? <p role="alert">{handoff.phase.message}</p> : null}
+      <button
+        type="button"
+        disabled={button.disabled}
+        onClick={button.onClick}
+      >
+        {button.label}
+      </button>
+    </>
+  );
+}
+
+async function renderHandoff(
+  onAuthorised: () => void,
+  options?: { readonly preparation?: WorkspaceHandoffPreparation },
+) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <HandoffHarness
+        onAuthorised={onAuthorised}
+        preparation={options?.preparation}
+      />,
+    ),
+  );
+  return { container, root };
+}
+
+function action(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector('button');
+  if (button === null) throw new Error('handoff action was not rendered');
+  return button;
+}
+
+async function settle(): Promise<void> {
+  await act(async () => Promise.resolve());
+}
+
+async function unmount(root: Root): Promise<void> {
+  await act(async () => root.unmount());
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => {
+      if (resolvePromise === undefined) throw new Error('deferred promise was not initialised');
+      resolvePromise(value);
+    },
+  };
+}

--- a/web/src/routes/useWorkspaceHandoff.ts
+++ b/web/src/routes/useWorkspaceHandoff.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  openPrepared,
+  prepareWorkspace,
+  type PreparedWorkspace,
+  type StepUpParams,
+} from '../api/workspace.ts';
+
+export type HandoffPhase =
+  | { readonly kind: 'contacting' }
+  | { readonly kind: 'ready'; readonly prepared: PreparedWorkspace }
+  | { readonly kind: 'authorising'; readonly prepared: PreparedWorkspace }
+  | { readonly kind: 'failed'; readonly message: string };
+
+export type HandoffFailureStage = 'prepare' | 'authorise';
+
+export type WorkspaceHandoffPreparation =
+  | { readonly kind: 'establishment' }
+  | { readonly kind: 'step-up'; readonly params: StepUpParams }
+  | { readonly kind: 'unavailable'; readonly message: string };
+
+type WorkspaceHandoffOptions = {
+  readonly preparation: WorkspaceHandoffPreparation;
+  readonly onFailMessage: (error: unknown, stage: HandoffFailureStage) => string;
+  readonly onAuthorised?: () => void;
+};
+
+export type WorkspaceHandoff = {
+  readonly phase: HandoffPhase;
+  readonly retry: () => void;
+  readonly authorise: () => void;
+};
+
+type HandoffActionLabels = {
+  readonly ready: string;
+  readonly authorising: string;
+};
+
+type HandoffAction = {
+  readonly label: string;
+  readonly disabled: boolean;
+  readonly onClick: (() => void) | undefined;
+};
+
+/** Derives the one launcher action from the hook's discriminated phase. */
+export function workspaceHandoffAction(
+  handoff: WorkspaceHandoff,
+  labels: HandoffActionLabels,
+  onRetry: () => void = handoff.retry,
+): HandoffAction {
+  switch (handoff.phase.kind) {
+    case 'contacting':
+      return { label: 'Contacting…', disabled: true, onClick: undefined };
+    case 'ready':
+      return { label: labels.ready, disabled: false, onClick: handoff.authorise };
+    case 'authorising':
+      return { label: labels.authorising, disabled: true, onClick: undefined };
+    case 'failed':
+      return { label: 'Try again', disabled: false, onClick: onRetry };
+  }
+}
+
+/**
+ * Owns one cross-origin workspace handoff from eager preparation through the
+ * popup wait. `authorise` deliberately calls `openPrepared` synchronously: no
+ * promise or effect may sit between the click and `window.open`.
+ */
+export function useWorkspaceHandoff(
+  origin: string,
+  options: WorkspaceHandoffOptions,
+): WorkspaceHandoff {
+  const [phase, setPhase] = useState<HandoffPhase>(() =>
+    options.preparation.kind === 'unavailable'
+      ? { kind: 'failed', message: options.preparation.message }
+      : { kind: 'contacting' },
+  );
+  const phaseRef = useRef(phase);
+  const liveRef = useRef(true);
+  const operationRef = useRef(0);
+  const onFailMessageRef = useRef(options.onFailMessage);
+  const onAuthorisedRef = useRef(options.onAuthorised);
+  onFailMessageRef.current = options.onFailMessage;
+  onAuthorisedRef.current = options.onAuthorised;
+
+  const preparationKind = options.preparation.kind;
+  const session =
+    options.preparation.kind === 'step-up' ? options.preparation.params.session : undefined;
+  const operation =
+    options.preparation.kind === 'step-up' ? options.preparation.params.operation : undefined;
+  const environment =
+    options.preparation.kind === 'step-up' ? options.preparation.params.environment : undefined;
+  const keySetKey =
+    options.preparation.kind === 'step-up' ? options.preparation.params.keySet.join(',') : undefined;
+  const unavailableMessage =
+    options.preparation.kind === 'unavailable' ? options.preparation.message : undefined;
+  const visiblePhase: HandoffPhase =
+    preparationKind === 'unavailable'
+      ? { kind: 'failed', message: unavailableMessage ?? 'Workspace handoff is unavailable.' }
+      : phase;
+
+  const retry = useCallback(() => {
+    const attempt = ++operationRef.current;
+    if (preparationKind === 'unavailable') {
+      const failed: HandoffPhase = {
+        kind: 'failed',
+        message: unavailableMessage ?? 'Workspace handoff is unavailable.',
+      };
+      phaseRef.current = failed;
+      setPhase(failed);
+      return;
+    }
+
+    const contacting: HandoffPhase = { kind: 'contacting' };
+    phaseRef.current = contacting;
+    setPhase(contacting);
+
+    const stepUp =
+      session === undefined || operation === undefined || environment === undefined
+        ? undefined
+        : {
+            session,
+            operation,
+            environment,
+            keySet: keySetKey === '' || keySetKey === undefined ? [] : keySetKey.split(','),
+          };
+    void prepareWorkspace(origin, stepUp)
+      .then((prepared) => {
+        if (!liveRef.current || operationRef.current !== attempt) return;
+        const ready: HandoffPhase = { kind: 'ready', prepared };
+        phaseRef.current = ready;
+        setPhase(ready);
+      })
+      .catch((error: unknown) => {
+        if (!liveRef.current || operationRef.current !== attempt) return;
+        const failed: HandoffPhase = {
+          kind: 'failed',
+          message: onFailMessageRef.current(error, 'prepare'),
+        };
+        phaseRef.current = failed;
+        setPhase(failed);
+      });
+  }, [environment, keySetKey, operation, origin, preparationKind, session, unavailableMessage]);
+
+  useEffect(() => {
+    liveRef.current = true;
+    return () => {
+      liveRef.current = false;
+      operationRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    retry();
+  }, [retry]);
+
+  const authorise = useCallback(() => {
+    const ready = phaseRef.current;
+    if (ready.kind !== 'ready') return;
+
+    const attempt = ++operationRef.current;
+    const authorising: HandoffPhase = { kind: 'authorising', prepared: ready.prepared };
+    phaseRef.current = authorising;
+    setPhase(authorising);
+
+    // Load-bearing popup invariant: this call remains in the click's stack.
+    void openPrepared(ready.prepared)
+      .then(() => {
+        if (!liveRef.current || operationRef.current !== attempt) return;
+        onAuthorisedRef.current?.();
+      })
+      .catch((error: unknown) => {
+        if (!liveRef.current || operationRef.current !== attempt) return;
+        const failed: HandoffPhase = {
+          kind: 'failed',
+          message: onFailMessageRef.current(error, 'authorise'),
+        };
+        phaseRef.current = failed;
+        setPhase(failed);
+      });
+  }, []);
+
+  return { phase: visiblePhase, retry, authorise };
+}


### PR DESCRIPTION
Closes #438.

Summary:
- centralize establishment and step-up launcher state in useWorkspaceHandoff
- keep popup launch synchronous while disabling duplicate sign-in attempts
- expose truthful failure and retry states across Ceremony, Remotes, and WorkspaceScope

Local validation:
- focused handoff tests: 8 passed
- web unit suite: 339 passed
- TypeScript typecheck: passed
- production Vite build: passed

Delivery guard: refresh or merge only when this is the lowest-numbered open non-draft PR.