### PR TITLE
Polish frontend loading and accessibility states #463

### DIFF
--- a/docs/handoff/issue-463-frontend-a11y-loading-polish.md
+++ b/docs/handoff/issue-463-frontend-a11y-loading-polish.md
@@ -1,0 +1,26 @@
+# Handoff: #463 frontend accessibility and loading-state polish
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/463. Base:
+`5543b70e48ebcf5043b69ec2457b6c954091e538`.
+
+## Contract
+
+- The members list announces `Loading members…` only while its grants query is
+  pending; its existing loaded-empty status and table remain unchanged.
+- The organisation retention panel announces `Loading the retention policy…`
+  only while its retention query is pending; the error and editor branches stay
+  mutually exclusive with that state.
+- The organisation Name input references its explanatory hint through
+  `aria-describedby` and a `useId`-derived hint id.
+- A pending revoke marks and disables only the button whose grant id matches the
+  TanStack mutation variables. Other revoke buttons remain available.
+- The acting revoke button exposes `Revoking…`, a matching accessible name, and
+  `aria-busy="true"`; no API or server contract changes.
+
+## Coverage
+
+- `web/src/routes/AccessibilityPolish.test.tsx` exercises all four behaviors at
+  the rendered accessible-DOM seam.
+- The tests cover pending-to-loaded rendering for both reads, resolved hint
+  association, and two sibling revoke actions with one in flight.
+- Generated outputs: none.

--- a/docs/handoff/issue-463-frontend-a11y-loading-polish.md
+++ b/docs/handoff/issue-463-frontend-a11y-loading-polish.md
@@ -1,7 +1,7 @@
 # Handoff: #463 frontend accessibility and loading-state polish
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/463. Base:
-`5543b70e48ebcf5043b69ec2457b6c954091e538`.
+`5543b70eae3f3851247ce34f842e976c60ad02cf`.
 
 ## Contract
 

