### PR TITLE
refactor(go): adopt Go 1.27 features — stdlib uuid, encoding/json/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/gofrs/flock v0.13.0
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.1
@@ -144,6 +143,7 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.18 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/admission"
@@ -448,7 +448,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	moduleWiring := newAdapterModuleWiring(cfg.AdapterEgressPolicy)
 	adapterWorker := &adapter.Worker{
 		Store: adapterRuntime, Loader: &adapterLoader{runtime: adapterRuntime, keyring: kr, moduleFactory: moduleWiring.worker},
-		ID: "adapter-worker-" + uuid.Must(uuid.NewV7()).String(), Poll: time.Second, Log: log,
+		ID: "adapter-worker-" + uuid.NewV7().String(), Poll: time.Second, Log: log,
 	}
 	adapterService := &service.Adapters{DB: db, Auth: authSvc, Keyring: kr, Budget: budget, ModuleFactory: moduleWiring.service}
 	definitionsService := &service.Definitions{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 )
@@ -133,12 +133,8 @@ type Event struct {
 }
 
 // NewEventID mints the project-pattern UUIDv7 id for an event.
-func NewEventID() (string, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return "", fmt.Errorf("audit: generate event id: %w", err)
-	}
-	return "evt_" + id.String(), nil
+func NewEventID() string {
+	return "evt_" + uuid.NewV7().String()
 }
 
 // Validate checks the event against the closed registry: registered type,

--- a/internal/authz/artifact_admission.go
+++ b/internal/authz/artifact_admission.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/api"
@@ -28,11 +27,7 @@ func (a *TxAuthorizer) AdmitOperation(ctx context.Context, caller Identity) erro
 		return nil
 	}
 
