### PR TITLE
Share pnpm virtual store across worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ships as one Go binary and supports both SQLite and PostgreSQL.
 ## Quick start
 
 Requires Go 1.27+, Node.js 26.7.0 (see [`.nvmrc`](./.nvmrc)), Corepack 0.35.0,
-and pnpm 11.10.0.
+and pnpm 11.24.0.
 
 ```bash
 git clone https://github.com/Hikyo-Org/Hikyo.git
@@ -111,7 +111,7 @@ cd Hikyo
 
 npm install --global --ignore-scripts corepack@0.35.0
 corepack enable
-corepack install --global pnpm@11.10.0
+corepack install --global pnpm@11.24.0
 pnpm --dir clients/ts install --frozen-lockfile
 pnpm --dir web install --frozen-lockfile
 pnpm --dir web build

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.24.0",
   "description": "Generated TypeScript client and Zod schemas for the Hikyo API. Generated from ../../api/openapi.yaml - never edited by hand.",
   "scripts": {
     "generate": "openapi-ts && node --experimental-strip-types scripts/generate-operations.ts",

--- a/clients/ts/pnpm-workspace.yaml
+++ b/clients/ts/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+virtualStoreType: global
+
 overrides:
   js-yaml@<4.3.1: 4.3.1

--- a/docs/handoff/global-pnpm-store.md
+++ b/docs/handoff/global-pnpm-store.md
@@ -1,0 +1,25 @@
+# Global pnpm virtual store
+
+## Goal
+
+Stop identical Hikyo worktrees from materializing a separate pnpm virtual store for every checkout.
+
+## Implementation
+
+- Pin all three JavaScript package roots to pnpm 11.24.0.
+- Set `virtualStoreType: global` in each package root's `pnpm-workspace.yaml`.
+- Treat every workspace configuration change as a full CI input.
+- Keep setup documentation aligned with the executable package-manager pins.
+
+pnpm stores dependency graphs under `~/Library/pnpm/store/v11/links` outside CI. Each worktree keeps only its package-root symlinks. pnpm disables the global virtual store automatically in CI.
+
+## Validation
+
+- Each package root reports `virtual-store-type=global`.
+- Frozen installs reused every package and downloaded none.
+- TypeScript SDK generation, typecheck, and 14 tests pass.
+- Web typecheck, 388 tests, and production build pass.
+- Docs check, build, policy checks, PWA checks, and offline browser test pass.
+- Changed-path classifier fixtures pass.
+
+The adoption also fixes an existing implicit event type in `Matrix.tsx` exposed by the current TypeScript toolchain.

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -37,5 +37,5 @@
     "typescript": "6.0.3",
     "workbox-build": "7.4.1"
   },
-  "packageManager": "pnpm@11.10.0"
+  "packageManager": "pnpm@11.24.0"
 }

--- a/docs/site/pnpm-workspace.yaml
+++ b/docs/site/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+virtualStoreType: global
+
 allowBuilds:
   esbuild: true
   sharp: true

--- a/docs/site/src/content/docs/docs/build-from-source.mdx
+++ b/docs/site/src/content/docs/docs/build-from-source.mdx
@@ -16,7 +16,7 @@ Install these exact toolchain lines:
 | Go | 1.27.0 or newer in the 1.27 line | Server and CLI |
 | Node.js | Version in `.nvmrc` | Embedded browser UI |
 | Corepack | 0.35.0, installed separately | Pinned pnpm launcher |
-| pnpm | 11.10.0 through Corepack | UI dependencies and build |
+| pnpm | 11.24.0 through Corepack | UI dependencies and build |
 
 Git is required for a source checkout. SQLite support is compiled into the
 binary; no local SQLite service is needed.
@@ -38,7 +38,7 @@ change interfaces and schema behavior without a compatibility promise.
 ```bash
 npm install --global --ignore-scripts corepack@0.35.0
 corepack enable
-corepack install --global pnpm@11.10.0
+corepack install --global pnpm@11.24.0
 pnpm --dir clients/ts install --frozen-lockfile
 pnpm --dir web install --frozen-lockfile
 pnpm --dir web build

--- a/docs/site/src/content/docs/docs/getting-started.mdx
+++ b/docs/site/src/content/docs/docs/getting-started.mdx
@@ -15,7 +15,7 @@ SQLite database, and one administrator account.
 
 - Go 1.27.0 or newer within the Go 1.27 line.
 - Node.js 26.7.0, matching the repository's `.nvmrc`.
