### PR TITLE
Validate pin expiry before disclosure ceremony #456

### DIFF
--- a/web/src/routes/HistoryDrawer.test.tsx
+++ b/web/src/routes/HistoryDrawer.test.tsx
@@ -4,17 +4,21 @@ import { act, createRef } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { renderForm, settle } from '../testkit/renderForm.tsx';
+import { renderForm, settle, typeInto } from '../testkit/renderForm.tsx';
 import { HistoryDrawer, PinReleaseOutcome } from './HistoryDrawer.tsx';
 
 type HistoryDrawerMocks = {
   preview: RetentionConsequence;
+  ceremonyRun: ReturnType<typeof vi.fn>;
   releaseMutate: ReturnType<typeof vi.fn>;
+  setPinMutate: ReturnType<typeof vi.fn>;
 };
 
 const mocks = vi.hoisted<HistoryDrawerMocks>(() => ({
   preview: 'retained',
+  ceremonyRun: vi.fn(),
   releaseMutate: vi.fn(),
+  setPinMutate: vi.fn(),
 }));
 
 vi.mock('../api/history.ts', async (importActual) => {
@@ -57,9 +61,15 @@ vi.mock('../api/history.ts', async (importActual) => {
       data: { inherited: false, mode: 'keep-if-either', max_age_seconds: 3600, last_revisions: 1 },
       isError: false,
     }),
-    useRevisionDetail: () => ({ data: { keys: [] }, isSuccess: true, isError: false }),
+    useRevisionDetail: () => ({
+      data: {
+        keys: [{ key_id: 'key_secret', name: 'TOKEN', classification: 'secret' }],
+      },
+      isSuccess: true,
+      isError: false,
+    }),
     useRestoreRevision: () => ({ mutate: vi.fn(), isPending: false }),
-    useSetRevisionPin: () => ({ mutate: vi.fn(), isPending: false }),
+    useSetRevisionPin: () => ({ mutate: mocks.setPinMutate, isPending: false }),
     useReleaseRevisionPin: () => ({ mutate: mocks.releaseMutate, isPending: false }),
   };
 });