-	id, err := audit.NewEventID()
-	if err != nil {
-		a.captureErr = errors.Join(a.captureErr, err)
-		return domain.ErrNotFound
-	}
+	id := audit.NewEventID()
 	wire := audit.FromContext(ctx)
 	credentialID := caller.CredentialID
 	if credentialID == "" {

--- a/internal/authz/denial.go
+++ b/internal/authz/denial.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -90,14 +89,7 @@ const (
 // claims. Instance-operation refusals are resolvable grant refusals with no
 // tenant object, so they take the instance trail too.
 func (a *TxAuthorizer) captureDenial(ctx context.Context, principal domain.PrincipalID, op Operation, spec authorizationSpec, resolution string, resolvedChain domain.Scope, claimed domain.Scope) {
-	id, err := audit.NewEventID()
-	if err != nil {
-		// Cannot mint an id (entropy exhaustion): nothing writable exists,
-		// so record the capture failure — settleDenials converts it into
-		// the loud refusal instead of the uniform denial (fail-closed).
-		a.captureErr = errors.Join(a.captureErr, err)
-		return
-	}
+	id := audit.NewEventID()
 	wire := audit.FromContext(ctx)
 	payload := audit.Payload{
 		"operation":  string(op),

--- a/internal/compose/cursor.go
+++ b/internal/compose/cursor.go
@@ -1,8 +1,7 @@
 package compose
 
 import (
-	"bytes"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"os"
@@ -90,9 +89,7 @@ func LoadCursor(stateDir string) (*CursorState, error) {
 		return nil, fmt.Errorf("compose: read cursor: %w", err)
 	}
 	var c CursorState
-	dec := json.NewDecoder(bytes.NewReader(b))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&c); err != nil {
+	if err := json.Unmarshal(b, &c, json.RejectUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("compose: parse cursor: %w", err)
 	}
 	return &c, nil

--- a/internal/crypto/keyring.go
+++ b/internal/crypto/keyring.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 )
 
 // Purpose distinguishes the tier-3 keys: one DEK per project, one instance
@@ -518,10 +518,7 @@ func (k *Keyring) mintTier3At(p Purpose, orgID, projectID string, version uint32
 	if err != nil {
 		return keyHandle{}, WrappedKey{}, err
 	}
-	id, err := uuid.NewV7()
-	if err != nil {
-		return keyHandle{}, WrappedKey{}, fmt.Errorf("crypto: generate key id: %w", err)
-	}
+	id := uuid.NewV7()
 	m := k.master.Load()
 	row := WrappedKey{
 		ID:               "dek_" + id.String(),

--- a/internal/isolation/scim_audit_coverage_test.go
+++ b/internal/isolation/scim_audit_coverage_test.go
@@ -918,10 +918,7 @@ func TestSCIMPayloadSchemasAreValidatedOnWrite(t *testing.T) {
 // every failure the fixture observes is attributable to the PAYLOAD.
 func scimAuditEnvelope(t *testing.T, typ audit.EventType, spec audit.TypeSpec) (audit.Event, audit.Trail, domain.Scope) {
 	t.Helper()
-	id, err := audit.NewEventID()
-	if err != nil {
-		t.Fatal(err)
-	}
+	id := audit.NewEventID()
 	e := audit.Event{
 		ID: id, Type: typ, SchemaVersion: spec.SchemaVersion,
 		OccurredAt: time.Now().UTC(),

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -307,14 +307,8 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	if _, err := s.consumeAdapterCeremony(ctx, actor, scope, []string{request.Target.EnvironmentID}, authz.OpAdapterConfigure, now); err != nil {
 		return AdapterView{}, err
 	}
-	adapterID, err := newID("adp")
-	if err != nil {
-		return AdapterView{}, err
-	}
-	targetID, err := newID("tgt")
-	if err != nil {
-		return AdapterView{}, err
-	}
+	adapterID := newID("adp")
+	targetID := newID("tgt")
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpAdapterConfigure, scope)
 	if err != nil {
 		return AdapterView{}, err
@@ -333,10 +327,7 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	if err := lease.Module.ValidateConfig(adapter.Config{Origin: request.Origin}); err != nil {
 		return AdapterView{}, err
 	}
-	configureEventID, err := audit.NewEventID()
-	if err != nil {
-		return AdapterView{}, err
-	}
+	configureEventID := audit.NewEventID()
 	beforeCreate, afterCreate := s.environmentCreateAudit(actor, scope, targetID, request.Target, configureEventID)
 	destination := adapterDestination(request.Target)
 	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: request.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, request.Target.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
@@ -518,14 +509,8 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 		return store.AdapterTarget{}, err
 	}
 	defer lease.Release()
-	targetID, err := newID("tgt")
-	if err != nil {
-		return store.AdapterTarget{}, err
-	}
-	configureEventID, err := audit.NewEventID()
-	if err != nil {
-		return store.AdapterTarget{}, err
-	}
+	targetID := newID("tgt")
+	configureEventID := audit.NewEventID()
 	beforeCreate, afterCreate := s.environmentCreateAudit(actor, scope, targetID, input, configureEventID)
 	destination := adapterDestination(input)
 	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{Config: adapter.Config{Origin: record.Origin}, Destination: destination, Access: adapter.Access{Credential: string(plain)}, Gate: s.providerGate(actor, authz.OpAdapterConfigure, scope, input.EnvironmentID), AllowEnvironmentCreate: true, BeforeEnvironmentCreate: beforeCreate, AfterEnvironmentCreate: afterCreate})
@@ -1560,10 +1545,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}
-	artifactID, err := newID("apl")
-	if err != nil {
-		return AdapterPlanResult{}, err
-	}
+	artifactID := newID("apl")
 	now := store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
@@ -1654,19 +1636,13 @@ func (s *Adapters) Adopt(ctx context.Context, actor Actor, scope domain.Scope, r
 	}
 	ledgerIDs := make([]string, len(request.Entries))
 	for i := range ledgerIDs {
-		id, err := newID("adl")
-		if err != nil {
-			return AdoptAdapterResult{}, err
-		}
+		id := newID("adl")
 		ledgerIDs[i] = id
 	}
-	jobID, err := newID("job")
-	if err != nil {
-		return AdoptAdapterResult{}, err
-	}
+	jobID := newID("job")
 	now := store.CanonTime(s.now())
 	var out AdoptAdapterResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err

--- a/internal/service/bootstrap.go
+++ b/internal/service/bootstrap.go
@@ -105,18 +105,9 @@ func (s *Auth) BootstrapAdmin(ctx context.Context, username, displayName, delive
 	if err != nil {
 		return BootstrapResult{}, err
 	}
-	principalID, err := newID("usr")
-	if err != nil {
-		return BootstrapResult{}, err
-	}
-	accountID, err := newID("acc")
-	if err != nil {
-		return BootstrapResult{}, err
-	}
-	authorityID, err := newID("cea")
-	if err != nil {
-		return BootstrapResult{}, err
-	}
+	principalID := newID("usr")
+	accountID := newID("acc")
+	authorityID := newID("cea")
 
 	now := s.now()
 	expires := now.Add(BootstrapLifetime)
@@ -148,10 +139,7 @@ func (s *Auth) BootstrapAdmin(ctx context.Context, username, displayName, delive
 		}
 		// One row per capability: the expansion is the point.
 		for _, capability := range caps {
-			grantID, err := newID("grt")
-			if err != nil {
-				return err
-			}
+			grantID := newID("grt")
 			if err := az.CreateGrant(ctx, grantID, domain.PrincipalID(principalID),
 				domain.Grant{Capability: capability}, now); err != nil {
 				return err
@@ -162,10 +150,7 @@ func (s *Auth) BootstrapAdmin(ctx context.Context, username, displayName, delive
 			// is the self-grant the amendment's own wording implies for
 			// pre-existing rows: manual(granted_by), visible as such on the
 			// membership line rather than invented as somebody else's act.
-			originID, err := newID("gor")
-			if err != nil {
-				return err
-			}
+			originID := newID("gor")
 			if err := az.AddGrantOrigin(ctx, originID, grantID, domain.PrincipalID(principalID),
 				authz.Origin{Kind: domain.OriginManual, Subject: principalID}, now); err != nil {
 				return err

--- a/internal/service/cli_reauth.go
+++ b/internal/service/cli_reauth.go
@@ -181,10 +181,7 @@ func (s *Auth) StartCLIReauth(ctx context.Context, presented string, intent Reau
 			return CLIReauthStart{}, s.rejectCLIReauthRequest(ctx, "start", ErrReauthUnitMismatch)
 		}
 	}
-	id, err := newID("crh")
-	if err != nil {
-		return CLIReauthStart{}, err
-	}
+	id := newID("crh")
 	state, verifier, err := crypto.NewArtifact(crypto.ArtifactHandoffState)
 	if err != nil {
 		return CLIReauthStart{}, err
@@ -490,10 +487,7 @@ func (s *Auth) RedeemCLIReauth(ctx context.Context, code, pkceVerifier string) (
 			if !now.Before(approved.WindowExpiresAt) || !now.Before(approved.HardExpiresAt) {
 				return captureCLIReauthFailure(ctx, az, "redeem", detail, "reauth_required", ErrCLIReauthInvalid)
 			}
-			id, err := newID("raw")
-			if err != nil {
-				return err
-			}
+			id := newID("raw")
 			// The CLI's window reproduces the browser window's binding exactly:
 			// an adapter share stays bound to its (purpose, operation, set); a
 			// disclosure window stays bound through its ceremony id alone, so

--- a/internal/service/credential_reset.go
+++ b/internal/service/credential_reset.go
@@ -63,10 +63,7 @@ func (s *Auth) ResetCredential(ctx context.Context, actor Actor, targetPrincipal
 	if err != nil {
 		return ResetResult{}, err
 	}
-	authorityID, err := newID("cea")
-	if err != nil {
-		return ResetResult{}, err
-	}
+	authorityID := newID("cea")
 	now := s.now()
 	target := domain.PrincipalID(targetPrincipal)
 	var out ResetResult
@@ -190,10 +187,7 @@ func (s *Auth) BreakGlassResetCredential(ctx context.Context, targetPrincipal, d
 	if err != nil {
 		return ResetResult{}, err
 	}
-	authorityID, err := newID("cea")
-	if err != nil {
-		return ResetResult{}, err
-	}
+	authorityID := newID("cea")
 	now := s.now()
 	target := domain.PrincipalID(targetPrincipal)
 	var out ResetResult

--- a/internal/service/definitions_apply.go
+++ b/internal/service/definitions_apply.go
@@ -291,10 +291,7 @@ func (s *Definitions) persistPlan(ctx context.Context, r store.Repos, az *authz.
 		return PlanView{}, err
 	}
 
-	planID, err := newID("dpl")
-	if err != nil {
-		return PlanView{}, err
-	}
+	planID := newID("dpl")
 	// The plan stores the CANONICAL bundle bytes, so a re-parse at apply is
 	// byte-identical to what was pinned.
 	canonical, err := definitions.Encode(bundle)

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -532,10 +532,7 @@ func (s *Definitions) executeResolution(ctx context.Context, r store.Repos, az *
 		}
 	}
 	for _, name := range res.EnvCreates {
-		id, err := newID("env")
-		if err != nil {
-			return err
-		}
+		id := newID("env")
 		order, err := r.Environments().NextOrder(ctx, p)
 		if err != nil {
 			return err
@@ -565,10 +562,7 @@ func (s *Definitions) executeResolution(ctx context.Context, r store.Repos, az *
 		}
 	}
 	for _, name := range res.GroupCreates {
-		id, err := newID("kgr")
-		if err != nil {
-			return err
-		}
+		id := newID("kgr")
 		if err := r.Catalogue().CreateGroup(ctx, p, store.NewCatalogueGroup{ID: id, Name: name, CreatedAt: now}); err != nil {
 			return err
 		}
@@ -781,10 +775,7 @@ func (s *Definitions) createKey(ctx context.Context, r store.Repos, caller authz
 	if err != nil {
 		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
-	id, err := newID("key")
-	if err != nil {
-		return err
-	}
+	id := newID("key")
 	groupID := ""
 	if k.Group != "" {
 		groupID = groupIDByName[k.Group]

--- a/internal/service/factors.go
+++ b/internal/service/factors.go
@@ -321,10 +321,7 @@ func (s *Auth) EnrolTOTPStart(ctx context.Context, presented, password string) (
 		return "", err
 	}
 	defer crypto.Zero(rawSeed)
-	totpID, err := newID("totp")
-	if err != nil {
-		return "", err
-	}
+	totpID := newID("totp")
 	sealer := s.Keyring.ForInstance()
 	sealed, err := sealer.SealField(totpSeedAAD(totpID), rawSeed)
 	if err != nil {
@@ -975,10 +972,7 @@ func (s *Auth) attemptRecovery(ctx context.Context, username, code string) (Reco
 	if err != nil {
 		return RecoveryResult{}, err
 	}
-	authorityID, err := newID("cea")
-	if err != nil {
-		return RecoveryResult{}, err
-	}
+	authorityID := newID("cea")
 	var (
 		out     RecoveryResult
 		refused error

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -170,13 +170,10 @@ func (s *Federation) CreateIssuer(ctx context.Context, actor Actor, req IssuerRe
 	if err := checkIssuerRequest(req); err != nil {
 		return IssuerView{}, err
 	}
-	id, err := newID("fis")
-	if err != nil {
-		return IssuerView{}, err
-	}
+	id := newID("fis")
 	now := s.now()
 	var out IssuerView
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err
@@ -426,10 +423,7 @@ func (s *Federation) CreateBinding(ctx context.Context, actor Actor, scope domai
 	if err != nil {
 		return BindingView{}, err
 	}
-	credID, err := newID("mcr")
-	if err != nil {
-		return BindingView{}, err
-	}
+	credID := newID("mcr")
 	now := s.now()
 	var out BindingView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {

--- a/internal/service/grants.go
+++ b/internal/service/grants.go
@@ -789,10 +789,7 @@ func writeGrantRowState(ctx context.Context, az *authz.TxAuthorizer, spec GrantS
 					domain.ErrLimitExceeded, MaxGrantsPerOrg)
 			}
 		}
-		grantID, err := newID("grt")
-		if err != nil {
-			return GrantResult{}, err
-		}
+		grantID := newID("grt")
 		if err := az.CreateGrant(ctx, grantID, spec.Target,
 			domain.Grant{Capability: spec.Capability, Scope: spec.Scope}, now); err != nil {
 			return GrantResult{}, err
@@ -813,10 +810,7 @@ func writeGrantRowState(ctx context.Context, az *authz.TxAuthorizer, spec GrantS
 		attach = !held
 	}
 	if attach {
-		originID, err := newID("gor")
-		if err != nil {
-			return GrantResult{}, err
-		}
+		originID := newID("gor")
 		if err := az.AddGrantOrigin(ctx, originID, out.GrantID, spec.Target, origin, now); err != nil {
 			return GrantResult{}, err
 		}

--- a/internal/service/hierarchy.go
+++ b/internal/service/hierarchy.go
@@ -165,10 +165,7 @@ func (s *Orgs) Create(ctx context.Context, actor Actor, name string, active bool
 	if err := checkName("organisation name", name); err != nil {
 		return Org{}, err
 	}
-	id, err := newID("org")
-	if err != nil {
-		return Org{}, err
-	}
+	id := newID("org")
 	now := time.Now().UTC()
 	org := store.Org{
 		ID:        id,
@@ -182,7 +179,7 @@ func (s *Orgs) Create(ctx context.Context, actor Actor, name string, active bool
 	// creates do not spend their bounded retries waiting on stale snapshots.
 	// This is a low-rate control-plane operation; sqlite already admits one
 	// writer at a time through BEGIN IMMEDIATE.
-	err = tx.WriteSerialized(ctx, s.DB, "hikyo:org-create", func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.WriteSerialized(ctx, s.DB, "hikyo:org-create", func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err
@@ -516,12 +513,9 @@ func (s *Projects) Create(ctx context.Context, actor Actor, org domain.OrgID, na
 	if err := checkName("project name", name); err != nil {
 		return Project{}, err
 	}
-	id, err := newID("prj")
-	if err != nil {
-		return Project{}, err
-	}
+	id := newID("prj")
 	proj := store.NewProject{ID: id, Name: name, CreatedAt: store.CanonTime(time.Now())}
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
 			return err
@@ -747,10 +741,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 	if err := checkName("environment name", name); err != nil {
 		return Environment{}, CloneResult{}, err
 	}
-	id, err := newID("env")
-	if err != nil {
-		return Environment{}, CloneResult{}, err
-	}
+	id := newID("env")
 	// Surface-2 block (#74) reached BEFORE the sealer mints the project DEK.
 	// Environment create is a first-mint ingress (a fresh project's first
 	// materialization mints the DEK here), so scanning only inside the write
@@ -1227,12 +1218,9 @@ func (s *Folders) Create(ctx context.Context, actor Actor, scope domain.Scope, p
 	if err := checkFolderPath(path); err != nil {
 		return Folder{}, err
 	}
-	id, err := newID("fld")
-	if err != nil {
-		return Folder{}, err
-	}
+	id := newID("fld")
 	folder := store.NewFolder{ID: id, Path: path, CreatedAt: store.CanonTime(time.Now())}
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
 			return err

--- a/internal/service/identities.go
+++ b/internal/service/identities.go
@@ -205,17 +205,11 @@ func (s *Identities) CreateServiceAccount(ctx context.Context, actor Actor, scop
 	if !domain.IsServiceAccountKind(kind) {
 		return ServiceAccountView{}, ErrServiceAccountKind
 	}
-	saID, err := newID("sa")
-	if err != nil {
-		return ServiceAccountView{}, err
-	}
-	principalID, err := newID("mch")
-	if err != nil {
-		return ServiceAccountView{}, err
-	}
+	saID := newID("sa")
+	principalID := newID("mch")
 	now := s.now()
 	var out ServiceAccountView
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err
@@ -358,13 +352,10 @@ func (s *Identities) MintCredential(ctx context.Context, actor Actor, scope doma
 	if req.Lifetime < 0 {
 		return MintResult{}, ErrCredentialLifetime
 	}
-	credID, err := newID("mcr")
-	if err != nil {
-		return MintResult{}, err
-	}
+	credID := newID("mcr")
 	now := s.now()
 	var out MintResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -536,10 +536,7 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	// declaration that differs from the one a later read returns, byte for
 	// byte, on exactly the values the canonicalization exists to normalize.
 	stored := compiled.Declaration()
-	id, err := newID("key")
-	if err != nil {
-		return Key{}, err
-	}
+	id := newID("key")
 	row := store.NewCatalogueKey{
 		ID: id, Name: spec.Name, FolderPath: spec.FolderPath,
 		Classification: spec.Classification, Description: spec.Description,
@@ -1510,13 +1507,10 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 	if err := schema.CheckGroupName(name); err != nil {
 		return KeyGroupView{}, fmt.Errorf("%w: %s", domain.ErrInvalid, err)
 	}
-	id, err := newID("kgr")
-	if err != nil {
-		return KeyGroupView{}, err
-	}
+	id := newID("kgr")
 	created := store.CanonTime(time.Now())
 	var rateCharged bool
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, time.Now().UTC())
 		if err != nil {
 			return err

--- a/internal/service/oidc.go
+++ b/internal/service/oidc.go
@@ -334,10 +334,7 @@ func (s *Providers) sealSecret(providerID, secret string) ([]byte, int64, error)
 }
 
 func (s *Providers) create(ctx context.Context, r store.Repos, az *authz.TxAuthorizer, p authz.Proof, principal domain.PrincipalID, slug string, in ProviderInput, out *ProviderView) error {
-	id, err := newID("oidcp")
-	if err != nil {
-		return err
-	}
+	id := newID("oidcp")
 	sealed, dek, err := s.sealSecret(id, in.ClientSecret)
 	if err != nil {
 		return err

--- a/internal/service/oidc_flow.go
+++ b/internal/service/oidc_flow.go
@@ -180,10 +180,7 @@ func (s *Auth) OIDCStart(ctx context.Context, slug, purpose, environmentID, pres
 	}
 	authURL := rp.AuthCodeURL(provider.ClientID, provider.RedirectURI, provider.Scopes, state, nonce, pkce, extra)
 
-	txID, err := newID("oidctx")
-	if err != nil {
-		return OIDCStartResult{}, err
-	}
+	txID := newID("oidctx")
 	newTx := authz.NewOIDCTransaction{
 		ID: txID, StateVerifier: stateVerifier, Nonce: crypto.ArtifactVerifier(nonce), PKCEVerifier: pkce,
 		ProviderID: provider.ID, Issuer: provider.Issuer, RedirectURI: provider.RedirectURI,
@@ -204,10 +201,7 @@ func (s *Auth) OIDCStart(ctx context.Context, slug, purpose, environmentID, pres
 		newTx.AccountID = account.ID
 	}
 	if purpose == purposeLink {
-		ceremonyID, cerr := newID("cer")
-		if cerr != nil {
-			return OIDCStartResult{}, cerr
-		}
+		ceremonyID := newID("cer")
 		newTx.CeremonyID = ceremonyID
 	}
 
@@ -571,18 +565,9 @@ func (s *Auth) jitProvision(ctx context.Context, az *authz.TxAuthorizer, prov au
 	if err != nil {
 		return authz.Account{}, "", err
 	}
-	principalID, err := newID("usr")
-	if err != nil {
-		return authz.Account{}, "", err
-	}
-	accountID, err := newID("acc")
-	if err != nil {
-		return authz.Account{}, "", err
-	}
-	identityID, err := newID("eid")
-	if err != nil {
-		return authz.Account{}, "", err
-	}
+	principalID := newID("usr")
+	accountID := newID("acc")
+	identityID := newID("eid")
 	// A generated handle, never the email or a provider-supplied username, so a
 	// JIT account cannot collide with or impersonate a local handle.
 	username := "oidc-" + accountID
@@ -640,10 +625,7 @@ func (s *Auth) completeLink(ctx context.Context, prov authz.OIDCProvider, txn au
 		} else if !errors.Is(e, domain.ErrNotFound) {
 			return e
 		}
-		identityID, e := newID("eid")
-		if e != nil {
-			return e
-		}
+		identityID := newID("eid")
 		if e := az.CreateExternalIdentity(ctx, authz.NewExternalIdentity{
 			ID: identityID, AccountID: account.ID, Kind: OIDCKind, Issuer: txn.Issuer,
 			Subject: claims.Subject, ProviderID: prov.ID, CredentialEpoch: epoch, CreatedAt: now,
@@ -798,10 +780,7 @@ func (s *Auth) completeReauth(ctx context.Context, prov authz.OIDCProvider, txn 
 			return e
 		}
 		completion.Assurance.Provider = prov.Slug
-		windowID, e := newID("raw")
-		if e != nil {
-			return e
-		}
+		windowID := newID("raw")
 		hardCap := s.hardCap()
 		hardExpires := now.Add(hardCap)
 		windowExpires := now.Add(effWin)

--- a/internal/service/pins.go
+++ b/internal/service/pins.go
@@ -287,10 +287,7 @@ func (s *Pins) Set(ctx context.Context, actor Actor, scope domain.Scope, request
 		}
 		action := PinCreated
 		eventType := audit.EventPinCreated
-		id, err := newID("pin")
-		if err != nil {
-			return err
-		}
+		id := newID("pin")
 		createdAt := now
 		if existingErr == nil {
 			if renewing {

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -1075,10 +1075,7 @@ func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *cryp
 	}
 
 	revision := previous + 1
-	snapshotID, err := newID("snp")
-	if err != nil {
-		return PublishedEnvironment{}, err
-	}
+	snapshotID := newID("snp")
 	if err := r.Snapshots().Insert(ctx, p, store.NewSnapshot{
 		ID: snapshotID, Revision: revision, SchemaRevision: schemaRevision,
 		PublishedBy: string(publisher), PublishedAt: now,
@@ -1100,10 +1097,7 @@ func materialize(ctx context.Context, r store.Repos, p authz.Proof, sealer *cryp
 		if !cell.set {
 			continue
 		}
-		entryID, err := newID("sne")
-		if err != nil {
-			return PublishedEnvironment{}, err
-		}
+		entryID := newID("sne")
 		sealed, err := sealer.SealField(snapshotAAD(
 			string(scope.Org), string(scope.Project), string(scope.Env), cell.key.ID, snapshotID, entryID), []byte(cell.value))
 		if err != nil {
@@ -1279,10 +1273,7 @@ func lineage(ctx context.Context, r store.Repos, p authz.Proof,
 func putCell(ctx context.Context, r store.Repos, p authz.Proof, sealer *crypto.ProjectSealer,
 	scope domain.Scope, key store.CatalogueKey, principal domain.PrincipalID,
 	value string, now time.Time) (string, error) {
-	id, err := newID("val")
-	if err != nil {
-		return "", err
-	}
+	id := newID("val")
 	entry := store.ValueEntry{
 		ID: id, OrgID: string(scope.Org), ProjectID: string(scope.Project),
 		EnvironmentID: string(scope.Env), KeyID: key.ID,

--- a/internal/service/reauth.go
+++ b/internal/service/reauth.go
@@ -581,10 +581,7 @@ func (s *Auth) reauthTOTP(ctx context.Context, presented string, intent ReauthIn
 			return err
 		}
 		for _, environmentID := range windowEnvironments {
-			windowID, err := newID("raw")
-			if err != nil {
-				return err
-			}
+			windowID := newID("raw")
 			windowExpires := now.Add(effectiveWindows[environmentID])
 			if windowExpires.After(hardExpires) {
 				windowExpires = hardExpires

--- a/internal/service/remotes.go
+++ b/internal/service/remotes.go
@@ -156,10 +156,7 @@ func (s *Remotes) AddRemote(ctx context.Context, actor Actor, name, rawURL, pin,
 	if s.Fetch == nil {
 		return RemoteView{}, errors.New("service: the directory surface has no outbound client wired")
 	}
-	id, err := newID("rmt")
-	if err != nil {
-		return RemoteView{}, err
-	}
+	id := newID("rmt")
 	now := s.now()
 
 	// Phase 1: authorize, and read the state the identity checks need. The

--- a/internal/service/rollback.go
+++ b/internal/service/rollback.go
@@ -214,11 +214,9 @@ func (s *Revisions) Restore(ctx context.Context, actor Actor, scope domain.Scope
 			if !changed {
 				continue
 			}
-			versionID, err := newID("pcv")
-			if err != nil {
-				return err
-			}
+			versionID := newID("pcv")
 			var sealed []byte
+			var err error
 			if operation == store.PendingSet {
 				sealed, err = sealer.SealField(pendingAAD(
 					string(scope.Org), string(scope.Project), string(scope.Env), key.ID, versionID), []byte(value))

--- a/internal/service/saml.go
+++ b/internal/service/saml.go
@@ -306,17 +306,11 @@ func (s *Auth) SAMLStart(ctx context.Context, slug, purpose, environmentID, pres
 	if err != nil {
 		return SAMLStartResult{}, err
 	}
-	transactionID, err := newID("samltx")
-	if err != nil {
-		return SAMLStartResult{}, err
-	}
+	transactionID := newID("samltx")
 	transaction := newSAMLTransaction(transactionID, request.RequestID, relayState, initiator,
 		provider, purpose, sessionID, account.ID, environmentID, epoch)
 	if purpose == purposeLink {
-		transaction.CeremonyID, err = newID("cer")
-		if err != nil {
-			return SAMLStartResult{}, err
-		}
+		transaction.CeremonyID = newID("cer")
 	}
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
 		now := s.now()
@@ -597,10 +591,7 @@ func (s *Auth) completeSAMLLink(ctx context.Context, az *authz.TxAuthorizer, cer
 		}
 		return LoginResult{}, ceremony.refuse(ctx, az, samlCauseInitiatorMismatch)
 	}
-	identityID, err := newID("eid")
-	if err != nil {
-		return LoginResult{}, err
-	}
+	identityID := newID("eid")
 	if err := az.CreateExternalIdentity(ctx, authz.NewExternalIdentity{
 		ID: identityID, AccountID: account.ID, Kind: SAMLKind, Issuer: transaction.EntityID,
 		Subject: subject, ProviderID: provider.ID, CredentialEpoch: epoch, CreatedAt: now,
@@ -687,10 +678,7 @@ func (s *Auth) completeSAMLReauth(ctx context.Context, az *authz.TxAuthorizer, c
 	if err != nil {
 		return LoginResult{}, err
 	}
-	windowID, err := newID("raw")
-	if err != nil {
-		return LoginResult{}, err
-	}
+	windowID := newID("raw")
 	hardCap := s.ReauthHardCap
 	if hardCap <= 0 {
 		hardCap = effectiveWindow

--- a/internal/service/saml_providers.go
+++ b/internal/service/saml_providers.go
@@ -229,10 +229,7 @@ func (s *SAMLProviders) Put(ctx context.Context, actor Actor, slug string, input
 			if previous != nil {
 				return ErrSAMLProviderRace
 			}
-			providerID, idErr := newID("samlp")
-			if idErr != nil {
-				return idErr
-			}
+			providerID := newID("samlp")
 			now := s.now()
 			provider := authz.NewSAMLProvider{
 				ID: providerID, Slug: slug, DisplayName: input.DisplayName, EntityID: metadata.EntityID,
@@ -1170,10 +1167,7 @@ type generatedSAMLSPKey struct {
 // to ensureSPKey, which fences on that version (fenceInstanceVersion) in the
 // write transaction before the SP-key row is inserted.
 func (s *SAMLProviders) generateSPKey() (generatedSAMLSPKey, error) {
-	id, err := newID("samlkey")
-	if err != nil {
-		return generatedSAMLSPKey{}, err
-	}
+	id := newID("samlkey")
 	privateKey, err := rsa.GenerateKey(rand.Reader, 3072)
 	if err != nil {
 		return generatedSAMLSPKey{}, err

--- a/internal/service/scan.go
+++ b/internal/service/scan.go
@@ -468,10 +468,7 @@ func scanConfigValue(ctx context.Context, r store.Repos, p authz.Proof, kr *cryp
 
 func recordDismissal(ctx context.Context, r store.Repos, p authz.Proof, kr *crypto.Keyring,
 	keyID, ruleDigest string, fingerprint []byte, ruleID string, principal domain.PrincipalID) error {
-	id, err := newID("dsm")
-	if err != nil {
-		return err
-	}
+	id := newID("dsm")
 	if err := r.ScanningDismissals().Insert(ctx, p, store.NewDismissal{
 		ID: id, KeyID: keyID, RuleDigest: ruleDigest, Fingerprint: fingerprint,
 		CreatedBy: string(principal), CreatedAt: time.Now(),

--- a/internal/service/scim.go
+++ b/internal/service/scim.go
@@ -587,10 +587,7 @@ func (s *SCIM) enterAttention(
 			return nil, nil
 		}
 	}
-	id, err := newID("sat")
-	if err != nil {
-		return nil, err
-	}
+	id := newID("sat")
 	if err := r.SCIM().EnterAttention(ctx, c.proof, store.SCIMAttentionRow{
 		ID: id, BindingID: c.binding.ID, State: string(state),
 		SubjectRef: subjectRef, Cause: string(cause), EnteredAt: now,
@@ -703,10 +700,7 @@ func (s *SCIM) mintCredential(
 	if err != nil {
 		return "", store.NewSCIMCredential{}, err
 	}
-	id, err := newID("scr")
-	if err != nil {
-		return "", store.NewSCIMCredential{}, err
-	}
+	id := newID("scr")
 	epoch, err := az.CredentialEpoch(ctx)
 	if err != nil {
 		return "", store.NewSCIMCredential{}, err

--- a/internal/service/scim_admin.go
+++ b/internal/service/scim_admin.go
@@ -99,14 +99,8 @@ func (s *SCIM) CreateBinding(ctx context.Context, actor Actor, org domain.OrgID,
 		}
 
 		now := s.now()
-		bindingID, err := newID("scb")
-		if err != nil {
-			return err
-		}
-		principalID, err := newID("prn")
-		if err != nil {
-			return err
-		}
+		bindingID := newID("scb")
+		principalID := newID("prn")
 		// The principal first: the binding row references it, and it carries
 		// its class at INSERT so it is never briefly unclassified.
 		if err := az.CreateProvisioningPrincipal(ctx, domain.PrincipalID(principalID), now); err != nil {

--- a/internal/service/scim_mapping.go
+++ b/internal/service/scim_mapping.go
@@ -148,10 +148,7 @@ func (s *SCIM) CreateMapping(ctx context.Context, actor Actor, org domain.OrgID,
 			}
 
 			now := s.now()
-			id, err := newID("scm")
-			if err != nil {
-				return err
-			}
+			id := newID("scm")
 			if err := r.SCIM().CreateMapping(ctx, p, store.NewSCIMMapping{
 				ID: id, BindingID: bindingID, GroupID: spec.GroupID,
 				Template:       string(spec.Template),

--- a/internal/service/scim_origin_release.go
+++ b/internal/service/scim_origin_release.go
@@ -246,10 +246,7 @@ func releaseSCIMOrigins(
 			// survives on a system-minted retention origin recording what
 			// triggered the conversion, and the binding enters the attention
 			// state naming the retained grant and principal.
-			originID, err := newID("gor")
-			if err != nil {
-				return out, nil, err
-			}
+			originID := newID("gor")
 			retention := authz.Origin{
 				Kind: domain.OriginLockoutRetention,
 				Subject: domain.SCIMRetentionKey{

--- a/internal/service/scim_wire.go
+++ b/internal/service/scim_wire.go
@@ -224,10 +224,7 @@ func (s *SCIM) CreateUser(ctx context.Context, actor Actor, org domain.OrgID, bi
 			if err != nil {
 				return nil, err
 			}
-			id, err := newID("scu")
-			if err != nil {
-				return nil, err
-			}
+			id := newID("scu")
 			if err := c.checkDeclaredSchemas(in.Attributes); err != nil {
 				return nil, err
 			}
@@ -300,17 +297,11 @@ func (s *SCIM) attachOrCreateAccount(
 		return "", "", err
 	}
 
-	principalID, err := newID("prn")
-	if err != nil {
-		return "", "", err
-	}
+	principalID := newID("prn")
 	if err := az.CreateHumanPrincipal(ctx, domain.PrincipalID(principalID), now); err != nil {
 		return "", "", err
 	}
-	newAccountID, err := newID("acc")
-	if err != nil {
-		return "", "", err
-	}
+	newAccountID := newID("acc")
 	// The account HANDLE is opaque, not the SCIM `userName`.
 	//
 	// `accounts.username` is globally unique and is the LOCAL LOGIN handle; a
@@ -320,20 +311,14 @@ func (s *SCIM) attachOrCreateAccount(
 	// DIFFERENT humans collided, and the collision failed create while attach
 	// succeeded, which is an existence oracle across orgs. The SCIM userName
 	// keeps living in `scim_users`, where it is scoped the way SCIM scopes it.
-	handle, err := newID("scim")
-	if err != nil {
-		return "", "", err
-	}
+	handle := newID("scim")
 	if err := az.CreateAccount(ctx, authz.Account{
 		ID: newAccountID, PrincipalID: domain.PrincipalID(principalID),
 		Username: handle, DisplayName: in.UserName, CreatedAt: now,
 	}); err != nil {
 		return "", "", err
 	}
-	identityID, err := newID("eid")
-	if err != nil {
-		return "", "", err
-	}
+	identityID := newID("eid")
 	epoch, err := az.CredentialEpoch(ctx)
 	if err != nil {
 		return "", "", err

--- a/internal/service/scim_wire.go
+++ b/internal/service/scim_wire.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"sort"
@@ -849,7 +849,9 @@ func unmarshalAttributes(raw string) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	// Parse, never cast: what came back out of storage goes through the same
-	// decoder the trust boundary used on the way in.
+	// decoder the trust boundary used on the way in. The stored form is
+	// written by marshalAttributes, so the v2 decoder's strict defaults
+	// (duplicate names, invalid UTF-8) hold it to exactly what we produce.
 	var out map[string]any
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
 		return nil, fmt.Errorf("service: stored SCIM attributes are not a JSON object: %w", err)

--- a/internal/service/scim_wire_bench_test.go
+++ b/internal/service/scim_wire_bench_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"testing"
+)
+
+func benchAttributes() map[string]any {
+	return map[string]any{
+		"userName":  "[EMAIL]",
+		"active":    true,
+		"nickName":  "wren",
+		"locale":    "en-GB",
+		"timezone":  "Europe/Amsterdam",
+		"title":     "Engineer",
+		"name":      map[string]any{"givenName": "Wren", "familyName": "De Vries", "formatted": "Wren de Vries"},
+		"emails":    []any{map[string]any{"value": "[EMAIL]", "primary": true, "type": "work"}},
+		"phoneNbrs": []any{map[string]any{"value": "+31 20 555 0100", "type": "work"}},
+		"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber": "4711",
+	}
+}
+
+func BenchmarkSCIMAttributesRoundTrip(b *testing.B) {
+	raw, err := marshalAttributes(benchAttributes())
+	if err != nil {
+		b.Fatal(err)
+	}
+	if raw == "" {
+		b.Fatal("empty fixture")
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		out, err := unmarshalAttributes(raw)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := marshalAttributes(out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/service/scim_wire_groups.go
+++ b/internal/service/scim_wire_groups.go
@@ -72,10 +72,7 @@ func (s *SCIM) CreateGroup(ctx context.Context, actor Actor, org domain.OrgID, b
 			// duplicate `userName` and a subject-source collision. A
 			// `displayName eq` probe that matches two groups is answered with
 			// two, which is what a ListResponse is for.
-			id, err := newID("scg")
-			if err != nil {
-				return nil, err
-			}
+			id := newID("scg")
 			if err := r.SCIM().CreateGroup(ctx, c.proof, store.NewSCIMGroup{
 				ID: id, BindingID: bindingID, DisplayName: in.DisplayName,
 				DisplayNameLower: fold(in.DisplayName), ExternalID: in.ExternalID,
@@ -251,10 +248,7 @@ func (s *SCIM) setMembers(
 		// left those users unauthorized until somebody happened to change the
 		// group.
 		if !have[id] {
-			memberID, err := newID("sgm")
-			if err != nil {
-				return nil, nil, nil, err
-			}
+			memberID := newID("sgm")
 			if err := r.SCIM().AddGroupMember(ctx, c.proof, store.SCIMGroupMember{
 				ID: memberID, BindingID: c.binding.ID, GroupID: groupID, UserID: id, CreatedAt: now,
 			}); err != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -9,10 +9,9 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
@@ -30,10 +29,7 @@ import (
 // carries the request's wire metadata; the actor class is resolved
 // server-side at the store boundary.
 func newAuditEvent(ctx context.Context, typ audit.EventType, principal domain.PrincipalID, obj audit.Object, outcome audit.Outcome, correlationID string, payload audit.Payload) (audit.Event, error) {
-	id, err := audit.NewEventID()
-	if err != nil {
-		return audit.Event{}, err
-	}
+	id := audit.NewEventID()
 	wire := audit.FromContext(ctx)
 	return audit.Event{
 		ID: id, Type: typ, SchemaVersion: 1,
@@ -187,10 +183,6 @@ func (a Actor) resolveSelf(ctx context.Context, az *authz.TxAuthorizer, now time
 	return az.AuthenticateSelfSurface(ctx, a.bearer, now)
 }
 
-func newID(prefix string) (string, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return "", fmt.Errorf("service: generate %s id: %w", prefix, err)
-	}
-	return prefix + "_" + id.String(), nil
+func newID(prefix string) string {
+	return prefix + "_" + uuid.NewV7().String()
 }

--- a/internal/service/session_completion.go
+++ b/internal/service/session_completion.go
@@ -159,10 +159,7 @@ func (s *Auth) createCompletedSession(ctx context.Context, az *authz.TxAuthorize
 			return LoginResult{}, err
 		}
 	}
-	sessionID, err := newID("ses")
-	if err != nil {
-		return LoginResult{}, err
-	}
+	sessionID := newID("ses")
 	generation, err := az.PrincipalGeneration(ctx, completion.account.PrincipalID)
 	if err != nil {
 		return LoginResult{}, err

--- a/internal/service/updates.go
+++ b/internal/service/updates.go
@@ -166,10 +166,7 @@ func (s *Updates) Request(ctx context.Context, actor Actor, version string) (upd
 	if err != nil {
 		return updater.Job{}, fmt.Errorf("update helper unavailable: %w", err)
 	}
-	jobID, err := newID("upd")
-	if err != nil {
-		return updater.Job{}, err
-	}
+	jobID := newID("upd")
 	now := time.Now
 	if s.Now != nil {
 		now = s.Now

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -394,10 +394,7 @@ func checkNotForbidden(key store.CatalogueKey, rules schema.PresenceRules, envID
 // into.
 func writeCell(ctx context.Context, r store.Repos, p authz.Proof, sealer *crypto.ProjectSealer,
 	scope domain.Scope, key store.CatalogueKey, principal domain.PrincipalID, value string) (time.Time, error) {
-	id, err := newID("val")
-	if err != nil {
-		return time.Time{}, err
-	}
+	id := newID("val")
 	entry := store.ValueEntry{
 		ID: id, OrgID: string(scope.Org), ProjectID: string(scope.Project),
 		EnvironmentID: string(scope.Env), KeyID: key.ID,
@@ -534,10 +531,7 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 		default:
 			baseline = entry.ID
 		}
-		versionID, err := newID("pcv")
-		if err != nil {
-			return stageWriteResult{}, err
-		}
+		versionID := newID("pcv")
 		var sealed []byte
 		if operation == store.PendingSet {
 			if sealed, err = sealer.SealField(

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -196,10 +196,7 @@ func (s *Auth) EnrolPasskeyStart(ctx context.Context, presented, password, code 
 		if err != nil {
 			return err
 		}
-		ceremonyID, err := newID("wac")
-		if err != nil {
-			return err
-		}
+		ceremonyID := newID("wac")
 		if err := az.CreateWebAuthnCeremony(ctx, authz.NewWebAuthnCeremony{
 			ID: ceremonyID, ChallengeVerifier: challengeVerifier(challenge), SessionData: sessionData,
 			AccountID: account.ID, SessionID: live.SessionID, Purpose: "enrol",
@@ -273,10 +270,7 @@ func (s *Auth) EnrolPasskeyFinish(ctx context.Context, presented string, respons
 	}
 	discoverable := credPropsDiscoverable(reg.CredProps)
 
-	credID, err := newID("wacred")
-	if err != nil {
-		return LoginResult{}, err
-	}
+	credID := newID("wacred")
 	result, err := writeCommittedLoginResult(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer, result *LoginResult) error {
 		now := s.now()
 		live, err := az.Authenticate(ctx, presented, now)
@@ -362,10 +356,7 @@ func (s *Auth) PasskeyLoginStart(ctx context.Context) ([]byte, error) {
 		if err != nil {
 			return err
 		}
-		ceremonyID, err := newID("wac")
-		if err != nil {
-			return err
-		}
+		ceremonyID := newID("wac")
 		return az.CreateWebAuthnCeremony(ctx, authz.NewWebAuthnCeremony{
 			ID: ceremonyID, ChallengeVerifier: challengeVerifier(challenge), SessionData: sessionData,
 			Purpose: "login", CredentialEpoch: epoch,
@@ -676,10 +667,7 @@ func (s *Auth) ReauthPasskeyFinish(ctx context.Context, presented string, respon
 		if err != nil {
 			return err
 		}
-		windowID, err := newID("raw")
-		if err != nil {
-			return err
-		}
+		windowID := newID("raw")
 		// The environment's effective window is resolved through the one seam, not
 		// the global s.ReauthWindow (A2): once #55 persists per-environment
 		// overrides, an env lowered to 0 opens the mandated single-decision gate
@@ -798,10 +786,7 @@ func (s *Auth) beginAccountCeremony(ctx context.Context, presented, purpose, ope
 		if err != nil {
 			return err
 		}
-		ceremonyID, err := newID("wac")
-		if err != nil {
-			return err
-		}
+		ceremonyID := newID("wac")
 		if err := az.CreateWebAuthnCeremony(ctx, authz.NewWebAuthnCeremony{
 			ID: ceremonyID, ChallengeVerifier: challengeVerifier(challenge), SessionData: sessionData,
 			AccountID: account.ID, SessionID: id.SessionID, Purpose: purpose,

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -214,21 +214,12 @@ func (s *Workspace) MintConnection(ctx context.Context, actor Actor, label strin
 	if req.Lifetime < 0 {
 		return MintConnectionResult{}, ErrCredentialLifetime
 	}
-	connID, err := newID("icn")
-	if err != nil {
-		return MintConnectionResult{}, err
-	}
-	principalID, err := newID("mch")
-	if err != nil {
-		return MintConnectionResult{}, err
-	}
-	grantID, err := newID("grn")
-	if err != nil {
-		return MintConnectionResult{}, err
-	}
+	connID := newID("icn")
+	principalID := newID("mch")
+	grantID := newID("grn")
 	now := s.now()
 	var out MintConnectionResult
-	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
 			return err
@@ -706,10 +697,7 @@ func (s *Workspace) StartHandoff(ctx context.Context, req HandoffRequest) (Hando
 		return HandoffStart{}, fmt.Errorf("%w: unknown handoff purpose %q", domain.ErrInvalid, req.Purpose)
 	}
 
-	id, err := newID("hnd")
-	if err != nil {
-		return HandoffStart{}, err
-	}
+	id := newID("hnd")
 	state, stateVerifier, err := crypto.NewArtifact(crypto.ArtifactHandoffState)
 	if err != nil {
 		return HandoffStart{}, err
@@ -1045,10 +1033,7 @@ func (s *Workspace) RedeemHandoff(ctx context.Context, code, pkceVerifier, origi
 	if err != nil {
 		return WorkspaceSession{}, err
 	}
-	sessionID, err := newID("ses")
-	if err != nil {
-		return WorkspaceSession{}, err
-	}
+	sessionID := newID("ses")
 	now := s.now()
 	var out WorkspaceSession
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
@@ -1271,10 +1256,7 @@ func (s *Workspace) elevate(
 	if err != nil {
 		return WorkspaceSession{}, err
 	}
-	windowID, err := newID("raw")
-	if err != nil {
-		return WorkspaceSession{}, err
-	}
+	windowID := newID("raw")
 	value, verifier, err := crypto.NewArtifact(crypto.ArtifactWorkspaceSession)
 	if err != nil {
 		return WorkspaceSession{}, err

--- a/internal/store/adapter_runtime.go
+++ b/internal/store/adapter_runtime.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"uuid"
 
 	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
@@ -488,7 +488,7 @@ func adapterEffectKey(effect adapter.Effect) string {
 	return string(effect.Surface) + "\x00" + strings.ToUpper(effect.EffectiveName)
 }
 
-func newAdapterID(prefix string) string { return prefix + "_" + uuid.Must(uuid.NewV7()).String() }
+func newAdapterID(prefix string) string { return prefix + "_" + uuid.NewV7().String() }
 
 func (j *adapterJournal) Reserve(ctx context.Context, effect adapter.Effect) (adapter.LedgerState, error) {
 	state := adapter.Reserved


### PR DESCRIPTION
**Stacked on #522** — merge that first; this branch is based on it.

Opportunistic adoption of Go 1.27 features, per the upgrade investigation. Three independent commits, revertible individually.

## 1. stdlib uuid swap (42 files, −288 lines)
github.com/google/uuid → the new stdlib `uuid` package (RFC 9562). Its `NewV7()` is infallible, so:
- `service.newID` and `audit.NewEventID` drop their impossible error returns
- ~95 call sites lose dead `if err != nil` branches (compiler-guided sweep; every deleted block existed solely to report id-generation failure)
- shared-`err` sites converted carefully (rollback restore loop, hierarchy creates, adapters, workspace, federation, identities, keys) — no other error path touched
- google/uuid moves from direct to indirect require (still pulled transitively by sops/k8s deps)

## 2. SCIM attribute serialisation → encoding/json/v2
`marshalAttributes`/`unmarshalAttributes`/`encodeAttr` in internal/service/scim_wire.go. The stored form is written by marshalAttributes itself, so v2's stricter defaults (duplicate names, invalid UTF-8 rejected) hold storage to exactly what we produce.

BenchmarkSCIMAttributesRoundTrip (10-attribute user fixture, 5-run medians):
| | ns/op | B/op | allocs/op |
|---|---|---|---|
| v1 | 7579 | 4352 | 92 |
| **v2** | **5150 (−32%)** | **3884** | **62 (−33%)** |

## 3. compose cursor → encoding/json/v2
DisallowUnknownFields decoder dance → one `json.Unmarshal(b, &c, json.RejectUnknownMembers(true))`. Migration also tightens two edges v1 left loose: duplicate member names now rejected (was last-write-wins), trailing data now an error (was ignored) — both consistent with cursor.json's documented strictly-parsed contract.

## Deliberately NOT adopted here
- oidcfed metadata parsing: external-input wire compat with real-world IdPs; strictness there is a separate decision.
- oidc.go policy unmarshal + server/api wire decoding: cold paths / owned by generated oapi-codegen runtime.
- Generic methods: no call site where they beat the existing shape; forcing one would be churn.

## Verification (on this stack's head)
- go build ./..., go vet ./..., gofmt clean, generated code + CRDs fresh
- Full suite all 69 packages incl. internal/isolation (115s): green