### PR TITLE
Validate Add Remote URLs and duplicate origins #461

### DIFF
--- a/docs/handoff/461-add-remote-validation.md
+++ b/docs/handoff/461-add-remote-validation.md
@@ -1,0 +1,23 @@
+# Handoff: #461 add-remote client validation
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/461 (audit finding `P8-b`).
+
+## Contract
+
+- The add-remote form trims and canonicalizes the submitted URL, then performs
+  a client pre-flight check for the server's bare HTTPS-origin grammar. The
+  server remains the authoritative validator.
+- Duplicate detection compares the submitted origin with the origins in the
+  existing `remotesKey` query through `safeOriginOf`. A match names the existing
+  remote and does not start the add mutation.
+- The URL input exposes URL semantics through `type="url"`. Client validation
+  still explicitly rejects HTTP because HTML URL validation accepts it.
+- A server `409` retains duplicate-identity guidance for alternate URLs, stale
+  cache data, and races. Exact duplicate origins get their own client refusal.
+
+## Coverage
+
+- `web/src/routes/Remotes.test.tsx` covers a whitespace-padded duplicate origin,
+  bare-host and HTTP refusals, URL input type, and trimmed mutation payload.
+- `web/src/api/remotes.ts` remains the sole owner of the shared query key,
+  mutation, and safe stored-origin parsing.

