### PR TITLE
Add panic-recovery middleware for the uniform internal-error contract (#511)

### DIFF
--- a/docs/handoff/511-panic-recovery-middleware.md
+++ b/docs/handoff/511-panic-recovery-middleware.md
@@ -41,6 +41,9 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/511 (ox-alpha audit, P1). Base:
   byte-identical to the fault leg, panic logged with method + path.
 - `TestRecoveryLeavesACommittedResponseAlone` — a panic after
   `WriteHeader(418)`: status and committed bytes unchanged.
+- `TestRecoveryKeepsTheAdvisoryStreamAStream` — the advisory stream visitor
+  behind the full stack: recoveryWriter satisfies and forwards `http.Flusher`,
+  so SSE keeps flushing (the visitor refuses a non-flushing writer outright).
 
 ## Verification
 

--- a/docs/handoff/511-panic-recovery-middleware.md
+++ b/docs/handoff/511-panic-recovery-middleware.md
@@ -1,0 +1,48 @@
+# Issue #511: panic-recovery middleware honouring the uniform internal-error contract
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/511 (ox-alpha audit, P1). Base:
+`f32bc23096f66e05f2ac8f44a8efd3816768d426`.
+
+## Contract
+
+- `a.recoverPanics` (`internal/server/recovery.go`) leads `a.Middleware()`
+  (`internal/server/api.go`), outermost of the API stack, so an invariant panic
+  anywhere below it — contract validation included — becomes the uniform
+  `internal` refusal instead of a dropped connection.
+- The recovered answer is rendered by the same writer a fault uses today
+  (`writeError` + `wirePolicyForCode(apigen.ErrorCodeInternal)`), so the body is
+  byte-identical to every other fault: fixed "internal error" message,
+  `redactDetail` policy, no panic text, no stack on the wire.
+- The panic value and stack land in the slog pipeline via
+  `a.Log.ErrorContext` (JSON in production), not the std logger net/http
+  recovers into. The op is named method + path because the contract operation
+  is not yet in context that far out.
+- `securityHeaders` and `workspaceCORS` are router-level, one layer up from the
+  recovery leg, so recovered refusals keep the static security baseline and
+  cross-origin readability.
+- A panic after the response was committed (e.g. a fault mid-advisory-stream)
+  leaves the committed writer alone — no second WriteHeader, no appended body —
+  and logs `handler panic after response committed`. `recoveryWriter` tracks
+  commitment and forwards `Flush`, so SSE streaming in `revisions.go` keeps
+  working through the wrapped writer.
+- No new imports beyond stdlib (`runtime/debug`) plus the existing `apigen`.
+
+## Tests
+
+`internal/server/recovery_test.go`:
+
+- `TestRecoveryRendersUniformInternalBody` — injected panic behind the full
+  middleware stack: 500, body byte-identical to the strict server's fault leg
+  (asserted via `renderContractError`), no detail member, panic value + stack
+  present in the slog JSON pipeline, and a subsequent normal request still
+  answers 200.
+- `TestRecoveryCoversTheLiveRouter` — a nil-service invariant panic through
+  `NewPublic`: 500, security baseline intact (`nosniff`, CSP), body
+  byte-identical to the fault leg, panic logged with method + path.
+- `TestRecoveryLeavesACommittedResponseAlone` — a panic after
+  `WriteHeader(418)`: status and committed bytes unchanged.
+
+## Verification
+
+- `go build ./...`, `go vet ./internal/server/` clean.
+- `go test ./...` green locally, full uncached run, against the PR head.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -487,9 +487,12 @@ func (a *API) GetOrg(ctx context.Context, req apigen.GetOrgRequestObject) (apige
 // Middleware
 // ---------------------------------------------------------------------------
 
-// Middleware returns the API stack, outermost first.
+// Middleware returns the API stack, outermost first. recoverPanics leads it so
+// an invariant panic anywhere below becomes the uniform internal refusal — see
+// internal/server/recovery.go.
 func (a *API) Middleware() []func(http.Handler) http.Handler {
 	return []func(http.Handler) http.Handler{
+		a.recoverPanics,
 		a.wireContext,
 		a.stashRequest,
 		a.extractBearer,

--- a/internal/server/recovery.go
+++ b/internal/server/recovery.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+)
+
+// recoverPanics is the OUTERMOST leg of the API stack, so a panic anywhere
+// below it — contract validation included — becomes the uniform `internal`
+// refusal instead of a dropped connection, and the panic value and stack land
+// in the slog pipeline rather than the std logger net/http recovers into.
+//
+// The service layer panics on state-reachable invariant violations (double
+// classification, an unknown fetch-result variant), so this leg is part of the
+// error contract, not a programmer-error net. The security-header and CORS
+// middlewares are router-level (server.go), one layer up, so a recovered answer
+// still carries them — the recovery writer is the inner one.
+//
+// When a handler has already committed the response before panicking — a fault
+// mid-advisory-stream, say — the status is gone and a second WriteHeader would
+// be the exact std-logger noise this leg exists to remove, so the committed
+// writer is left alone and the log alone carries the failure.
+func (a *API) recoverPanics(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &recoveryWriter{ResponseWriter: w}
+		defer func() {
+			p := recover()
+			if p == nil {
+				return
+			}
+			// Mirror a.fault: the wire carries nothing derived from the cause,
+			// the process log carries everything. The contract operation is not
+			// yet in context this far out, so method and path name the op.
+			if a.Log != nil {
+				msg := "handler panic"
+				if rec.wroteHeader {
+					msg = "handler panic after response committed"
+				}
+				a.Log.ErrorContext(r.Context(), msg,
+					"op", r.Method+" "+r.URL.Path,
+					"err", fmt.Sprintf("%v", p),
+					"stack", string(debug.Stack()))
+			}
+			if !rec.wroteHeader {
+				writeError(rec, wirePolicyForCode(apigen.ErrorCodeInternal), "")
+			}
+		}()
+		next.ServeHTTP(rec, r)
+	})
+}
+
+// recoveryWriter tracks whether the response was committed, so a panic after a
+// partial write cannot graft a second status onto the stream. Flush forwards so
+// the advisory stream (revisions.go) stays a stream; without it every event
+// would sit in a buffer until the response ended, which for a stream is never.
+type recoveryWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *recoveryWriter) WriteHeader(status int) {
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *recoveryWriter) Write(b []byte) (int, error) {
+	// A bare Write is an implicit 200 (net/http), and counts as committed.
+	w.wroteHeader = true
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *recoveryWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/server/recovery_test.go
+++ b/internal/server/recovery_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+)
+
+func TestRecoveryRendersUniformInternalBody(t *testing.T) {
+	var pipeline bytes.Buffer
+	api := &API{Log: slog.New(slog.NewJSONHandler(&pipeline, nil))}
+	stack := api.Middleware()
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Hikyo-Test-Panic") == "1" {
+			panic("chargeDefaultAtEntry called for non-default-expensive operation")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	for i := len(stack) - 1; i >= 0; i-- {
+		handler = stack[i](handler)
+	}
+
+	panicRequest := httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil)
+	panicRequest.Header.Set("X-Hikyo-Test-Panic", "1")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, panicRequest)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", recorder.Code)
+	}
+	// The reference body is what a fault renders today, through the strict
+	// server's own error leg; the recovered body must be byte-identical.
+	reference := renderContractError(t, http.MethodGet, "/api/v1/meta", errors.New("private fault"))
+	if recorder.Body.String() != reference.Body.String() {
+		t.Fatalf("recovered body differs from the fault body:\nrecovered: %s\nreference: %s",
+			recorder.Body.String(), reference.Body.String())
+	}
+	var body apigen.Error
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Error.Code != apigen.ErrorCodeInternal || body.Error.Message != "internal error" || body.Error.Detail != nil {
+		t.Fatalf("body = %+v, want the fixed internal body", body)
+	}
+	for _, want := range []string{"handler panic", "chargeDefaultAtEntry", "stack"} {
+		if !strings.Contains(pipeline.String(), want) {
+			t.Fatalf("panic did not land in the slog pipeline (%q missing):\n%s", want, pipeline.String())
+		}
+	}
+
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil))
+	if recorder.Code != http.StatusOK || recorder.Body.String() != `{"ok":true}` {
+		t.Fatalf("subsequent normal request = %d %q, want 200 %q",
+			recorder.Code, recorder.Body.String(), `{"ok":true}`)
+	}
+}
+
+func TestRecoveryCoversTheLiveRouter(t *testing.T) {
+	var pipeline bytes.Buffer
+	api := &API{Log: slog.New(slog.NewJSONHandler(&pipeline, nil))}
+	handler := NewPublic(nil, api, nil, PublicOptions{})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/orgs", nil))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", recorder.Code)
+	}
+	// securityHeaders and workspaceCORS are router-level, one layer UP from the
+	// recovery leg, so a recovered refusal carries them like any other answer.
+	if recorder.Header().Get("X-Content-Type-Options") != "nosniff" || recorder.Header().Get("Content-Security-Policy") == "" {
+		t.Fatalf("recovered response lost the security baseline: %v", recorder.Header())
+	}
+	reference := renderContractError(t, http.MethodGet, "/api/v1/orgs", errors.New("private fault"))
+	if recorder.Body.String() != reference.Body.String() {
+		t.Fatalf("recovered body differs from the fault body:\nrecovered: %s\nreference: %s",
+			recorder.Body.String(), reference.Body.String())
+	}
+	for _, want := range []string{"handler panic", "GET /api/v1/orgs", "nil pointer"} {
+		if !strings.Contains(pipeline.String(), want) {
+			t.Fatalf("panic did not land in the slog pipeline (%q missing):\n%s", want, pipeline.String())
+		}
+	}
+}
+
+func TestRecoveryLeavesACommittedResponseAlone(t *testing.T) {
+	api := &API{}
+	stack := api.Middleware()
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("partial"))
+		panic("fault after the status line")
+	})
+	for i := len(stack) - 1; i >= 0; i-- {
+		handler = stack[i](handler)
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil))
+
+	if recorder.Code != http.StatusTeapot {
+		t.Fatalf("status = %d, want the already-committed %d", recorder.Code, http.StatusTeapot)
+	}
+	if recorder.Body.String() != "partial" {
+		t.Fatalf("body = %q, want the committed bytes alone", recorder.Body.String())
+	}
+}

