### PR TITLE
Stage definitions-source changes behind Apply #455

### DIFF
--- a/docs/handoff/455-staged-definitions-source.md
+++ b/docs/handoff/455-staged-definitions-source.md
@@ -1,0 +1,19 @@
+# Issue #455 — staged definitions-source governance
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/455
+
+## Contract
+
+- Changing the Definitions source selector stages a local choice and performs no write.
+- `Apply definitions source` is enabled only when the staged choice differs from saved settings
+  and no mutation is pending.
+- Applying sends the existing definitions-settings mutation once. Query invalidation resynchronises
+  the staged choice from the saved server response.
+- The Git-mode notice continues to describe saved policy, not an unapplied staged choice.
+
+## Coverage
+
+- The project-settings component test pins no mutation on selection and one exact Git payload on
+  Apply.
+- The browser settings flow now applies the staged choice before checking persisted Git policy.
+- API contracts and generated outputs are unchanged.

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -431,6 +431,8 @@ test.describe('project settings', () => {
       // project-settings remains capable of changing its own governance mode.
       await persistedSource.selectOption('db');
       await expect(persistedSource).toHaveValue('db');
+      await expect(persistedNotice).toBeVisible();
+      await persistedPolicy.getByRole('button', { name: 'Apply definitions source' }).click();
       await expect(persistedNotice).toHaveCount(0);
       await page.reload();
       await expect(page.locator('#project-policy').getByLabel('Definitions source')).toHaveValue(

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -384,6 +384,7 @@ test.describe('project settings', () => {
 
       // Select by contract value: labels are presentation and may be localised.
       await source.selectOption('git');
+      await policy.getByRole('button', { name: 'Apply definitions source' }).click();
       const gitNotice = policy.getByRole('alert').filter({
         hasText:
           'Definitions for this project are managed in Git — changes arrive through `definitions plan` / `definitions apply`.',

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AuthProvider } from '../app/AuthProvider.tsx';
 import { created, renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
 import { NewEnvironmentForm, ProjectSettings } from './ProjectSettings.tsx';
 
@@ -69,6 +70,9 @@ describe('definitions policy', () => {
       const input = args[0];
       const request = input instanceof Request ? input : new Request(input);
       const path = new URL(request.url, 'http://localhost').pathname;
+      if (request.method === 'GET' && path === '/api/v1/auth/whoami') {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
       if (
         request.method === 'PUT' &&
         path === '/api/v1/orgs/org_1/projects/project_1/definitions/settings'
@@ -86,11 +90,13 @@ describe('definitions policy', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const view = await renderForm(
-      <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
-        <Routes>
-          <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
-        </Routes>
-      </MemoryRouter>,
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
+          <Routes>
+            <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
     );
 
     try {

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
 import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { created, renderForm, settle, typeInto } from '../testkit/renderForm.tsx';
-import { NewEnvironmentForm } from './ProjectSettings.tsx';
+import { created, renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { NewEnvironmentForm, ProjectSettings } from './ProjectSettings.tsx';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -60,3 +61,148 @@ describe('NewEnvironmentForm', () => {
     expect(status?.textContent).toContain('Environment staging created.');
   });
 });
+
+describe('definitions policy', () => {
+  it('stages the selected source until Apply sends one mutation', async () => {
+    let savedDefinitionsSource: 'db' | 'git' = 'db';
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const input = args[0];
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url, 'http://localhost').pathname;
+      if (
+        request.method === 'PUT' &&
+        path === '/api/v1/orgs/org_1/projects/project_1/definitions/settings'
+      ) {
+        savedDefinitionsSource = 'git';
+      }
+      const json = settingsResponse(request.method, path, savedDefinitionsSource);
+      return Promise.resolve(
+        new Response(JSON.stringify(json), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = await renderForm(
+      <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
+        <Routes>
+          <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    try {
+      await settleTask();
+      const source = labelledSelect(view.container, 'Definitions source');
+      const apply = button(view.container, 'Apply definitions source');
+
+      expect(source.value).toBe('db');
+      expect(apply.disabled).toBe(true);
+
+      await act(async () => {
+        selectOption(source, 'git');
+      });
+
+      expect(source.value).toBe('git');
+      expect(apply.disabled).toBe(false);
+      expect(definitionsWrites(fetchMock.mock.calls)).toHaveLength(0);
+
+      await act(async () => {
+        apply.click();
+      });
+      await settleTask();
+
+      const writes = definitionsWrites(fetchMock.mock.calls);
+      expect(writes).toHaveLength(1);
+      const write = writes[0];
+      if (write === undefined) {
+        throw new Error('the definitions mutation is missing');
+      }
+      expect(write.method).toBe('PUT');
+      expect(await write.json()).toEqual({ definitions_source: 'git' });
+      expect(source.value).toBe('git');
+      expect(apply.disabled).toBe(true);
+    } finally {
+      await view.unmount();
+    }
+  });
+});
+
+function settingsResponse(
+  method: string,
+  path: string,
+  definitionsSource: 'db' | 'git',
+): unknown {
+  const projectPath = '/api/v1/orgs/org_1/projects/project_1';
+  if (method === 'GET' && path === projectPath) {
+    return {
+      id: 'prj_123e4567-e89b-12d3-a456-426614174000',
+      org_id: 'org_123e4567-e89b-12d3-a456-426614174001',
+      name: 'project_1',
+      created_at: '2026-01-01T00:00:00Z',
+    };
+  }
+  if (method === 'GET' && path === `${projectPath}/environments`) {
+    return { items: [], count: 0 };
+  }
+  if (method === 'GET' && path === '/api/v1/orgs/org_1/retention') {
+    return { mode: 'keep-if-either', max_age_seconds: 7_776_000, last_revisions: 10 };
+  }
+  if (method === 'GET' && path === `${projectPath}/retention`) {
+    return {
+      inherited: true,
+      mode: 'keep-if-either',
+      max_age_seconds: 7_776_000,
+      last_revisions: 10,
+    };
+  }
+  if (
+    (method === 'GET' || method === 'PUT') &&
+    path === `${projectPath}/definitions/settings`
+  ) {
+    return { definitions_source: definitionsSource };
+  }
+  throw new Error(`unexpected ${method} ${path}`);
+}
+
+function labelledSelect(container: HTMLElement, text: string): HTMLSelectElement {
+  const label = [...container.querySelectorAll('label')].find(
+    (candidate) => candidate.textContent === text,
+  );
+  const select = label?.htmlFor === undefined ? null : container.querySelector(`#${label.htmlFor}`);
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error(`${text} select is missing`);
+  }
+  return select;
+}
+
+function button(container: HTMLElement, text: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+  if (!(match instanceof HTMLButtonElement)) {
+    throw new Error(`${text} button is missing`);
+  }
+  return match;
+}
+
+function selectOption(select: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+  if (setter === undefined) {
+    throw new Error('HTMLSelectElement exposes no value setter');
+  }
+  setter.call(select, value);
+  select.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function definitionsWrites(calls: readonly Parameters<typeof fetch>[]): Request[] {
+  return calls.flatMap(([input]) => {
+    const request = input instanceof Request ? input : new Request(input);
+    return request.method === 'PUT' &&
+      new URL(request.url, 'http://localhost').pathname.endsWith('/definitions/settings')
+      ? [request]
+      : [];
+  });
+}

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -171,7 +171,7 @@ export function ProjectSettings() {
           <DefinitionsPolicy
             settings={definitionsSettings.data}
             busy={setDefinitionsSettings.isPending}
-            onChange={(source) =>
+            onApply={(source) =>
               setDefinitionsSettings.mutate(source, {
                 onSuccess: (result) =>
                   feedback.ok(
@@ -271,23 +271,29 @@ export function ProjectSettings() {
 function DefinitionsPolicy({
   settings,
   busy,
-  onChange,
+  onApply,
 }: {
   settings: DefinitionsSettings;
   busy: boolean;
-  onChange: (source: DefinitionsSettings['definitions_source']) => void;
+  onApply: (source: DefinitionsSettings['definitions_source']) => void;
 }) {
   const sourceId = useId();
+  const [source, setSource] = useState(settings.definitions_source);
   const lastApply = settings.last_apply;
+
+  useEffect(() => {
+    setSource(settings.definitions_source);
+  }, [settings.definitions_source]);
+
   return (
     <div className="settings-block">
       <div className="field">
         <label htmlFor={sourceId}>Definitions source</label>
         <select
           id={sourceId}
-          value={settings.definitions_source}
+          value={source}
           disabled={busy}
-          onChange={(event) => onChange(parseDefinitionsSource(event.currentTarget.value))}
+          onChange={(event) => setSource(parseDefinitionsSource(event.currentTarget.value))}
         >
           <option value="db">Database</option>
           <option value="git">Git</option>
@@ -297,6 +303,16 @@ function DefinitionsPolicy({
           <span className="mono">definitions plan</span> /{' '}
           <span className="mono">definitions apply</span>. Values remain editable in either mode.
         </p>
+      </div>
+      <div className="panel__actions">
+        <button
+          type="button"
+          className="btn"
+          disabled={busy || source === settings.definitions_source}
+          onClick={() => onApply(source)}
+        >
+          Apply definitions source
+        </button>
       </div>
       {settings.definitions_source === 'git' ? <Alert>{GIT_DEFINITIONS_NOTICE}</Alert> : null}
       {lastApply === undefined ? null : (


### PR DESCRIPTION
## Summary

- stage Definitions source changes locally until explicit Apply
- resynchronise staged state after saved settings refetch
- cover no-write-before-Apply and persisted Git settings flow

## Validation

- `git diff --cached --check` passed before commit
- standards review round 2: CLEAN
- specification review: CLEAN
- local tests deferred while host memory pressure remains high; CI started on pushed head

Closes #455