### PR TITLE
Centralize matrix invalidation prefixes #453

### DIFF
--- a/docs/handoff/issue-453-matrix-invalidation-prefixes.md
+++ b/docs/handoff/issue-453-matrix-invalidation-prefixes.md
@@ -1,0 +1,24 @@
+# Handoff: #453 matrix invalidation prefixes
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/453. Base:
+`5543b70eae3f3851247ce34f842e976c60ad02cf`.
+
+## Contract
+
+- `api/keys.ts` owns the project-wide prefixes for values, matrix signals, and
+  pending drafts.
+- Each full environment query key is built from its project-wide prefix, so a
+  prefix rename cannot drift from the corresponding full key.
+- Matrix publish uses the three project-wide builders without changing its
+  intentional all-environment invalidation behavior.
+- Revision restore refreshes values, signals, pending drafts, revision history,
+  and revision pins after success.
+
+## Coverage
+
+- Key tests prove each project-wide key equals the first three elements of its
+  full environment key.
+- Restore-hook coverage proves the exact five cache invalidations.
+- Local validation was deferred before the first push because host memory
+  pressure was high; pull-request CI is the first full runner.
+- Generated outputs: none.

--- a/web/src/api/history-restore.test.tsx
+++ b/web/src/api/history-restore.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { useRestoreRevision } from './history.ts';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function RestoreHarness() {
+  const restore = useRestoreRevision({
+    org: 'org_a',
+    project: 'project_a',
+    environment: 'environment_a',
+  });
+  return (
+    <button type="button" onClick={() => restore.mutate({ revision: 3n })}>
+      Restore
+    </button>
+  );
+}
+
+describe('useRestoreRevision', () => {
+  it('refreshes every matrix and history cache changed by a restore', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify({
+        revision: 3,
+        changes: [],
+        preview: { token: 'preview_token', environments: [] },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )));
+    const { container, client } = await renderForm(<RestoreHarness />);
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => container.querySelector('button')?.click());
+    await settle();
+
+    expect(invalidate.mock.calls.map(([filters]) => filters?.queryKey ?? [])).toEqual([
+      ['values', 'org_a', 'project_a', 'environment_a'],
+      ['matrix-signals', 'org_a', 'project_a'],
+      ['matrix-pending', 'org_a', 'project_a'],
+      ['revisions', 'org_a', 'project_a', 'environment_a'],
+      ['revision-pins', 'org_a', 'project_a', 'environment_a'],
+    ]);
+  });
+});

--- a/web/src/api/history.ts
+++ b/web/src/api/history.ts
@@ -20,9 +20,11 @@ import { z } from 'zod';
 import { ApiError, parsed } from './client.ts';
 import {
   pinsKey,
+  pendingMatrixKey,
   projectRetentionKey,
   revisionDetailKey,
   revisionsKey,
+  signalsMatrixKey,
   valuesKey,
   type EnvRef,
   type MatrixRef,
@@ -237,8 +239,10 @@ export function useRestoreRevision(env: EnvRef) {
     onSuccess: () =>
       Promise.all([
         queries.invalidateQueries({ queryKey: valuesKey(env) }),
-        queries.invalidateQueries({ queryKey: ['matrix-signals', env.org, env.project] }),
-        queries.invalidateQueries({ queryKey: ['matrix-pending', env.org, env.project] }),
+        queries.invalidateQueries({ queryKey: signalsMatrixKey(env) }),
+        queries.invalidateQueries({ queryKey: pendingMatrixKey(env) }),
+        queries.invalidateQueries({ queryKey: revisionsKey(env) }),
+        queries.invalidateQueries({ queryKey: pinsKey(env) }),
       ]),
   });
 }

