### PR TITLE
Minimal UI update

### DIFF
--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -127,8 +127,8 @@ const faq = [
             <p class="eyebrow"><span class="live" aria-hidden="true"></span> 0.x · one Go binary · self-hosted</p>
             <h1>Every environment<br /><span>answers for itself.</span></h1>
             <p class="lede">
-              Hikyo gives self-hosting teams one view of validated configuration and secrets. Every value is
-              explicit: see what is set, catch what is missing, and require deliberate access before sensitive
+              Hikyo gives <strong>self-hosting</strong> teams one view of validated configuration and secrets. Every value is
+              explicit: see what is set, catch what is missing, and require <strong>deliberate access</strong> before sensitive
               values move.
             </p>
             <div class="hero-actions">
@@ -223,8 +223,8 @@ const faq = [
             <p class="kicker">// one path from intent to runtime</p>
             <h2 id="flow-heading">Declare once. Decide per environment.</h2>
             <p class="section-lede">
-              Hikyo separates the shape of a key from each environment's value, then keeps delivery inside the
-              same authorization model.
+              Hikyo separates the <strong>shape of a key</strong> from each environment's value, then keeps delivery inside the
+              same <strong>authorization model</strong>.
             </p>
           </div>
           <ol class="steps" data-flow-steps>
@@ -252,15 +252,14 @@ const faq = [
           <p class="kicker">// explicit state, deliberate access</p>
           <h2 id="product-heading">A dense surface that stays honest.</h2>
           <p class="section-lede">
-            A growing key catalogue across several environments should stay scannable. Hikyo makes absence visible
-            and keeps secret material behind a separate disclosure path.
+            A growing key catalogue across several environments should <strong>stay scannable</strong>. Hikyo makes <strong>absence visible</strong> and keeps secret material behind a separate <strong>disclosure path</strong>.
           </p>
 
           <article class="feature-row">
             <div class="feature-copy">
               <h3>Every environment answers for itself.</h3>
               <p>
-                Values never fall through a hidden inheritance chain. Each cell is explicitly set or absent, so
+                Values never fall through a <strong>hidden inheritance</strong> chain. Each cell is <strong>explicitly set or absent</strong>, so
                 production cannot quietly borrow a development default.
               </p>
               <p class="feature-note"><span>▸</span> Flat values: no inheritance, no hidden fallback.</p>
@@ -280,8 +279,8 @@ const faq = [
             <div class="feature-copy">
               <h3>Revealing a secret is a ceremony.</h3>
               <p>
-                Secrets stay masked until you deliberately re-authenticate. Reveal windows remask automatically,
-                and clipboard copies become individual audited disclosures.
+                Secrets <strong>stay masked</strong> until you deliberately re-authenticate. Reveal windows remask automatically,
+                and clipboard copies become individual <strong>audited disclosures</strong>.
               </p>
               <p class="feature-note"><span>▸</span> Write-only replacement never needs the current plaintext.</p>
             </div>
@@ -299,8 +298,8 @@ const faq = [
             <div class="feature-copy">
               <h3>Invalid changes stop at write time.</h3>
               <p>
-                Key declarations distinguish config from secrets and attach validation rules. Invalid values are
-                refused, and a value required in an environment cannot be cleared there.
+                Key declarations distinguish config from secrets and attach <strong>validation rules</strong>. Invalid values are
+                refused, and a value required in an environment <strong>cannot be cleared</strong> there.
               </p>
               <p class="feature-note"><span>▸</span> The server validates the value and presence rule together.</p>
             </div>
@@ -319,8 +318,8 @@ const faq = [
             <div class="feature-copy">
               <h3>Delivery fails closed at the boundary.</h3>
               <p>
-                A workload gets configuration through its scoped identity. Secret plaintext also requires the
-                project machine-reveal opt-in and a reveal grant; otherwise delivery stops before the child starts.
+                A workload gets configuration through its <strong>scoped identity</strong>. Secret plaintext also requires the
+                project <strong>machine-reveal opt-in</strong> and a <strong>reveal grant</strong>; otherwise delivery stops before the child starts.
               </p>
               <p class="feature-note"><span>▸</span> The happy path writes no plaintext file to the host disk.</p>
             </div>
@@ -344,8 +343,8 @@ const faq = [
             <p class="kicker">// runs where you do</p>
             <h2 id="self-host-heading">Own the keys. Own the data.</h2>
             <p class="section-lede">
-              Self-hosting is the product, not a paid tier. Run one binary with its embedded web UI, choose SQLite
-              or PostgreSQL, and hold the root key outside the datastore it protects.
+              Self-hosting is the product, <strong>not a paid tier</strong>. Run one binary with its embedded web UI, choose SQLite
+              or PostgreSQL, and hold the root key <strong>outside the datastore</strong> it protects.
             </p>
             <div class="section-actions">
               <a class="button button-primary" href={repository} data-posthog-event="github_cta_clicked" data-posthog-placement="self_host">Inspect the source</a>
@@ -369,7 +368,7 @@ const faq = [
               <h2 id="comparison-heading">Different tools, different jobs.</h2>
             </div>
             <p class="section-lede">
-              Hikyo starts with explicit environment state and validated values. OpenBao leads on dynamic
+              Hikyo starts with <strong>explicit environment state</strong> and validated values. OpenBao leads on dynamic
               infrastructure credentials; Infisical and Phase pair broad delivery workflows with paid tiers.
             </p>
           </div>
@@ -498,9 +497,9 @@ const faq = [
             </p>
             <p>
               The environment matrix is the core idea: <strong>explicit state you can inspect</strong>, disclosure
-              you must intend, and refusals that name the safe next action.
+              you <strong>must intend</strong>, and refusals that name the <strong>safe</strong> next action.
             </p>
-            <p>No badge wall. No hidden operational tier. Infrastructure you can reason about.</p>
+            <p>No badge wall. <strong>No hidden operational tier</strong>. Infrastructure you can reason about.</p>
           </div>
           <p class="signature">Built in the open · MPL-2.0 · no <code>/ee</code></p>
         </div>
@@ -512,7 +511,7 @@ const faq = [
             <p class="kicker">// before you evaluate it</p>
             <h2 id="faq-heading">Questions worth answering plainly.</h2>
             <p class="section-lede">
-              Hikyo is open, self-hosted, and still pre-1.0. These boundaries matter before you place it near real
+              Hikyo is open, self-hosted, and still <strong>pre-1.0</strong>. These boundaries matter before you place it near real
               configuration or secret material.
             </p>
             <a
@@ -536,7 +535,7 @@ const faq = [
       <section class="final-cta" aria-labelledby="final-heading">
         <div class="wrap">
           <h2 id="final-heading">Config you can reason about.</h2>
-          <p>Hikyo is under active 0.x development. Read the code, inspect the decisions, and follow the road to 1.0.</p>
+          <p>Hikyo is under active 0.x development. Read the code, inspect the decisions, and follow the <strong>road to 1.0</strong>.</p>
           <div class="section-actions">
             <a
               class="button button-primary"

--- a/docs/site/src/styles/landing.css
+++ b/docs/site/src/styles/landing.css
@@ -23,6 +23,23 @@
   --sans: 'Instrument Sans', sans-serif;
   --max-width: 70rem;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  /*
+   * Section separators that sit on open ground rather than on a tinted band.
+   * The raked field runs straight under them, so a plain hairline disappears
+   * into it; these carry the accent so the page still reads as sectioned. Used
+   * on the feature rules and the closing rule under the comparison table; the
+   * stack strip keeps the plain hairline, since it reads as a band already.
+   */
+  --rule-open: color-mix(in oklab, var(--accent) 55%, var(--line));
+  /*
+   * Groove colour: the logo's dark navy, held at its hue and its muted chroma
+   * but lifted in lightness. The literal ink (#111E2F) cannot be used here -
+   * against this background it measures 1.10, below even the page's own 1.58
+   * hairlines, so the pattern would simply not exist.
+   * Alternates: cyan oklch(0.52 0.08 200), warm oklch(0.52 0.08 50).
+   */
+  --rake: oklch(0.48 0.05 258);
+  --rake-aa: 0.75px;
   color-scheme: dark;
 }
 
@@ -41,6 +58,11 @@
   --danger: oklch(0.48 0.16 30);
   --danger-quiet: oklch(0.5 0.15 30 / 0.1);
   --warning: oklch(0.52 0.13 75);
+  --rule-open: color-mix(in oklab, var(--accent) 55%, var(--line));
+  /* Same navy on paper. The literal ink measures 15.20 here, darker than the
+   * body text; this keeps the hue and lands near the other themes' weight.
+   * Alternates: cyan oklch(0.76 0.07 200), warm oklch(0.76 0.07 58). */
+  --rake: oklch(0.7 0.05 258);
   color-scheme: light;
 }
 
@@ -53,6 +75,7 @@ html {
 }
 
 body {
+  position: relative; /* containing block for the page-length garden field */
   min-width: 20rem;
   margin: 0;
   background: var(--bg);
@@ -125,6 +148,115 @@ button {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
+
+/* ------------------------------------------------------------- atmosphere */
+
+/*
+ * --rake-gap has to be a registered property, not a plain custom property:
+ * unregistered ones are interpolated as tokens, so an animation would jump
+ * between the two values instead of easing through the lengths between them.
+ */
+@property --rake-gap {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 28px;
+}
+
+/*
+ * Karesansui: one stone, one rake.
+ *
+ * A single field anchored to the whole document, so it never restarts at a
+ * section boundary. The stone sits off the top-right corner and the grooves
+ * sweep out from it across the entire scroll length: tight arcs up by the hero,
+ * flattening into long slow curves by the footer, the way a raked field reads
+ * as it recedes.
+ *
+ * Groove spacing is constant, so density is even top to bottom and only
+ * curvature changes. That is what keeps it feeling like one continuous surface
+ * rather than a texture that repeats.
+ *
+ * The grooves are antialiased analytically: CSS gradients are evaluated per
+ * pixel with no supersampling, so a hard stop stair-steps along a curve. The
+ * --rake-aa ramp on either side makes each boundary pixel coverage-weighted,
+ * which is what a rasteriser's AA does, at zero cost. Keep it sub-pixel; much
+ * past 1px it stops reading as a sharp line and starts reading as blur.
+ */
+body::before {
+  --stone: 94% -2%;
+  --rake-gap: 28px;
+
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  content: '';
+  pointer-events: none;
+  opacity: 0.4;
+  background: repeating-radial-gradient(
+    circle at var(--stone),
+    transparent 0 calc(var(--rake-gap) - var(--rake-aa)),
+    var(--rake) var(--rake-gap),
+    var(--rake) calc(var(--rake-gap) + 1px),
+    transparent calc(var(--rake-gap) + 1px + var(--rake-aa))
+  );
+
+  /*
+   * Even presence down the length, easing off only at the extreme ends so the
+   * sand neither collides with the header nor stops abruptly at the footer.
+   *
+   * Strength lives on `opacity` rather than in the mask alpha, so the mask is
+   * purely shape and the two are independent to tune.
+   *
+   * The groove colour has to clear the page's own hairlines to register at all:
+   * --line sits at about 1.58 contrast against the background, so anything at
+   * or below that reads as more of the same furniture. These sit near 3.3 in
+   * dark and 2.0 in light before opacity is applied.
+   */
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    #000 3%,
+    #000 95%,
+    transparent 100%
+  );
+}
+
+/*
+ * The sand breathes: the grooves themselves open and close, rather than the
+ * layer being scaled. Scaling would thicken the 1px strokes along with the
+ * spacing; animating the gap leaves the strokes crisp and moves only the
+ * intervals, which is what a comb drawn slowly through sand actually does.
+ *
+ * Amplitude and duration are locked together by the geometry. The rings are
+ * anchored at the stone, so a ring at radius R sits at index R/gap, and
+ * widening the gap by d moves it by (R/gap) * d. That multiplier is about 45
+ * up by the hero and about 325 at the foot of the page, so the bottom always
+ * travels roughly seven times further than the top for the same d.
+ *
+ * 28px to 52px is a deep breath: the field nearly halves its density at the top
+ * of the cycle and closes right back up.
+ *
+ * Two details make it read as moving rather than parked. The easing is a sine
+ * in-out rather than the default ease-in-out, which sits nearly still at both
+ * ends of the cycle. And the negative delay starts the page a quarter of the way
+ * in, at peak velocity, instead of at the bottom of the breath where nothing
+ * appears to happen for the first half-minute.
+ *
+ * Duration still trades against the far field: a ring at radius R moves
+ * (R/gap) * d, and that multiplier is about 45 by the hero but 335 at the foot
+ * of the page. Shorten this much further and the bottom starts to visibly flow.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  body::before {
+    animation: rake-breathe 300s cubic-bezier(0.37, 0, 0.63, 1) -75s infinite alternate;
+  }
+}
+
+@keyframes rake-breathe {
+  to {
+    --rake-gap: 52px;
+  }
+}
+
 
 .site-header {
   position: sticky;
@@ -811,7 +943,7 @@ h2 {
   align-items: center;
   gap: clamp(1.75rem, 5vw, 4.25rem);
   padding-block: clamp(2.5rem, 6vw, 4.5rem);
-  border-block-start: 1px solid var(--line-soft);
+  border-block-start: 1px solid var(--rule-open);
 }
 
 .feature-row:first-of-type {
@@ -1087,12 +1219,8 @@ h2 {
   font-size: 0.875rem;
 }
 
-.specs strong {
-  color: var(--text);
-}
-
 .comparison {
-  border-block-end: 1px solid var(--line);
+  border-block-end: 1px solid var(--rule-open);
 }
 
 .comparison-intro {
@@ -1106,11 +1234,33 @@ h2 {
   margin-block-end: 0.15rem;
 }
 
+/*
+ * The data cells are transparent, so the raked field behind the page reads
+ * straight through the table and fights the glyphs. A frosted panel puts the
+ * pattern out of focus behind the numbers while keeping it present.
+ */
 .comparison-scroll {
   margin-block-start: clamp(2rem, 5vw, 3.25rem);
   overflow-x: auto;
   border-block: 1px solid var(--line);
   outline: none;
+  background: color-mix(in oklab, var(--bg) 46%, transparent);
+  backdrop-filter: blur(3px) saturate(1.08);
+}
+
+/* No backdrop-filter, or the reader has asked for less transparency: fall back
+ * to an opaque panel rather than leaving the pattern showing through. */
+@supports not (backdrop-filter: blur(2px)) {
+  .comparison-scroll {
+    background: var(--bg);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .comparison-scroll {
+    background: var(--bg);
+    backdrop-filter: none;
+  }
 }
 
 .comparison-scroll:focus-visible {
@@ -1172,14 +1322,14 @@ h2 {
 }
 
 .comparison-table tbody th {
-  background: var(--bg);
+  background: transparent;
   color: var(--text-dim);
   font-size: 0.875rem;
   font-weight: 500;
 }
 
 .comparison-table .hikyo-column {
-  background: color-mix(in oklab, var(--accent) 7%, var(--bg));
+  background: color-mix(in oklab, var(--accent) 9%, transparent);
 }
 
 .comparison-table thead .hikyo-column {
@@ -1189,7 +1339,7 @@ h2 {
 
 .comparison-table tbody tr:hover th,
 .comparison-table tbody tr:hover td:not(.hikyo-column) {
-  background: color-mix(in oklab, var(--accent) 3%, var(--bg));
+  background: color-mix(in oklab, var(--accent) 5%, transparent);
 }
 
 .comparison-status {
@@ -1333,8 +1483,15 @@ h2 {
   margin: 0;
 }
 
-.why-body strong {
-  color: var(--text);
+/* Keywords inside the grey body copy: the page accent, at full weight. */
+.lede strong,
+.section-lede strong,
+.feature-copy p strong,
+.final-cta p strong,
+.why-body strong,
+.specs strong {
+  color: var(--accent);
+  font-weight: 700;
 }
 
 .signature {
@@ -1611,6 +1768,11 @@ h2 {
     position: sticky;
     left: 0;
     z-index: 1;
+  }
+
+  /* Sticky again means opaque again: cells must not scroll visibly beneath it. */
+  .comparison-table tbody th {
+    background: var(--bg);
   }
 
   .comparison-table thead th:first-child {

--- a/docs/site/src/styles/landing.css
+++ b/docs/site/src/styles/landing.css
@@ -23,22 +23,11 @@
   --sans: 'Instrument Sans', sans-serif;
   --max-width: 70rem;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
-  /*
-   * Section separators that sit on open ground rather than on a tinted band.
-   * The raked field runs straight under them, so a plain hairline disappears
-   * into it; these carry the accent so the page still reads as sectioned. Used
-   * on the feature rules and the closing rule under the comparison table; the
-   * stack strip keeps the plain hairline, since it reads as a band already.
-   */
+  /* Separators over open ground: a plain hairline vanishes into the pattern. */
   --rule-open: color-mix(in oklab, var(--accent) 55%, var(--line));
-  /*
-   * Groove colour: the logo's dark navy, held at its hue and its muted chroma
-   * but lifted in lightness. The literal ink (#111E2F) cannot be used here -
-   * against this background it measures 1.10, below even the page's own 1.58
-   * hairlines, so the pattern would simply not exist.
-   * Alternates: cyan oklch(0.52 0.08 200), warm oklch(0.52 0.08 50).
-   */
+  /* Groove colour: the logo navy, lifted. The literal ink reads 1.10 here. */
   --rake: oklch(0.48 0.05 258);
+  /* Sub-pixel ramp per groove edge: gradients get no supersampling. */
   --rake-aa: 0.75px;
   color-scheme: dark;
 }
@@ -59,9 +48,7 @@
   --danger-quiet: oklch(0.5 0.15 30 / 0.1);
   --warning: oklch(0.52 0.13 75);
   --rule-open: color-mix(in oklab, var(--accent) 55%, var(--line));
-  /* Same navy on paper. The literal ink measures 15.20 here, darker than the
-   * body text; this keeps the hue and lands near the other themes' weight.
-   * Alternates: cyan oklch(0.76 0.07 200), warm oklch(0.76 0.07 58). */
+  /* Same navy on paper; the literal ink reads 15.20, darker than body text. */
   --rake: oklch(0.7 0.05 258);
   color-scheme: light;
 }
@@ -151,36 +138,14 @@ button {
 
 /* ------------------------------------------------------------- atmosphere */
 
-/*
- * --rake-gap has to be a registered property, not a plain custom property:
- * unregistered ones are interpolated as tokens, so an animation would jump
- * between the two values instead of easing through the lengths between them.
- */
+/* Registered so it can be animated; unregistered properties jump, not ease. */
 @property --rake-gap {
   syntax: '<length>';
   inherits: false;
   initial-value: 28px;
 }
 
-/*
- * Karesansui: one stone, one rake.
- *
- * A single field anchored to the whole document, so it never restarts at a
- * section boundary. The stone sits off the top-right corner and the grooves
- * sweep out from it across the entire scroll length: tight arcs up by the hero,
- * flattening into long slow curves by the footer, the way a raked field reads
- * as it recedes.
- *
- * Groove spacing is constant, so density is even top to bottom and only
- * curvature changes. That is what keeps it feeling like one continuous surface
- * rather than a texture that repeats.
- *
- * The grooves are antialiased analytically: CSS gradients are evaluated per
- * pixel with no supersampling, so a hard stop stair-steps along a curve. The
- * --rake-aa ramp on either side makes each boundary pixel coverage-weighted,
- * which is what a rasteriser's AA does, at zero cost. Keep it sub-pixel; much
- * past 1px it stops reading as a sharp line and starts reading as blur.
- */
+/* Raked sand: one stone off the top-right, arcs across the whole document. */
 body::before {
   --stone: 94% -2%;
   --rake-gap: 28px;
@@ -199,18 +164,7 @@ body::before {
     transparent calc(var(--rake-gap) + 1px + var(--rake-aa))
   );
 
-  /*
-   * Even presence down the length, easing off only at the extreme ends so the
-   * sand neither collides with the header nor stops abruptly at the footer.
-   *
-   * Strength lives on `opacity` rather than in the mask alpha, so the mask is
-   * purely shape and the two are independent to tune.
-   *
-   * The groove colour has to clear the page's own hairlines to register at all:
-   * --line sits at about 1.58 contrast against the background, so anything at
-   * or below that reads as more of the same furniture. These sit near 3.3 in
-   * dark and 2.0 in light before opacity is applied.
-   */
+  /* Shape only; strength is on opacity so the two tune independently. */
   mask-image: linear-gradient(
     to bottom,
     transparent 0%,
@@ -220,31 +174,7 @@ body::before {
   );
 }
 
-/*
- * The sand breathes: the grooves themselves open and close, rather than the
- * layer being scaled. Scaling would thicken the 1px strokes along with the
- * spacing; animating the gap leaves the strokes crisp and moves only the
- * intervals, which is what a comb drawn slowly through sand actually does.
- *
- * Amplitude and duration are locked together by the geometry. The rings are
- * anchored at the stone, so a ring at radius R sits at index R/gap, and
- * widening the gap by d moves it by (R/gap) * d. That multiplier is about 45
- * up by the hero and about 325 at the foot of the page, so the bottom always
- * travels roughly seven times further than the top for the same d.
- *
- * 28px to 52px is a deep breath: the field nearly halves its density at the top
- * of the cycle and closes right back up.
- *
- * Two details make it read as moving rather than parked. The easing is a sine
- * in-out rather than the default ease-in-out, which sits nearly still at both
- * ends of the cycle. And the negative delay starts the page a quarter of the way
- * in, at peak velocity, instead of at the bottom of the breath where nothing
- * appears to happen for the first half-minute.
- *
- * Duration still trades against the far field: a ring at radius R moves
- * (R/gap) * d, and that multiplier is about 45 by the hero but 335 at the foot
- * of the page. Shorten this much further and the bottom starts to visibly flow.
- */
+/* Gaps open and close; scaling instead would thicken the strokes with them. */
 @media (prefers-reduced-motion: no-preference) {
   body::before {
     animation: rake-breathe 300s cubic-bezier(0.37, 0, 0.63, 1) -75s infinite alternate;
@@ -1234,11 +1164,7 @@ h2 {
   margin-block-end: 0.15rem;
 }
 
-/*
- * The data cells are transparent, so the raked field behind the page reads
- * straight through the table and fights the glyphs. A frosted panel puts the
- * pattern out of focus behind the numbers while keeping it present.
- */
+/* Frosted so the pattern sits out of focus behind the glyphs, not through them. */
 .comparison-scroll {
   margin-block-start: clamp(2rem, 5vw, 3.25rem);
   overflow-x: auto;
@@ -1248,8 +1174,7 @@ h2 {
   backdrop-filter: blur(3px) saturate(1.08);
 }
 
-/* No backdrop-filter, or the reader has asked for less transparency: fall back
- * to an opaque panel rather than leaving the pattern showing through. */
+/* No backdrop-filter: opaque panel rather than the pattern showing through. */
 @supports not (backdrop-filter: blur(2px)) {
   .comparison-scroll {
     background: var(--bg);
@@ -1770,7 +1695,7 @@ h2 {
     z-index: 1;
   }
 
-  /* Sticky again means opaque again: cells must not scroll visibly beneath it. */
+  /* Sticky, so opaque: cells must not scroll visibly beneath it. */
   .comparison-table tbody th {
     background: var(--bg);
   }


### PR DESCRIPTION
Minimal UI update to the landing page.

Adds a raked-sand background pattern drawn from the mark, and emphasises key terms in the body copy.

## What changed

- **Pattern** — one `repeating-radial-gradient` on `body::before`, anchored to the document so it never restarts at a section boundary. Grooves carry a sub-pixel ramp on each edge: CSS gradients are evaluated per pixel with no supersampling, so a hard stop stair-steps along a curve.
- **Animation** — `--rake-gap` is a registered property so it can be animated. The grooves open and close over 300s rather than the layer being scaled, which would thicken the 1px strokes along with the spacing. Disabled under `prefers-reduced-motion`.
- **Comparison table** — a frosted panel so the pattern sits out of focus behind the glyphs, with solid fallbacks for no `backdrop-filter` and for `prefers-reduced-transparency`. The sticky first column stays opaque on mobile, or rows scroll visibly beneath it.
- **Separators** — the three that sit on open ground carry the accent so they still read against the pattern; every bordered element that already has a tinted band behind it keeps the plain hairline.
- **Copy** — keywords in the grey body text set in the accent. No wording changed; the FAQ answers are deliberately untouched because they also feed the `FAQPage` structured data.

## Verification

`docs/site` gates all pass locally:

- `check-oss-policy.sh` — locked strings `Every value is explicit` and `Mozilla Public License 2.0` both still resolve
- `check-docs-pwa.sh`, `test-pwa-offline.mjs`, `test-posthog.mjs`
- `astro check` — 0 errors, 0 warnings, 0 hints

Checked in both themes and at 390px. Animation measured at a steady 60fps (median 16.7ms frame time, no frames over 20ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)