### PR TITLE
Serialize login authentication ceremonies #459

### DIFF
--- a/docs/handoff/issue-459-auth-ceremony-busy-state.md
+++ b/docs/handoff/issue-459-auth-ceremony-busy-state.md
@@ -1,0 +1,21 @@
+# Handoff: #459 authentication ceremony busy state
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/459. Base:
+`5543b70eae3f3851247ce34f842e976c60ad02cf`.
+
+## Contract
+
+- Password, passkey, and OIDC login share one page-level busy state.
+- While any login mutation is pending, username and password inputs plus every
+  authentication button are disabled.
+- Each method keeps its existing method-specific pending label and error
+  presentation.
+
+## Coverage
+
+- Component tests cover both passkey and OIDC pending states through the
+  rendered login form and require all five available controls to be disabled.
+- Local web validation was deferred before the first push because host swap
+  remained above 89% used. CI validates the initial exact PR head while local
+  validation waits for memory pressure to subside.
+- Generated outputs: none.

--- a/docs/handoff/issue-459-auth-ceremony-busy-state.md
+++ b/docs/handoff/issue-459-auth-ceremony-busy-state.md
@@ -15,6 +15,9 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/459. Base:
 
 - Component tests cover both passkey and OIDC pending states through the
   rendered login form and require all five available controls to be disabled.
+- Browser coverage holds the OIDC start request pending, requires the same five
+  controls to be disabled, and runs the serious/critical axe assertion against
+  that pending state.
 - Local web validation was deferred before the first push because host swap
   remained above 89% used. CI validates the initial exact PR head while local
   validation waits for memory pressure to subside.

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -2,11 +2,12 @@ import { expect, test, type Page } from '@playwright/test';
 
 import {
   expectContrast,
+  expectNoSeriousAxeViolations,
   expectPinnedAssertionSet,
   expectStatusIsTextAndAria,
   measureSurfaceLuminance,
 } from '../fixtures/assertions.ts';
-import { ADMIN } from '../fixtures/instance.ts';
+import { ADMIN, OIDC_PROVIDER } from '../fixtures/instance.ts';
 
 async function expectLoginSurface(page: Page, theme: 'dark' | 'light') {
   await page.emulateMedia({ colorScheme: theme });
@@ -139,6 +140,39 @@ test.describe('login', () => {
       session: Object.entries(globalThis.sessionStorage),
     }));
     expect(JSON.stringify(stored)).not.toContain('hik_1_');
