### PR TITLE
Announce secret reveals once #449

### DIFF
--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -148,7 +148,7 @@ describe('Values reveal accessibility', () => {
     expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
     const announcement = container.querySelector('.values__reveal-announcement');
     expect(announcement?.getAttribute('role')).toBe('status');
-    expect(announcement?.textContent).toBe('KEY_A revealed');
+    expect(announcement?.textContent).toBe('KEY_A revealed — re-masks in 10 seconds');
     expect(container.querySelector('.values__plain')?.getAttribute('aria-label')).toBe(
       'KEY_A revealed',
     );
@@ -187,7 +187,7 @@ describe('Values reveal accessibility', () => {
 
     expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
     expect(container.querySelector('.values__reveal-announcement')?.textContent).toBe(
-      '2 secrets revealed',
+      '2 secrets revealed — re-mask in 10 seconds',
     );
     expect(container.querySelectorAll('.values__countdown')).toHaveLength(2);
     expect(container.querySelectorAll('.values__countdown[aria-hidden="true"]')).toHaveLength(2);

--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -40,12 +40,20 @@ vi.mock('../api/values.ts', async (importActual) => {
     useSetValue: () => ({ mutate: vi.fn() }),
     useValues: () => ({
       data: {
-        items: [{
-          key_id: 'key-a',
-          name: 'KEY_A',
-          classification: 'secret',
-          set: true,
-        }],
+        items: [
+          {
+            key_id: 'key-a',
+            name: 'KEY_A',
+            classification: 'secret',
+            set: true,
+          },
+          {
+            key_id: 'key-b',
+            name: 'KEY_B',
+            classification: 'secret',
+            set: true,
+          },
+        ],
       },
       isError: false,
     }),
@@ -125,6 +133,64 @@ beforeEach(() => {
 });
 
 describe('Values ceremony task ownership', () => {
+  it('announces one reveal once and keeps its ticking countdown visual-only', async () => {
+    mocks.fetchRevealWindow.mockResolvedValueOnce(revealWindow(true));
+    mocks.revealOne.mockResolvedValueOnce({
+      key_id: 'key-a',
+      name: 'KEY_A',
+      value: 'revealed-value',
+    });
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'Reveal KEY_A').click());
+    await settle();
+
+    const announcement = container.querySelector('.values__reveal-announcement');
+    expect(announcement?.getAttribute('role')).toBe('status');
+    expect(announcement?.textContent).toBe('KEY_A revealed — re-masks in 10s');
+    expect(container.querySelector('.values__plain')?.getAttribute('aria-label')).toBe(
+      'KEY_A revealed',
+    );
+    expect(container.querySelector('.values__countdown')?.getAttribute('aria-hidden')).toBe(
+      'true',
+    );
+    expect(container.querySelector('.values__countdown')?.hasAttribute('role')).toBe(false);
+    await act(async () => root.unmount());
+  });
+
+  it('uses one reveal announcement when every secret is disclosed', async () => {
+    mocks.fetchRevealWindow.mockResolvedValueOnce(revealWindow(true));
+    mocks.revealAll.mockResolvedValueOnce({
+      items: [
+        {
+          key_id: 'key-a',
+          name: 'KEY_A',
+          classification: 'secret',
+          value: 'revealed-a',
+        },
+        {
+          key_id: 'key-b',
+          name: 'KEY_B',
+          classification: 'secret',
+          value: 'revealed-b',
+        },
+      ],
+    });
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'Reveal every secret').click());
+    await settle();
+
+    expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
+    expect(container.querySelector('.values__reveal-announcement')?.textContent).toBe(
+      '2 secrets revealed — re-mask in 10s',
+    );
+    expect(container.querySelectorAll('.values__countdown')).toHaveLength(2);
+    expect(container.querySelectorAll('.values__countdown[aria-hidden="true"]')).toHaveLength(2);
+    expect(container.querySelectorAll('.values__countdown[role]')).toHaveLength(0);
+    await act(async () => root.unmount());
+  });
+
   it('ignores a guard completion from the environment visited before navigation', async () => {
     const pending = deferred<RevealWindow>();
     mocks.fetchRevealWindow.mockImplementationOnce(() => pending.promise);

--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -132,7 +132,7 @@ beforeEach(() => {
   mocks.revealOne.mockReset();
 });
 
-describe('Values ceremony task ownership', () => {
+describe('Values reveal accessibility', () => {
   it('announces one reveal once and keeps its ticking countdown visual-only', async () => {
     mocks.fetchRevealWindow.mockResolvedValueOnce(revealWindow(true));
     mocks.revealOne.mockResolvedValueOnce({
@@ -145,6 +145,7 @@ describe('Values ceremony task ownership', () => {
     await act(async () => button(container, 'Reveal KEY_A').click());
     await settle();
 
+    expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
     const announcement = container.querySelector('.values__reveal-announcement');
     expect(announcement?.getAttribute('role')).toBe('status');
     expect(announcement?.textContent).toBe('KEY_A revealed — re-masks in 10s');
@@ -177,6 +178,9 @@ describe('Values ceremony task ownership', () => {
       ],
     });
     const { container, root } = await renderValues();
+    const liveRegionCount = container.querySelectorAll(
+      '[role="status"], [aria-live="polite"]',
+    ).length;
 
     await act(async () => button(container, 'Reveal every secret').click());
     await settle();
@@ -188,9 +192,14 @@ describe('Values ceremony task ownership', () => {
     expect(container.querySelectorAll('.values__countdown')).toHaveLength(2);
     expect(container.querySelectorAll('.values__countdown[aria-hidden="true"]')).toHaveLength(2);
     expect(container.querySelectorAll('.values__countdown[role]')).toHaveLength(0);
+    expect(container.querySelectorAll('[role="status"], [aria-live="polite"]')).toHaveLength(
+      liveRegionCount,
+    );
     await act(async () => root.unmount());
   });
+});
 
+describe('Values ceremony task ownership', () => {
   it('ignores a guard completion from the environment visited before navigation', async () => {
     const pending = deferred<RevealWindow>();
     mocks.fetchRevealWindow.mockImplementationOnce(() => pending.promise);

--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -148,7 +148,7 @@ describe('Values reveal accessibility', () => {
     expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
     const announcement = container.querySelector('.values__reveal-announcement');
     expect(announcement?.getAttribute('role')).toBe('status');
-    expect(announcement?.textContent).toBe('KEY_A revealed — re-masks in 10s');
+    expect(announcement?.textContent).toBe('KEY_A revealed');
     expect(container.querySelector('.values__plain')?.getAttribute('aria-label')).toBe(
       'KEY_A revealed',
     );
@@ -187,7 +187,7 @@ describe('Values reveal accessibility', () => {
 
     expect(container.querySelectorAll('.values__reveal-announcement')).toHaveLength(1);
     expect(container.querySelector('.values__reveal-announcement')?.textContent).toBe(
-      '2 secrets revealed — re-mask in 10s',
+      '2 secrets revealed',
     );
     expect(container.querySelectorAll('.values__countdown')).toHaveLength(2);
     expect(container.querySelectorAll('.values__countdown[aria-hidden="true"]')).toHaveLength(2);

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -252,7 +252,7 @@ export function Values() {
     setAudit((prev) => [...names.map((n) => `Disclosure recorded · ${n}`), ...prev].slice(0, AUDIT_LINES));
   }, []);
 
-  const show = useCallback(
+  const recordDisclosures = useCallback(
     (entries: Array<{ id: string; name: string; value: string }>) => {
       const until = Date.now() + REMASK_MS;
       setDisclosed((current) => {
@@ -288,7 +288,7 @@ export function Values() {
               setRefusal('The server disclosed no value for that key.');
               return;
             }
-            show([{ id: fresh.key_id, name: fresh.name, value: fresh.value }]);
+            recordDisclosures([{ id: fresh.key_id, name: fresh.name, value: fresh.value }]);
           });
         } catch (err) {
           ceremony.commit(task, () => {
@@ -307,7 +307,7 @@ export function Values() {
         try {
           const fresh = await revealAll.mutateAsync();
           ceremony.commit(task, () => {
-            show(
+            recordDisclosures(
               fresh.items
                 .filter((c) => c.classification === 'secret' && c.value !== undefined)
                 .map((c) => ({ id: c.key_id, name: c.name, value: c.value ?? '' })),
@@ -431,15 +431,11 @@ export function Values() {
         </p>
       ) : null}
 
-      {revealAnnouncement !== null ? (
-        <p
-          key={revealAnnouncement.id}
-          className="values__reveal-announcement visually-hidden"
-          role="status"
-        >
-          {revealAnnouncement.message}
-        </p>
-      ) : null}
+      <p className="values__reveal-announcement visually-hidden" role="status">
+        {revealAnnouncement === null ? null : (
+          <span key={revealAnnouncement.id}>{revealAnnouncement.message}</span>
+        )}
+      </p>
 
       <div className="values__bar">
         <button

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -62,6 +62,7 @@ const MASK = '••••••••';
 const AUDIT_LINES = 12;
 
 type Disclosed = { value: string; until: number };
+type RevealAnnouncement = { id: number; message: string };
 
 /**
  * cellKey identifies a disclosed cell by ENVIRONMENT and key id.
@@ -98,6 +99,7 @@ export function Values() {
   const [now, setNow] = useState(() => Date.now());
   const [refusal, setRefusal] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [revealAnnouncement, setRevealAnnouncement] = useState<RevealAnnouncement | null>(null);
   const [audit, setAudit] = useState<string[]>([]);
   const [editing, setEditing] = useState<string | null>(null);
   const [destination, setDestination] = useState('');
@@ -119,6 +121,7 @@ export function Values() {
     setEditing(null);
     setRefusal(null);
     setNotice(null);
+    setRevealAnnouncement(null);
     setAudit([]);
   }, [env.org, env.project, env.environment]);
 
@@ -259,6 +262,16 @@ export function Values() {
         }
         return next;
       });
+      const [first] = entries;
+      if (first !== undefined) {
+        const subject =
+          entries.length === 1 ? `${first.name} revealed` : `${entries.length} secrets revealed`;
+        const verb = entries.length === 1 ? 're-masks' : 're-mask';
+        setRevealAnnouncement((current) => ({
+          id: (current?.id ?? 0) + 1,
+          message: `${subject} — ${verb} in ${String(REMASK_MS / 1000)}s`,
+        }));
+      }
       noteDisclosure(entries.map((e) => e.name));
     },
     [env.environment, noteDisclosure],
@@ -418,6 +431,16 @@ export function Values() {
         </p>
       ) : null}
 
+      {revealAnnouncement !== null ? (
+        <p
+          key={revealAnnouncement.id}
+          className="values__reveal-announcement visually-hidden"
+          role="status"
+        >
+          {revealAnnouncement.message}
+        </p>
+      ) : null}
+
       <div className="values__bar">
         <button
           className="btn"
@@ -496,9 +519,9 @@ export function Values() {
                   {!cell.set ? (
                     <span className="values__absent">absent</span>
                   ) : live !== undefined ? (
-                    <span className="mono values__plain">
+                    <span className="mono values__plain" aria-label={`${cell.name} revealed`}>
                       {live.value}
-                      <span className="values__countdown" role="status">
+                      <span className="values__countdown" aria-hidden="true">
                         {`re-masks in ${remaining}s`}
                       </span>
                     </span>

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -264,10 +264,12 @@ export function Values() {
       });
       const [first] = entries;
       if (first !== undefined) {
+        const subject =
+          entries.length === 1 ? `${first.name} revealed` : `${entries.length} secrets revealed`;
+        const verb = entries.length === 1 ? 're-masks' : 're-mask';
         setRevealAnnouncement((current) => ({
           id: (current?.id ?? 0) + 1,
-          message:
-            entries.length === 1 ? `${first.name} revealed` : `${entries.length} secrets revealed`,
+          message: `${subject} — ${verb} in ${String(REMASK_MS / 1000)} seconds`,
         }));
       }
       noteDisclosure(entries.map((e) => e.name));

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -264,12 +264,10 @@ export function Values() {
       });
       const [first] = entries;
       if (first !== undefined) {
-        const subject =
-          entries.length === 1 ? `${first.name} revealed` : `${entries.length} secrets revealed`;
-        const verb = entries.length === 1 ? 're-masks' : 're-mask';
         setRevealAnnouncement((current) => ({
           id: (current?.id ?? 0) + 1,
-          message: `${subject} — ${verb} in ${String(REMASK_MS / 1000)}s`,
+          message:
+            entries.length === 1 ? `${first.name} revealed` : `${entries.length} secrets revealed`,
         }));
       }
       noteDisclosure(entries.map((e) => e.name));


### PR DESCRIPTION
Closes #449

## Summary
- announce each reveal once through one polite live region
- keep per-cell countdowns visual-only
- label revealed values for assistive technology
- cover reveal-one and reveal-all accessibility behavior

## Validation
- `pnpm --dir web exec vitest run src/routes/Values.ceremony-task.test.tsx` (5 passed)
- `pnpm --dir web typecheck`
- `pnpm --dir web test` (336 passed)
- standards review CLEAN
- spec review CLEAN