### PR TITLE
Dismiss account menu with standard focus behavior #462

### DIFF
--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 import {
+  expectNoSeriousAxeViolations,
   expectPinnedAssertionSet,
   expectStatusIsTextAndAria,
 } from '../fixtures/assertions.ts';
@@ -90,6 +91,21 @@ test.describe('app chrome', () => {
     // The choice survives a reload: it is a decision, not a session mood.
     await page.reload();
     await expect(page.locator('html')).toHaveAttribute('data-theme', second ?? '');
+  });
+
+  test('Escape dismisses the account menu and restores focus', async ({ page }) => {
+    const account = page.getByRole('button', { name: /^Account:/ });
+    await account.click();
+
+    await expect(account).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByRole('menuitem', { name: 'Sign out' })).toBeFocused();
+    await expectNoSeriousAxeViolations(page);
+
+    await page.keyboard.press('Escape');
+
+    await expect(account).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByRole('menu', { name: 'Account' })).toHaveCount(0);
+    await expect(account).toBeFocused();
   });
 
   // The rail's zero state remains a real supported state even though the

--- a/web/src/routes/Shell.account.test.tsx
+++ b/web/src/routes/Shell.account.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WhoAmI } from '../api/session.ts';
+import { AccountEntry } from './Shell.tsx';
+
+vi.mock('../api/session.ts', async (importOriginal) => {
+  const session = await importOriginal<typeof import('../api/session.ts')>();
+  return {
+    ...session,
+    useLogout: () => ({ isPending: false, mutate: vi.fn() }),
+  };
+});
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const session: WhoAmI = {
+  session: {
+    id: 'ses_123e4567-e89b-12d3-a456-426614174000',
+    artifact: 'browser',
+    created_at: '2026-08-24T08:00:00Z',
+    idle_expires_at: '2026-08-24T08:30:00Z',
+    absolute_expires_at: '2026-08-24T16:00:00Z',
+    assurance: {
+      method: 'local-password',
+      factors: ['password'],
+      authenticated_at: '2026-08-24T08:00:00Z',
+    },
+  },
+  principal: {
+    id: 'prn_123e4567-e89b-12d3-a456-426614174000',
+    kind: 'human',
+    display_name: 'Alice Example',
+  },
+};
+
+function accountButton(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector('button[aria-haspopup="menu"]');
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('account entry has no menu trigger');
+  }
+  return button;
+}
+
+function signOutButton(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector('[role="menuitem"]');
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('account menu has no sign-out item');
+  }
+  return button;
+}
+
+async function renderAccountEntry(): Promise<{
+  container: HTMLDivElement;
+  trigger: HTMLButtonElement;
+  unmount: () => Promise<void>;
+}> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <AccountEntry session={session} updateVersions={[]} />
+      </MemoryRouter>,
+    );
+  });
+
+  return {
+    container,
+    trigger: accountButton(container),
+    unmount: async () => act(async () => root.unmount()),
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('account menu', () => {
+  it('moves focus into the menu, then Escape closes it and restores the trigger', async () => {
+    const { container, trigger, unmount } = await renderAccountEntry();
+    await act(async () => trigger.click());
+
+    const signOut = signOutButton(container);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(signOut);
+
+    await act(async () => {
+      signOut.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+    });
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+
+    await unmount();
+  });
+
+  it('closes when a pointer press starts outside the account entry', async () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'Outside';
+    document.body.append(outside);
+    const { container, trigger, unmount } = await renderAccountEntry();
+    await act(async () => trigger.click());
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+
+    await act(async () => {
+      outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    });
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await unmount();
+  });
+
+  it('closes when focus leaves the account entry without a pointer press', async () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'Outside';
+    document.body.append(outside);
+    const { container, trigger, unmount } = await renderAccountEntry();
+    await act(async () => trigger.click());
+    expect(document.activeElement).toBe(signOutButton(container));
+
+    await act(async () => outside.focus());
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await unmount();
+  });
+});

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { generatePath, matchPath, NavLink, Outlet, useLocation, useNavigate } from 'react-router';
 
 import { useLogout, useOrgs, type WhoAmI } from '../api/session.ts';
@@ -279,7 +279,7 @@ export function Shell({ session }: { session: WhoAmI }) {
   );
 }
 
-function AccountEntry({
+export function AccountEntry({
   session,
   updateVersions,
 }: {
@@ -287,14 +287,55 @@ function AccountEntry({
   updateVersions: readonly string[];
 }) {
   const [open, setOpen] = useState(false);
+  const entryRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuItemRef = useRef<HTMLButtonElement>(null);
   const logout = useLogout();
+  const location = useLocation();
   const name = session.principal.display_name ?? session.principal.id;
 
+  useEffect(() => setOpen(false), [location.pathname]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    menuItemRef.current?.focus();
+    const dismissOutside = (event: PointerEvent) => {
+      const entry = entryRef.current;
+      if (entry !== null && !event.composedPath().includes(entry)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', dismissOutside);
+    return () => document.removeEventListener('pointerdown', dismissOutside);
+  }, [open]);
+
   return (
-    <div className="account-entry">
+    <div
+      className="account-entry"
+      ref={entryRef}
+      onBlur={(event) => {
+        const next = event.relatedTarget;
+        if (!(next instanceof Node) || !event.currentTarget.contains(next)) {
+          setOpen(false);
+        }
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape' || !open) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }}
+    >
       <button
         type="button"
         className="avatar"
+        ref={triggerRef}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`Account: ${name}${updateVersions.length === 0 ? '' : `; ${updateVersions.length} update${updateVersions.length === 1 ? '' : 's'} available`}`}
@@ -307,13 +348,14 @@ function AccountEntry({
       </button>
       {open ? (
         <div className="menu" role="menu" aria-label="Account">
-          <p className="menu__label">
+          <p className="menu__label" role="none">
             Signed in as <span className="mono">{name}</span>
           </p>
           <button
             type="button"
             role="menuitem"
             className="menu__item"
+            ref={menuItemRef}
             onClick={() => logout.mutate()}
             disabled={logout.isPending}
           >


### PR DESCRIPTION
## Summary

- move focus into the account menu when it opens
- dismiss on Escape, outside pointer press, focus exit, and route changes
- restore trigger focus after Escape and cover the open state with axe

## Validation

- `pnpm --dir web exec vitest run src/routes/Shell.account.test.tsx`
- `pnpm --dir web test` (343 tests)
- `pnpm --dir web run typecheck`
- `pnpm --dir web run build`

Closes #462