--- a/internal/server/recovery_test.go
+++ b/internal/server/recovery_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/service"
 )
 
 func TestRecoveryRendersUniformInternalBody(t *testing.T) {
@@ -90,6 +92,34 @@ func TestRecoveryCoversTheLiveRouter(t *testing.T) {
 		if !strings.Contains(pipeline.String(), want) {
 			t.Fatalf("panic did not land in the slog pipeline (%q missing):\n%s", want, pipeline.String())
 		}
+	}
+}
+
+func TestRecoveryKeepsTheAdvisoryStreamAStream(t *testing.T) {
+	api := &API{}
+	stack := api.Middleware()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	stream := eventStream{ctx: ctx, events: make(chan service.AdvisoryEvent), retry: advisoryRetryBase}
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The visitor refuses a non-flushing writer outright; running it behind
+		// the full stack proves recoveryWriter satisfies and forwards Flusher.
+		if err := stream.VisitWatchProjectEventsResponse(w); err != nil {
+			t.Error(err)
+		}
+	})
+	for i := len(stack) - 1; i >= 0; i-- {
+		handler = stack[i](handler)
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil))
+
+	if !recorder.Flushed {
+		t.Fatal("flush did not reach the recorder; the advisory stream would buffer until it ended")
+	}
+	if !strings.HasPrefix(recorder.Body.String(), "retry: ") {
+		t.Fatalf("SSE preamble lost through the stack: %q", recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
Closes #511.

## What

Adds `a.recoverPanics` as the outermost leg of the API middleware stack, so an invariant panic anywhere below it — contract validation included — becomes the uniform `internal_error` refusal instead of a dropped connection, and the panic value and stack land in the slog JSON pipeline rather than the std logger `net/http` recovers into.

## Why

The service layer uses panic for state-reachable invariant violations (`budget.go:38`, `budget_classification.go:57`, `remotes.go:758-767`), so a panic is part of the error contract, not a programmer-error net. Today `net/http` recovers per-connection, but the client gets a reset instead of the fixed body and the stack goes to the std logger, bypassing the slog pipeline.

## How

- Recovery renders through the exact writer a fault uses today (`writeError` + `wirePolicyForCode(apigen.ErrorCodeInternal)`) — byte-identical body, `redactDetail` policy, nothing derived from the cause on the wire.
- `securityHeaders` and `workspaceCORS` are router-level, one layer up from the recovery leg, so recovered refusals keep the security baseline and cross-origin readability.
- A panic after the response was committed (fault mid-advisory-stream) is logged and left alone — no second `WriteHeader`, no appended body. `recoveryWriter` tracks commitment and forwards `Flush` so SSE streaming keeps working.
- No new dependencies beyond stdlib.

## Tests

- Injected panic behind the full middleware stack: 500, body byte-identical to the strict server's fault leg, no detail member, panic + stack in the slog pipeline, subsequent normal request answers 200.
- Nil-service invariant panic through the live router: 500, security baseline intact, body byte-identical, op logged as method + path.
- Panic after a committed response: status and committed bytes unchanged.

Full handoff: `docs/handoff/511-panic-recovery-middleware.md`.