### PR TITLE
Add copy controls for display-once account secrets #454

### DIFF
--- a/docs/handoff/issue-454-display-once-copy.md
+++ b/docs/handoff/issue-454-display-once-copy.md
@@ -19,7 +19,8 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/454. Base:
   clipboard payloads, success feedback, refusal feedback, and unchanged storage
   gate.
 - Local execution was deferred before the first push because host memory
-  pressure was high. Run the focused web test, web typecheck, lint, and the full
-  repository suite before merge when pressure subsides; exact-head CI remains
-  authoritative.
+  pressure was high. After pressure subsided, the focused component test passed
+  3/3, the full web suite passed 343/343 across 45 files, TypeScript typechecking
+  passed, and the production Vite build passed. The web package has no ESLint
+  script; exact-head CI remains authoritative for repository gates.
 - Generated outputs: none.

--- a/docs/handoff/issue-454-display-once-copy.md
+++ b/docs/handoff/issue-454-display-once-copy.md
@@ -1,0 +1,25 @@
+# Handoff: #454 display-once secret copy
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/454. Base:
+`5543b70eae3f3851247ce34f842e976c60ad02cf`.
+
+## Contract
+
+- The TOTP enrolment URI and regenerated recovery codes have local `Copy`
+  controls while their display-once values are visible.
+- TOTP copies the exact `otpauth` URI. Recovery codes copy as one code per line.
+- Both controls use `app/clipboard.ts`; missing or blocked browser clipboard
+  access becomes an operator-visible refusal instead of an uncaught error.
+- Copy success does not acknowledge storage. Recovery-code dismissal remains
+  blocked until the operator explicitly checks the existing storage gate.
+
+## Coverage
+
+- Account-security component coverage checks the exact recovery-code and TOTP
+  clipboard payloads, success feedback, refusal feedback, and unchanged storage
+  gate.
+- Local execution was deferred before the first push because host memory
+  pressure was high. Run the focused web test, web typecheck, lint, and the full
+  repository suite before merge when pressure subsides; exact-head CI remains
+  authoritative.
+- Generated outputs: none.

--- a/web/src/routes/AccountSecurity.display-once-copy.test.tsx
+++ b/web/src/routes/AccountSecurity.display-once-copy.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle, typeInto } from '../testkit/renderForm.tsx';
+import { AccountSecurity } from './AccountSecurity.tsx';
+
+const mocks = vi.hoisted(() => ({
+  regenerate: vi.fn(),
+  startTotp: vi.fn(),
+  totpFetching: false,
+  writeClipboard: vi.fn(),
+}));
+
+vi.mock('../app/clipboard.ts', () => ({ writeClipboard: mocks.writeClipboard }));
+
+vi.mock('../app/AuthProvider.tsx', () => ({
+  useAuth: () => ({
+    identity: {
+      principal: { id: 'acc_test', display_name: 'Test account' },
+      session: { assurance: { factors: ['password'] } },
+    },
+  }),
+}));
+
+vi.mock('../app/theme.ts', () => ({
+  themeLabel: (choice: string) => choice,
+  useThemeChoice: () => ['system', vi.fn()],
+}));
+
+vi.mock('../app/notifications.tsx', () => ({
+  clearNotification: vi.fn(),
+  notifyFailure: vi.fn(),
+}));
+
+vi.mock('../api/oidcChannel.ts', () => ({ rememberOIDCReturn: vi.fn() }));
+
+vi.mock('../api/remotes.ts', () => ({
+  useRevokeSession: () => ({ isPending: false, mutate: vi.fn() }),
+  useSessions: () => ({
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+    data: { items: [] },
+  }),
+}));
+
+vi.mock('../api/account.ts', () => {
+  const mutation = () => ({ isPending: false, mutate: vi.fn() });
+  return {
+    accountFailureText: () => 'Account change refused.',
+    useAuthMethods: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      data: { providers: [] },
+    }),
+    useConfirmTotp: mutation,
+    useEnrolPasskey: mutation,
+    useEnrolTotpStart: () => ({ isPending: false, mutate: mocks.startTotp }),
+    useIdentities: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      data: { identities: [] },
+    }),
+    useLinkIdentity: mutation,
+    usePasskeys: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      data: { passkeys: [] },
+    }),
+    useRegenerateRecoveryCodes: () => ({ isPending: false, mutate: mocks.regenerate }),
+    useRemovePasskey: mutation,
+    useRemoveTotp: mutation,
+    useTotpStatus: () => ({
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      isFetching: mocks.totpFetching,
+      data: { confirmed: false, pending: false },
+    }),
+    useUnlinkIdentity: mutation,
+  };
+});
+
+afterEach(() => {
+  mocks.totpFetching = false;
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === name,
+  );
+  if (button === undefined) {
+    throw new Error(`button ${name} is missing`);
+  }
+  return button;
+}
+
+async function submitProof(container: HTMLElement): Promise<void> {
+  const input = container.querySelector('dialog input[type="password"]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('proof input is missing');
+  }
+  const form = input.closest('form');
+  if (!(form instanceof HTMLFormElement)) {
+    throw new Error('proof form is missing');
+  }
+  await act(async () => typeInto(input, 'existing-password'));
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+  await settle();
+}
+
+describe('display-once account secrets', () => {
+  it('copies recovery codes as newline-separated text and announces success', async () => {
+    mocks.regenerate.mockImplementation(
+      (
+        _input: { proof: string },
+        options: { onSuccess: (result: { recovery_codes: readonly string[] }) => void },
+      ) => options.onSuccess({ recovery_codes: ['recover-one', 'recover-two'] }),
+    );
+    mocks.writeClipboard.mockResolvedValue('ok');
+
+    const { container } = await renderForm(<AccountSecurity />);
+    await act(async () => buttonNamed(container, 'Replace recovery codes').click());
+    await submitProof(container);
+    await act(async () => buttonNamed(container, 'Copy').click());
+    await settle();
+
+    expect(mocks.writeClipboard).toHaveBeenCalledWith('recover-one\nrecover-two');
+    expect(container.textContent).toContain('Recovery codes copied.');
+  });
+
+  it('keeps recovery-code storage unconfirmed when clipboard access is refused', async () => {
+    mocks.regenerate.mockImplementation(
+      (
+        _input: { proof: string },
+        options: { onSuccess: (result: { recovery_codes: readonly string[] }) => void },
+      ) => options.onSuccess({ recovery_codes: ['recover-only'] }),
+    );
+    mocks.writeClipboard.mockResolvedValue('refused');
+
+    const { container } = await renderForm(<AccountSecurity />);
+    await act(async () => buttonNamed(container, 'Replace recovery codes').click());
+    await submitProof(container);
+    await act(async () => buttonNamed(container, 'Copy').click());
+    await settle();
+
+    expect(container.textContent).toContain(
+      'This browser refused clipboard access, so nothing was copied.',
+    );
+    expect(buttonNamed(container, 'Done').disabled).toBe(true);
+  });
+
+  it('copies the exact display-once authenticator URI', async () => {
+    const uri = 'otpauth://totp/Hikyo:test?secret=SEED&issuer=Hikyo';
+    mocks.startTotp.mockImplementation(
+      (
+        _input: { password: string },
+        options: { onSuccess: (result: { otpauth_uri: string }) => void },
+      ) => {
+        mocks.totpFetching = true;
+        options.onSuccess({ otpauth_uri: uri });
+      },
+    );
+    mocks.writeClipboard.mockResolvedValue('ok');
+
+    const { container } = await renderForm(<AccountSecurity />);
+    await act(async () => buttonNamed(container, 'Enrol an authenticator').click());
+    await submitProof(container);
+    await act(async () => buttonNamed(container, 'Copy').click());
+    await settle();
+
+    expect(mocks.writeClipboard).toHaveBeenCalledWith(uri);
+    expect(container.textContent).toContain('Authenticator setup copied.');
+  });
+});