-- Corepack 0.35.0 with pnpm 11.10.0.
+- Corepack 0.35.0 with pnpm 11.24.0.
 
 ## 1. Clone and build
 
@@ -24,7 +24,7 @@ git clone https://github.com/Hikyo-Org/Hikyo.git
 cd hikyo
 npm install --global --ignore-scripts corepack@0.35.0
 corepack enable
-corepack install --global pnpm@11.10.0
+corepack install --global pnpm@11.24.0
 pnpm --dir clients/ts install --frozen-lockfile
 pnpm --dir web install --frozen-lockfile
 pnpm --dir web build

--- a/docs/site/src/content/docs/docs/self-hosting.mdx
+++ b/docs/site/src/content/docs/docs/self-hosting.mdx
@@ -30,7 +30,7 @@ Until Hikyo publishes a stable release, build from a reviewed commit:
 ```bash
 npm install --global --ignore-scripts corepack@0.35.0
 corepack enable
-corepack install --global pnpm@11.10.0
+corepack install --global pnpm@11.24.0
 pnpm --dir clients/ts install --frozen-lockfile
 pnpm --dir web install --frozen-lockfile
 pnpm --dir web build

--- a/scripts/ci/classify-changed-paths.sh
+++ b/scripts/ci/classify-changed-paths.sh
@@ -57,9 +57,9 @@ else
 		# Dependency manifests and build/tool configuration can affect more than
 		# their owning directory, so keep them on the full integration backstop.
 		go.mod | go.sum | sqlc.yaml | .goreleaser.yaml | \
-			web/package.json | web/pnpm-lock.yaml | web/tsconfig*.json | web/*.config.* | \
+			web/package.json | web/pnpm-lock.yaml | web/pnpm-workspace.yaml | web/tsconfig*.json | web/*.config.* | \
 			clients/ts/package.json | clients/ts/pnpm-lock.yaml | clients/ts/pnpm-workspace.yaml | clients/ts/tsconfig*.json | clients/ts/*.config.* | \
-			docs/site/package.json | docs/site/pnpm-lock.yaml | docs/site/tsconfig*.json | docs/site/*.config.*)
+			docs/site/package.json | docs/site/pnpm-lock.yaml | docs/site/pnpm-workspace.yaml | docs/site/tsconfig*.json | docs/site/*.config.*)
 			all_jobs
 			;;
 		LICENSE)

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -101,9 +101,11 @@ done
 for dependency_or_config in \
 	'go.sum' \
 	'web/pnpm-lock.yaml' \
+	'web/pnpm-workspace.yaml' \
 	'clients/ts/package.json' \
 	'clients/ts/pnpm-workspace.yaml' \
 	'docs/site/package.json' \
+	'docs/site/pnpm-workspace.yaml' \
 	'.goreleaser.yaml'; do
 	expect_plan "$dependency_or_config" "$all_jobs" "$dependency_or_config"
 done

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.24.0",
   "description": "The Hikyo single-page application. Built by Vite into ../internal/webui/dist, embedded by the server binary under the `ui` build tag.",
   "scripts": {
     "dev": "vite",

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+virtualStoreType: global

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { generatePath, Link, useParams } from 'react-router';
 
 import { historyHref } from '../api/history.ts';
@@ -620,7 +620,7 @@ export function Matrix({ historyOpen = false }: { historyOpen?: boolean } = {}) 
                               className="btn matrix__history-link"
                               data-history-environment={environment.id}
                               to={historyLink({ ...ref, env: environment.id })}
-                              onClick={(event) => {
+                              onClick={(event: MouseEvent<HTMLAnchorElement>) => {
                                 historyOpener.current = event.currentTarget;
                               }}
                             >


### PR DESCRIPTION
Summary:
- Upgrade all JavaScript package roots to pnpm 11.24.0.
- Use the global virtual store so identical worktrees share dependency graphs.
- Treat every pnpm workspace config as a full CI input.
- Fix the existing Matrix history-link event type exposed by TypeScript 7.

Validation:
- Frozen installs reused all packages with zero downloads.
- SDK verify: 14 tests passed.
- Web: typecheck, 388 tests, and production build passed.
- Docs verify: checks, build, policy, PWA, and offline browser tests passed.
- Changed-path classifier and ShellCheck passed.

Handoff: docs/handoff/global-pnpm-store.md