### PR TITLE
Land authenticated users on Projects #460

### DIFF
--- a/docs/handoff/460-post-login-projects.md
+++ b/docs/handoff/460-post-login-projects.md
@@ -1,0 +1,35 @@
+# Issue #460: post-login projects landing
+
+## State
+
+Implemented in this PR. Authenticated visits to `/login` now land on the real,
+state-aware Projects surface instead of the inert Overview placeholder. The
+deferred Overview dashboard remains unchanged.
+
+## Contract
+
+- An authenticated visit to `/login` redirects to `/projects` with history
+  replacement.
+- The Projects page owns the zero-organisation, zero-project, and populated
+  states.
+- The Overview route remains available from the sidebar pending its dedicated
+  dashboard ticket.
+- The zero-organisation state never renders the stale “choose a project”
+  instruction beside “No organisations yet.”
+
+## Evidence
+
+- `web/e2e/flows/shell.spec.ts` asserts the authenticated `/login` redirect URL
+  and Projects heading.
+- The shell zero-organisation test asserts the stale Overview instruction is
+  absent.
+
+## Validation
+
+Run from the repository root with the pinned Node version:
+
+```sh
+fnm exec --using 26 -- corepack pnpm --dir web run typecheck
+fnm exec --using 26 -- corepack pnpm --dir web run test
+fnm exec --using 26 -- corepack pnpm --dir web exec playwright test web/e2e/flows/shell.spec.ts
+```

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -111,7 +111,7 @@ test.describe('app chrome', () => {
     );
     await page.goto('/login');
     await openNav(page);
-    const notice = page.getByRole('status');
+    const notice = page.getByRole('status').filter({ hasText: 'No organisations yet' });
     await expectStatusIsTextAndAria(page, notice);
     await expect(notice).toContainText('No organisations yet');
     await expect(page.getByText(/choose a project/i)).toHaveCount(0);

--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -68,12 +68,12 @@ test.describe('app chrome', () => {
     await expect(page.getByRole('heading', { name: 'Projects', level: 1 })).toBeVisible();
   });
 
-  test('redirects the public login route to overview with a live session', async ({ page }) => {
+  test('redirects the public login route to projects with a live session', async ({ page }) => {
     await page.goto('/login');
 
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/projects$/);
     await expect(page.getByRole('navigation', { name: 'Organisations' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Projects', level: 1 })).toBeVisible();
   });
 
   test('the binary toggle flips theme and keeps the choice explicit', async ({ page }) => {
@@ -109,11 +109,12 @@ test.describe('app chrome', () => {
         body: JSON.stringify({ items: [], count: 0 }),
       }),
     );
-    await page.reload();
+    await page.goto('/login');
     await openNav(page);
     const notice = page.getByRole('status');
     await expectStatusIsTextAndAria(page, notice);
     await expect(notice).toContainText('No organisations yet');
+    await expect(page.getByText(/choose a project/i)).toHaveCount(0);
     // And no step-up wall: nothing on the navigation surface asks for one.
     await expect(page.getByText(/second factor/i)).toHaveCount(0);
   });

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -158,7 +158,7 @@ export function App() {
         <Routes>
           <Route
             path={surfaceById('login').path}
-            element={<Navigate to={surfaceById('overview').path} replace />}
+            element={<Navigate to={surfaceById('projects').path} replace />}
           />
           {sessionChromelessSurfaces.map((surface) => (
             <Route key={surface.id} path={surface.path} element={ELEMENTS[surface.id]} />


### PR DESCRIPTION
Closes #460

## What changed
- redirect authenticated visits to /login toward /projects
- assert the redirect reaches the real Projects surface
- prove the zero-organisation walk never shows the stale Overview instruction

## Validation
- standards review: CLEAN
- issue #460 spec review: CLEAN
- local typecheck/tests deferred because host swap pressure is 7.46/8.0 GiB; trusted CI is running first