--- a/web/src/routes/AccountSecurity.tsx
+++ b/web/src/routes/AccountSecurity.tsx
@@ -19,6 +19,7 @@ import {
 import { rememberOIDCReturn } from '../api/oidcChannel.ts';
 import { useRevokeSession, useSessions, type ActiveSession } from '../api/remotes.ts';
 import { useAuth } from '../app/AuthProvider.tsx';
+import { writeClipboard } from '../app/clipboard.ts';
 import { themeLabel, useThemeChoice, type ThemeChoice } from '../app/theme.ts';
 import { clearNotification, notifyFailure } from '../app/notifications.tsx';
 import { Alert, Done, JumpIndex, Panel } from './Sections.tsx';
@@ -308,6 +309,10 @@ export function AccountSecurity() {
               the new factor separately.
             </p>
             <p className="enrolment__uri mono">{otpauth}</p>
+            <DisplayOnceCopy
+              value={otpauth}
+              success="Authenticator setup copied. Store it somewhere safe; clipboard history may retain it."
+            />
             <div className="field">
               <label htmlFor={codeId}>Code from the authenticator</label>
               <input
@@ -653,6 +658,10 @@ function RecoveryCodes({ codes, onClose }: { codes: readonly string[]; onClose: 
           </li>
         ))}
       </ul>
+      <DisplayOnceCopy
+        value={codes.join('\n')}
+        success="Recovery codes copied. Store them somewhere safe; clipboard history may retain them."
+      />
       {cancelAttempted ? (
         <Alert>
           These codes cannot be dismissed yet. Store them, then acknowledge that below; the
@@ -674,6 +683,39 @@ function RecoveryCodes({ codes, onClose }: { codes: readonly string[]; onClose: 
         </button>
       </div>
     </dialog>
+  );
+}
+
+function DisplayOnceCopy({ value, success }: { value: string; success: string }) {
+  const [status, setStatus] = useState<string | null>(null);
+
+  return (
+    <>
+      <div className="panel__actions">
+        <button
+          type="button"
+          className="btn"
+          onClick={async () => {
+            const result = await writeClipboard(value);
+            setStatus(
+              result === 'ok'
+                ? success
+                : 'This browser refused clipboard access, so nothing was copied.',
+            );
+          }}
+        >
+          Copy
+        </button>
+      </div>
+      {status === null ? null : (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            ⧉
+          </span>
+          <span>{status}</span>
+        </p>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #454

- copy TOTP setup URI through shared safe clipboard boundary
- copy recovery codes as newline-separated text
- show local success/refusal feedback without changing stored acknowledgement
- cover exact payloads, refusal behavior, and unchanged gate

Local execution is deferred until host memory pressure subsides. Exact-head CI has started.