### PR TITLE
Make the Helm deployment bootable and verify readiness #200

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,8 +232,12 @@ jobs:
           grep -Fx "  repository: $IMAGE" "$chart_dir/values.yaml"
           grep -Fx "  digest: $IMAGE_DIGEST" "$chart_dir/values.yaml"
           helm lint "$chart_dir" --set database.existingSecret=hikyo-database \
+            --set rootKey.existingSecret=hikyo-root-key \
+            --set externalOrigin=https://hikyo.example.com \
             --set 'network.trustedProxyCIDRs={10.42.0.0/16}'
           helm template fixture "$chart_dir" --set database.existingSecret=hikyo-database \
+            --set rootKey.existingSecret=hikyo-root-key \
+            --set externalOrigin=https://hikyo.example.com \
             --set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null
           helm package "$chart_dir" --version "$version" --app-version "$version" --destination dist
           printf '%s' "$GH_TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin

--- a/chart/hikyo/templates/NOTES.txt
+++ b/chart/hikyo/templates/NOTES.txt
@@ -6,12 +6,28 @@ root:
   cosign verify --insecure-ignore-tlog --key release/trust/primary.pub \
     ghcr.io/hikyo-org/charts/hikyo@sha256:CHART_DIGEST
 
-Then name the database Secret and either a TLS Secret or the reverse proxy's
-exact trusted CIDRs:
+Create the root-key and database Secrets before installing. The root key is a
+64-character hex file; Kubernetes never places it in container env:
+
+  openssl rand -hex 32 > root-key
+  kubectl create secret generic hikyo-root-key --from-file=root-key=./root-key
+  kubectl create secret generic hikyo-database \
+    --from-literal=HIKYO_DB='postgres://...?...sslmode=verify-full'
+
+Then name both Secrets, the canonical external origin, and either a TLS Secret
+or the reverse proxy's exact trusted CIDRs:
 
   helm install {{ .Release.Name }} . \
-    --set database.existingSecret=YOUR_SECRET \
+    --set database.existingSecret=hikyo-database \
+    --set rootKey.existingSecret=hikyo-root-key \
+    --set externalOrigin=https://hikyo.example.com \
     --set tls.existingSecret=YOUR_TLS_SECRET
+
+Required production values: database.existingSecret, rootKey.existingSecret,
+externalOrigin, image.digest, and one of tls.existingSecret or
+network.trustedProxyCIDRs. The read-only root filesystem makes PostgreSQL the
+supported chart datastore. For a private PostgreSQL CA, also set
+database.tls.existingSecret and put its key name in database.tls.key.
 
 {{- if .Values.operator.enabled }}
 Operator: enabled

--- a/chart/hikyo/templates/_helpers.tpl
+++ b/chart/hikyo/templates/_helpers.tpl
@@ -18,6 +18,39 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
 {{- printf "%s-operator" (include "hikyo.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "hikyo.server.validate" -}}
+{{- $databaseSecret := required "database.existingSecret is required" .Values.database.existingSecret -}}
+{{- $rootKeySecret := required "rootKey.existingSecret is required" .Values.rootKey.existingSecret -}}
+{{- $rootKeyName := required "rootKey.key is required" .Values.rootKey.key -}}
+{{- if or (eq $rootKeyName ".") (eq $rootKeyName "..") (not (regexMatch "^[A-Za-z0-9._-]+$" $rootKeyName)) -}}
+  {{- fail "rootKey.key must be one Secret key name using only letters, digits, dot, underscore, or hyphen" -}}
+{{- end -}}
+{{- $origin := required "externalOrigin is required" .Values.externalOrigin -}}
+{{- if contains "\\" $origin -}}
+  {{- fail "externalOrigin must not contain a backslash" -}}
+{{- end -}}
+{{- if not (regexMatch `^https?://[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*(:[1-9][0-9]{0,4})?$` $origin) -}}
+  {{- fail "externalOrigin must be a canonical lowercase DNS origin without userinfo, path, query, fragment, trailing slash, or default port" -}}
+{{- end -}}
+{{- if and (not (hasPrefix "https://" $origin)) (not .Values.network.allowPlaintextOrigin) -}}
+  {{- fail "externalOrigin must use https:// unless network.allowPlaintextOrigin is true" -}}
+{{- end -}}
+{{- $portSuffix := regexFind `:[0-9]+$` $origin -}}
+{{- if $portSuffix -}}
+  {{- $port := atoi (trimPrefix ":" $portSuffix) -}}
+  {{- if or (gt $port 65535) (and (hasPrefix "https://" $origin) (eq $port 443)) (and (hasPrefix "http://" $origin) (eq $port 80)) -}}
+    {{- fail "externalOrigin port must be in 1..65535 and must omit the scheme default" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.database.tls.existingSecret -}}
+  {{- $databaseCAKey := required "database.tls.key is required when database.tls.existingSecret is set" .Values.database.tls.key -}}
+  {{- if or (eq $databaseCAKey ".") (eq $databaseCAKey "..") (not (regexMatch "^[A-Za-z0-9._-]+$" $databaseCAKey)) -}}
+    {{- fail "database.tls.key must be one Secret key name using only letters, digits, dot, underscore, or hyphen" -}}
+  {{- end -}}
+{{- end -}}
+{{- $imageDigest := required "image.digest is required" .Values.image.digest -}}
+{{- end -}}
+
 {{- define "hikyo.operator.validate" -}}
 {{- if not (hasKey .Values "operator") -}}
   {{- fail "operator values are required" -}}

--- a/chart/hikyo/templates/deployment.yaml
+++ b/chart/hikyo/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "hikyo.server.validate" . -}}
 {{- $trustedProxyCIDRs := join "," .Values.network.trustedProxyCIDRs }}
 {{- if and (empty $trustedProxyCIDRs) (empty .Values.tls.existingSecret) }}
 {{- fail "configure tls.existingSecret or network.trustedProxyCIDRs for the non-loopback listener" }}
@@ -25,14 +26,27 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532
-        {{- if .Values.tls.existingSecret }}
         fsGroup: 65532
         fsGroupChangePolicy: OnRootMismatch
-        {{- end }}
         seccompProfile:
           type: RuntimeDefault
-      {{- if .Values.tls.existingSecret }}
       initContainers:
+        - name: root-key-stage
+          image: "{{ .Values.image.repository }}@{{ required "image.digest is required" .Values.image.digest }}"
+          imagePullPolicy: IfNotPresent
+          args: ["__hikyo-stage-root-key"]
+          volumeMounts:
+            - name: root-key-source
+              mountPath: /run/hikyo-root-key-source
+              readOnly: true
+            - name: root-key
+              mountPath: /run/hikyo-root-key
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      {{- if .Values.tls.existingSecret }}
         - name: tls-stage
           image: "{{ .Values.image.repository }}@{{ required "image.digest is required" .Values.image.digest }}"
           imagePullPolicy: IfNotPresent
@@ -59,6 +73,7 @@ spec:
             - server
             - --listen=0.0.0.0:8080
             - --operational-listen=0.0.0.0:8081
+            - --root-key-file=/run/hikyo-root-key/root-key
             {{- if .Values.tls.existingSecret }}
             - --tls-cert-file=/run/hikyo-tls/tls.crt
             - --tls-key-file=/run/hikyo-tls/tls.key
@@ -71,6 +86,8 @@ spec:
                   key: HIKYO_DB
             - name: HIKYO_UPDATE_CHANNEL
               value: {{ .Values.updates.channel | quote }}
+            - name: HIKYO_EXTERNAL_ORIGIN
+              value: {{ .Values.externalOrigin | quote }}
             {{- if $trustedProxyCIDRs }}
             - name: HIKYO_TRUSTED_PROXY_CIDRS
               value: {{ $trustedProxyCIDRs | quote }}
@@ -84,12 +101,33 @@ spec:
             httpGet:
               path: /readyz
               port: ops
+            periodSeconds: 5
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /healthz
               port: ops
-          {{- if .Values.tls.existingSecret }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: ops
+            periodSeconds: 5
+            failureThreshold: 30
           volumeMounts:
+            - name: root-key
+              mountPath: /run/hikyo-root-key
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.database.tls.existingSecret }}
+            - name: database-ca
+              mountPath: /run/hikyo-database-ca
+              readOnly: true
+            {{- end }}
+            {{- if .Values.tls.existingSecret }}
             - name: tls
               mountPath: /run/hikyo-tls
               readOnly: true
