### PR TITLE
Clear stale matrix mutation refusal banners #448

### DIFF
--- a/docs/handoff/448-matrix-mutation-error.md
+++ b/docs/handoff/448-matrix-mutation-error.md
@@ -1,0 +1,31 @@
+# Issue #448 — matrix mutation refusal ownership
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/448. Delivery PR:
+https://github.com/Hikyo-Org/Hikyo/pull/475.
+
+**State: implemented.** Stage, clear, and copy refusals are owned by the row
+editor instance that initiated them. They no longer duplicate above the grid
+or survive editor close, key changes, and project changes.
+
+## Contract
+
+- An editor-originated mutation refusal renders only inside its row editor.
+- Closing the editor or resetting the matrix scope clears its visible refusal.
+- A late asynchronous rejection remains bound to the original selection object,
+  so reopening the same cell cannot surface stale feedback.
+- Copy refusals remain visible while their originating editor stays open.
+- No API, generated contract, or migration changed.
+
+## Coverage
+
+`web/src/routes/Matrix.mutation-error.test.tsx` exercises the Matrix route and
+proves both the settled-rejection path and the close-before-rejection race. The
+assertion matches alert text by containment so the removed grid glyph cannot
+hide a duplicate announcement.
+
+## Review and validation
+
+Two-axis review completed in three bounded rounds. Spec review found and then
+verified the late-rejection ownership fix; Standards review found and then
+verified the test helper's narrowed `Error` contract. Final verdicts are
+Standards `CLEAN` and Spec `SOUND`. PR #475 records exact-head CI results.

