### PR TITLE
Give value writes success and failure feedback #447

### DIFF
--- a/web/src/api/values.ts
+++ b/web/src/api/values.ts
@@ -444,6 +444,32 @@ export function disclosureRefusalText(error: unknown): string {
   return 'The values could not be disclosed.';
 }
 
+/** Map a value-write refusal without pretending an unconfirmed request was rolled back. */
+export function writeRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return error.detail ?? 'The server refused this value as invalid.';
+      case 401:
+        return 'Your session ended. Sign in again before staging this value.';
+      case 403:
+        return 'You are not permitted to stage this value.';
+      case 404:
+        return 'This value is no longer here. Reload before trying again.';
+      case 409:
+        return (
+          error.detail ??
+          'This value changed before your draft could be staged. Reload and try again.'
+        );
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return 'The server did not confirm whether this value was staged. Reload to check before trying again.';
+    }
+  }
+  return 'The server did not confirm whether this value was staged. Reload to check before trying again.';
+}
+
 /** useRevealOne discloses a single cell. */
 export function useRevealOne(env: EnvRef) {
   const queries = useQueryClient();

--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -4,10 +4,9 @@ import { createRoot, type Root } from 'react-dom/client';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ApiError } from '../api/client.ts';
 import type { RevealWindow } from '../api/values.ts';
 import { deferred, revealWindow } from '../testkit/ceremony.ts';
-import { settle, typeInto } from '../testkit/renderForm.tsx';
+import { settle } from '../testkit/renderForm.tsx';
 import type { CeremonyRequest } from './Ceremony.tsx';
 import { Values } from './Values.tsx';
 
