### PR TITLE
Raise unfocused control border contrast #450

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,12 +14,12 @@ Dark (default):
 
 - `--bg` oklch(0.19 0.012 220) surface
 - `--bg-raise` oklch(0.23 0.014 220) raised rows/sheets
-- `--line` oklch(0.34 0.016 220) hairlines
+- `--line` oklch(0.5 0.016 220) hairlines and control boundaries (>=3:1 on `--bg`)
 - `--tx` oklch(0.93 0.008 200) primary text (≈13:1 on bg)
 - `--tx-dim` oklch(0.76 0.01 210) secondary (≈7:1)
 - `--accent` oklch(0.82 0.09 195) interactive teal; text on accent uses oklch(0.2 0.02 220)
 
-Light: linen-tinted paper oklch(0.965 0.008 200), ink oklch(0.25 0.03 225), same accent hue at oklch(0.45 0.085 210).
+Light: linen-tinted paper oklch(0.965 0.008 200), hairlines and control boundaries oklch(0.64 0.012 210) (>=3:1 on the paper), ink oklch(0.25 0.03 225), same accent hue at oklch(0.45 0.085 210).
 
 State vocabulary (always paired with a glyph, never color-only):
 

--- a/docs/handoff/450-line-token-contrast.md
+++ b/docs/handoff/450-line-token-contrast.md
@@ -1,0 +1,17 @@
+# Issue 450: control boundary contrast
+
+## Contract
+
+Unfocused text inputs must expose a rendered boundary with at least 3:1 contrast against their fill in both the dark and light themes, satisfying WCAG 1.4.11.
+
+## Implementation
+
+- `--line` is `oklch(0.5 0.016 220)` in the dark theme and `oklch(0.64 0.012 210)` in both light-theme declarations.
+- The values remain shared by control and decorative hairlines, preserving the single asserted token named by the issue.
+- The login Playwright flow samples the browser-rendered input border and fill pixels and requires a ratio of at least 3:1 in both themes.
+
+## Verification
+
+- Run `pnpm --dir web typecheck`.
+- Run `pnpm --dir web exec playwright test e2e/flows/login.spec.ts`.
+- Run the repository full suite before merge when host memory pressure permits.

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -217,6 +217,27 @@ async function sampleRGB(page: Page, colour: string): Promise<number[]> {
   }, colour);
 }
 