@@ -94,7 +104,7 @@ vi.mock('./useProtectedPublishCeremony.ts', () => ({
   useProtectedPublishCeremony: () => ({
     request: null,
     error: null,
-    run: vi.fn(),
+    run: mocks.ceremonyRun,
     onAuthorised: vi.fn(),
     onCancel: vi.fn(),
   }),
@@ -102,7 +112,9 @@ vi.mock('./useProtectedPublishCeremony.ts', () => ({
 
 beforeEach(() => {
   mocks.preview = 'retained';
+  mocks.ceremonyRun.mockReset();
   mocks.releaseMutate.mockReset();
+  mocks.setPinMutate.mockReset();
 });
 
 describe('PinReleaseOutcome', () => {
@@ -162,6 +174,30 @@ function buttonNamed(container: HTMLElement, name: string): HTMLButtonElement {
 }
 
 describe('HistoryDrawer pin release flow', () => {
+  it('refuses a cleared expiry before starting disclosure or pinning', async () => {
+    const { container } = await renderForm(drawer());
+
+    await act(async () => buttonNamed(container, 'Pin r4…').click());
+    const expiry = container.querySelector<HTMLInputElement>('#history-pin-expiry');
+    const submit = container.querySelector<HTMLButtonElement>('#history-pin-submit');
+    if (expiry === null || submit === null) {
+      throw new Error('pin expiry controls are missing');
+    }
+
+    expect(expiry.min).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(expiry.max).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(expiry.max > expiry.min).toBe(true);
+    await act(async () => typeInto(expiry, ''));
+    await settle();
+
+    expect(submit.disabled).toBe(true);
+    expect(container.querySelector('#history-pin-refusal')?.textContent).toContain(
+      'Invalid pin expiry date',
+    );
+    expect(mocks.ceremonyRun).not.toHaveBeenCalled();
+    expect(mocks.setPinMutate).not.toHaveBeenCalled();
+  });
+
   it('passes the server response into the outcome instead of stale drawer state', async () => {
     mocks.releaseMutate.mockImplementation((_workload, options) => {
       options.onSuccess({ revision: 11n, retention_consequence: 'already_collected' });

--- a/web/src/routes/HistoryDrawer.tsx
+++ b/web/src/routes/HistoryDrawer.tsx
@@ -40,6 +40,7 @@ import {
   pinAction,
   pinCeremonyUnit,
   pinExpiry,
+  pinExpiryDateBounds,
   pinExpiryInstant,
   pinComparedToLatest,
   pinSchemaOverrideOffered,
@@ -184,6 +185,7 @@ export function HistoryDrawer({
   // whose rows disagree about "now" by a few milliseconds can render two
   // different expiry tiers for the same instant.
   const [now] = useState(() => new Date());
+  const expiryBounds = pinExpiryDateBounds(now);
 
   const revisions = useMemo<readonly HistoryRevision[]>(
     () => (history.data?.items ?? []).map(toHistoryRevision),
@@ -342,6 +344,16 @@ export function HistoryDrawer({
     readonly overrideSchema: boolean;
     readonly revisionKeys: readonly HistorySnapshotKey[];
   }) => {
+    let expiresAt: string;
+    try {
+      expiresAt = pinExpiryInstant(input.expiresAt);
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+      setRefusal(error.message);
+      return;
+    }
     const historical = input.revision !== currentRevision;
     const unit = historical
       ? pinCeremonyUnit(input.revisionKeys, cellsByEnvironment.get(environment.id) ?? [])
@@ -351,7 +363,7 @@ export function HistoryDrawer({
         {
           workloadPrincipalID: input.workloadPrincipalID,
           revision: input.revision,
-          expiresAt: pinExpiryInstant(input.expiresAt),
+          expiresAt,
           overrideSchema: input.overrideSchema,
         },
         {
@@ -735,6 +747,8 @@ export function HistoryDrawer({
             existingPin: pinRows.find((pin) => pin.workloadPrincipalId === account.principal_id),
           }))}
           state={sheet}
+          expiryMinimum={expiryBounds.minimum}
+          expiryMaximum={expiryBounds.maximum}
           busy={setPin.isPending}
           refusal={refusal ?? guard.error}
           comparisonBusy={comparePin.isPending}
@@ -768,7 +782,24 @@ export function HistoryDrawer({
               : null
           }
           onCompare={() => comparePin.mutate({ environmentId: environment.id, revision: sheet.revision })}
-          onChange={(next) => setSheet({ ...sheet, ...next })}
+          onChange={(next) => {
+            setSheet({ ...sheet, ...next });
+            if (next.expiresAt === undefined) {
+              return;
+            }
+            if (next.expiresAt !== '') {
+              setRefusal(null);
+              return;
+            }
+            try {
+              pinExpiryInstant(next.expiresAt);
+            } catch (error) {
+              if (!(error instanceof Error)) {
+                throw error;
+              }
+              setRefusal(error.message);
+            }
+          }}
           onSubmit={() =>
             runPin({
               revision: sheet.revision,
@@ -1210,6 +1241,8 @@ function PinSheet({
   currentRevision,
   workloads,
   state,
+  expiryMinimum,
+  expiryMaximum,
   busy,
   refusal,
   comparisonBusy,
@@ -1235,6 +1268,8 @@ function PinSheet({
     readonly overrideSchema: boolean;
     readonly offerOverride: boolean;
   };
+  expiryMinimum: string;
+  expiryMaximum: string;
   busy: boolean;
   refusal: string | null;
   comparisonBusy: boolean;
@@ -1339,6 +1374,8 @@ function PinSheet({
         id="history-pin-expiry"
         className="mono"
         type="date"
+        min={expiryMinimum}
+        max={expiryMaximum}
         value={state.expiresAt}
         onChange={(event) => onChange({ expiresAt: event.target.value })}
       />
@@ -1400,7 +1437,7 @@ function PinSheet({
           id="history-pin-submit"
           type="button"
           className="btn btn--primary"
-          disabled={busy || state.workloadPrincipalID === ''}
+          disabled={busy || state.workloadPrincipalID === '' || state.expiresAt === ''}
           onClick={onSubmit}
         >
           {busy ? 'Pinning…' : moveMayCollect ? `${plan.label} — old values may be collected` : plan.label}

--- a/web/src/routes/history-state.test.ts
+++ b/web/src/routes/history-state.test.ts
@@ -3,6 +3,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 import {
   pinAction,
   pinExpiry,
+  pinExpiryDateBounds,
   pinExpiryInstant,
   pinComparedToLatest,
   revisionActionGate,
@@ -397,6 +398,19 @@ describe('defaultPinExpiry', () => {
 
   it('refuses an impossible date input loudly', () => {
     expect(() => pinExpiryInstant('2026-02-30')).toThrow('Invalid pin expiry date: 2026-02-30');
+  });
+
+  it('caps the date input at the latest end-of-day inside 365 exact days', () => {
+    const now = new Date('2026-03-07T15:00:00Z');
+    const bounds = pinExpiryDateBounds(now);
+
+    expect(bounds).toEqual({ minimum: '2026-03-07', maximum: '2027-03-06' });
+    expect(new Date(pinExpiryInstant(bounds.maximum)).getTime()).toBeLessThanOrEqual(
+      now.getTime() + 365 * 24 * 60 * 60 * 1_000,
+    );
+    expect(new Date(pinExpiryInstant('2027-03-07')).getTime()).toBeGreaterThan(
+      now.getTime() + 365 * 24 * 60 * 60 * 1_000,
+    );
   });
 });
 

--- a/web/src/routes/history-state.ts
+++ b/web/src/routes/history-state.ts
@@ -455,9 +455,30 @@ export function pinSchemaOverrideOffered(detail: string | undefined): boolean {
 
 /** The service's own default pin lifetime (180 days), as a `<input type=date>` value. */
 export function defaultPinExpiry(now: Date): string {
+  return localDateInputValue(localDateAfterDays(now, 180));
+}
+
+/** Native date bounds whose end-of-day instant fits the service's exact 365-day cap. */
+export function pinExpiryDateBounds(now: Date): {
+  readonly minimum: string;
+  readonly maximum: string;
+} {
+  const maximumInstant = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1_000);
+  const maximumDate = new Date(maximumInstant.getTime());
+  maximumDate.setHours(23, 59, 59, 999);
+  if (maximumDate.getTime() > maximumInstant.getTime()) {
+    maximumDate.setDate(maximumDate.getDate() - 1);
+  }
+  return {
+    minimum: localDateInputValue(now),
+    maximum: localDateInputValue(maximumDate),
+  };
+}
+
+function localDateAfterDays(now: Date, days: number): Date {
   const at = new Date(now.getTime());
-  at.setDate(at.getDate() + 180);
-  return localDateInputValue(at);
+  at.setDate(at.getDate() + days);
+  return at;
 }
 
 function localDateInputValue(date: Date): string {


### PR DESCRIPTION
Closes #456

## What changed
- validate expiry before disclosure ceremony or mutation
- refuse cleared expiry and enforce native date bounds
- cap selectable end-of-day at the exact 365-day server limit

## Validation
- pnpm --dir web test (342 passed)
- pnpm --dir web run typecheck
- pnpm --dir web run build