@@ -15,30 +14,11 @@ const mocks = vi.hoisted(() => ({
   copy: vi.fn(),
   fetchRevealWindow: vi.fn(),
   revealAll: vi.fn(),
-  revealGuard: { canReveal: true },
   revealOne: vi.fn(),
-  setValue: vi.fn(),
 }));
 
 vi.mock('../api/values.ts', async (importActual) => {
   const actual = await importActual<typeof import('../api/values.ts')>();
-  const { useState } = await import('react');
-
-  function useSetValue() {
-    const [isPending, setIsPending] = useState(false);
-    return {
-      isPending,
-      mutateAsync: async (input: { key: string; value: string }) => {
-        setIsPending(true);
-        try {
-          return await mocks.setValue(input);
-        } finally {
-          setIsPending(false);
-        }
-      },
-    };
-  }
-
   return {
     ...actual,
     fetchRevealWindow: mocks.fetchRevealWindow,
@@ -55,9 +35,9 @@ vi.mock('../api/values.ts', async (importActual) => {
     useRevealAll: () => ({ mutateAsync: mocks.revealAll }),
     useRevealOne: () => ({ mutateAsync: mocks.revealOne }),
     useRevealWindow: () => ({
-      data: { ...revealWindow(true), can_reveal: mocks.revealGuard.canReveal },
+      data: revealWindow(true),
     }),
-    useSetValue,
+    useSetValue: () => ({ isPending: false, mutateAsync: vi.fn() }),
     useValues: () => ({
       data: {
         items: [{
@@ -141,9 +121,7 @@ beforeEach(() => {
   mocks.copy.mockReset();
   mocks.fetchRevealWindow.mockReset();
   mocks.revealAll.mockReset();
-  mocks.revealGuard.canReveal = true;
   mocks.revealOne.mockReset();
-  mocks.setValue.mockReset();
 });
 
 describe('Values ceremony task ownership', () => {
@@ -198,66 +176,6 @@ describe('Values ceremony task ownership', () => {
 
     expect(container.textContent).not.toContain('must-not-cross-environments');
     expect(container.textContent).toContain('No disclosures yet.');
-    await act(async () => root.unmount());
-  });
-});
-
-describe('Values write feedback', () => {
-  it('confirms a staged value and closes the editor after the server accepts it', async () => {
-    mocks.setValue.mockResolvedValueOnce({ id: 'pending-a' });
-    const { container, root } = await renderValues();
-
-    await act(async () => button(container, 'KEY_A').click());
-    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
-    if (input === null) throw new Error('value editor is missing');
-    typeInto(input, 'replacement');
-    await act(async () => button(container, 'Save draft').click());
-    await settle();
-
-    expect(mocks.setValue).toHaveBeenCalledWith({ key: 'KEY_A', value: 'replacement' });
-    expect(container.querySelector('#edit-key-a')).toBeNull();
-    expect(container.textContent).toContain('KEY_A staged.');
-    await act(async () => root.unmount());
-  });
-
-  it('shows saving, then surfaces a refusal and keeps the rejected draft editable', async () => {
-    mocks.revealGuard.canReveal = false;
-    let rejectWrite: (reason?: unknown) => void = () => undefined;
-    mocks.setValue.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectWrite = reject;
-        }),
-    );
-    const { container, root } = await renderValues();
-
-    await act(async () => button(container, 'KEY_A').click());
-    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
-    if (input === null) throw new Error('value editor is missing');
-    expect(input.dataset['writeOnly']).toBe('true');
-    typeInto(input, 'correctable draft');
-    await act(async () => button(container, 'Save draft').click());
-
-    expect(button(container, 'Saving…').disabled).toBe(true);
-
-    await act(async () => rejectWrite(new ApiError(403, 'forbidden')));
-    await settle();
-
-    const retained = container.querySelector<HTMLInputElement>('#edit-key-a');
-    expect(retained?.value).toBe('correctable draft');
-    expect(container.textContent).toContain('You are not permitted to stage this value.');
-    await act(async () => root.unmount());
-  });
-
-  it('treats an empty submission as unchanged without issuing a write', async () => {
-    const { container, root } = await renderValues();
-
-    await act(async () => button(container, 'KEY_A').click());
-    await act(async () => button(container, 'Save draft').click());
-    await settle();
-
-    expect(mocks.setValue).not.toHaveBeenCalled();
-    expect(container.querySelector('#edit-key-a')).toBeNull();
     await act(async () => root.unmount());
   });
 });

--- a/web/src/routes/Values.ceremony-task.test.tsx
+++ b/web/src/routes/Values.ceremony-task.test.tsx
@@ -4,9 +4,10 @@ import { createRoot, type Root } from 'react-dom/client';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ApiError } from '../api/client.ts';
 import type { RevealWindow } from '../api/values.ts';
 import { deferred, revealWindow } from '../testkit/ceremony.ts';
-import { settle } from '../testkit/renderForm.tsx';
+import { settle, typeInto } from '../testkit/renderForm.tsx';
 import type { CeremonyRequest } from './Ceremony.tsx';
 import { Values } from './Values.tsx';
 
@@ -14,11 +15,30 @@ const mocks = vi.hoisted(() => ({
   copy: vi.fn(),
   fetchRevealWindow: vi.fn(),
   revealAll: vi.fn(),
+  revealGuard: { canReveal: true },
   revealOne: vi.fn(),
+  setValue: vi.fn(),
 }));
 
 vi.mock('../api/values.ts', async (importActual) => {
   const actual = await importActual<typeof import('../api/values.ts')>();
+  const { useState } = await import('react');
+
+  function useSetValue() {
+    const [isPending, setIsPending] = useState(false);
+    return {
+      isPending,
+      mutateAsync: async (input: { key: string; value: string }) => {
+        setIsPending(true);
+        try {
+          return await mocks.setValue(input);
+        } finally {
+          setIsPending(false);
+        }
+      },
+    };
+  }
+
   return {
     ...actual,
     fetchRevealWindow: mocks.fetchRevealWindow,
@@ -35,9 +55,9 @@ vi.mock('../api/values.ts', async (importActual) => {
     useRevealAll: () => ({ mutateAsync: mocks.revealAll }),
     useRevealOne: () => ({ mutateAsync: mocks.revealOne }),
     useRevealWindow: () => ({
-      data: revealWindow(true),
+      data: { ...revealWindow(true), can_reveal: mocks.revealGuard.canReveal },
     }),
-    useSetValue: () => ({ mutate: vi.fn() }),
+    useSetValue,
     useValues: () => ({
       data: {
         items: [{
@@ -121,7 +141,9 @@ beforeEach(() => {
   mocks.copy.mockReset();
   mocks.fetchRevealWindow.mockReset();
   mocks.revealAll.mockReset();
+  mocks.revealGuard.canReveal = true;
   mocks.revealOne.mockReset();
+  mocks.setValue.mockReset();
 });
 
 describe('Values ceremony task ownership', () => {
@@ -176,6 +198,66 @@ describe('Values ceremony task ownership', () => {
 
     expect(container.textContent).not.toContain('must-not-cross-environments');
     expect(container.textContent).toContain('No disclosures yet.');
+    await act(async () => root.unmount());
+  });
+});
+
+describe('Values write feedback', () => {
+  it('confirms a staged value and closes the editor after the server accepts it', async () => {
+    mocks.setValue.mockResolvedValueOnce({ id: 'pending-a' });
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
+    if (input === null) throw new Error('value editor is missing');
+    typeInto(input, 'replacement');
+    await act(async () => button(container, 'Save draft').click());
+    await settle();
+
+    expect(mocks.setValue).toHaveBeenCalledWith({ key: 'KEY_A', value: 'replacement' });
+    expect(container.querySelector('#edit-key-a')).toBeNull();
+    expect(container.textContent).toContain('KEY_A staged.');
+    await act(async () => root.unmount());
+  });
+
+  it('shows saving, then surfaces a refusal and keeps the rejected draft editable', async () => {
+    mocks.revealGuard.canReveal = false;
+    let rejectWrite: (reason?: unknown) => void = () => undefined;
+    mocks.setValue.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectWrite = reject;
+        }),
+    );
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
+    if (input === null) throw new Error('value editor is missing');
+    expect(input.dataset['writeOnly']).toBe('true');
+    typeInto(input, 'correctable draft');
+    await act(async () => button(container, 'Save draft').click());
+
+    expect(button(container, 'Saving…').disabled).toBe(true);
+
+    await act(async () => rejectWrite(new ApiError(403, 'forbidden')));
+    await settle();
+
+    const retained = container.querySelector<HTMLInputElement>('#edit-key-a');
+    expect(retained?.value).toBe('correctable draft');
+    expect(container.textContent).toContain('You are not permitted to stage this value.');
+    await act(async () => root.unmount());
+  });
+
+  it('treats an empty submission as unchanged without issuing a write', async () => {
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    await act(async () => button(container, 'Save draft').click());
+    await settle();
+
+    expect(mocks.setValue).not.toHaveBeenCalled();
+    expect(container.querySelector('#edit-key-a')).toBeNull();
     await act(async () => root.unmount());
   });
 });

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -11,6 +11,7 @@ import {
   useRevealWindow,
   useSetValue,
   useValues,
+  writeRefusalText,
   type EnvRef,
   type RevealWindow,
   type ValueCell,
@@ -382,6 +383,25 @@ export function Values() {
     );
   };
 
+  const saveDraft = async (cell: ValueCell, value: string): Promise<void> => {
+    // Empty means UNCHANGED. There is no per-row clear: clearing a value stays
+    // a per-cell action, as the prototype's resolution fixed.
+    if (value === '') {
+      setEditing(null);
+      return;
+    }
+
+    setRefusal(null);
+    setNotice(null);
+    try {
+      await setValue.mutateAsync({ key: cell.name, value });
+      setEditing((current) => (current === cell.name ? null : current));
+      setNotice(`${cell.name} staged.`);
+    } catch (error) {
+      setRefusal(writeRefusalText(error));
+    }
+  };
+
   const chip = guard === undefined ? null : windowChip(guard, now);
 
   return (
@@ -537,15 +557,8 @@ export function Values() {
                     <RowEditor
                       cell={cell}
                       writeOnly={writeOnly}
-                      onSave={(value) => {
-                        setEditing(null);
-                        // Empty means UNCHANGED. There is no per-row clear:
-                        // clearing a value stays a per-cell action, as the
-                        // prototype's resolution fixed.
-                        if (value !== '') {
-                          setValue.mutate({ key: cell.name, value });
-                        }
-                      }}
+                      saving={setValue.isPending}
+                      onSave={(value) => void saveDraft(cell, value)}
                     />
                   </td>
                 ) : null}
@@ -634,10 +647,12 @@ function windowChip(state: RevealWindow, now: number) {
 function RowEditor({
   cell,
   writeOnly,
+  saving,
   onSave,
 }: {
   cell: ValueCell;
   writeOnly: boolean;
+  saving: boolean;
   onSave: (value: string) => void;
 }) {
   const [draft, setDraft] = useState('');
@@ -662,6 +677,7 @@ function RowEditor({
           }
           data-write-only={writeOnly}
           value={draft}
+          disabled={saving}
           onChange={(event) => setDraft(event.target.value)}
         />
       </div>
@@ -671,8 +687,8 @@ function RowEditor({
           changes nothing.
         </p>
       ) : null}
-      <button className="btn btn--primary" type="submit">
-        Save draft
+      <button className="btn btn--primary" type="submit" disabled={saving}>
+        {saving ? 'Saving…' : 'Save draft'}
       </button>
     </form>
   );

--- a/web/src/routes/Values.tsx
+++ b/web/src/routes/Values.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 
 import {
@@ -102,6 +102,7 @@ export function Values() {
   const [audit, setAudit] = useState<string[]>([]);
   const [editing, setEditing] = useState<string | null>(null);
   const [destination, setDestination] = useState('');
+  const writeGeneration = useRef(0);
   const ceremony = useCeremonyTask([
     env.org,
     env.project,
@@ -116,11 +117,15 @@ export function Values() {
   // waiting to be answered, the act it was staged for, an open editor and the
   // clipboard notice, none of which mean anything in a different environment.
   useEffect(() => {
+    writeGeneration.current += 1;
     setDisclosed({});
     setEditing(null);
     setRefusal(null);
     setNotice(null);
     setAudit([]);
+    return () => {
+      writeGeneration.current += 1;
+    };
   }, [env.org, env.project, env.environment]);
 
   // One ticker drives every countdown on the surface: the remask timers and
@@ -387,17 +392,19 @@ export function Values() {
     // Empty means UNCHANGED. There is no per-row clear: clearing a value stays
     // a per-cell action, as the prototype's resolution fixed.
     if (value === '') {
-      setEditing(null);
       return;
     }
 
+    const generation = writeGeneration.current;
     setRefusal(null);
     setNotice(null);
     try {
       await setValue.mutateAsync({ key: cell.name, value });
+      if (writeGeneration.current !== generation) return;
       setEditing((current) => (current === cell.name ? null : current));
       setNotice(`${cell.name} staged.`);
     } catch (error) {
+      if (writeGeneration.current !== generation) return;
       setRefusal(writeRefusalText(error));
     }
   };
@@ -508,6 +515,7 @@ export function Values() {
                     type="button"
                     onClick={() => setEditing(editing === cell.name ? null : cell.name)}
                     aria-expanded={editing === cell.name}
+                    disabled={setValue.isPending}
                   >
                     {cell.name}
                   </button>

--- a/web/src/routes/Values.write-feedback.test.tsx
+++ b/web/src/routes/Values.write-feedback.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../api/client.ts';
+import { deferred, revealWindow } from '../testkit/ceremony.ts';
+import { settle, typeInto } from '../testkit/renderForm.tsx';
+import { Values } from './Values.tsx';
+
+const mocks = vi.hoisted(() => ({
+  canReveal: { value: true },
+  setValue: vi.fn(),
+}));
+
+vi.mock('../api/values.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/values.ts')>();
+  const { useState } = await import('react');
+
+  function useSetValue() {
+    const [isPending, setIsPending] = useState(false);
+    return {
+      isPending,
+      mutateAsync: async (input: { key: string; value: string }) => {
+        setIsPending(true);
+        try {
+          return await mocks.setValue(input);
+        } finally {
+          setIsPending(false);
+        }
+      },
+    };
+  }
+
+  return {
+    ...actual,
+    useCopyValues: () => ({ mutateAsync: vi.fn() }),
+    useEnvironments: () => ({ data: { items: [] } }),
+    useRevealAll: () => ({ mutateAsync: vi.fn() }),
+    useRevealOne: () => ({ mutateAsync: vi.fn() }),
+    useRevealWindow: () => ({
+      data: { ...revealWindow(true), can_reveal: mocks.canReveal.value },
+    }),
+    useSetValue,
+    useValues: () => ({
+      data: {
+        items: [
+          {
+            key_id: 'key-a',
+            name: 'KEY_A',
+            classification: 'secret',
+            set: true,
+          },
+        ],
+      },
+      isError: false,
+    }),
+  };
+});
+
+vi.mock('../api/transport.tsx', () => ({
+  useTransport: () => ({ client: undefined }),
+}));
+
+function App() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => navigate('/orgs/org-a/projects/project-a/environments/env-b/values')}
+      >
+        Navigate
+      </button>
+      <Routes>
+        <Route
+          path="/orgs/:org/projects/:project/environments/:environment/values"
+          element={<Values />}
+        />
+      </Routes>
+    </>
+  );
+}
+
+async function renderValues(): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={['/orgs/org-a/projects/project-a/environments/env-a/values']}>
+        <App />
+      </MemoryRouter>,
+    );
+  });
+  return { container, root };
+}
+
+function button(container: HTMLElement, name: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent === name || candidate.getAttribute('aria-label') === name,
+  );
+  if (match === undefined) throw new Error(`button ${name} is missing`);
+  return match;
+}
+
+beforeEach(() => {
+  mocks.canReveal.value = true;
+  mocks.setValue.mockReset();
+});
+
+describe('Values write feedback', () => {
+  it('confirms a staged value and closes the editor after the server accepts it', async () => {
+    mocks.setValue.mockResolvedValueOnce({ id: 'pending-a' });
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
+    if (input === null) throw new Error('value editor is missing');
+    typeInto(input, 'replacement');
+    await act(async () => button(container, 'Save draft').click());
+    await settle();
+
+    expect(mocks.setValue).toHaveBeenCalledWith({ key: 'KEY_A', value: 'replacement' });
+    expect(container.querySelector('#edit-key-a')).toBeNull();
+    expect(container.textContent).toContain('KEY_A staged.');
+    await act(async () => root.unmount());
+  });
+
+  it('shows saving, then surfaces a refusal and keeps the rejected draft editable', async () => {
+    mocks.canReveal.value = false;
+    let rejectWrite: (reason?: unknown) => void = () => undefined;
+    mocks.setValue.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectWrite = reject;
+        }),
+    );
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
+    if (input === null) throw new Error('value editor is missing');
+    expect(input.dataset['writeOnly']).toBe('true');
+    typeInto(input, 'correctable draft');
+    await act(async () => button(container, 'Save draft').click());
+
+    expect(button(container, 'Saving…').disabled).toBe(true);
+    expect(button(container, 'KEY_A').disabled).toBe(true);
+
+    await act(async () => rejectWrite(new ApiError(403, 'forbidden')));
+    await settle();
+
+    const retained = container.querySelector<HTMLInputElement>('#edit-key-a');
+    expect(retained?.value).toBe('correctable draft');
+    expect(container.textContent).toContain('You are not permitted to stage this value.');
+    await act(async () => root.unmount());
+  });
+
+  it('leaves an empty submission unchanged without issuing a write', async () => {
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    await act(async () => button(container, 'Save draft').click());
+    await settle();
+
+    expect(mocks.setValue).not.toHaveBeenCalled();
+    expect(container.querySelector('#edit-key-a')).not.toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it('does not report a write that settles after navigation', async () => {
+    const pending = deferred<{ id: string }>();
+    mocks.setValue.mockImplementationOnce(() => pending.promise);
+    const { container, root } = await renderValues();
+
+    await act(async () => button(container, 'KEY_A').click());
+    const input = container.querySelector<HTMLInputElement>('#edit-key-a');
+    if (input === null) throw new Error('value editor is missing');
+    typeInto(input, 'old-environment draft');
+    await act(async () => button(container, 'Save draft').click());
+    await act(async () => button(container, 'Navigate').click());
+    await act(async () => pending.resolve({ id: 'pending-a' }));
+    await settle();
+
+    expect(container.textContent).not.toContain('KEY_A staged.');
+    expect(container.querySelector('#edit-key-a')).toBeNull();
+    await act(async () => root.unmount());
+  });
+});


### PR DESCRIPTION
Closes #447

## What changed
- keep value editor open until the write settles
- show saving, success, and refusal feedback
- retain rejected drafts for correction
- ignore write completions from a previously visited environment
- cover success, rejection, empty no-op, and navigation ownership

## Validation
- `pnpm --dir web exec vitest run src/routes/Values.write-feedback.test.tsx src/routes/Values.ceremony-task.test.tsx --maxWorkers=1` (7 passed)
- `pnpm --dir web run typecheck`
- `pnpm --dir web exec vitest run --maxWorkers=1` (338 passed)
- `git diff --check`