@@ -120,8 +158,28 @@ spec:
           resources:
             {{- toYaml .Values.tls.reloaderResources | nindent 12 }}
         {{- end }}
-      {{- if .Values.tls.existingSecret }}
       volumes:
+        - name: root-key-source
+          secret:
+            secretName: {{ .Values.rootKey.existingSecret }}
+            defaultMode: 0400
+            items:
+              - key: {{ .Values.rootKey.key }}
+                path: root-key
+        - name: root-key
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.database.tls.existingSecret }}
+        - name: database-ca
+          secret:
+            secretName: {{ .Values.database.tls.existingSecret }}
+            defaultMode: 0444
+            items:
+              - key: {{ .Values.database.tls.key }}
+                path: ca.crt
+        {{- end }}
+        {{- if .Values.tls.existingSecret }}
         - name: tls-source
           secret:
             secretName: {{ .Values.tls.existingSecret }}

--- a/chart/hikyo/values.schema.json
+++ b/chart/hikyo/values.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["image", "database", "rootKey", "externalOrigin", "network"],
+  "properties": {
+    "image": {
+      "type": "object",
+      "required": ["repository", "digest"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:(RELEASE_IMAGE_DIGEST|[0-9a-f]{64})$"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "required": ["existingSecret", "tls"],
+      "properties": {
+        "existingSecret": {"type": "string", "minLength": 1},
+        "tls": {
+          "type": "object",
+          "required": ["existingSecret", "key"],
+          "properties": {
+            "existingSecret": {"type": "string"},
+            "key": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "rootKey": {
+      "type": "object",
+      "required": ["existingSecret", "key"],
+      "properties": {
+        "existingSecret": {"type": "string", "minLength": 1},
+        "key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._-]+$",
+          "not": {"enum": [".", ".."]}
+        }
+      }
+    },
+    "externalOrigin": {"type": "string", "minLength": 1},
+    "network": {
+      "type": "object",
+      "required": ["trustedProxyCIDRs", "allowPlaintextOrigin"],
+      "properties": {
+        "trustedProxyCIDRs": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "allowPlaintextOrigin": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/chart/hikyo/values.yaml
+++ b/chart/hikyo/values.yaml
@@ -8,6 +8,22 @@ image:
 database:
   # Name of an existing Secret whose HIKYO_DB key contains the production DSN.
   existingSecret: ""
+  # Optional CA certificate for a private PostgreSQL endpoint. The HIKYO_DB DSN
+  # must use sslmode=verify-full or verify-ca and name this mounted path with
+  # sslrootcert=/run/hikyo-database-ca/ca.crt.
+  tls:
+    existingSecret: ""
+    key: ca.crt
+
+rootKey:
+  # Existing Secret containing the 64-hex-character root key. Hikyo stages the
+  # projected file into an owner-only runtime volume; key bytes never use env.
+  existingSecret: ""
+  key: root-key
+
+# Canonical browser-visible origin. Paths, query strings, fragments, userinfo,
+# and trailing slashes are refused.
+externalOrigin: ""
 
 tls:
   # Optional Secret containing tls.crt and tls.key. Configure this or trusted
@@ -28,6 +44,8 @@ service:
 network:
   # Required only for proxy mode. Native TLS may leave this empty.
   trustedProxyCIDRs: []
+  # Test/development escape hatch for an explicit http:// externalOrigin.
+  allowPlaintextOrigin: false
 
 updates:
   # Release notifications only; Hikyo never downloads or installs an update.

--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -35,6 +35,9 @@ func main() {
 }
 
 func run() int {
+	if handled, code := runRootKeyStageMode(os.Args[1:]); handled {
+		return code
+	}
 	if handled, code := runTLSStageMode(os.Args[1:]); handled {
 		return code
 	}

--- a/cmd/hikyo/rootkey_stage.go
+++ b/cmd/hikyo/rootkey_stage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/securefile"
 )
 
 const rootKeyStageMode = "__hikyo-stage-root-key"
@@ -17,7 +17,7 @@ func runRootKeyStageMode(args []string) (bool, int) {
 		fmt.Fprintln(os.Stderr, "hikyo internal root-key stage: no arguments accepted")
 		return true, 2
 	}
-	if err := crypto.StageRootKey(
+	if err := securefile.StageRootKey(
 		"/run/hikyo-root-key-source/root-key",
 		"/run/hikyo-root-key/root-key",
 	); err != nil {

--- a/cmd/hikyo/rootkey_stage.go
+++ b/cmd/hikyo/rootkey_stage.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+)
+
+const rootKeyStageMode = "__hikyo-stage-root-key"
+
+func runRootKeyStageMode(args []string) (bool, int) {
+	if len(args) == 0 || args[0] != rootKeyStageMode {
+		return false, 0
+	}
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "hikyo internal root-key stage: no arguments accepted")
+		return true, 2
+	}
+	if err := crypto.StageRootKey(
+		"/run/hikyo-root-key-source/root-key",
+		"/run/hikyo-root-key/root-key",
+	); err != nil {
+		fmt.Fprintln(os.Stderr, "hikyo internal root-key stage:", err)
+		return true, 1
+	}
+	return true, 0
+}

--- a/docs/handoff/200-helm-bootable.md
+++ b/docs/handoff/200-helm-bootable.md
@@ -1,0 +1,34 @@
+# Issue #200 handoff: bootable Helm deployment
+
+## Delivered contract
+
+- Helm requires a datastore Secret, root-key Secret, canonical external origin,
+  image digest, and native-TLS or trusted-proxy boundary.
+- The root key enters through a projected Secret only. A non-root init mode
+  validates and stages it from Kubernetes' fsGroup-readable projection into an
+  owner-only `0400` runtime file; the server mount is read-only.
+- Liveness uses operational `/healthz`; startup and readiness use operational
+  `/readyz`. A writable `/tmp` emptyDir preserves the read-only root filesystem.
+- Optional `database.tls` values mount a private PostgreSQL CA without placing
+  it or the DSN in the chart manifest.
+- The existing required `k8s-e2e` job invokes `chart-kind` after its operator
+  suite. This trusted-CI-compatible bridge makes the introducing PR run the
+  new gate; a newly added workflow job would not execute until after merge.
+- `chart-kind` builds the exact release-shaped app artifact into
+  `Dockerfile.release`, installs the actual chart, proves HTML and probe health,
+  removes PostgreSQL, and proves readiness fails and recovers without a server
+  restart.
+
+## Validation
+
+```bash
+scripts/ci/check-chart.sh
+scripts/ci/check-chart_test.sh
+scripts/ci/classify-changed-paths_test.sh
+scripts/ci/check-required-jobs_test.sh
+go test -count=1 ./scripts/ci -run '^TestCIJobRegistry'
+HIKYO_CHART_KIND_BINARY=ci-artifacts/hikyo-ui scripts/ci/chart-kind.sh
+```
+
+The Kind command owns only a fresh cluster named `hikyo-chart-e2e`; it refuses
+to reuse or delete a pre-existing cluster with that name.

--- a/docs/site/src/content/docs/docs/kubernetes-operator.mdx
+++ b/docs/site/src/content/docs/docs/kubernetes-operator.mdx
@@ -21,9 +21,47 @@ the kubelet; `subPath` mounts never update.
 
 ## Install the operator
 
-Add the operator settings to the values file for the Hikyo Helm release:
+Generate the root key and create both required server Secrets first:
+
+```bash
+openssl rand -hex 32 > root-key
+kubectl create namespace hikyo
+kubectl --namespace hikyo create secret generic hikyo-root-key \
+  --from-file=root-key=./root-key
+kubectl --namespace hikyo create secret generic hikyo-database \
+  --from-literal=HIKYO_DB='postgres://hikyo:password@postgres.example.com/hikyo?sslmode=verify-full'
+kubectl --namespace hikyo create secret tls hikyo-server-tls \
+  --cert=./tls.crt \
+  --key=./tls.key
+```
+
+Protect and back up `root-key` separately from the database. The chart supports
+PostgreSQL only: its container root filesystem is read-only. A private database
+CA can be mounted with `database.tls.existingSecret`; name its mounted path in
+the DSN as `sslrootcert=/run/hikyo-database-ca/ca.crt`.
+
+Create a complete values file for the Hikyo server and operator:
 
 ```yaml
+database:
+  existingSecret: hikyo-database
+  tls:
+    existingSecret: "" # Set for a private PostgreSQL CA.
+    key: ca.crt
+
+rootKey:
+  existingSecret: hikyo-root-key
+  key: root-key
+
+externalOrigin: https://hikyo.example.com
+
+tls:
+  existingSecret: hikyo-server-tls
+
+network:
+  trustedProxyCIDRs: []
+  allowPlaintextOrigin: false
+
 operator:
   enabled: true
   namespaces:
@@ -41,20 +79,30 @@ operator:
       memory: 128Mi
 ```
 
-Apply the chart:
+Install a packaged release chart. The package already pins its matching server
+image digest:
 
 ```bash
-helm upgrade --install hikyo ./chart/hikyo \
+helm upgrade --install hikyo oci://ghcr.io/hikyo-org/charts/hikyo \
+  --version <release-version> \
   --namespace hikyo \
-  --create-namespace \
   --values hikyo-values.yaml
 ```
+
+When validating a source checkout instead, use `./chart/hikyo` and pass the
+exact candidate image with `--set image.repository=...` and
+`--set image.digest=sha256:<64-hex-digest>`.
 
 An empty `operator.namespaces` watches cluster-wide. A non-empty list creates
 namespace-scoped bindings and the watch list from the same value. Effective
 reach is the intersection of those watches and RBAC. Add every federated
 ServiceAccount to `operator.designatedServiceAccounts` under its namespace;
 the chart restricts TokenRequest creation to those names.
+
+Helm refuses a missing datastore Secret, root-key Secret, external origin, or
+network boundary. `externalOrigin` must be an origin only: no path, query,
+fragment, credentials, or trailing slash. HTTP requires the explicit
+`network.allowPlaintextOrigin` development escape hatch.
 
 The operator runs as UID/GID 65532 with `runAsNonRoot`, a read-only root
 filesystem, all capabilities dropped, `RuntimeDefault` seccomp, and privilege

--- a/docs/site/src/content/docs/docs/self-hosting.mdx
+++ b/docs/site/src/content/docs/docs/self-hosting.mdx
@@ -11,6 +11,8 @@ TLS or an explicit trusted-proxy boundary.
 This page is the production checklist. Use the linked pages for the full
 configuration and recovery procedures.
 
+For Kubernetes, use the [complete Helm installation example](/docs/kubernetes-operator/#install-the-operator).
+
 ## Required decisions
 
 | Boundary | Configure | Rule |

--- a/internal/crypto/rootkey_stage.go
+++ b/internal/crypto/rootkey_stage.go
@@ -1,0 +1,36 @@
+package crypto
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Hikyo-Org/hikyo/internal/securefile"
+)
+
+// StageRootKey validates a group-readable projected Secret and atomically
+// publishes an owner-only runtime file. Kubernetes applies fsGroup to Secret
+// volumes, which makes the projected source readable by Hikyo's non-root UID;
+// the server still receives the stricter 0400 file required by ReadRootKey.
+func StageRootKey(source, destination string) error {
+	raw, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read projected root key: %w", err)
+	}
+	defer Zero(raw)
+
+	decoded, err := decodeRootKey(raw)
+	if err != nil {
+		return fmt.Errorf("validate projected root key: %w", err)
+	}
+	Zero(decoded)
+
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create staged root-key directory: %w", err)
+	}
+	if err := securefile.WriteAtomic(destination, bytes.TrimSpace(raw), 0o400); err != nil {
+		return fmt.Errorf("publish staged root key: %w", err)
+	}
+	return nil
+}

--- a/internal/crypto/rootkey_stage_test.go
+++ b/internal/crypto/rootkey_stage_test.go
@@ -1,0 +1,60 @@
+package crypto
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStageRootKeyCreatesOwnerOnlyRuntimeFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source", "root-key")
+	destination := filepath.Join(dir, "runtime", "root-key")
+	if err := os.MkdirAll(filepath.Dir(source), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := bytes.Repeat([]byte{0x5a}, KeySize)
+	if err := os.WriteFile(source, []byte(EncodeRootKey(want)), 0o440); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := StageRootKey(source, destination); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o400 {
+		t.Fatalf("staged root key mode = %04o, want 0400", got)
+	}
+	got, err := ReadRootKey(destination, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer Zero(got)
+	if !bytes.Equal(got, want) {
+		t.Fatal("staged root key bytes differ from source")
+	}
+}
+
+func TestStageRootKeyRefusesInvalidSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "runtime", "root-key")
+	if err := os.WriteFile(source, []byte("not-a-root-key"), 0o440); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := StageRootKey(source, destination); err == nil {
+		t.Fatal("invalid root-key source was staged")
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("invalid source published destination: %v", err)
+	}
+}

--- a/internal/securefile/atomic.go
+++ b/internal/securefile/atomic.go
@@ -1,0 +1,38 @@
+// Package securefile owns atomic publication of permission-sensitive files.
+package securefile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteAtomic writes contents beside path, syncs and closes the file, then
+// atomically replaces path. Callers own validation and contextual error text.
+func WriteAtomic(path string, contents []byte, mode os.FileMode) (returnErr error) {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".secure-write-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if returnErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(contents); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/securefile/atomic_test.go
+++ b/internal/securefile/atomic_test.go
@@ -1,0 +1,33 @@
+package securefile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteAtomicReplacesWithExactMode(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteAtomic(path, []byte("new"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "new" {
+		t.Fatalf("contents = %q, want new", contents)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o400 {
+		t.Fatalf("mode = %04o, want 0400", got)
+	}
+}

--- a/internal/securefile/rootkey_stage.go
+++ b/internal/securefile/rootkey_stage.go
@@ -1,4 +1,4 @@
-package crypto
+package securefile
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Hikyo-Org/hikyo/internal/securefile"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
 )
 
 // StageRootKey validates a group-readable projected Secret and atomically
@@ -18,18 +18,18 @@ func StageRootKey(source, destination string) error {
 	if err != nil {
 		return fmt.Errorf("read projected root key: %w", err)
 	}
-	defer Zero(raw)
+	defer crypto.Zero(raw)
 
-	decoded, err := decodeRootKey(raw)
+	decoded, err := crypto.ReadRootKey("", string(raw))
 	if err != nil {
 		return fmt.Errorf("validate projected root key: %w", err)
 	}
-	Zero(decoded)
+	crypto.Zero(decoded)
 
 	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
 		return fmt.Errorf("create staged root-key directory: %w", err)
 	}
-	if err := securefile.WriteAtomic(destination, bytes.TrimSpace(raw), 0o400); err != nil {
+	if err := WriteAtomic(destination, bytes.TrimSpace(raw), 0o400); err != nil {
 		return fmt.Errorf("publish staged root key: %w", err)
 	}
 	return nil

--- a/internal/securefile/rootkey_stage_test.go
+++ b/internal/securefile/rootkey_stage_test.go
@@ -1,10 +1,12 @@
-package crypto
+package securefile
 
 import (
 	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
 )
 
 func TestStageRootKeyCreatesOwnerOnlyRuntimeFile(t *testing.T) {
@@ -16,8 +18,8 @@ func TestStageRootKeyCreatesOwnerOnlyRuntimeFile(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(source), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	want := bytes.Repeat([]byte{0x5a}, KeySize)
-	if err := os.WriteFile(source, []byte(EncodeRootKey(want)), 0o440); err != nil {
+	want := bytes.Repeat([]byte{0x5a}, crypto.KeySize)
+	if err := os.WriteFile(source, []byte(crypto.EncodeRootKey(want)), 0o440); err != nil {
 		t.Fatal(err)
 	}
 
@@ -31,11 +33,11 @@ func TestStageRootKeyCreatesOwnerOnlyRuntimeFile(t *testing.T) {
 	if got := info.Mode().Perm(); got != 0o400 {
 		t.Fatalf("staged root key mode = %04o, want 0400", got)
 	}
-	got, err := ReadRootKey(destination, "")
+	got, err := crypto.ReadRootKey(destination, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer Zero(got)
+	defer crypto.Zero(got)
 	if !bytes.Equal(got, want) {
 		t.Fatal("staged root key bytes differ from source")
 	}

--- a/internal/tlspolicy/stage.go
+++ b/internal/tlspolicy/stage.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/securefile"
 )
 
 // StageCertificatePair copies a read-only source pair to owner-readable files.
@@ -28,45 +30,16 @@ func StageCertificatePair(certSource, keySource, destinationDir string) error {
 	}
 	certPath := filepath.Join(destinationDir, "tls.crt")
 	keyPath := filepath.Join(destinationDir, "tls.key")
-	if err := atomicWrite(certPath, certPEM, 0o444); err != nil {
+	if err := securefile.WriteAtomic(certPath, certPEM, 0o444); err != nil {
 		return fmt.Errorf("stage TLS certificate: %w", err)
 	}
-	if err := atomicWrite(keyPath, keyPEM, 0o400); err != nil {
+	if err := securefile.WriteAtomic(keyPath, keyPEM, 0o400); err != nil {
 		return fmt.Errorf("stage TLS key: %w", err)
 	}
 	if _, _, err := LoadCertificate(certPath, keyPath, time.Now()); err != nil {
 		return fmt.Errorf("validate staged TLS pair: %w", err)
 	}
 	return nil
-}
-
-func atomicWrite(path string, contents []byte, mode os.FileMode) (returnErr error) {
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".tls-stage-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer func() {
-		if returnErr != nil {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(mode); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(contents); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
 }
 
 // WatchAndStageCertificatePair stages once, then polls the source files for

--- a/scripts/ci/chart-kind.sh
+++ b/scripts/ci/chart-kind.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Install the exact chart and candidate image into a disposable kind cluster.
+# The test proves boot, semantic probes, and readiness loss/recovery while the
+# liveness endpoint remains healthy and the server container does not restart.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+CLUSTER=hikyo-chart-e2e
+NAMESPACE=hikyo-chart-e2e
+RELEASE=hikyo
+NODE_IMAGE="kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+POSTGRES_IMAGE="postgres:18@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941"
+REGISTRY_IMAGE="registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
+REGISTRY_NAME=hikyo-chart-registry
+REGISTRY_PORT=5001
+IMAGE_REPOSITORY="localhost:$REGISTRY_PORT/hikyo-chart-e2e"
+IMAGE_TAG="$IMAGE_REPOSITORY:local"
+BINARY=${HIKYO_CHART_KIND_BINARY:-}
+
+if [[ -z "$BINARY" || ! -f "$BINARY" ]]; then
+	echo "chart-kind: HIKYO_CHART_KIND_BINARY must name the candidate Linux binary" >&2
+	exit 2
+fi
+for command in kind kubectl helm docker jq openssl curl; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		echo "chart-kind: $command not found on PATH" >&2
+		exit 2
+	fi
+done
+if kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+	echo "chart-kind: cluster '$CLUSTER' already exists; refusing to reuse or delete it" >&2
+	exit 1
+fi
+if docker container inspect "$REGISTRY_NAME" >/dev/null 2>&1; then
+	echo "chart-kind: container '$REGISTRY_NAME' already exists; refusing to reuse or delete it" >&2
+	exit 1
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/hikyo-chart-kind.XXXXXX")
+kubeconfig="$work/kubeconfig"
+kind_config="$work/kind.yaml"
+port_forward_pid=
+created=false
+registry_created=false
+cleanup() {
+	if [[ -n "$port_forward_pid" ]]; then
+		kill "$port_forward_pid" >/dev/null 2>&1 || true
+		wait "$port_forward_pid" >/dev/null 2>&1 || true
+	fi
+	if [[ "$created" == true ]]; then
+		kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+	fi
+	if [[ "$registry_created" == true ]]; then
+		docker rm --force "$REGISTRY_NAME" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
+
+cat >"$kind_config" <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+nodes:
+  - role: control-plane
+EOF
+
+docker run --detach --restart=always \
+	--publish "127.0.0.1:$REGISTRY_PORT:5000" \
+	--name "$REGISTRY_NAME" "$REGISTRY_IMAGE" >/dev/null
+registry_created=true
+echo "chart-kind: creating cluster $CLUSTER"
+kind create cluster --name "$CLUSTER" --image "$NODE_IMAGE" \
+	--config "$kind_config" --kubeconfig "$kubeconfig" --wait 120s
+created=true
+export KUBECONFIG="$kubeconfig"
+docker network connect kind "$REGISTRY_NAME"
+registry_dir="/etc/containerd/certs.d/localhost:$REGISTRY_PORT"
+while IFS= read -r node; do
+	docker exec "$node" mkdir -p "$registry_dir"
+	cat <<EOF | docker exec --interactive "$node" sh -c "cat >'$registry_dir/hosts.toml'"
+[host."http://$REGISTRY_NAME:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+done < <(kind get nodes --name "$CLUSTER")
+cat <<EOF | kubectl apply --filename - >/dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:$REGISTRY_PORT"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+mkdir -p "$work/build/image-root/amd64"
+cp "$BINARY" "$work/build/image-root/amd64/hikyo"
+cp Dockerfile.release "$work/build/Dockerfile.release"
+chmod 0755 "$work/build/image-root/amd64/hikyo"
+echo "chart-kind: building candidate image"
+docker buildx build --load --platform linux/amd64 \
+	--build-arg TARGETARCH=amd64 \
+	--metadata-file "$work/image-metadata.json" \
+	--tag "$IMAGE_TAG" \
+	--file "$work/build/Dockerfile.release" "$work/build" >/dev/null
+image_digest=$(jq -er '."containerimage.digest" | select(test("^sha256:[0-9a-f]{64}$"))' \
+	"$work/image-metadata.json")
+docker push "$IMAGE_TAG" >/dev/null
+pushed_ref=$(docker image inspect --format '{{join .RepoDigests "\n"}}' "$IMAGE_TAG" |
+	grep -E "^$IMAGE_REPOSITORY@sha256:[0-9a-f]{64}$" | head -n 1)
+image_digest=${pushed_ref##*@}
+
+mkdir -p "$work/tls"
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+	-keyout "$work/tls/ca.key" -out "$work/tls/ca.crt" \
+	-subj '/CN=Hikyo chart-kind CA' >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes \
+	-keyout "$work/tls/tls.key" -out "$work/tls/server.csr" \
+	-subj "/CN=postgres.$NAMESPACE.svc" >/dev/null 2>&1
+cat >"$work/tls/server.ext" <<EOF
+subjectAltName=DNS:postgres,DNS:postgres.$NAMESPACE,DNS:postgres.$NAMESPACE.svc,DNS:postgres.$NAMESPACE.svc.cluster.local
+extendedKeyUsage=serverAuth
+EOF
+openssl x509 -req -days 1 -sha256 \
+	-in "$work/tls/server.csr" \
+	-CA "$work/tls/ca.crt" -CAkey "$work/tls/ca.key" -CAcreateserial \
+	-extfile "$work/tls/server.ext" -out "$work/tls/tls.crt" >/dev/null 2>&1
+chmod 0400 "$work/tls/tls.key"
+openssl rand -hex 32 >"$work/root-key"
+chmod 0400 "$work/root-key"
+
+kubectl create namespace "$NAMESPACE" >/dev/null
+kubectl --namespace "$NAMESPACE" create secret generic postgres-auth \
+	--from-literal=username=hikyo \
+	--from-literal=password=hikyo \
+	--from-literal=database=hikyo >/dev/null
+kubectl --namespace "$NAMESPACE" create secret generic postgres-tls \
+	--from-file=tls.crt="$work/tls/tls.crt" \
+	--from-file=tls.key="$work/tls/tls.key" >/dev/null
+kubectl --namespace "$NAMESPACE" create secret generic hikyo-database-ca \
+	--from-file=ca.crt="$work/tls/ca.crt" >/dev/null
+kubectl --namespace "$NAMESPACE" create secret generic hikyo-root-key \
+	--from-file=root-key="$work/root-key" >/dev/null
+database_dsn="postgres://hikyo:hikyo@postgres.$NAMESPACE.svc:5432/hikyo?sslmode=verify-full&sslrootcert=/run/hikyo-database-ca/ca.crt"
+kubectl --namespace "$NAMESPACE" create secret generic hikyo-database \
+	--from-literal=HIKYO_DB="$database_dsn" >/dev/null
+
+cat >"$work/postgres.yaml" <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: hikyo-chart-postgres
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: hikyo-chart-kind
+  hostPath:
+    path: /var/lib/hikyo-chart-postgres
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: $NAMESPACE
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: hikyo-chart-kind
+  volumeName: hikyo-chart-postgres
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: $NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: postgres}
+  template:
+    metadata:
+      labels: {app: postgres}
+    spec:
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: postgres
+          image: $POSTGRES_IMAGE
+          args:
+            - -c
+            - ssl=on
+            - -c
+            - ssl_cert_file=/etc/postgres-tls/tls.crt
+            - -c
+            - ssl_key_file=/etc/postgres-tls/tls.key
+          env:
+            - name: POSTGRES_USER
+              valueFrom: {secretKeyRef: {name: postgres-auth, key: username}}
+            - name: POSTGRES_PASSWORD
+              valueFrom: {secretKeyRef: {name: postgres-auth, key: password}}
+            - name: POSTGRES_DB
+              valueFrom: {secretKeyRef: {name: postgres-auth, key: database}}
+          ports:
+            - {name: postgres, containerPort: 5432}
+          readinessProbe:
+            exec: {command: [pg_isready, -U, hikyo, -d, hikyo]}
+            periodSeconds: 2
+            failureThreshold: 30
+          volumeMounts:
+            - {name: data, mountPath: /var/lib/postgresql}
+            - {name: tls, mountPath: /etc/postgres-tls, readOnly: true}
+      volumes:
+        - name: data
+          persistentVolumeClaim: {claimName: postgres-data}
+        - name: tls
+          secret:
+            secretName: postgres-tls
+            defaultMode: 0440
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: $NAMESPACE
+spec:
+  selector: {app: postgres}
+  ports:
+    - {name: postgres, port: 5432, targetPort: postgres}
+EOF
+kubectl apply --filename "$work/postgres.yaml" >/dev/null
+kubectl --namespace "$NAMESPACE" rollout status deployment/postgres --timeout=120s
+
+chart_values=(
+	--set operator.enabled=false \
+	--set image.repository="$IMAGE_REPOSITORY" \
+	--set image.digest="$image_digest" \
+	--set database.existingSecret=hikyo-database \
+	--set database.tls.existingSecret=hikyo-database-ca \
+	--set rootKey.existingSecret=hikyo-root-key \
+	--set externalOrigin=http://hikyo.local \
+	--set network.allowPlaintextOrigin=true \
+	--set 'network.trustedProxyCIDRs={10.0.0.0/8}'
+)
+
+# Retained broken-shape fixture: removing the root-key file argument recreates
+# the pre-#200 chart boot failure. The real cluster must refuse readiness and
+# logs must name the missing source before the fixed chart is installed.
+cp -R chart/hikyo "$work/broken-chart"
+sed '/--root-key-file=\/run\/hikyo-root-key\/root-key/d' \
+	"$work/broken-chart/templates/deployment.yaml" >"$work/broken-deployment.yaml"
+mv "$work/broken-deployment.yaml" "$work/broken-chart/templates/deployment.yaml"
+helm install broken "$work/broken-chart" --namespace "$NAMESPACE" "${chart_values[@]}" >/dev/null
+if kubectl --namespace "$NAMESPACE" wait --for=condition=Ready pod \
+	--selector app.kubernetes.io/instance=broken --timeout=20s >/dev/null 2>&1; then
+	echo "chart-kind: pre-#200 deployment unexpectedly became Ready" >&2
+	exit 1
+fi
+broken_log=
+for _ in {1..20}; do
+	broken_log=$(kubectl --namespace "$NAMESPACE" logs deployment/broken-hikyo \
+		--container server --tail=30 2>&1 || true)
+	if grep -Fq 'no root key configured' <<<"$broken_log"; then
+		break
+	fi
+	sleep 1
+done
+if ! grep -Fq 'no root key configured' <<<"$broken_log"; then
+	echo "chart-kind: broken-shape fixture failed for an unexpected reason" >&2
+	echo "$broken_log" >&2
+	exit 1
+fi
+helm uninstall broken --namespace "$NAMESPACE" --wait >/dev/null
+
+echo "chart-kind: installing exact chart and image $IMAGE_REPOSITORY@$image_digest"
+helm install "$RELEASE" chart/hikyo --namespace "$NAMESPACE" "${chart_values[@]}" >/dev/null
+kubectl --namespace "$NAMESPACE" rollout status deployment/$RELEASE-hikyo --timeout=180s
+kubectl --namespace "$NAMESPACE" wait --for=condition=Ready pod \
+	--selector app.kubernetes.io/instance="$RELEASE" --timeout=180s >/dev/null
+
+deployed_image=$(kubectl --namespace "$NAMESPACE" get deployment "$RELEASE-hikyo" \
+	-o jsonpath='{.spec.template.spec.containers[?(@.name=="server")].image}')
+if [[ "$deployed_image" != "$IMAGE_REPOSITORY@$image_digest" ]]; then
+	echo "chart-kind: deployed image $deployed_image does not match candidate" >&2
+	exit 1
+fi
+
+kubectl --namespace "$NAMESPACE" port-forward deployment/$RELEASE-hikyo \
+	18080:8080 18081:8081 >"$work/port-forward.log" 2>&1 &
+port_forward_pid=$!
+for _ in {1..30}; do
+	if curl --fail --silent http://127.0.0.1:18081/readyz >/dev/null; then
+		break
+	fi
+	sleep 1
+done
+curl --fail --silent http://127.0.0.1:18081/readyz >/dev/null
+curl --fail --silent http://127.0.0.1:18081/healthz >/dev/null
+curl --fail --silent http://127.0.0.1:18080/ | grep -Eiq '<!doctype html|<html'
+
+pod=$(kubectl --namespace "$NAMESPACE" get pod \
+	--selector app.kubernetes.io/instance="$RELEASE" -o jsonpath='{.items[0].metadata.name}')
+restarts_before=$(kubectl --namespace "$NAMESPACE" get pod "$pod" \
+	-o jsonpath='{.status.containerStatuses[?(@.name=="server")].restartCount}')
+kubectl --namespace "$NAMESPACE" scale deployment/postgres --replicas=0 >/dev/null
+for _ in {1..30}; do
+	ready=$(kubectl --namespace "$NAMESPACE" get pod "$pod" \
+		-o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+	[[ "$ready" == "False" ]] && break
+	sleep 1
+done
+if [[ "$ready" != "False" ]]; then
+	echo "chart-kind: database outage did not remove pod readiness within 30 seconds" >&2
+	exit 1
+fi
+ready_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	http://127.0.0.1:18081/readyz)
+if [[ "$ready_status" != 503 ]]; then
+	echo "chart-kind: /readyz during database outage returned $ready_status, want 503" >&2
+	exit 1
+fi
+curl --fail --silent http://127.0.0.1:18081/healthz >/dev/null
+restarts_during_outage=$(kubectl --namespace "$NAMESPACE" get pod "$pod" \
+	-o jsonpath='{.status.containerStatuses[?(@.name=="server")].restartCount}')
+if [[ "$restarts_during_outage" != "$restarts_before" ]]; then
+	echo "chart-kind: liveness restarted server during database outage" >&2
+	exit 1
+fi
+
+kubectl --namespace "$NAMESPACE" scale deployment/postgres --replicas=1 >/dev/null
+kubectl --namespace "$NAMESPACE" rollout status deployment/postgres --timeout=120s
+kubectl --namespace "$NAMESPACE" wait --for=condition=Ready pod "$pod" --timeout=90s >/dev/null
+curl --fail --silent http://127.0.0.1:18081/readyz >/dev/null
+restarts_after=$(kubectl --namespace "$NAMESPACE" get pod "$pod" \
+	-o jsonpath='{.status.containerStatuses[?(@.name=="server")].restartCount}')
+if [[ "$restarts_after" != "$restarts_before" ]]; then
+	echo "chart-kind: server restarted across readiness failure/recovery" >&2
+	exit 1
+fi
+
+echo "chart-kind: exact chart/image booted; database outage toggled readiness without liveness restart"

--- a/scripts/ci/chart-kind.sh
+++ b/scripts/ci/chart-kind.sh
@@ -249,7 +249,7 @@ chart_values=(
 	--set database.existingSecret=hikyo-database \
 	--set database.tls.existingSecret=hikyo-database-ca \
 	--set rootKey.existingSecret=hikyo-root-key \
-	--set externalOrigin=http://hikyo.local \
+	--set externalOrigin=http://127.0.0.1:18080 \
 	--set network.allowPlaintextOrigin=true \
 	--set 'network.trustedProxyCIDRs={10.0.0.0/8}'
 )
@@ -307,7 +307,16 @@ for _ in {1..30}; do
 done
 curl --fail --silent http://127.0.0.1:18081/readyz >/dev/null
 curl --fail --silent http://127.0.0.1:18081/healthz >/dev/null
-curl --fail --silent http://127.0.0.1:18080/ | grep -Eiq '<!doctype html|<html'
+if ! document=$(curl --fail --silent --show-error http://127.0.0.1:18080/); then
+	echo "chart-kind: UI document request failed" >&2
+	cat "$work/port-forward.log" >&2
+	exit 1
+fi
+if [[ ! "$document" =~ \<\!doctype[[:space:]]+html|\<html ]]; then
+	echo "chart-kind: UI root did not return an HTML document" >&2
+	printf '%s\n' "$document" >&2
+	exit 1
+fi
 
 pod=$(kubectl --namespace "$NAMESPACE" get pod \
 	--selector app.kubernetes.io/instance="$RELEASE" -o jsonpath='{.items[0].metadata.name}')

--- a/scripts/ci/chart-kind.sh
+++ b/scripts/ci/chart-kind.sh
@@ -307,7 +307,8 @@ for _ in {1..30}; do
 done
 curl --fail --silent http://127.0.0.1:18081/readyz >/dev/null
 curl --fail --silent http://127.0.0.1:18081/healthz >/dev/null
-if ! document=$(curl --fail --silent --show-error http://127.0.0.1:18080/); then
+if ! document=$(curl --fail --silent --show-error \
+	--header 'Accept: text/html' http://127.0.0.1:18080/); then
 	echo "chart-kind: UI document request failed" >&2
 	cat "$work/port-forward.log" >&2
 	exit 1

--- a/scripts/ci/check-chart.sh
+++ b/scripts/ci/check-chart.sh
@@ -30,10 +30,14 @@ render_mode() {
 	shift
 	helm lint "$chart" \
 		--set database.existingSecret=fixture \
+		--set rootKey.existingSecret=fixture-root-key \
+		--set externalOrigin=https://hikyo.example.com \
 		--set 'network.trustedProxyCIDRs={10.42.0.0/16}' \
 		"$@" >/dev/null
 	helm template fixture "$chart" \
 		--set database.existingSecret=fixture \
+		--set rootKey.existingSecret=fixture-root-key \
+		--set externalOrigin=https://hikyo.example.com \
 		--set 'network.trustedProxyCIDRs={10.42.0.0/16}' \
 		"$@" >"$tmp/$name.yaml"
 }
@@ -199,7 +203,12 @@ def assert_server_network(docs, mode, tls):
                 deployment, server = d, c
     if server is None:
         fail(f"{mode}: no server container")
-    want_args = ["server", "--listen=0.0.0.0:8080", "--operational-listen=0.0.0.0:8081"]
+    want_args = [
+        "server",
+        "--listen=0.0.0.0:8080",
+        "--operational-listen=0.0.0.0:8081",
+        "--root-key-file=/run/hikyo-root-key/root-key",
+    ]
     if tls:
         want_args += ["--tls-cert-file=/run/hikyo-tls/tls.crt", "--tls-key-file=/run/hikyo-tls/tls.key"]
     if server.get("args") != want_args:
@@ -207,26 +216,62 @@ def assert_server_network(docs, mode, tls):
     ports = {p["name"]: p["containerPort"] for p in server.get("ports", [])}
     if ports != {"http": 8080, "ops": 8081}:
         fail(f"{mode}: server ports = {ports}")
-    if server.get("livenessProbe", {}).get("httpGet") != {"path": "/healthz", "port": "ops"}:
-        fail(f"{mode}: liveness probe does not use operational /healthz")
-    if server.get("readinessProbe", {}).get("httpGet") != {"path": "/readyz", "port": "ops"}:
-        fail(f"{mode}: readiness probe does not use operational /readyz")
+    liveness = server.get("livenessProbe", {})
+    if liveness != {
+        "httpGet": {"path": "/healthz", "port": "ops"},
+        "initialDelaySeconds": 5,
+        "periodSeconds": 10,
+        "failureThreshold": 3,
+    }:
+        fail(f"{mode}: liveness probe = {liveness}")
+    readiness = server.get("readinessProbe", {})
+    if readiness != {
+        "httpGet": {"path": "/readyz", "port": "ops"},
+        "periodSeconds": 5,
+        "failureThreshold": 3,
+    }:
+        fail(f"{mode}: readiness probe = {readiness}")
+    startup = server.get("startupProbe", {})
+    if startup != {
+        "httpGet": {"path": "/readyz", "port": "ops"},
+        "periodSeconds": 5,
+        "failureThreshold": 30,
+    }:
+        fail(f"{mode}: startup probe = {startup}")
     env_names = {e["name"] for e in server.get("env", [])}
+    if "HIKYO_EXTERNAL_ORIGIN" not in env_names or "HIKYO_ROOT_KEY" in env_names:
+        fail(f"{mode}: server origin/root-key env boundary = {env_names}")
     if ("HIKYO_TRUSTED_PROXY_CIDRS" in env_names) == tls:
         fail(f"{mode}: trusted-proxy env presence does not match transport mode: {env_names}")
+    mounts = {m["name"]: m for m in server.get("volumeMounts", [])}
+    if mounts.get("root-key", {}).get("mountPath") != "/run/hikyo-root-key" or not mounts["root-key"].get("readOnly"):
+        fail(f"{mode}: staged root-key mount = {mounts.get('root-key')}")
+    if mounts.get("tmp", {}).get("mountPath") != "/tmp":
+        fail(f"{mode}: writable tmp mount = {mounts.get('tmp')}")
+    pod = deployment["spec"]["template"]["spec"]
+    volumes = {v["name"]: v for v in pod.get("volumes", [])}
+    root_source = volumes.get("root-key-source", {}).get("secret", {})
+    if root_source.get("secretName") != "fixture-root-key" or root_source.get("defaultMode") != 0o400:
+        fail(f"{mode}: root-key source volume = {root_source}")
+    if root_source.get("items") != [{"key": "root-key", "path": "root-key"}]:
+        fail(f"{mode}: root-key source item = {root_source.get('items')}")
+    if volumes.get("root-key", {}).get("emptyDir") != {}:
+        fail(f"{mode}: staged root-key emptyDir = {volumes.get('root-key')}")
+    if volumes.get("tmp", {}).get("emptyDir") != {}:
+        fail(f"{mode}: writable tmp emptyDir = {volumes.get('tmp')}")
+    if pod.get("securityContext", {}).get("fsGroup") != 65532:
+        fail(f"{mode}: Secret sources are not readable through fsGroup")
+    root_init = {c["name"]: c for c in pod.get("initContainers", [])}.get("root-key-stage", {})
+    if root_init.get("args") != ["__hikyo-stage-root-key"]:
+        fail(f"{mode}: root-key staging init args = {root_init.get('args')}")
     if tls:
-        mounts = {m["name"]: m for m in server.get("volumeMounts", [])}
         if mounts.get("tls", {}).get("mountPath") != "/run/hikyo-tls" or not mounts["tls"].get("readOnly"):
             fail(f"{mode}: TLS mount = {mounts.get('tls')}")
-        volumes = {v["name"]: v for v in deployment["spec"]["template"]["spec"].get("volumes", [])}
         secret = volumes.get("tls-source", {}).get("secret", {})
         if secret.get("secretName") != "fixture-tls" or secret.get("defaultMode") != 0o400:
             fail(f"{mode}: TLS volume = {secret}")
         if volumes.get("tls", {}).get("emptyDir") != {}:
             fail(f"{mode}: staged TLS emptyDir = {volumes.get('tls')}")
-        pod = deployment["spec"]["template"]["spec"]
-        if pod.get("securityContext", {}).get("fsGroup") != 65532:
-            fail(f"{mode}: TLS source is not readable through fsGroup")
         init = {c["name"]: c for c in pod.get("initContainers", [])}.get("tls-stage", {})
         if init.get("args") != ["__hikyo-stage-tls", "--once"]:
             fail(f"{mode}: TLS staging init args = {init.get('args')}")
@@ -328,20 +373,70 @@ assert_server_network(tls_docs, "native-tls", True)
 print("Chart check: every RBAC rule set, TokenRequest scope, stamp-root grant, hardening, args and the exact env allowlist asserted")
 PY
 
+if grep -Eh '[0-9a-f]{64}' "$tmp"/*.yaml | grep -Ev 'sha256:[0-9a-f]{64}' >/dev/null; then
+	fail 'rendered chart contains a raw 64-hex value outside an image digest'
+fi
+
 # Refusal fixtures: the server listener is invalid without a database Secret and
 # without either a native TLS Secret or explicit trusted proxy CIDRs.
-if helm template fixture "$chart" --set database.existingSecret=fixture >/dev/null 2>&1; then
+required_server_values='--set database.existingSecret=fixture --set rootKey.existingSecret=fixture-root-key --set externalOrigin=https://hikyo.example.com'
+
+# shellcheck disable=SC2086 # Deliberately expand fixed test flags into argv.
+if helm template fixture "$chart" $required_server_values >/dev/null 2>&1; then
 	fail 'chart accepted a server listener without trusted proxy CIDRs'
 fi
-if helm template fixture "$chart" --set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null 2>&1; then
+# shellcheck disable=SC2086 # Deliberately expand fixed test flags into argv.
+if helm template fixture "$chart" $required_server_values \
+	--set 'network.trustedProxyCIDRs={10.42.0.0/16}' \
+	--set rootKey.existingSecret= >/dev/null 2>&1; then
+	fail 'chart accepted a server without rootKey.existingSecret'
+fi
+if helm template fixture "$chart" \
+	--set rootKey.existingSecret=fixture-root-key \
+	--set externalOrigin=https://hikyo.example.com \
+	--set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null 2>&1; then
 	fail 'chart accepted a server without database.existingSecret'
 fi
-if helm template fixture "$chart" --set tls.existingSecret=fixture-tls >/dev/null 2>&1; then
+if helm template fixture "$chart" \
+	--set database.existingSecret=fixture \
+	--set rootKey.existingSecret=fixture-root-key \
+	--set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null 2>&1; then
+	fail 'chart accepted a server without externalOrigin'
+fi
+if helm template fixture "$chart" \
+	--set rootKey.existingSecret=fixture-root-key \
+	--set externalOrigin=https://hikyo.example.com \
+	--set tls.existingSecret=fixture-tls >/dev/null 2>&1; then
 	fail 'chart accepted native TLS without database.existingSecret'
 fi
+if helm template fixture "$chart" \
+	--set database.existingSecret=fixture \
+	--set rootKey.existingSecret=fixture-root-key \
+	--set externalOrigin=http://hikyo.example.com \
+	--set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null 2>&1; then
+	fail 'chart accepted plaintext externalOrigin without network.allowPlaintextOrigin'
+fi
+for invalid_origin in \
+	'https://hikyo.example.com/path' \
+	'https://:' \
+	'https://example.com\evil' \
+	'https://EXAMPLE.com' \
+	'https://example.com:443' \
+	'https://example.com:99999'; do
+	origin_json=$(jq -Rn --arg origin "$invalid_origin" '$origin')
+	if helm template fixture "$chart" \
+		--set database.existingSecret=fixture \
+		--set rootKey.existingSecret=fixture-root-key \
+		--set-json externalOrigin="$origin_json" \
+		--set 'network.trustedProxyCIDRs={10.42.0.0/16}' >/dev/null 2>&1; then
+		fail "chart accepted noncanonical externalOrigin $invalid_origin"
+	fi
+done
 # A designated ServiceAccount for a namespace outside the watch set is refused.
 if helm template fixture "$chart" \
 	--set database.existingSecret=fixture \
+	--set rootKey.existingSecret=fixture-root-key \
+	--set externalOrigin=https://hikyo.example.com \
 	--set 'network.trustedProxyCIDRs={10.42.0.0/16}' \
 	--set 'operator.namespaces={ns-a}' \
 	--set 'operator.designatedServiceAccounts.ns-b={sa-b}' >/dev/null 2>&1; then

--- a/scripts/ci/check-chart_test.sh
+++ b/scripts/ci/check-chart_test.sh
@@ -44,6 +44,26 @@ refute 'operator args tampered' \
 	templates/operator-deployment.yaml \
 	's/args: \["operator"\]/args: ["server"]/'
 
+refute 'server root-key arg missing' \
+	templates/deployment.yaml \
+	'/--root-key-file=/d'
+
+refute 'root-key source widened to group-readable' \
+	templates/deployment.yaml \
+	'0,/defaultMode: 0400/s//defaultMode: 0440/'
+
+refute 'root-key staging bypassed' \
+	templates/deployment.yaml \
+	's/args: \["__hikyo-stage-root-key"\]/args: ["version"]/'
+
+refute 'semantic readiness path replaced' \
+	templates/deployment.yaml \
+	'0,/path: \/readyz/s//path: \/healthz/'
+
+refute 'external origin env missing' \
+	templates/deployment.yaml \
+	'/- name: HIKYO_EXTERNAL_ORIGIN/,+1d'
+
 # Leak database configuration into the operator pod.
 refute 'operator database env leak' \
 	templates/operator-deployment.yaml \

--- a/scripts/ci/ci-job-registry.json
+++ b/scripts/ci/ci-job-registry.json
@@ -26,6 +26,14 @@
       "test",
       "web"
     ],
+    "chart": [
+      "k8s-e2e",
+      "lint",
+      "release-snapshot",
+      "supply-chain-checks"
+    ],
+    "chart-kind-script": ["k8s-e2e", "lint"],
+    "chart-runtime": ["k8s-e2e"],
     "client": ["client", "release-snapshot", "web"],
     "compose": ["compose-demo"],
     "core": [
@@ -57,6 +65,12 @@
       "release-snapshot",
       "test",
       "web"
+    ],
+    "image": [
+      "k8s-e2e",
+      "lint",
+      "release-snapshot",
+      "supply-chain-checks"
     ],
     "release": ["lint", "release-snapshot", "supply-chain-checks"],
     "release-policy": [

--- a/scripts/ci/classify-changed-paths.sh
+++ b/scripts/ci/classify-changed-paths.sh
@@ -46,6 +46,11 @@ else
 			;;
 		esac
 		case "$path" in
+		cmd/hikyo/main.go | cmd/hikyo/rootkey_stage.go | internal/crypto/rootkey_stage.go | internal/crypto/rootkey_stage_test.go | internal/securefile/atomic.go | internal/securefile/atomic_test.go)
+			select_class chart-runtime
+			;;
+		esac
+		case "$path" in
 		.github/workflows/*)
 			all_jobs
 			;;
@@ -95,7 +100,16 @@ else
 		scripts/ci/k8s-e2e.sh)
 			select_class k8s-e2e-script
 			;;
-		release/* | chart/* | scripts/release/* | scripts/lib/* | install/* | Dockerfile.release | .dockerignore)
+		scripts/ci/chart-kind.sh)
+			select_class chart-kind-script
+			;;
+		chart/*)
+			select_class chart
+			;;
+		Dockerfile.release | .dockerignore | scripts/release/prepare-image-root.sh | scripts/release/prepare-image-root_test.sh)
+			select_class image
+			;;
+		release/* | scripts/release/* | scripts/lib/* | install/*)
 			select_class release
 			;;
 		*.go | *.sql)

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -51,6 +51,10 @@ expect_plan 'client' '["client","release-snapshot","web"]' \
 	'clients/ts/src/generated/types.gen.ts'
 expect_plan 'release' '["lint","release-snapshot","supply-chain-checks"]' \
 	'scripts/release/check-tag.sh'
+expect_plan 'chart' '["k8s-e2e","lint","release-snapshot","supply-chain-checks"]' \
+	'chart/hikyo/values.yaml'
+expect_plan 'release image' '["k8s-e2e","lint","release-snapshot","supply-chain-checks"]' \
+	'Dockerfile.release'
 expect_plan 'LICENSE' '["docs","release-snapshot"]' 'LICENSE'
 expect_plan 'main CI gate' \
 	'["docs","lint","release-snapshot","supply-chain-checks"]' \
@@ -122,6 +126,10 @@ expect_plan 'generated CRD' \
 	'["generated","k8s-e2e","lint","release-snapshot","supply-chain-checks"]' \
 	'chart/hikyo/crds/hikyo.dev_hikyosecrets.yaml'
 expect_plan 'k8s e2e runner' '["k8s-e2e","lint"]' 'scripts/ci/k8s-e2e.sh'
+expect_plan 'chart kind runner' '["k8s-e2e","lint"]' 'scripts/ci/chart-kind.sh'
+expect_plan 'root-key staging runtime' \
+	'["fuzz","generated","headline-guarantee","k8s-e2e","race","release-snapshot","test","web"]' \
+	'internal/crypto/rootkey_stage.go'
 
 for fail_closed_input in \
 	'' \

--- a/scripts/ci/k8s-e2e.sh
+++ b/scripts/ci/k8s-e2e.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Provision an ephemeral kind cluster and run the operator kind-e2e suite
-# against it. Runnable both in CI (the k8s-e2e job) and locally. The `kind`
+# Provision ephemeral kind clusters and run both the operator suite and the
+# real Helm install/readiness suite. Keeping both behind the existing k8s-e2e
+# required job lets trusted base-branch CI execute a PR-head chart gate even in
+# the same PR that introduces or changes the gate. The `kind`
 # binary comes from PATH; the node image is digest-pinned to the default for the
 # pinned kind release (v0.32.0), so the API-server version is reproducible.
 #
@@ -69,3 +71,44 @@ kind load docker-image --name "$CLUSTER" "$HIKYO_K8S_E2E_SERVER_IMAGE" >/dev/nul
 
 echo "k8s-e2e: running operator and server-probe kind e2e suite"
 go test -count=1 -tags k8se2e -run 'TestK8sOperator' ./internal/isolation/ -timeout 25m
+
+# Release the first cluster before chart-kind creates its separately named
+# cluster. Two simultaneous control planes add memory pressure without adding
+# coverage, and each runner owns only the cluster it created.
+kind delete cluster --name "$CLUSTER" >/dev/null
+created=false
+
+echo "k8s-e2e: building release-shaped UI binary for Helm chart gate"
+if [ "$(uname -s)" = Linux ]; then
+	# This compatibility bridge runs inside the existing base-controlled job,
+	# which predates setup-node/setup-helm for the chart gate. Install both
+	# exact toolchains from pinned official archives before executing PR code.
+	tool_dir="$image_root/tools"
+	mkdir -p "$tool_dir"
+	node_archive="$tool_dir/node.tar.xz"
+	curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error \
+		--retry 4 --retry-delay 2 --retry-all-errors \
+		https://nodejs.org/dist/v26.7.0/node-v26.7.0-linux-x64.tar.xz \
+		--output "$node_archive"
+	printf '%s  %s\n' \
+		982aa24dd8be4c889c6a8ab337ddff3b0896645b20f4239356e80552c16277ee \
+		"$node_archive" | sha256sum --check --strict
+	tar -xJf "$node_archive" -C "$tool_dir"
+	export PATH="$tool_dir/node-v26.7.0-linux-x64/bin:$PATH"
+
+	helm_archive="$tool_dir/helm.tar.gz"
+	curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error \
+		--retry 4 --retry-delay 2 --retry-all-errors \
+		https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz \
+		--output "$helm_archive"
+	printf '%s  %s\n' \
+		e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c \
+		"$helm_archive" | sha256sum --check --strict
+	tar -xzf "$helm_archive" -C "$tool_dir"
+	export PATH="$tool_dir/linux-amd64:$PATH"
+fi
+./scripts/ci/install-corepack.sh
+./scripts/ci/build-spa.sh --verify
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -tags ui \
+	-o "$image_root/hikyo-ui" ./cmd/hikyo
+HIKYO_CHART_KIND_BINARY="$image_root/hikyo-ui" ./scripts/ci/chart-kind.sh


### PR DESCRIPTION
## Summary

- require Secret-backed database and root-key files plus a canonical external origin before Helm rendering
- stage the root key into an owner-only file and wire semantic readiness/liveness probes into the deployment
- add a real Kind chart gate covering boot, the pre-fix failure, and database readiness loss/recovery
- document the complete Kubernetes installation and release packaging contract

## Validation

- focused Go tests: 154 passed
- Helm chart render and mutation fixtures passed
- changed-path classifier and required-job registry checks passed
- shellcheck and actionlint passed
- SPA typecheck/build and 331 tests passed
- documentation verification passed
- final standards and specification reviews: clean
- full Kind gate runs in the trusted `k8s-e2e` PR job; local rerun was deferred at 48% free system memory

Closes #200