--- a/web/src/routes/Remotes.test.tsx
+++ b/web/src/routes/Remotes.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { AddRemote } from './Remotes.tsx';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) {
+    await cleanup();
+  }
+  vi.unstubAllGlobals();
+});
+
+const peer = {
+  id: 'rmt_123e4567-e89b-12d3-a456-426614174000',
+  name: 'production',
+  url: 'https://peer.example/',
+  spki_pin: 'peer-pin',
+  created_at: '2026-01-01T00:00:00Z',
+  created_by: 'principal-1',
+  state: 'ok',
+  last_attempt_at: '2026-01-01T00:00:00Z',
+  stale: false,
+};
+
+function remoteList(items: readonly (typeof peer)[]): Response {
+  return new Response(JSON.stringify({ items, count: items.length }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function renderAddRemote(items: readonly (typeof peer)[]) {
+  const fetchMock = vi.fn((request: RequestInfo | URL) => {
+    const method = request instanceof Request ? request.method : 'GET';
+    if (method === 'GET') {
+      return Promise.resolve(remoteList(items));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ ...peer, url: 'https://new.example' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const rendered = await renderForm(<AddRemote />);
+  cleanups.push(rendered.unmount);
+  await settleTask();
+  return { container: rendered.container, fetchMock };
+}
+
+function input(container: HTMLElement, id: string): HTMLInputElement {
+  const found = container.querySelector(`#${id}`);
+  if (!(found instanceof HTMLInputElement)) {
+    throw new Error(`input ${id} is missing`);
+  }
+  return found;
+}
+
+async function submit(container: HTMLElement): Promise<void> {
+  const form = container.querySelector('form');
+  if (!(form instanceof HTMLFormElement)) {
+    throw new Error('the add-remote form is missing');
+  }
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+  await settleTask();
+}
+
+describe('AddRemote', () => {
+  it('blocks an existing origin before starting the mutation', async () => {
+    const { container, fetchMock } = await renderAddRemote([peer]);
+    const url = input(container, 'remote-url');
+
+    expect(url.type).toBe('url');
+    await act(async () => typeInto(url, '  https://peer.example  '));
+    await submit(container);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'This origin is already added as production.',
+    );
+  });
+
+  it.each([
+    'hikyo.example',
+    'http://hikyo.example',
+    'https://hikyo.example/a/..',
+    'https://@hikyo.example',
+  ])(
+    'blocks invalid remote URL %s before starting the mutation',
+    async (rawURL) => {
+      const { container, fetchMock } = await renderAddRemote([]);
+
+      await act(async () => typeInto(input(container, 'remote-url'), rawURL));
+      await submit(container);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Enter a bare HTTPS origin',
+      );
+    },
+  );
+
+  it('trims a valid origin before posting it', async () => {
+    const { container, fetchMock } = await renderAddRemote([]);
+    await act(async () => {
+      typeInto(input(container, 'remote-name'), 'new-peer');
+      typeInto(input(container, 'remote-url'), '  https://new.example/  ');
+      typeInto(input(container, 'remote-pin'), 'new-pin');
+      typeInto(input(container, 'remote-credential'), 'new-credential');
+    });
+    await submit(container);
+
+    const request = fetchMock.mock.calls
+      .map(([candidate]) => candidate)
+      .find((candidate) => candidate instanceof Request && candidate.method === 'POST');
+    if (!(request instanceof Request)) {
+      throw new Error('the add mutation did not send a Request');
+    }
+    expect(await request.json()).toMatchObject({ url: 'https://new.example' });
+  });
+});

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -5,8 +5,8 @@ import { generatePath, Link } from 'react-router';
 import { ApiError } from '../api/client.ts';
 import { useProjects } from '../api/matrix.ts';
 import {
-  originOf,
   remoteStateText,
+  safeOriginOf,
   stalenessText,
   useAddRemote,
   useAddWorkspaceOrigin,
@@ -109,7 +109,7 @@ function RemoteCard({ remote }: { remote: Remote }) {
   const [opening, setOpening] = useState(false);
   const [ended, setEnded] = useState(false);
   const [prepared, setPrepared] = useState<PreparedWorkspace | null>(null);
-  const origin = safeOrigin(remote.url);
+  const origin = safeOriginOf(remote.url);
   const live = workspaces.find((w) => w.origin === origin);
   const updateStatuses = useRemoteUpdateStatuses(live === undefined ? [] : [live]);
   const updateProbe = updateStatuses[0];
@@ -337,17 +337,37 @@ function RemoteCard({ remote }: { remote: Remote }) {
   );
 }
 
-function AddRemote() {
+export function AddRemote() {
   const add = useAddRemote();
+  const remotes = useRemotes();
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
   const [pin, setPin] = useState('');
   const [credential, setCredential] = useState('');
+  const [validationFailure, setValidationFailure] = useState<string | null>(null);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    const trimmedURL = url.trim();
+    const submittedOrigin = remoteOriginForSubmit(trimmedURL);
+    if (submittedOrigin === null) {
+      setValidationFailure(
+        'Enter a bare HTTPS origin, for example https://hikyo.example, with no path, query, fragment, or user information.',
+      );
+      return;
+    }
+    const duplicate = remotes.data?.items.find(
+      (remote) => safeOriginOf(remote.url) === submittedOrigin,
+    );
+    if (duplicate !== undefined) {
+      setValidationFailure(`This origin is already added as ${duplicate.name}.`);
+      return;
+    }
+
+    setValidationFailure(null);
     add.mutate(
-      { name, url, spkiPin: pin, credential },
+      { name, url: submittedOrigin, spkiPin: pin, credential },
       {
         onSuccess: () => {
           setName('');
@@ -368,12 +388,14 @@ function AddRemote() {
         self-signed instance on your own network safe to point at.
       </p>
       <form className="form" onSubmit={onSubmit} noValidate>
-        {add.isError ? (
+        {validationFailure !== null || add.isError ? (
           <p className="alert" role="alert">
             <span className="alert__glyph" aria-hidden="true">
               !
             </span>
-            <span>{addFailureText(add.error)}</span>
+            <span>
+              {validationFailure ?? addFailureText(add.error)}
+            </span>
           </p>
         ) : null}
         <div className="field">
@@ -384,9 +406,14 @@ function AddRemote() {
           <label htmlFor="remote-url">URL</label>
           <input
             id="remote-url"
+            type="url"
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setValidationFailure(null);
+            }}
             placeholder="https://hikyo.example"
+            aria-invalid={validationFailure !== null}
             required
           />
         </div>
@@ -632,12 +659,27 @@ function OrgProjects({
   );
 }
 
-/** safeOrigin never throws on a stored URL the browser cannot parse. */
-function safeOrigin(url: string): string {
+/** Mirror the server's bare-HTTPS-origin grammar for client pre-flight checks. */
+function remoteOriginForSubmit(url: string): string | null {
+  if (!/^https:\/\/[^\s/?#@]+\/?$/.test(url)) {
+    return null;
+  }
   try {
-    return originOf(url);
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== 'https:' ||
+      parsed.hostname === '' ||
+      parsed.username !== '' ||
+      parsed.password !== '' ||
+      parsed.pathname !== '/' ||
+      parsed.search !== '' ||
+      parsed.hash !== ''
+    ) {
+      return null;
+    }
+    return parsed.origin;
   } catch {
-    return url;
+    return null;
   }
 }
 
@@ -647,7 +689,7 @@ function addFailureText(error: unknown): string {
       case 400:
         return 'That entry was refused: the URL must be a bare https origin and the fingerprint must be the base64 SHA-256 of the public key.';
       case 409:
-        return 'That entry was refused at the verifying fetch — it may point at this instance itself, at an instance already added, or at a key that does not match the fingerprint.';
+        return 'The server could not verify this remote. Check that it is reachable, its credential and fingerprint are current, and it is not this instance or an instance already listed under another URL.';
       case 429:
         return 'Too many attempts right now. Wait a moment and try again.';
       default:


### PR DESCRIPTION
## Summary

- validate and canonicalize bare HTTPS origins before mutation
- block cached duplicate origins with a precise inline refusal
- preserve accurate server-side 409 guidance for identity aliases and races
- cover invalid, duplicate, and trimmed submission paths

## Validation

- two-axis code review: CLEAN at round 3 of 3
- local suite deferred while host memory pressure is high; CI started first

Closes #461