+  });
+
+  test('keeps every login control accessible while an OIDC ceremony is pending', async ({
+    page,
+  }) => {
+    const startPath = `**/api/v1/auth/oidc/${OIDC_PROVIDER.slug}/start`;
+    let releaseStart = () => undefined;
+    const pendingStart = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    await page.route(startPath, async (route) => {
+      await pendingStart;
+      await route.abort();
+    });
+
+    try {
+      await page.goto('/login');
+      const oidc = page.getByRole('button', {
+        name: `Continue with ${OIDC_PROVIDER.displayName}`,
+      });
+      await oidc.click();
+      await expect(oidc).toHaveText('Contacting identity provider…');
+
+      const controls = page.locator('input, button');
+      await expect(controls).toHaveCount(5);
+      for (const control of await controls.all()) {
+        await expect(control).toBeDisabled();
+      }
+      await expectNoSeriousAxeViolations(page);
+    } finally {
+      releaseStart();
+      await page.unroute(startPath);
+    }
   });
 
   // The palette is a dual-theme palette, so conformance is a dual-theme claim:

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page, type Route } from '@playwright/test';
 
 import {
   expectContrast,
@@ -147,13 +147,24 @@ test.describe('login', () => {
   }) => {
     const startPath = `**/api/v1/auth/oidc/${OIDC_PROVIDER.slug}/start`;
     let releaseStart: () => void = () => undefined;
+    let startHandlerActive = false;
+    let finishStartHandler: () => void = () => undefined;
     const pendingStart = new Promise<void>((resolve) => {
       releaseStart = resolve;
     });
-    await page.route(startPath, async (route) => {
-      await pendingStart;
-      await route.abort();
+    const startHandlerFinished = new Promise<void>((resolve) => {
+      finishStartHandler = resolve;
     });
+    const holdStart = async (route: Route) => {
+      startHandlerActive = true;
+      await pendingStart;
+      try {
+        await route.abort();
+      } finally {
+        finishStartHandler();
+      }
+    };
+    await page.route(startPath, holdStart);
 
     try {
       await page.goto('/login');
@@ -161,7 +172,9 @@ test.describe('login', () => {
         name: `Continue with ${OIDC_PROVIDER.displayName}`,
       });
       await oidc.click();
-      await expect(oidc).toHaveText('Contacting identity provider…');
+      await expect(
+        page.getByRole('button', { name: 'Contacting identity provider…' }),
+      ).toBeDisabled();
 
       const controls = page.locator('input, button');
       await expect(controls).toHaveCount(5);
@@ -171,7 +184,8 @@ test.describe('login', () => {
       await expectNoSeriousAxeViolations(page);
     } finally {
       releaseStart();
-      await page.unroute(startPath);
+      if (startHandlerActive) await startHandlerFinished;
+      await page.unroute(startPath, holdStart);
     }
   });
 

--- a/web/e2e/flows/login.spec.ts
+++ b/web/e2e/flows/login.spec.ts
@@ -146,7 +146,7 @@ test.describe('login', () => {
     page,
   }) => {
     const startPath = `**/api/v1/auth/oidc/${OIDC_PROVIDER.slug}/start`;
-    let releaseStart = () => undefined;
+    let releaseStart: () => void = () => undefined;
     const pendingStart = new Promise<void>((resolve) => {
       releaseStart = resolve;
     });

--- a/web/src/routes/Login.oidc.test.tsx
+++ b/web/src/routes/Login.oidc.test.tsx
@@ -5,7 +5,12 @@ import { beforeEach, expect, it, vi } from 'vitest';
 
 import { Login } from './Login.tsx';
 
-const mocks = vi.hoisted(() => ({ oidc: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  login: { mutate: vi.fn(), isPending: false, isError: false },
+  oidc: { mutate: vi.fn(), isPending: false, isError: false },
+  passkey: { mutate: vi.fn(), isPending: false, isError: false },
+  passkeysAvailable: false,
+}));
 
 vi.mock('../api/account.ts', () => ({
   useAuthMethods: () => ({
@@ -21,17 +26,25 @@ vi.mock('../api/account.ts', () => ({
 
 vi.mock('../api/session.ts', () => ({
   loginFailureText: () => 'Sign-in failed.',
-  useLogin: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
-  useOIDCLogin: () => ({ mutate: mocks.oidc, isPending: false, isError: false }),
+  useLogin: () => mocks.login,
+  useOIDCLogin: () => mocks.oidc,
 }));
 
 vi.mock('../api/stepup.ts', () => ({
-  passkeysAvailable: () => false,
+  passkeysAvailable: () => mocks.passkeysAvailable,
   stepUpFailureText: () => 'Passkey failed.',
-  usePasskeyLogin: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  usePasskeyLogin: () => mocks.passkey,
 }));
 
-beforeEach(() => mocks.oidc.mockReset());
+beforeEach(() => {
+  mocks.login.mutate.mockReset();
+  mocks.oidc.mutate.mockReset();
+  mocks.passkey.mutate.mockReset();
+  mocks.login.isPending = false;
+  mocks.oidc.isPending = false;
+  mocks.passkey.isPending = false;
+  mocks.passkeysAvailable = false;
+});
 
 it('offers each configured OIDC provider and starts the selected login', async () => {
   const container = document.createElement('div');
@@ -44,6 +57,26 @@ it('offers each configured OIDC provider and starts the selected login', async (
   expect(button).toBeDefined();
   expect(container.textContent).not.toContain('Continue with SAML SSO');
   await act(async () => button?.click());
-  expect(mocks.oidc).toHaveBeenCalledWith('strict');
+  expect(mocks.oidc.mutate).toHaveBeenCalledWith('strict');
+  await act(async () => root.unmount());
+});
+
+it.each([
+  ['passkey', () => (mocks.passkey.isPending = true)],
+  ['OIDC', () => (mocks.oidc.isPending = true)],
+])('disables every login control while a %s ceremony is pending', async (_method, setPending) => {
+  mocks.passkeysAvailable = true;
+  setPending();
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  await act(async () => root.render(<Login />));
+
+  const controls = container.querySelectorAll<HTMLInputElement | HTMLButtonElement>('input, button');
+  expect(controls.length).toBe(5);
+  for (const control of controls) {
+    expect(control.disabled).toBe(true);
+  }
+
   await act(async () => root.unmount());
 });

--- a/web/src/routes/Login.tsx
+++ b/web/src/routes/Login.tsx
@@ -22,6 +22,7 @@ export function Login() {
   const methods = useAuthMethods();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const busy = login.isPending || passkey.isPending || oidc.isPending;
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -50,6 +51,7 @@ export function Login() {
             name="username"
             autoComplete="username"
             required
+            disabled={busy}
             value={username}
             onChange={(e) => setUsername(e.target.value)}
           />
@@ -63,12 +65,13 @@ export function Login() {
             type="password"
             autoComplete="current-password"
             required
+            disabled={busy}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
         </div>
 
-        <button className="btn btn--primary" type="submit" disabled={login.isPending}>
+        <button className="btn btn--primary" type="submit" disabled={busy}>
           {login.isPending ? 'Signing in…' : 'Sign in'}
         </button>
         {passkeysAvailable() ? (
@@ -80,7 +83,7 @@ export function Login() {
               className="btn"
               type="button"
               onClick={() => passkey.mutate()}
-              disabled={login.isPending || passkey.isPending}
+              disabled={busy}
             >
               {passkey.isPending ? 'Waiting for the passkey…' : 'Use a passkey instead'}
             </button>
@@ -102,7 +105,7 @@ export function Login() {
               type="button"
               key={provider.slug}
               onClick={() => oidc.mutate(provider.slug)}
-              disabled={login.isPending || passkey.isPending || oidc.isPending}
+              disabled={busy}
             >
               {oidc.isPending ? 'Contacting identity provider…' : `Continue with ${provider.display_name}`}
             </button>


### PR DESCRIPTION
Closes #459

## Summary
- derive one busy state across password, passkey, and OIDC login
- disable all login inputs and buttons while any ceremony is pending
- cover pending passkey and OIDC states through the rendered login form

## Validation
- local web tests deferred while host swap remains above 89% used
- CI validates the exact pushed head

## Review
- two-axis Codex standards/spec review in progress; no Opus or Claude used