--- a/web/src/routes/AccessibilityPolish.test.tsx
+++ b/web/src/routes/AccessibilityPolish.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment happy-dom
+import { act, type ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Grant } from '../api/identities.ts';
+import type { RetentionPolicy } from '../api/settings.ts';
+import { renderForm } from '../testkit/renderForm.tsx';
+import { Members } from './Members.tsx';
+import { OrgSettings } from './OrgSettings.tsx';
+
+type RouteMocks = {
+  grants: {
+    data: { items: Grant[]; count: number } | undefined;
+    error: null;
+    isError: boolean;
+    isPending: boolean;
+    isSuccess: boolean;
+    refetch: ReturnType<typeof vi.fn>;
+  };
+  org: {
+    data: { id: string; name: string; active: boolean; created_at: string };
+    isError: boolean;
+  };
+  projects: {
+    data: { items: never[]; count: number };
+    isError: boolean;
+    isPending: boolean;
+    isSuccess: boolean;
+  };
+  retention: {
+    data: RetentionPolicy | undefined;
+    isError: boolean;
+    isPending: boolean;
+  };
+  topology: {
+    projects: never[];
+    isError: boolean;
+    isPending: boolean;
+    ready: boolean;
+  };
+};
+
+const mocks = vi.hoisted<RouteMocks>(() => ({
+  grants: {
+    data: undefined,
+    error: null,
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+    refetch: vi.fn(),
+  },
+  org: {
+    data: {
+      id: 'org_acme',
+      name: 'Acme',
+      active: true,
+      created_at: '2026-08-24T08:00:00Z',
+    },
+    isError: false,
+  },
+  projects: {
+    data: { items: [], count: 0 },
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+  },
+  retention: {
+    data: undefined,
+    isError: false,
+    isPending: true,
+  },
+  topology: {
+    projects: [],
+    isError: false,
+    isPending: false,
+    ready: true,
+  },
+}));
+
+vi.mock('../api/access.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/access.ts')>();
+  const { useState } = await import('react');
+  return {
+    ...actual,
+    useOrgGrants: () => mocks.grants,
+    useRevokeGrant: () => {
+      const [variables, setVariables] = useState<{ grant: Grant }>();
+      const [isPending, setIsPending] = useState(false);
+      return {
+        isPending,
+        variables,
+        mutate: (input: { grant: Grant }) => {
+          setVariables(input);
+          setIsPending(true);
+        },
+      };
+    },
+  };
+});
+
+vi.mock('../api/settings.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/settings.ts')>();
+  return {
+    ...actual,
+    useDeleteOrg: () => ({ isPending: false, mutate: vi.fn() }),
+    useOrg: () => mocks.org,
+    useOrgRetention: () => mocks.retention,
+    useOrgTopology: () => mocks.topology,
+    useProjectRetentions: () => new Map(),
+    useProjects: () => mocks.projects,
+    useRenameOrg: () => ({ isPending: false, mutate: vi.fn() }),
+    useSetOrgRetention: () => ({ isPending: false, mutate: vi.fn() }),
+  };
+});
+
+vi.mock('../app/AuthProvider.tsx', () => ({
+  useAuth: () => ({ identity: { principal: { id: 'usr_current' } } }),
+}));
+
+const grants: readonly Grant[] = [
+  {
+    id: 'grn_edit',
+    principal_id: 'usr_alice',
+    capability: 'edit',
+    scope: { org_id: 'org_acme' },
+    origins: [{ kind: 'manual', subject: 'usr_admin' }],
+    created_at: '2026-08-24T08:00:00Z',
+  },
+  {
+    id: 'grn_reveal',
+    principal_id: 'usr_alice',
+    capability: 'reveal',
+    scope: { org_id: 'org_acme' },
+    origins: [{ kind: 'manual', subject: 'usr_admin' }],
+    created_at: '2026-08-24T08:00:00Z',
+  },
+];
+
+beforeEach(() => {
+  mocks.grants = {
+    data: undefined,
+    error: null,
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+    refetch: vi.fn(),
+  };
+  mocks.retention = {
+    data: undefined,
+    isError: false,
+    isPending: true,
+  };
+});
+
+function atRoute(path: string, pattern: string, node: ReactNode) {
+  return (
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={pattern} element={node} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+async function renderMembers() {
+  return renderForm(atRoute('/orgs/org_acme/members', '/orgs/:org/members', <Members />));
+}
+
+async function renderOrgSettings() {
+  return renderForm(
+    atRoute('/orgs/org_acme/settings', '/orgs/:org/settings', <OrgSettings />),
+  );
+}
+
+describe('Members accessibility polish', () => {
+  it('announces the initial list load only while grants are pending', async () => {
+    const pending = await renderMembers();
+    expect(pending.container.querySelector('#members-list [role="status"]')?.textContent).toBe(
+      'Loading members…',
+    );
+    await pending.unmount();
+
+    mocks.grants = {
+      data: { items: [...grants], count: grants.length },
+      error: null,
+      isError: false,
+      isPending: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    };
+    const loaded = await renderMembers();
+
+    expect(loaded.container.querySelector('#members-list [role="status"]')).toBeNull();
+    expect(loaded.container.querySelector('#members-list table')).not.toBeNull();
+    await loaded.unmount();
+  });
+
+  it('attributes an in-flight revoke to only the acting row', async () => {
+    mocks.grants = {
+      data: { items: [...grants], count: grants.length },
+      error: null,
+      isError: false,
+      isPending: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    };
+    const view = await renderMembers();
+    const buttons = [...view.container.querySelectorAll<HTMLButtonElement>('#members-list button')]
+      .filter((button) => button.textContent === 'Revoke');
+    const acting = buttons[0];
+    const sibling = buttons[1];
+    if (acting === undefined || sibling === undefined) {
+      throw new Error('expected two revoke buttons');
+    }
+
+    await act(async () => acting.click());
+
+    expect(acting.textContent).toBe('Revoking…');
+    expect(acting.disabled).toBe(true);
+    expect(acting.getAttribute('aria-busy')).toBe('true');
+    expect(sibling.textContent).toBe('Revoke');
+    expect(sibling.disabled).toBe(false);
+    expect(sibling.hasAttribute('aria-busy')).toBe(false);
+    await view.unmount();
+  });
+});
+
+describe('Organisation settings accessibility polish', () => {
+  it('announces the retention read only while it is pending', async () => {
+    const pending = await renderOrgSettings();
+    expect(pending.container.querySelector('#org-retention [role="status"]')?.textContent).toBe(
+      'Loading the retention policy…',
+    );
+    await pending.unmount();
+
+    mocks.retention = {
+      data: { mode: 'unlimited', max_age_seconds: null, last_revisions: null },
+      isError: false,
+      isPending: false,
+    };
+    const loaded = await renderOrgSettings();
+
+    expect(
+      [...loaded.container.querySelectorAll('#org-retention [role="status"]')].some(
+        (status) => status.textContent === 'Loading the retention policy…',
+      ),
+    ).toBe(false);
+    expect(
+      [...loaded.container.querySelectorAll('#org-retention button')].some(
+        (button) => button.textContent === 'Save retention',
+      ),
+    ).toBe(true);
+    await loaded.unmount();
+  });
+
+  it('associates the organisation Name input with its explanatory hint', async () => {
+    const view = await renderOrgSettings();
+    const input = view.container.querySelector<HTMLInputElement>('#org-identity input');
+    if (input === null) {
+      throw new Error('organisation Name input is missing');
+    }
+    const hintId = input.getAttribute('aria-describedby');
+    const hint = hintId === null ? null : view.container.ownerDocument.getElementById(hintId);
+
+    expect(hintId).not.toBeNull();
+    expect(hint === null ? false : view.container.contains(hint)).toBe(true);
+    expect(hint?.textContent).toContain('Renaming an organisation is instance-operator work');
+    await view.unmount();
+  });
+});

--- a/web/src/routes/AccessibilityPolish.test.tsx
+++ b/web/src/routes/AccessibilityPolish.test.tsx
@@ -137,8 +137,8 @@ const grants: readonly Grant[] = [
   },
 ];
 
-beforeEach(() => {
-  mocks.grants = {
+function pendingGrants(): RouteMocks['grants'] {
+  return {
     data: undefined,
     error: null,
     isError: false,
@@ -146,6 +146,21 @@ beforeEach(() => {
     isSuccess: false,
     refetch: vi.fn(),
   };
+}
+
+function loadedGrants(items: readonly Grant[]): RouteMocks['grants'] {
+  return {
+    data: { items: [...items], count: items.length },
+    error: null,
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    refetch: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  mocks.grants = pendingGrants();
   mocks.retention = {
     data: undefined,
     isError: false,
@@ -181,14 +196,7 @@ describe('Members accessibility polish', () => {
     );
     await pending.unmount();
 
-    mocks.grants = {
-      data: { items: [...grants], count: grants.length },
-      error: null,
-      isError: false,
-      isPending: false,
-      isSuccess: true,
-      refetch: vi.fn(),
-    };
+    mocks.grants = loadedGrants(grants);
     const loaded = await renderMembers();
 
     expect(loaded.container.querySelector('#members-list [role="status"]')).toBeNull();
@@ -197,14 +205,7 @@ describe('Members accessibility polish', () => {
   });
 
   it('attributes an in-flight revoke to only the acting row', async () => {
-    mocks.grants = {
-      data: { items: [...grants], count: grants.length },
-      error: null,
-      isError: false,
-      isPending: false,
-      isSuccess: true,
-      refetch: vi.fn(),
-    };
+    mocks.grants = loadedGrants(grants);
     const view = await renderMembers();
     const buttons = [...view.container.querySelectorAll<HTMLButtonElement>('#members-list button')]
       .filter((button) => button.textContent === 'Revoke');

--- a/web/src/routes/Members.tsx
+++ b/web/src/routes/Members.tsx
@@ -159,6 +159,8 @@ export function Members() {
           operator, so it does not offer to revoke one.
         </p>
 
+        {grants.isPending ? <p role="status">Loading members…</p> : null}
+
         {grants.isSuccess && rows.length === 0 ? (
           <p role="status">
             No grants inside this organisation yet. Everyone reaching it does so from instance scope.
@@ -191,32 +193,38 @@ export function Members() {
                   </td>
                   <td>
                     <ul className="capabilities">
-                      {row.grants.map((grant) => (
-                        <li key={grant.id} className="capability">
-                          <span className="capability__name mono">{grant.capability}</span>
-                          {/* Origin chips per capability line: the SCIM
-                              amendment's own requirement, and the one thing
-                              that tells a break-glass grant from an ordinary
-                              one after an incident. */}
-                          {grant.origins.map((origin) => (
-                            <span
-                              className="badge"
-                              key={`${origin.kind}:${origin.subject}`}
+                      {row.grants.map((grant) => {
+                        const revoking =
+                          revoke.isPending && revoke.variables?.grant.id === grant.id;
+                        const revokeLabel = `${revoking ? 'Revoking' : 'Revoke'} ${grant.capability} on ${row.scopeLabel} for ${row.principal}`;
+                        return (
+                          <li key={grant.id} className="capability">
+                            <span className="capability__name mono">{grant.capability}</span>
+                            {/* Origin chips per capability line: the SCIM
+                                amendment's own requirement, and the one thing
+                                that tells a break-glass grant from an ordinary
+                                one after an incident. */}
+                            {grant.origins.map((origin) => (
+                              <span
+                                className="badge"
+                                key={`${origin.kind}:${origin.subject}`}
+                              >
+                                {origin.kind}: {origin.subject}
+                              </span>
+                            ))}
+                            <button
+                              type="button"
+                              className="btn btn--quiet"
+                              disabled={revoking}
+                              aria-busy={revoking ? true : undefined}
+                              aria-label={revokeLabel}
+                              onClick={() => onRevoke(grant)}
                             >
-                              {origin.kind}: {origin.subject}
-                            </span>
-                          ))}
-                          <button
-                            type="button"
-                            className="btn btn--quiet"
-                            disabled={revoke.isPending}
-                            aria-label={`Revoke ${grant.capability} on ${row.scopeLabel} for ${row.principal}`}
-                            onClick={() => onRevoke(grant)}
-                          >
-                            Revoke
-                          </button>
-                        </li>
-                      ))}
+                              {revoking ? 'Revoking…' : 'Revoke'}
+                            </button>
+                          </li>
+                        );
+                      })}
                     </ul>
                   </td>
                 </tr>

--- a/web/src/routes/OrgSettings.tsx
+++ b/web/src/routes/OrgSettings.tsx
@@ -127,11 +127,12 @@ export function OrgSettings() {
           <label htmlFor={nameId}>Name</label>
           <input
             id={nameId}
+            aria-describedby={`${nameId}-hint`}
             value={name}
             disabled={current === undefined}
             onChange={(event) => setName(event.target.value)}
           />
-          <p className="field__hint">
+          <p id={`${nameId}-hint`} className="field__hint">
             Renaming an organisation is instance-operator work: the permission model has no
             org-lifecycle capability, so an organisation administrator is refused here with the same
             answer a missing organisation gets.
@@ -164,6 +165,7 @@ export function OrgSettings() {
           The cap every project in this organisation inherits, and the ceiling no project override
           may exceed. Payload collection is what this bounds; who changed what is permanent.
         </p>
+        {retention.isPending ? <p role="status">Loading the retention policy…</p> : null}
         {retention.isError ? (
           <Alert>The retention policy could not be read for this organisation.</Alert>
         ) : null}


### PR DESCRIPTION
Closes #463

## What changed
- announce members and organisation-retention initial loads
- associate the organisation Name hint with its input
- attribute revoke progress to only the acting grant row
- add route-level accessible-DOM regression coverage and handoff

## Local verification
- `pnpm run typecheck`
- `pnpm run test` (45 files, 344 tests)
- `pnpm run build`