### PR TITLE
Validate federated binding identity fields locally #458

### DIFF
--- a/docs/handoff/458-binding-identity-validation.md
+++ b/docs/handoff/458-binding-identity-validation.md
@@ -1,0 +1,20 @@
+# Issue #458 — local binding identity validation
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/458. Base:
+`5543b70e`.
+
+## Contract
+
+- The federated-binding form refuses blank or whitespace-only `issuer` and
+  `subject` values before claim validation or any create request.
+- Each refusal names the missing byte-exact identity field and states that
+  nothing was bound.
+- Preset-filled happy paths, request payloads, routes, persistence, and
+  generated outputs remain unchanged.
+
+## Coverage
+
+- The machine-access Playwright flow blanks each field through the public form,
+  submits it, checks the local refusal, and proves no binding-create POST fired.
+- Local test execution was deferred before the first push because host memory
+  pressure remained high; exact-head CI is required before merge.

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -324,6 +324,15 @@ test.describe('machine access', () => {
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
+    let createRequests = 0;
+    page.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        /\/service-accounts\/[^/]+\/bindings$/.test(new URL(request.url()).pathname)
+      ) {
+        createRequests += 1;
+      }
+    });
     // The Kubernetes preset fills the byte-exact issuer and the UID pin the
     // server refuses a binding without.
     await expect(dialog.getByLabel('Issuer')).toHaveValue(seed.machine.issuer);
@@ -357,6 +366,24 @@ test.describe('machine access', () => {
     await dialog.getByRole('button', { name: 'Bind this identity' }).click();
     await expect(dialog.getByRole('alert')).toContainText('An audience is mandatory');
     await dialog.getByLabel('Audience').fill(seed.machine.audience);
+
+    // Issuer and subject carry the byte-exact identity. Empty values are
+    // refused locally, before the create mutation can reach the server.
+    const issuer = dialog.getByLabel('Issuer');
+    const validIssuer = await issuer.inputValue();
+    await issuer.fill('');
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('An issuer is mandatory');
+    expect(createRequests).toBe(0);
+    await issuer.fill(validIssuer);
+
+    const subject = dialog.getByLabel('Subject, matched byte-for-byte');
+    const validSubject = await subject.inputValue();
+    await subject.fill('');
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('A subject is mandatory');
+    expect(createRequests).toBe(0);
+    await subject.fill(validSubject);
 
     await dialog.getByLabel('Event name').selectOption('pull_request_target');
     const refusal = dialog.getByRole('alert');

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1405,6 +1405,18 @@ function BindingDialog({
       );
       return;
     }
+    if (issuer.trim() === '') {
+      setFailure(
+        'An issuer is mandatory because federated bindings match it byte-for-byte. Nothing was bound.',
+      );
+      return;
+    }
+    if (subject.trim() === '') {
+      setFailure(
+        'A subject is mandatory because federated bindings match it byte-for-byte. Nothing was bound.',
+      );
+      return;
+    }
     const pins = pinsOrRefusal();
     if (typeof pins === 'string') {
       setFailure(pins);


### PR DESCRIPTION
Closes #458

## Summary
- refuse blank issuer and subject in the binding form before mutation
- prove each refusal names the field and sends no create request
- record the implementation contract in the issue handoff

## Validation
- `git diff --check`
- local tests deferred before first push due high host memory pressure; exact-head CI required before merge