--- a/web/src/routes/Matrix.mutation-error.test.tsx
+++ b/web/src/routes/Matrix.mutation-error.test.tsx
@@ -202,10 +202,10 @@ function typeInto(textarea: HTMLTextAreaElement, value: string): void {
   textarea.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
-function deferred<T>(): { readonly promise: Promise<T>; readonly reject: (reason?: unknown) => void } {
-  let reject: ((reason?: unknown) => void) | undefined;
+function deferred<T>(): { readonly promise: Promise<T>; readonly reject: (reason: Error) => void } {
+  let reject: ((reason: Error) => void) | undefined;
   const promise = new Promise<T>((_resolve, rejectPromise) => {
-    reject = rejectPromise;
+    reject = (reason) => rejectPromise(reason);
   });
   if (reject === undefined) throw new Error('deferred rejection was not initialized');
   return { promise, reject };

--- a/web/src/routes/Matrix.mutation-error.test.tsx
+++ b/web/src/routes/Matrix.mutation-error.test.tsx
@@ -131,13 +131,7 @@ beforeEach(() => {
 
 describe('Matrix mutation refusal ownership', () => {
   it('shows an editor refusal once and removes it when the editor closes', async () => {
-    const view = await renderForm(
-      <MemoryRouter initialEntries={['/orgs/org_a/projects/project_a/matrix']}>
-        <Routes>
-          <Route path="/orgs/:org/projects/:project/matrix" element={<Matrix />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    const view = await renderMatrix();
 
     await act(async () => buttonNamed(view.container, 'LOG_LEVEL in development: info').click());
     const textarea = view.container.querySelector<HTMLTextAreaElement>('textarea');
@@ -154,7 +148,38 @@ describe('Matrix mutation refusal ownership', () => {
 
     await view.unmount();
   });
+
+  it('does not carry a late refusal into a reopened editor', async () => {
+    const pending = deferred<{ readonly findings: readonly never[] }>();
+    mocks.stage.mockReturnValue(pending.promise);
+    const view = await renderMatrix();
+
+    await act(async () => buttonNamed(view.container, 'LOG_LEVEL in development: info').click());
+    const textarea = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    if (textarea === null) throw new Error('matrix row editor textarea is missing');
+    await act(async () => typeInto(textarea, 'debug'));
+    await act(async () => buttonNamed(view.container, 'Save 1 draft').click());
+    await act(async () => buttonNamed(view.container, 'Close row editor').click());
+
+    pending.reject(new Error('stage rejected after close'));
+    await settle();
+    await act(async () => buttonNamed(view.container, 'LOG_LEVEL in development: info').click());
+
+    expect(alertsNamed(view.container, 'The server could not stage this value.')).toHaveLength(0);
+
+    await view.unmount();
+  });
 });
+
+function renderMatrix() {
+  return renderForm(
+    <MemoryRouter initialEntries={['/orgs/org_a/projects/project_a/matrix']}>
+      <Routes>
+        <Route path="/orgs/:org/projects/:project/matrix" element={<Matrix />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
 
 function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
   const button = [...container.querySelectorAll('button')].find(
@@ -175,4 +200,13 @@ function typeInto(textarea: HTMLTextAreaElement, value: string): void {
   if (setter === undefined) throw new Error('HTMLTextAreaElement exposes no value setter');
   setter.call(textarea, value);
   textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function deferred<T>(): { readonly promise: Promise<T>; readonly reject: (reason?: unknown) => void } {
+  let reject: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((_resolve, rejectPromise) => {
+    reject = rejectPromise;
+  });
+  if (reject === undefined) throw new Error('deferred rejection was not initialized');
+  return { promise, reject };
 }

--- a/web/src/routes/Matrix.mutation-error.test.tsx
+++ b/web/src/routes/Matrix.mutation-error.test.tsx
@@ -166,7 +166,7 @@ function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
 
 function alertsNamed(container: HTMLElement, text: string): readonly Element[] {
   return [...container.querySelectorAll('[role="alert"]')].filter(
-    (alert) => alert.textContent === text,
+    (alert) => alert.textContent?.includes(text) === true,
   );
 }
 

--- a/web/src/routes/Matrix.mutation-error.test.tsx
+++ b/web/src/routes/Matrix.mutation-error.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { Matrix } from './Matrix.tsx';
+
+const mocks = vi.hoisted(() => ({
+  stage: vi.fn<() => Promise<{ readonly findings: readonly never[] }>>(),
+}));
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { readonly count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index, end: index + 1 })),
+    getTotalSize: () => count,
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn(),
+  }),
+}));
+
+vi.mock('../api/transport.tsx', async (importActual) => {
+  const actual = await importActual<typeof import('../api/transport.tsx')>();
+  return { ...actual, useWorkspaceContext: () => null };
+});
+
+vi.mock('../api/matrix.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/matrix.ts')>();
+  return {
+    ...actual,
+    useMatrixProject: () => ({
+      environments: {
+        data: {
+          items: [{
+            id: 'env_a',
+            org_id: 'org_a',
+            project_id: 'project_a',
+            name: 'development',
+            display_order: 0,
+            created_at: '2026-08-24T08:00:00Z',
+          }],
+          count: 1,
+        },
+        isPending: false,
+        isError: false,
+      },
+      keys: {
+        data: {
+          items: [{
+            id: 'key_a',
+            org_id: 'org_a',
+            project_id: 'project_a',
+            name: 'LOG_LEVEL',
+            folder_path: '',
+            classification: 'config',
+            description: '',
+            deprecated: false,
+            deprecation_note: '',
+            declaration: { rule: { type: 'string', allow_empty: true } },
+            presence: {
+              required_in: { mode: 'none' },
+              forbidden_in: { mode: 'none' },
+            },
+            group_id: '',
+            created_at: '2026-08-24T08:00:00Z',
+          }],
+          count: 1,
+        },
+        isPending: false,
+        isError: false,
+      },
+      groups: { data: { items: [], count: 0 }, isPending: false, isError: false },
+      environmentRows: [{
+        environmentId: 'env_a',
+        environment: {
+          id: 'env_a',
+          org_id: 'org_a',
+          project_id: 'project_a',
+          name: 'development',
+          display_order: 0,
+          created_at: '2026-08-24T08:00:00Z',
+        },
+        readiness: 'ready',
+        values: {
+          status: 'ready',
+          data: {
+            items: [{
+              key_id: 'key_a',
+              name: 'LOG_LEVEL',
+              classification: 'config',
+              set: true,
+              revealed: true,
+              value: 'info',
+            }],
+            count: 1,
+          },
+        },
+        signals: { status: 'ready', data: { environment_id: 'env_a', revision: 1n, cells: [] } },
+        settings: { status: 'ready', data: { protected: false } },
+        pendingDrafts: { status: 'ready', data: { items: [], count: 0 } },
+      }],
+    }),
+    useStageMatrixValue: () => ({ mutateAsync: mocks.stage, isPending: false }),
+    useClearMatrixValue: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    usePublishMatrix: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    }),
+    useCopyMatrixConfig: () => ({ mutate: vi.fn(), isPending: false }),
+    useReclassifyKey: () => ({ mutateAsync: vi.fn() }),
+  };
+});
+
+vi.mock('./useProtectedPublishCeremony.ts', () => ({
+  useProtectedPublishCeremony: () => ({
+    request: null,
+    error: null,
+    run: vi.fn(),
+    onAuthorised: vi.fn(),
+    onCancel: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  mocks.stage.mockReset();
+  mocks.stage.mockRejectedValue(new Error('stage rejected'));
+});
+
+describe('Matrix mutation refusal ownership', () => {
+  it('shows an editor refusal once and removes it when the editor closes', async () => {
+    const view = await renderForm(
+      <MemoryRouter initialEntries={['/orgs/org_a/projects/project_a/matrix']}>
+        <Routes>
+          <Route path="/orgs/:org/projects/:project/matrix" element={<Matrix />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await act(async () => buttonNamed(view.container, 'LOG_LEVEL in development: info').click());
+    const textarea = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    if (textarea === null) throw new Error('matrix row editor textarea is missing');
+    await act(async () => typeInto(textarea, 'debug'));
+    await act(async () => buttonNamed(view.container, 'Save 1 draft').click());
+    await settle();
+
+    const refusal = 'The server could not stage this value.';
+    expect(alertsNamed(view.container, refusal)).toHaveLength(1);
+
+    await act(async () => buttonNamed(view.container, 'Close row editor').click());
+    expect(alertsNamed(view.container, refusal)).toHaveLength(0);
+
+    await view.unmount();
+  });
+});
+
+function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')].find(
+    (candidate) => candidate.getAttribute('aria-label') === name || candidate.textContent === name,
+  );
+  if (button === undefined) throw new Error(`button ${name} is missing`);
+  return button;
+}
+
+function alertsNamed(container: HTMLElement, text: string): readonly Element[] {
+  return [...container.querySelectorAll('[role="alert"]')].filter(
+    (alert) => alert.textContent === text,
+  );
+}
+
+function typeInto(textarea: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  if (setter === undefined) throw new Error('HTMLTextAreaElement exposes no value setter');
+  setter.call(textarea, value);
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -130,6 +130,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
     setCollapsedGroups(new Set());
     setFilter('all');
     setSelection(null);
+    setMutationError(null);
   }, [ref.org, ref.project, environmentSignature]);
 
   const valuesByCell = useMemo(() => {
@@ -454,13 +455,6 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
         </p>
       )}
 
-      {mutationError === null ? null : (
-        <p className="alert" role="alert">
-          <span className="alert__glyph" aria-hidden="true">!</span>
-          <span>{mutationError}</span>
-        </p>
-      )}
-
       {backgroundRefreshError ? (
         <p className="alert" role="status">
           <span className="alert__glyph" aria-hidden="true">!</span>
@@ -774,7 +768,10 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
           })}
           busy={stage.isPending || clear.isPending || copy.isPending}
           mutationError={mutationError}
-          onClose={() => setSelection(null)}
+          onClose={() => {
+            setMutationError(null);
+            setSelection(null);
+          }}
           onApply={async (changes) => {
             setMutationError(null);
             let normalizedCount = 0;

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -104,7 +104,10 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
   const [validationErrors, setValidationErrors] = useState<readonly MatrixValidationError[]>([]);
   const [publishOpen, setPublishOpen] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
-  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<{
+    readonly owner: Selection;
+    readonly message: string;
+  } | null>(null);
   const matrixScroll = useRef<HTMLDivElement>(null);
   const historyOpener = useRef<HTMLAnchorElement>(null);
   const [mobileLayout, setMobileLayout] = useState(
@@ -748,7 +751,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
         </div>
       </div>
 
-      {selectedKey === undefined || selectedEnvironment === undefined ? null : (
+      {selection === null || selectedKey === undefined || selectedEnvironment === undefined ? null : (
         <MatrixRowEditor
           refData={ref}
           keyRecord={selectedKey}
@@ -767,7 +770,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
             };
           })}
           busy={stage.isPending || clear.isPending || copy.isPending}
-          mutationError={mutationError}
+          mutationError={mutationError?.owner === selection ? mutationError.message : null}
           onClose={() => {
             setMutationError(null);
             setSelection(null);
@@ -808,12 +811,13 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
                 }
                 clearValidation(selectedKey.id, change.environmentId);
               } catch (error) {
-                setMutationError(
-                  matrixMutationError(
+                setMutationError({
+                  owner: selection,
+                  message: matrixMutationError(
                     error instanceof Error ? error : new Error('matrix mutation failed'),
                     change.operation === 'set' ? 'stage' : 'clear',
                   ),
-                );
+                });
                 throw error;
               }
             }
@@ -842,7 +846,10 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
                   );
                   setSelection(null);
                 },
-                onError: (error) => setMutationError(matrixMutationError(error, 'copy')),
+                onError: (error) => setMutationError({
+                  owner: selection,
+                  message: matrixMutationError(error, 'copy'),
+                }),
               },
             );
           }}


### PR DESCRIPTION
Closes #448.

## What changed
- keep matrix mutation refusals inside the row editor instead of duplicating them above the grid
- clear refusal state when the editor closes or the matrix scope changes
- cover rejection, single rendering, and close cleanup through the Matrix route UI

## Validation
- local test/typecheck deferred while host memory pressure is high, per request
- CI is running on the pushed head