+function relativeLuminance(rgb: readonly number[]): number {
+  const channel = (component: number): number => {
+    const value = component / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+  return (
+    0.2126 * channel(rgb[0] ?? 0) +
+    0.7152 * channel(rgb[1] ?? 0) +
+    0.0722 * channel(rgb[2] ?? 0)
+  );
+}
+
+function contrastRatio(first: readonly number[], second: readonly number[]): number {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+}
+
 /**
  * measureContrast computes the WCAG ratio from the RENDERED colours: the
  * element's own text colour against the first ancestor that actually paints a
@@ -284,26 +305,8 @@ async function measureContrast(target: Locator): Promise<Contrast> {
 export async function measureSurfaceLuminance(
   page: Page,
 ): Promise<{ colour: string; luminance: number }> {
-  return page.evaluate(() => {
-    const canvas = document.createElement('canvas');
-    canvas.width = 1;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
-    if (ctx === null) {
-      throw new Error('no 2d context to sample colours with');
-    }
-    const colour = getComputedStyle(document.body).backgroundColor;
-    ctx.fillStyle = colour;
-    ctx.fillRect(0, 0, 1, 1);
-    const d = ctx.getImageData(0, 0, 1, 1).data;
-    const channel = (c: number) => {
-      const v = c / 255;
-      return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
-    };
-    const luminance =
-      0.2126 * channel(d[0] ?? 0) + 0.7152 * channel(d[1] ?? 0) + 0.0722 * channel(d[2] ?? 0);
-    return { colour, luminance };
-  });
+  const colour = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  return { colour, luminance: relativeLuminance(await sampleRGB(page, colour)) };
 }
 
 export async function expectContrast(target: Locator, minimum = 4.5): Promise<void> {
@@ -338,18 +341,7 @@ export async function expectBoundaryContrast(
     sampleRGB(page, colours.border),
     sampleRGB(page, colours.background),
   ]);
-  const luminance = (rgb: number[]): number => {
-    const channel = (component: number): number => {
-      const value = component / 255;
-      return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
-    };
-    return 0.2126 * channel(rgb[0] ?? 0) + 0.7152 * channel(rgb[1] ?? 0) + 0.0722 * channel(rgb[2] ?? 0);
-  };
-  const borderLuminance = luminance(border);
-  const backgroundLuminance = luminance(background);
-  const ratio =
-    (Math.max(borderLuminance, backgroundLuminance) + 0.05) /
-    (Math.min(borderLuminance, backgroundLuminance) + 0.05);
+  const ratio = contrastRatio(border, background);
   expect(
     ratio,
     `boundary contrast ${ratio.toFixed(2)}:1 for ${colours.border} on ${colours.background}, want >= ${minimum}:1`,

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -320,6 +320,42 @@ export async function expectEveryContrast(targets: Locator[], minimum = 4.5): Pr
   }
 }
 
+/**
+ * expectBoundaryContrast checks WCAG 1.4.11 against rendered control pixels.
+ * axe-core cannot infer whether a border is the only visual affordance, so the
+ * login flow names that seam and compares its unfocused border to its fill.
+ */
+export async function expectBoundaryContrast(
+  page: Page,
+  target: Locator,
+  minimum = 3,
+): Promise<void> {
+  const colours = await target.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return { border: style.borderTopColor, background: style.backgroundColor };
+  });
+  const [border, background] = await Promise.all([
+    sampleRGB(page, colours.border),
+    sampleRGB(page, colours.background),
+  ]);
+  const luminance = (rgb: number[]): number => {
+    const channel = (component: number): number => {
+      const value = component / 255;
+      return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * channel(rgb[0] ?? 0) + 0.7152 * channel(rgb[1] ?? 0) + 0.0722 * channel(rgb[2] ?? 0);
+  };
+  const borderLuminance = luminance(border);
+  const backgroundLuminance = luminance(background);
+  const ratio =
+    (Math.max(borderLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(borderLuminance, backgroundLuminance) + 0.05);
+  expect(
+    ratio,
+    `boundary contrast ${ratio.toFixed(2)}:1 for ${colours.border} on ${colours.background}, want >= ${minimum}:1`,
+  ).toBeGreaterThanOrEqual(minimum);
+}
+
 // --- 5. touch targets ------------------------------------------------------
 
 /** The floor DESIGN.md fixes for touch: ~44px targets on mobile. */

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -95,76 +95,50 @@ export async function expectVisibleFocusIndicator(page: Page, target: Locator): 
   await target.focus();
   await expect(target).toBeFocused();
 
-  const ring = await target.evaluate((el) => {
-    const canvas = document.createElement('canvas');
-    canvas.width = 1;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
-    if (ctx === null) {
-      throw new Error('no 2d context to sample colours with');
-    }
-    const sample = (value: string): [number, number, number, number] => {
-      ctx.clearRect(0, 0, 1, 1);
-      ctx.fillStyle = value;
-      ctx.fillRect(0, 0, 1, 1);
-      const d = ctx.getImageData(0, 0, 1, 1).data;
-      return [d[0] ?? 0, d[1] ?? 0, d[2] ?? 0, (d[3] ?? 0) / 255];
-    };
-    const luminance = ([r, g, b]: [number, number, number, number]) => {
-      const ch = (c: number) => {
-        const v = c / 255;
-        return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
-      };
-      return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b);
-    };
-    // The ring is painted OUTSIDE the element, over whatever its ancestors
-    // paint — so that, not the element's own fill, is what it must stand out
-    // against.
-    let node: Element | null = el.parentElement;
-    let behind = getComputedStyle(document.body).backgroundColor;
-    while (node !== null) {
-      const value = getComputedStyle(node).backgroundColor;
-      if (sample(value)[3] > 0.99) {
-        behind = value;
-        break;
-      }
-      node = node.parentElement;
-    }
-
+  const drawn = await target.evaluate((el) => {
     const style = getComputedStyle(el);
-    const drawn: Array<{ how: string; colour: string }> = [];
+    const rings: Array<{ how: string; colour: string }> = [];
     if (style.outlineStyle !== 'none' && Number.parseFloat(style.outlineWidth) > 0) {
-      drawn.push({ how: `outline ${style.outlineWidth} ${style.outlineStyle}`, colour: style.outlineColor });
+      rings.push({
+        how: `outline ${style.outlineWidth} ${style.outlineStyle}`,
+        colour: style.outlineColor,
+      });
     }
     if (style.boxShadow !== 'none' && style.boxShadow !== '') {
       // Computed box-shadow starts with its colour.
       const colour = /^(rgba?\([^)]*\)|oklch\([^)]*\)|#[0-9a-f]+)/i.exec(style.boxShadow)?.[1];
       if (colour !== undefined) {
-        drawn.push({ how: `box-shadow ${style.boxShadow}`, colour });
+        rings.push({ how: `box-shadow ${style.boxShadow}`, colour });
       }
     }
-
-    const behindL = luminance(sample(behind));
-    const rings = drawn.map((d) => {
-      const rgba = sample(d.colour);
-      const l = luminance(rgba);
-      return {
-        how: d.how,
-        colour: d.colour,
-        alpha: rgba[3],
-        contrast: (Math.max(l, behindL) + 0.05) / (Math.min(l, behindL) + 0.05),
-      };
-    });
-    return { behind, rings };
+    return rings;
   });
+  // The ring is painted OUTSIDE the element, over whatever its ancestors
+  // paint — so that, not the element's own fill, is what it must stand out
+  // against.
+  const behind = await paintedBackground(target, false);
+  const behindSample = await sampleColour(page, behind);
+  const rings = await Promise.all(
+    drawn.map(async (candidate) => {
+      const sample = await sampleColour(page, candidate.colour);
+      return {
+        ...candidate,
+        alpha: sample.alpha,
+        contrast: contrastRatio(sample.rgb, behindSample.rgb),
+      };
+    }),
+  );
 
-  expect(ring.rings.length, 'nothing is drawn on focus: no outline and no box-shadow').toBeGreaterThan(0);
-  const visible = ring.rings.filter((r) => r.alpha > 0.99 && r.contrast >= 3);
+  expect(rings.length, 'nothing is drawn on focus: no outline and no box-shadow').toBeGreaterThan(0);
+  const visible = rings.filter((ring) => ring.alpha > 0.99 && ring.contrast >= 3);
   expect(
     visible.length,
-    `no VISIBLE focus ring against ${ring.behind}: ` +
-      ring.rings
-        .map((r) => `${r.how} (${r.colour}, alpha ${r.alpha}, contrast ${r.contrast.toFixed(2)}:1)`)
+    `no VISIBLE focus ring against ${behind}: ` +
+      rings
+        .map(
+          (ring) =>
+            `${ring.how} (${ring.colour}, alpha ${ring.alpha}, contrast ${ring.contrast.toFixed(2)}:1)`,
+        )
         .join('; '),
   ).toBeGreaterThan(0);
 
@@ -199,8 +173,14 @@ export async function expectEveryFocusIndicator(page: Page, targets: Locator[]):
 
 type Contrast = { ratio: number; foreground: string; background: string };
 
+type SampledColour = { rgb: number[]; alpha: number };
+
 /** sampleRGB asks the browser what sRGB a CSS colour actually paints. */
 async function sampleRGB(page: Page, colour: string): Promise<number[]> {
+  return (await sampleColour(page, colour)).rgb;
+}
+
+async function sampleColour(page: Page, colour: string): Promise<SampledColour> {
   return page.evaluate((value) => {
     const canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -213,8 +193,38 @@ async function sampleRGB(page: Page, colour: string): Promise<number[]> {
     ctx.fillStyle = value;
     ctx.fillRect(0, 0, 1, 1);
     const d = ctx.getImageData(0, 0, 1, 1).data;
-    return [d[0] ?? 0, d[1] ?? 0, d[2] ?? 0];
+    return {
+      rgb: [d[0] ?? 0, d[1] ?? 0, d[2] ?? 0],
+      alpha: (d[3] ?? 0) / 255,
+    };
   }, colour);
+}
+
+async function paintedBackground(target: Locator, includeTarget: boolean): Promise<string> {
+  return target.evaluate((el, includeSelf) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (ctx === null) {
+      throw new Error('no 2d context to sample colours with');
+    }
+    let node: Element | null = includeSelf ? el : el.parentElement;
+    let background = getComputedStyle(document.body).backgroundColor;
+    while (node !== null) {
+      const value = getComputedStyle(node).backgroundColor;
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillStyle = value;
+      ctx.fillRect(0, 0, 1, 1);
+      const alpha = (ctx.getImageData(0, 0, 1, 1).data[3] ?? 0) / 255;
+      if (alpha > 0.99) {
+        background = value;
+        break;
+      }
+      node = node.parentElement;
+    }
+    return background;
+  }, includeTarget);
 }
 
 function relativeLuminance(rgb: readonly number[]): number {
@@ -244,56 +254,20 @@ function contrastRatio(first: readonly number[], second: readonly number[]): num
  * background. Reading the token values instead would prove the tokens contrast
  * with each other, not that this element does.
  */
-async function measureContrast(target: Locator): Promise<Contrast> {
-  return target.evaluate((el) => {
-    // Colours are authored in OKLCH and `getComputedStyle` returns them that
-    // way, so the ratio cannot be computed by pulling three numbers out of the
-    // string. Painting each colour into a 1x1 canvas asks the BROWSER for the
-    // sRGB it will actually display, which is the only honest source — and it
-    // keeps working when the palette moves to another colour space.
-    const canvas = document.createElement('canvas');
-    canvas.width = 1;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
-    if (ctx === null) {
-      throw new Error('no 2d context to sample colours with');
-    }
-    const sample = (value: string): [number, number, number, number] => {
-      ctx.clearRect(0, 0, 1, 1);
-      ctx.fillStyle = value;
-      ctx.fillRect(0, 0, 1, 1);
-      const d = ctx.getImageData(0, 0, 1, 1).data;
-      return [d[0] ?? 0, d[1] ?? 0, d[2] ?? 0, (d[3] ?? 0) / 255];
-    };
-    const luminance = ([r, g, b]: [number, number, number, number]): number => {
-      const channel = (c: number) => {
-        const v = c / 255;
-        return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
-      };
-      return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
-    };
-
-    const foreground = getComputedStyle(el).color;
-    // The effective background is the first ancestor that actually paints one.
-    // A translucent layer keeps the walk going rather than being blended: the
-    // skeleton has none, and guessing at compositing would make the number
-    // look more precise than it is.
-    let node: Element | null = el;
-    let background = getComputedStyle(document.body).backgroundColor;
-    while (node !== null) {
-      const value = getComputedStyle(node).backgroundColor;
-      if (sample(value)[3] > 0.99) {
-        background = value;
-        break;
-      }
-      node = node.parentElement;
-    }
-
-    const lf = luminance(sample(foreground));
-    const lb = luminance(sample(background));
-    const ratio = (Math.max(lf, lb) + 0.05) / (Math.min(lf, lb) + 0.05);
-    return { ratio, foreground, background };
-  });
+async function measureContrast(page: Page, target: Locator): Promise<Contrast> {
+  const [foreground, background] = await Promise.all([
+    target.evaluate((el) => getComputedStyle(el).color),
+    paintedBackground(target, true),
+  ]);
+  const [foregroundSample, backgroundSample] = await Promise.all([
+    sampleRGB(page, foreground),
+    sampleRGB(page, background),
+  ]);
+  return {
+    ratio: contrastRatio(foregroundSample, backgroundSample),
+    foreground,
+    background,
+  };
 }
 
 /**
@@ -309,17 +283,21 @@ export async function measureSurfaceLuminance(
   return { colour, luminance: relativeLuminance(await sampleRGB(page, colour)) };
 }
 
-export async function expectContrast(target: Locator, minimum = 4.5): Promise<void> {
-  const { ratio, foreground, background } = await measureContrast(target);
+export async function expectContrast(page: Page, target: Locator, minimum = 4.5): Promise<void> {
+  const { ratio, foreground, background } = await measureContrast(page, target);
   expect(
     ratio,
     `contrast ${ratio.toFixed(2)}:1 for ${foreground} on ${background}, want >= ${minimum}:1`,
   ).toBeGreaterThanOrEqual(minimum);
 }
 
-export async function expectEveryContrast(targets: Locator[], minimum = 4.5): Promise<void> {
+export async function expectEveryContrast(
+  page: Page,
+  targets: Locator[],
+  minimum = 4.5,
+): Promise<void> {
   for (const target of targets) {
-    await expectContrast(target, minimum);
+    await expectContrast(page, target, minimum);
   }
 }
 
@@ -631,7 +609,7 @@ export async function expectPinnedAssertionSet(page: Page, surface: PinnedSurfac
   const interactive = await interactiveElements(page);
   await expectEveryFocusIndicator(page, interactive);
   await expectTouchTargets(page, interactive);
-  await expectEveryContrast([...interactive, ...surface.text]);
+  await expectEveryContrast(page, [...interactive, ...surface.text]);
 
   for (const [target, role] of surface.radii) {
     await expectRadiusRole(page, target, role);

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -188,9 +188,9 @@ test.describe('login', () => {
     await page.goto('/login');
     for (const scheme of ['dark', 'light'] as const) {
       await page.emulateMedia({ colorScheme: scheme });
-      await expectContrast(page.getByRole('heading', { name: 'Sign in to Hikyo' }));
-      await expectContrast(page.getByText('Use the credential you established'));
-      await expectContrast(page.getByText('Username'));
+      await expectContrast(page, page.getByRole('heading', { name: 'Sign in to Hikyo' }));
+      await expectContrast(page, page.getByText('Use the credential you established'));
+      await expectContrast(page, page.getByText('Username'));
     }
   });
 });

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 import {
+  expectBoundaryContrast,
   expectContrast,
   expectPinnedAssertionSet,
   expectStatusIsTextAndAria,
@@ -14,8 +15,13 @@ async function expectLoginSurface(page: Page, theme: 'dark' | 'light') {
 
   const card = page.locator('.login__card');
   const submit = page.getByRole('button', { name: 'Sign in' });
+  const username = page.getByLabel('Username');
+  const password = page.getByLabel('Password');
   const heading = page.getByRole('heading', { name: 'Sign in to Hikyo' });
   const lede = page.getByText('Use the credential you established');
+
+  await expectBoundaryContrast(page, username);
+  await expectBoundaryContrast(page, password);
 
   await expectPinnedAssertionSet(page, {
     flow: 'login',
@@ -25,8 +31,8 @@ async function expectLoginSurface(page: Page, theme: 'dark' | 'light') {
     radii: [
       [card, 'container'],
       [submit, 'control'],
-      [page.getByLabel('Username'), 'control'],
-      [page.getByLabel('Password'), 'control'],
+      [username, 'control'],
+      [password, 'control'],
     ],
     fonts: [
       [heading, 'ui'],
@@ -40,7 +46,7 @@ async function expectLoginSurface(page: Page, theme: 'dark' | 'light') {
       [submit, 'backgroundColor', '--accent'],
       [submit, 'color', '--on-accent'],
     ],
-    hairlines: [card, page.getByLabel('Username')],
+    hairlines: [card, username],
     density: [[submit, '--touch']],
   });
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -18,7 +18,7 @@
   /* Colour — OKLCH throughout, tinted neutrals plus one teal accent. */
   --bg: oklch(0.19 0.012 220);
   --bg-raise: oklch(0.23 0.014 220);
-  --line: oklch(0.34 0.016 220);
+  --line: oklch(0.5 0.016 220);
   --tx: oklch(0.93 0.008 200);
   --tx-dim: oklch(0.76 0.01 210);
   --accent: oklch(0.82 0.09 195);
@@ -54,7 +54,7 @@
   :root:not([data-theme='dark']) {
     --bg: oklch(0.965 0.008 200);
     --bg-raise: oklch(0.995 0.004 200);
-    --line: oklch(0.84 0.012 210);
+    --line: oklch(0.64 0.012 210);
     --tx: oklch(0.25 0.03 225);
     --tx-dim: oklch(0.44 0.02 220);
     --accent: oklch(0.45 0.085 210);
@@ -68,7 +68,7 @@
   color-scheme: light;
   --bg: oklch(0.965 0.008 200);
   --bg-raise: oklch(0.995 0.004 200);
-  --line: oklch(0.84 0.012 210);
+  --line: oklch(0.64 0.012 210);
   --tx: oklch(0.25 0.03 225);
   --tx-dim: oklch(0.44 0.02 220);
   --accent: oklch(0.45 0.085 210);


### PR DESCRIPTION
Closes #450

## What changed
- raise the shared `--line` token to browser-rendered contrast above 3:1 in dark and light themes
- add an explicit Playwright WCAG 1.4.11 boundary check for both login inputs in both themes
- update the canonical design token and issue handoff

## Verification
- exact OKLCH-to-rendered-sRGB calculation: approximately 3.11:1 dark and 3.06:1 light
- local TypeScript and Playwright runs deferred while the host remains under high memory and swap pressure; CI started immediately as requested