--- a/web/src/api/keys.test.ts
+++ b/web/src/api/keys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  pendingDraftsKey,
+  pendingMatrixKey,
+  signalsKey,
+  signalsMatrixKey,
+  valuesKey,
+  valuesMatrixKey,
+  type EnvRef,
+} from './keys.ts';
+
+const env: EnvRef = {
+  org: 'org_a',
+  project: 'project_a',
+  environment: 'environment_a',
+};
+
+describe('matrix-wide query keys', () => {
+  it.each([
+    [valuesMatrixKey(env), valuesKey(env)],
+    [signalsMatrixKey(env), signalsKey(env, env.environment)],
+    [pendingMatrixKey(env), pendingDraftsKey(env, env.environment)],
+  ])('matches the full query key prefix', (matrixKey, fullKey) => {
+    expect(matrixKey).toEqual(fullKey.slice(0, 3));
+  });
+});

--- a/web/src/api/keys.ts
+++ b/web/src/api/keys.ts
@@ -3,8 +3,10 @@ import type { QueryClient } from '@tanstack/react-query';
 export type EnvRef = { org: string; project: string; environment: string };
 export type MatrixRef = { readonly org: string; readonly project: string };
 
+export const valuesMatrixKey = (ref: MatrixRef) =>
+  ['values', ref.org, ref.project] as const;
 export const valuesKey = (env: EnvRef) =>
-  ['values', env.org, env.project, env.environment] as const;
+  [...valuesMatrixKey(env), env.environment] as const;
 export const windowKey = (env: EnvRef) =>
   ['reveal-window', env.org, env.project, env.environment] as const;
 export const revisionsKey = (env: EnvRef) =>
@@ -21,10 +23,14 @@ export const matrixKeysKey = (ref: MatrixRef) =>
   ['matrix-keys', ref.org, ref.project] as const;
 export const matrixGroupsKey = (ref: MatrixRef) =>
   ['matrix-groups', ref.org, ref.project] as const;
+export const signalsMatrixKey = (ref: MatrixRef) =>
+  ['matrix-signals', ref.org, ref.project] as const;
 export const signalsKey = (ref: MatrixRef, environment: string) =>
-  ['matrix-signals', ref.org, ref.project, environment] as const;
+  [...signalsMatrixKey(ref), environment] as const;
+export const pendingMatrixKey = (ref: MatrixRef) =>
+  ['matrix-pending', ref.org, ref.project] as const;
 export const pendingDraftsKey = (ref: MatrixRef, environment: string) =>
-  ['matrix-pending', ref.org, ref.project, environment] as const;
+  [...pendingMatrixKey(ref), environment] as const;
 
 /** Every cache whose destination-owned state changes after a successful copy. */
 export function copyInvalidationKeys(

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -31,10 +31,13 @@ import {
   matrixGroupsKey,
   matrixKeysKey,
   pendingDraftsKey,
+  pendingMatrixKey,
   pinsKey,
   revisionsKey,
   signalsKey,
+  signalsMatrixKey,
   valuesKey,
+  valuesMatrixKey,
   windowKey,
   type MatrixRef,
 } from './keys.ts';
@@ -671,9 +674,9 @@ export function usePublishMatrix(ref: MatrixRef) {
     onSuccess: (result, input) => {
       forgetRestorePreviews(ref, input.versionIds);
       return Promise.all([
-        queries.invalidateQueries({ queryKey: ['values', ref.org, ref.project] }),
-        queries.invalidateQueries({ queryKey: ['matrix-signals', ref.org, ref.project] }),
-        queries.invalidateQueries({ queryKey: ['matrix-pending', ref.org, ref.project] }),
+        queries.invalidateQueries({ queryKey: valuesMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: signalsMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: pendingMatrixKey(ref) }),
         ...result.environments.flatMap((published) => {
           const env = { ...ref, environment: published.environment_id };
           return [


### PR DESCRIPTION
## Summary
- centralize project-wide values, signals, and pending-draft query keys
- use those builders after matrix publish and history restore
- refresh revision history and pins after restore
- add key-prefix and restore invalidation coverage

## Validation
- staged diff passed standards and issue-spec review
- local tests deferred before first push because host memory pressure is high; CI is the first runner

Closes #453