### PR TITLE
perf(web): adopt advisory SSE stream in matrix (#510)

### DIFF
--- a/docs/handoff/510-matrix-advisory-stream.md
+++ b/docs/handoff/510-matrix-advisory-stream.md
@@ -1,0 +1,70 @@
+# #510 — Matrix advisory stream (SSE) with polling fallback
+
+Implementing ticket: [#510](https://github.com/Hikyo-Org/Hikyo/issues/510) —
+[P1] Adopt SSE advisory stream for matrix signals; demote 2s per-env polling to fallback.
+
+## What shipped
+
+Frontend-only. The server needed nothing: the advisory channel was already
+end-to-end (`internal/server/revisions.go` `WatchProjectEvents`, fan-out in
+`internal/service/advisory.go`, generated `watchProjectEventsOp`).
+
+- `web/src/api/advisory.ts` (new) — the stream boundary:
+  - `parseAdvisoryEvent` parses each stream payload against the wire shape of
+    `wireAdvisory` (`internal/server/revisions.go`). Unknown event types are
+    SKIPPED (advisory channel is additive; an unknown fact must not kill
+    delivery); a known type with a malformed body throws (parse-don't-cast).
+  - `watchProjectAdvisoryStream` drives the generated op with an
+    `AbortController`. Two reconnection layers: hey-api's fetch-SSE client
+    retries failed attempts internally (`onSseError` per failure); a CLEAN
+    server close (slow-client drop, shutdown) ends the iteration and this
+    loop re-subscribes with jittered backoff (1s base, 10s cap). Abort is the
+    whole teardown — route leave aborts, nothing lingers.
+  - `useAdvisoryStream` owns the subscription per `useMatrixProject` mount:
+    opened on mount, aborted on unmount/route change; connection state is
+    React state.
+- `web/src/api/matrix.ts`: `advisoryInvalidations(ref, event)` maps events to
+  exactly the cache prefixes named: published → values + signals +
+  pendingDrafts of the event's environment; cell.changed → signals (the
+  signals queryFn's `signalsRequireValuesRefresh` cascade still decides when
+  values must follow); pending.staged → pending drafts + signals. The
+  signals queries read `refetchInterval: signalsPollInterval(state)` — poll
+  2s only while the stream is not healthy.
+- `web/prototype/mock-api.ts`: a never-ending heartbeat stream for
+  `/events`, so the prototype goes healthy instead of reconnecting forever
+  against a 404.
+- `web/e2e/flows/matrix.spec.ts`: three flows — zero periodic signals
+  requests on an idle healthy tab + teardown on client-side route leave;
+  fallback poll activates on a blocked stream and stops on recovery;
+  a publish on a SECOND page reaches an idle page without a reload.
+
+## Decisions worth remembering
+
+- **Fetch-based SSE over native `EventSource`**: the generated op is
+  hey-api's fetch transport, which runs request interceptors — that is what
+  lets the workspace tier's bearer header ride the stream (native
+  EventSource cannot carry an Authorization header, the same reason
+  remotes.ts stays on polling). Cookie sessions need nothing extra.
+- **Unknown event types are skipped, known types are strict.** The channel
+  is advisory-only and additive; the fallback refetch covers anything a
+  skipped event would have conveyed.
+- **No replay handling in the client.** There is no `Last-Event-ID` resume
+  anywhere; freshness during any gap belongs to the fallback poll.
+- `pending.staged` is wired too (draft list + signals), beyond the ticket's
+  two event types — it is the same stream, one extra invalidation, and it
+  keeps other-principal write-presence live while polling is off.
+
+## Verification at time of writing
+
+- `pnpm --dir web run typecheck`, `pnpm --dir web run test` (392 tests, 58
+  files) green locally.
+- Playwright flows (desktop + mobile) run in CI; the new tests assert the
+  request counter, fallback activation/recovery, and cross-tab delivery
+  against the real Go binary.
+
+## Non-goals / follow-ups
+
+- The workspace matrix's SSE was not additionally asserted in the
+  two-instance flow (CORS + bearer are proven generally; a workspace failure
+  degrades to the fallback poll, which is today's behavior).
+- The prototype mock never emits events; mutations still self-invalidate.

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -419,4 +419,137 @@ test.describe('environment matrix', () => {
       });
     }
   }
+
+  /**
+   * The advisory stream (#510). These sit after the edit/publish legs so the
+   * fixture tenant is in its settled shape: one healthy stream replaces the
+   * 2s-per-environment signals poll, the poll returns only while the stream
+   * is not healthy, and a publish on a SECOND tab reaches the first without a
+   * reload — which is the whole point of demoting the poll.
+   */
+
+  test('holds one advisory stream, drops the fallback poll while healthy, and closes it on route leave', async ({ page }) => {
+    const eventsPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/events`;
+    const signals: string[] = [];
+    let eventsResponses = 0;
+    let eventsFailedCount = 0;
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname.endsWith('/signals')) {
+        signals.push(request.url());
+      }
+    });
+    page.on('response', (response) => {
+      if (new URL(response.url()).pathname === eventsPath && response.status() === 200) {
+        eventsResponses += 1;
+      }
+    });
+    page.on('requestfailed', (request) => {
+      if (new URL(request.url()).pathname === eventsPath) {
+        eventsFailedCount += 1;
+      }
+    });
+
+    // A fresh navigation under THESE listeners: the stream this test reasons
+    // about is the one it can see open.
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+    // Exactly one stream, and it actually opened: the 200 carries the retry
+    // hint the client's reconnection cadence then honours.
+    await expect
+      .poll(() => eventsResponses, { timeout: 15_000 })
+      .toBe(1);
+
+    // Idle window longer than three fallback cadences: a healthy stream holds
+    // ZERO periodic signals requests — the failure mode #510 exists to fix.
+    const before = signals.length;
+    await page.waitForTimeout(7_000);
+    expect(signals.slice(before).length).toBe(0);
+
+    // Leaving the matrix is the subscription's whole teardown: the stream's
+    // request is aborted, not left open behind the route. A client-side link,
+    // so this proves the React cleanup and not just a document teardown.
+    await page.locator('.matrix__history-link').first().click();
+    await expect
+      .poll(() => eventsFailedCount, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+  });
+
+  test('activates the 2s fallback poll when the stream cannot connect and stops it on recovery', async ({ page }) => {
+    const eventsPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/events`;
+    await page.route('**/api/v1/orgs/*/projects/*/events', (route) => route.abort());
+    // The reload is what puts the block in front of THIS page's stream: the
+    // beforeEach navigation already opened one before the route existed.
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+    await page.waitForTimeout(1_500); // the mount-time signals fetches land
+
+    // With the stream refused, the fallback owns freshness: signals requests
+    // keep arriving at the fallback cadence.
+    let signalsCount = 0;
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname.endsWith('/signals')) {
+        signalsCount += 1;
+      }
+    });
+    await page.waitForTimeout(6_000);
+    expect(signalsCount).toBeGreaterThanOrEqual(2);
+
+    // Recovery: unblock the stream; the client's retry loop reconnects, the
+    // stream goes healthy, and the fallback falls silent again.
+    await page.unroute('**/api/v1/orgs/*/projects/*/events');
+    await page.waitForResponse(
+      (response) => new URL(response.url()).pathname === eventsPath && response.status() === 200,
+      { timeout: 20_000 },
+    );
+    await page.waitForTimeout(1_000); // let the healthy transition land
+    const atRecovery = signalsCount;
+    await page.waitForTimeout(6_000);
+    expect(signalsCount).toBe(atRecovery);
+  });
+
+  test('delivers another session\u2019s publish to an idle matrix without a reload', async ({ passkeyPage: page }, testInfo) => {
+    const eventsPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/events`;
+    // Reload under THIS test's listener, so the 200 below is this page's own
+    // stream and the idle assertion is about the stream, not a stale one.
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+    await page.waitForResponse(
+      (response) => new URL(response.url()).pathname === eventsPath && response.status() === 200,
+      { timeout: 15_000 },
+    );
+
+    // A second page in the same context is a second browser session over the
+    // same signed-in identity. It stages and publishes through the ordinary
+    // matrix UI — development only, so no protected ceremony is involved —
+    // while the first page sits idle on the same surface.
+    const observer = await page.context().newPage();
+    try {
+      await observer.goto(MATRIX_PATH);
+      await expect(observer.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+
+      const value = `live-${testInfo.project.name}`;
+      await observer.getByRole('button', { name: /^LOG_LEVEL in development:/ }).click();
+      const editor = observer.getByRole('dialog');
+      await editor.getByLabel('development value').fill(value);
+      await editor.getByRole('button', { name: 'Save 1 draft' }).click();
+      await expect(observer.locator('.notice')).toContainText(`1 draft updated for LOG_LEVEL`);
+
+      await observer.getByRole('button', { name: /Review & publish/ }).click();
+      const publishSheet = observer.getByRole('region', { name: 'Publish drafts' });
+      const publish = publishSheet.getByRole('button', { name: /Publish selected/ });
+      await expect(publish).toBeEnabled();
+      await publish.click();
+      await expect(observer.locator('.notice')).toContainText(/Published atomically/);
+
+      // The idle page repaints the published cell from the advisory events —
+      // the signals fallback poll is not running, so nothing else could have
+      // brought the new value in.
+      await expect(page.getByRole('button', { name: /LOG_LEVEL in development:/ })).toContainText(
+        value,
+        { timeout: 10_000 },
+      );
+    } finally {
+      await observer.close();
+    }
+  });
 });

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -467,8 +467,15 @@ test.describe('environment matrix', () => {
 
     // Leaving the matrix is the subscription's whole teardown: the stream's
     // request is aborted, not left open behind the route. A client-side link,
-    // so this proves the React cleanup and not just a document teardown.
-    await page.locator('.matrix__history-link').first().click();
+    // so this proves the React cleanup and not just a document teardown —
+    // matrix/history renders the same Matrix with its drawer open and
+    // deliberately keeps the stream, so the target is another surface.
+    const menu = page.getByRole('button', { name: 'Menu' });
+    if (await menu.isVisible()) {
+      await menu.click();
+    }
+    await page.getByRole('link', { name: 'Members & access', exact: true }).click();
+    await expect(page).toHaveURL(/\/members/);
     await expect
       .poll(() => eventsFailedCount, { timeout: 10_000 })
       .toBeGreaterThan(0);
@@ -509,14 +516,20 @@ test.describe('environment matrix', () => {
 
   test('delivers another session\u2019s publish to an idle matrix without a reload', async ({ passkeyPage: page }, testInfo) => {
     const eventsPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/events`;
-    // Reload under THIS test's listener, so the 200 below is this page's own
-    // stream and the idle assertion is about the stream, not a stale one.
+    // Register the listener BEFORE the navigation: the stream can open before
+    // the heading settles, and the 200 below must be THIS page's own stream —
+    // the idle assertion at the end is about live delivery, not a stale poll.
+    let streamOpen = false;
+    page.on('response', (response) => {
+      if (new URL(response.url()).pathname === eventsPath && response.status() === 200) {
+        streamOpen = true;
+      }
+    });
     await page.goto(MATRIX_PATH);
     await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
-    await page.waitForResponse(
-      (response) => new URL(response.url()).pathname === eventsPath && response.status() === 200,
-      { timeout: 15_000 },
-    );
+    await expect
+      .poll(() => streamOpen, { timeout: 15_000 })
+      .toBe(true);
 
     // A second page in the same context is a second browser session over the
     // same signed-in identity. It stages and publishes through the ordinary

--- a/web/prototype/mock-api.ts
+++ b/web/prototype/mock-api.ts
@@ -663,6 +663,27 @@ function mockApi(request: IncomingMessage, response: ServerResponse): boolean | 
     }
   }
 
+  // The advisory stream (#510). The prototype has no event source to subscribe
+  // to, but the matrix asks for one and — without an answer — reconnects at
+  // its backoff forever while the fallback poll runs. Answer with a healthy,
+  // never-ending stream of heartbeats instead: the stream goes healthy, the
+  // fallback poll never starts, and the prototype exercises the same
+  // one-connection shape the real server serves. No events are emitted: the
+  // prototype's mutations invalidate their own caches through the ordinary
+  // mutation responses.
+  if (method === 'GET' && path.endsWith('/events')) {
+    response.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    });
+    response.write('retry: 5000\n\n');
+    const heartbeat = setInterval(() => response.write(': heartbeat\n\n'), 15_000);
+    response.on('close', () => {
+      clearInterval(heartbeat);
+    });
+    return true;
+  }
+
   if (path === '/api/v1/orgs' && method === 'POST') {
     return body(request).then((raw) => {
       const input = zCreateOrgRequest.parse(JSON.parse(raw));

--- a/web/src/api/advisory-stream.test.ts
+++ b/web/src/api/advisory-stream.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { watchProjectAdvisoryStream } from './advisory.ts';
+
+/**
+ * The stream loop is tested against a scripted fake of the generated stream
+ * operation, because the real one is a fetch transport: what this module owns
+ * is the STATE MACHINE around the iteration — parse, dispatch, reconnect after
+ * a clean end, stop on abort — and a script can hold all of that while the
+ * hey-api transport itself is proven by the flow suite against the real
+ * server, which is the only honest way to prove an SSE handshake.
+ */
+
+const ref = { org: 'org_a', project: 'project_a' };
+
+const hoisted = vi.hoisted(() => ({
+  calls: [] as { readonly options: Record<string, unknown> }[],
+  script: [] as ((options: Record<string, unknown>) => { stream: AsyncGenerator<unknown> })[],
+}));
+
+vi.mock('@hikyo/operations', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hikyo/operations')>();
+  return {
+    ...actual,
+    watchProjectEventsOp: {
+      call: async (options: unknown) => {
+        hoisted.calls.push({ options: options as Record<string, unknown> });
+        const step = hoisted.script.shift();
+        if (step === undefined) {
+          return hang(options);
+        }
+        return step(options as Record<string, unknown>);
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  hoisted.calls.length = 0;
+  hoisted.script.length = 0;
+});
+
+/** hang mirrors a stream the server never ends: iteration blocks until abort. */
+function hang(options: unknown): { stream: AsyncGenerator<unknown> } {
+  const signal = (options as { signal?: AbortSignal }).signal;
+  return {
+    stream: (async function* () {
+      await new Promise<void>((resolve) => {
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    })(),
+  };
+}
+
+/** script queues one stream that yields the events, then ends cleanly. */
+function script(...events: readonly unknown[]): void {
+  hoisted.script.push(() => ({
+    stream: (async function* () {
+      for (const event of events) {
+        yield event;
+      }
+    })(),
+  }));
+}
+
+/** failingScript queues one stream whose iteration throws immediately. */
+function failingScript(): void {
+  hoisted.script.push(() => ({
+    stream: (async function* () {
+      throw new Error('connection refused');
+    })(),
+  }));
+}
+
+function handlers(state: { events: unknown[]; states: string[] }) {
+  return {
+    onEvent: (event: unknown) => {
+      state.events.push(event);
+    },
+    onState: (connection: string) => {
+      state.states.push(connection);
+    },
+  };
+}
+
+describe('watchProjectAdvisoryStream', () => {
+  it('parses and dispatches events, skips unknown ones, and reconnects after a clean end', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = { events: [] as unknown[], states: [] as string[] };
+      script(
+        { type: 'revision.published', environment_id: 'env_a', revision: 3 },
+        { type: 'environment.created', environment_id: 'env_x' },
+        { type: 'cell.changed', environment_id: 'env_a', key_id: 'key_1', name: 'LOG_LEVEL', revision: 3 },
+      );
+      // Nothing further is scripted: the reconnect hangs open, as a healthy
+      // stream would, and no further calls are made in the window.
+      const handle = watchProjectAdvisoryStream(ref, {}, handlers(state));
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(state.events).toEqual([
+        { type: 'revision.published', environmentId: 'env_a', revision: 3n },
+        { type: 'cell.changed', environmentId: 'env_a', keyId: 'key_1', keyName: 'LOG_LEVEL', revision: 3n },
+      ]);
+      expect(hoisted.calls.length).toBe(2);
+      expect(hoisted.calls[0]?.options['path']).toEqual({ org: ref.org, project: ref.project });
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('marks the fallback state when a stream fails, then reconnects after backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = { events: [] as unknown[], states: [] as string[] };
+      failingScript();
+      // Nothing further is scripted: the reconnect hangs open.
+      const handle = watchProjectAdvisoryStream(ref, {}, handlers(state));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(state.states).toContain('failed');
+      expect(hoisted.calls.length).toBe(1);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(hoisted.calls.length).toBe(2);
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops subscribing when disposed, even mid-backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = { events: [] as unknown[], states: [] as string[] };
+      script();
+      const handle = watchProjectAdvisoryStream(ref, {}, handlers(state));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(hoisted.calls.length).toBe(1);
+      await handle.stop();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(hoisted.calls.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/src/api/advisory.test.ts
+++ b/web/src/api/advisory.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseAdvisoryEvent,
+  signalsPollInterval,
+  SIGNALS_FALLBACK_POLL_MS,
+} from './advisory.ts';
+import { advisoryInvalidations } from './matrix.ts';
+
+const ref = { org: 'org_a', project: 'project_a' };
+const envDev = 'env_01989abc-def0-7123-8123-123456789abc';
+const envProd = 'env_01989abc-def0-7123-8123-123456789abd';
+const keyId = 'key_01989abc-def0-7123-8123-123456789abc';
+
+describe('advisory event boundary', () => {
+  it('parses the three event types the advisory channel emits', () => {
+    expect(
+      parseAdvisoryEvent({ type: 'revision.published', environment_id: envDev, revision: 3 }),
+    ).toEqual({ type: 'revision.published', environmentId: envDev, revision: 3n });
+    expect(
+      parseAdvisoryEvent({
+        type: 'cell.changed',
+        environment_id: envProd,
+        key_id: keyId,
+        name: 'LOG_LEVEL',
+        revision: 4,
+      }),
+    ).toEqual({
+      type: 'cell.changed',
+      environmentId: envProd,
+      keyId,
+      keyName: 'LOG_LEVEL',
+      revision: 4n,
+    });
+    expect(
+      parseAdvisoryEvent({
+        type: 'pending.staged',
+        environment_id: envDev,
+        key_id: keyId,
+        name: 'LOG_LEVEL',
+        actor_id: 'usr_self',
+      }),
+    ).toEqual({
+      type: 'pending.staged',
+      environmentId: envDev,
+      keyId: keyId,
+      keyName: 'LOG_LEVEL',
+      actorId: 'usr_self',
+    });
+  });
+
+  it('keeps an unknown event type from killing the stream', () => {
+    expect(parseAdvisoryEvent({ type: 'environment.created', environment_id: envDev })).toBeNull();
+  });
+
+  it('refuses a known type whose payload the wire contract does not describe', () => {
+    expect(() =>
+      parseAdvisoryEvent({ type: 'revision.published', environment_id: envDev }),
+    ).toThrow();
+    expect(() => parseAdvisoryEvent({ type: 'cell.changed', environment_id: envDev })).toThrow();
+    expect(() =>
+      parseAdvisoryEvent({ type: 'pending.staged', environment_id: envDev, key_id: keyId }),
+    ).toThrow();
+    expect(() => parseAdvisoryEvent('retry: 100')).toThrow();
+    expect(() => parseAdvisoryEvent({ type: 'cell.changed' })).toThrow();
+    expect(() =>
+      parseAdvisoryEvent({
+        type: 'cell.changed',
+        environment_id: envDev,
+        key_id: keyId,
+        name: 'LOG_LEVEL',
+        revision: 0,
+      }),
+    ).toThrow(/positive revision/);
+  });
+});
+
+describe('advisory invalidation mapping', () => {
+  it('publishes refresh the moved environment, its signals, and its pending drafts', () => {
+    expect(
+      advisoryInvalidations(ref, {
+        type: 'revision.published',
+        environmentId: envDev,
+        revision: 3n,
+      }),
+    ).toEqual([
+      ['values', ref.org, ref.project, envDev],
+      ['matrix-signals', ref.org, ref.project, envDev],
+      ['matrix-pending', ref.org, ref.project, envDev],
+    ]);
+  });
+
+  it('cell changes touch only the signals query, which cascades to values on advancement', () => {
+    expect(
+      advisoryInvalidations(ref, {
+        type: 'cell.changed',
+        environmentId: envProd,
+        keyId: keyId,
+        keyName: 'LOG_LEVEL',
+        revision: 4n,
+      }),
+    ).toEqual([['matrix-signals', ref.org, ref.project, envProd]]);
+  });
+
+  it('staged drafts refresh the pending list and the write-presence cells', () => {
+    expect(
+      advisoryInvalidations(ref, {
+        type: 'pending.staged',
+        environmentId: envDev,
+        keyId: keyId,
+        keyName: 'LOG_LEVEL',
+      }),
+    ).toEqual([
+      ['matrix-pending', ref.org, ref.project, envDev],
+      ['matrix-signals', ref.org, ref.project, envDev],
+    ]);
+  });
+});
+
+describe('fallback poll selector', () => {
+  it('polls exactly while the stream is not healthy', () => {
+    expect(signalsPollInterval('healthy')).toBe(false);
+    expect(signalsPollInterval('connecting')).toBe(SIGNALS_FALLBACK_POLL_MS);
+    expect(signalsPollInterval('failed')).toBe(SIGNALS_FALLBACK_POLL_MS);
+  });
+});

--- a/web/src/api/advisory.ts
+++ b/web/src/api/advisory.ts
@@ -1,0 +1,294 @@
+import { watchProjectEventsOp } from '@hikyo/operations';
+import { useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+
+import type { MatrixRef } from './keys.ts';
+import type { TransportOptions } from './transport.tsx';
+
+/**
+ * The advisory event stream boundary (#510, system-architecture ADR §
+ * Real-time; revision-model ADR § Live updates).
+ *
+ * The server already ships the whole channel: an SSE endpoint with heartbeats
+ * and dead-peer detection, a bounded fan-out service that authorizes and
+ * projects every event, and a generated streaming operation bound to its
+ * success status. The matrix opens ONE such stream per open project and
+ * invalidates react-query caches from its events, instead of polling every
+ * environment's signals every two seconds. That per-environment poll remains,
+ * demoted to the documented fallback: it runs while the stream has never
+ * connected or has failed, and stops once the stream is healthy again.
+ *
+ * The channel is ADVISORY ONLY and replays nothing (`Last-Event-ID` refetches
+ * nothing): a client that misses events refetches current state from the
+ * signals endpoint. The fallback poll is that refetch — it runs precisely
+ * while the stream is not healthy, so a dropped stream costs two seconds of
+ * age, never correctness.
+ */
+
+/** The event types the revision-model ADR enumerates. */
+export type AdvisoryEventType = 'revision.published' | 'cell.changed' | 'pending.staged';
+
+/** One advisory event, camelCased for the SPA. */
+export type AdvisoryEvent = {
+  readonly type: AdvisoryEventType;
+  readonly environmentId: string;
+  readonly keyId?: string;
+  readonly keyName?: string;
+  readonly revision?: bigint;
+  readonly actorId?: string;
+};
+
+/**
+ * The wire envelope every event shares (`wireAdvisory`, internal/server/
+ * revisions.go): the type, and the environment the event was authorized
+ * against. Metadata only — no field here could hold a value or a change
+ * token, and the schemas below must never grow one.
+ */
+const zAdvisoryEnvelope = z.object({
+  type: z.string(),
+  environment_id: z.string().min(1),
+});
+
+const zEventKey = {
+  key_id: z.string().min(1),
+  name: z.string().min(1),
+} as const;
+
+/** A JSON number on the wire; bigint at this boundary, like every revision. */
+const zEventRevision = z.coerce
+  .bigint()
+  .min(BigInt(1), { error: 'Invalid value: expected a positive revision' })
+  .max(BigInt('9223372036854775807'), { error: 'Invalid value: expected an int64 revision' });
+
+const zRevisionPublishedWire = z.object({
+  type: z.literal('revision.published'),
+  environment_id: z.string().min(1),
+  revision: zEventRevision,
+});
+
+const zCellChangedWire = z.object({
+  type: z.literal('cell.changed'),
+  environment_id: z.string().min(1),
+  ...zEventKey,
+  revision: zEventRevision,
+});
+
+const zPendingStagedWire = z.object({
+  type: z.literal('pending.staged'),
+  environment_id: z.string().min(1),
+  ...zEventKey,
+  // The actor survives only on the recipient's OWN events (advisory.go's
+  // projection blanks everyone else), so `actor_id` present means "your own
+  // draft" — a fact the recipient already knows and may act on.
+  actor_id: z.string().min(1).optional(),
+});
+
+/**
+ * parseAdvisoryEvent narrows one stream payload, returning null for an event
+ * type this build does not know. Unknown types are skipped, never fatal: the
+ * channel is additive by design, and a future server naming a new fact must
+ * not kill delivery of the types this build does understand — nothing was
+ * missed that the fallback refetch would not fetch. A KNOWN type with a
+ * malformed body is refused loudly instead: a silently-accepted wrong shape is
+ * the bug this Zod boundary exists to stop.
+ */
+export function parseAdvisoryEvent(input: unknown): AdvisoryEvent | null {
+  const envelope = zAdvisoryEnvelope.parse(input);
+  switch (envelope.type) {
+    case 'revision.published':
+      return wireAdvisoryEvent(zRevisionPublishedWire.parse(input));
+    case 'cell.changed':
+      return wireAdvisoryEvent(zCellChangedWire.parse(input));
+    case 'pending.staged':
+      return wireAdvisoryEvent(zPendingStagedWire.parse(input));
+    default:
+      return null;
+  }
+}
+
+function wireAdvisoryEvent(wire: {
+  type: AdvisoryEventType;
+  environment_id: string;
+  key_id?: string;
+  name?: string;
+  revision?: bigint;
+  actor_id?: string;
+}): AdvisoryEvent {
+  return {
+    type: wire.type,
+    environmentId: wire.environment_id,
+    ...(wire.key_id === undefined ? {} : { keyId: wire.key_id }),
+    ...(wire.name === undefined ? {} : { keyName: wire.name }),
+    ...(wire.revision === undefined ? {} : { revision: wire.revision }),
+    ...(wire.actor_id === undefined ? {} : { actorId: wire.actor_id }),
+  };
+}
+
+/** How live the stream believes it is. Anything but `healthy` polls. */
+export type AdvisoryConnectionState = 'connecting' | 'healthy' | 'failed';
+
+export type AdvisoryHandlers = {
+  /** One parsed event; the consumer invalidates what the event names. */
+  readonly onEvent: (event: AdvisoryEvent) => void;
+  /** Connection-state transitions, driving the fallback poll. */
+  readonly onState: (state: AdvisoryConnectionState) => void;
+};
+
+/**
+ * The client-side reconnect cadence for attempts the server never answered.
+ * After a CONNECTED stream the server's own jittered `retry:` hint governs,
+ * so this only bounds the dark: one second before the first retry, ten at the
+ * ceiling — a compromise between a reconnect storm and a tab that sits stale
+ * behind its fallback poll for half a minute.
+ */
+const ADVISORY_RECONNECT_BASE_MS = 1_000;
+const ADVISORY_RECONNECT_MAX_MS = 10_000;
+
+/** The matrix's fallback cadence: the poll #510 demotes from primary to fallback. */
+export const SIGNALS_FALLBACK_POLL_MS = 2_000;
+
+/**
+ * signalsPollInterval is the fallback-poll selector the signals queries read:
+ * poll while the stream is not healthy, and never while it is. Pure, so the
+ * connection logic is testable without a stream.
+ */
+export function signalsPollInterval(state: AdvisoryConnectionState): number | false {
+  return state === 'healthy' ? false : SIGNALS_FALLBACK_POLL_MS;
+}
+
+/**
+ * watchProjectAdvisoryStream opens the generated stream and drives it until
+ * the returned disposer is called.
+ *
+ * Reconnection is layered, and both layers are load-bearing:
+ *
+ *  - hey-api's fetch-SSE client retries a FAILED attempt (a refused connection,
+ *    a non-2xx handshake) internally, surfacing each failure through
+ *    `onSseError`; the iteration only ends when the server ends the response
+ *    cleanly — the slow-client drop, an instance shutting down.
+ *  - That clean end ends the iteration, and this loop re-subscribes after its
+ *    own jittered backoff.
+ *
+ * The abort signal is the whole teardown: aborting cancels the in-flight
+ * read and stops the retry loop, so disposal closes the connection even
+ * mid-backoff. The route-leave cleanup is an abort, not a leak.
+ */
+export function watchProjectAdvisoryStream(
+  ref: MatrixRef,
+  transport: TransportOptions,
+  handlers: AdvisoryHandlers,
+): { stop: () => Promise<void> } {
+  const controller = new AbortController();
+  let resolveDone: (() => void) | undefined;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  const run = async (): Promise<void> => {
+    let backoffMs = ADVISORY_RECONNECT_BASE_MS;
+    try {
+      while (!controller.signal.aborted) {
+        handlers.onState('connecting');
+        try {
+          const result = await watchProjectEventsOp.call({
+            path: { org: ref.org, project: ref.project },
+            signal: controller.signal,
+            onSseEvent: () => handlers.onState('healthy'),
+            onSseError: () => handlers.onState('failed'),
+            sseDefaultRetryDelay: ADVISORY_RECONNECT_BASE_MS,
+            sseMaxRetryDelay: ADVISORY_RECONNECT_MAX_MS,
+            ...transport,
+          });
+          for await (const data of result.stream) {
+            handlers.onState('healthy');
+            const event = parseAdvisoryEvent(data);
+            if (event !== null) {
+              handlers.onEvent(event);
+            }
+          }
+        } catch {
+          // The stream ended: a failed attempt the client already reported,
+          // a refusal (401/404/429), or the abort. The state below resumes
+          // the fallback poll for exactly the window the stream is not live.
+        }
+        handlers.onState('failed');
+        if (controller.signal.aborted) {
+          break;
+        }
+        await sleep(jitter(backoffMs), controller.signal);
+        backoffMs = Math.min(backoffMs * 2, ADVISORY_RECONNECT_MAX_MS);
+      }
+    } finally {
+      resolveDone?.();
+    }
+  };
+  void run();
+  return {
+    stop: () => {
+      controller.abort();
+      return done;
+    },
+  };
+}
+
+/** `retry:` hints aside, reconnects are jittered so a server restart wave does not synchronise clients. */
+function jitter(ms: number): number {
+  return ms + Math.floor(Math.random() * ms);
+}
+
+/** Abort-aware sleep: disposal interrupts a backoff instead of outliving it. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(finish, ms);
+    signal.addEventListener('abort', finish, { once: true });
+    function finish(): void {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', finish);
+      resolve();
+    }
+  });
+}
+
+/**
+ * useAdvisoryStream owns one project's advisory subscription for the lifetime
+ * of the calling component: opened on mount, aborted on unmount, re-opened if
+ * the project ref changes. The event handler runs through a latest-ref so a
+ * re-render never re-subscribes, and the connection state is React state so
+ * the fallback poll re-renders with it.
+ */
+export function useAdvisoryStream(
+  ref: MatrixRef,
+  transport: TransportOptions,
+  onEvent: (event: AdvisoryEvent) => void,
+  enabled: boolean,
+): AdvisoryConnectionState {
+  const [state, setState] = useState<AdvisoryConnectionState>('connecting');
+  const live = useRef({ onEvent, transport });
+  useEffect(() => {
+    live.current = { onEvent, transport };
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    let stopped = false;
+    const handle = watchProjectAdvisoryStream(
+      ref,
+      live.current.transport,
+      {
+        onEvent: (event) => live.current.onEvent(event),
+        onState: (connection) => {
+          if (!stopped) {
+            setState(connection);
+          }
+        },
+      },
+    );
+    return () => {
+      stopped = true;
+      void handle.stop();
+    };
+  }, [enabled, ref.org, ref.project]);
+
+  return enabled ? state : 'connecting';
+}

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -24,6 +24,11 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 import { useMemo } from 'react';
 import { z } from 'zod';
 
+import {
+  signalsPollInterval,
+  useAdvisoryStream,
+  type AdvisoryEvent,
+} from './advisory.ts';
 import { ApiError, parsed } from './client.ts';
 import { callerSafeRefusal } from './history.ts';
 import {
@@ -52,9 +57,10 @@ export type { MatrixRef } from './keys.ts';
  *
  * The matrix reads one project catalogue and then fans out over the project's
  * environments. Every body crosses the generated Zod schema at this boundary;
- * the component receives only parsed domain records. Signals poll because the
- * API documents this endpoint as the fallback when the advisory SSE stream is
- * unavailable, and this surface does not need a second live-update protocol.
+ * the component receives only parsed domain records. Live updates ride the
+ * advisory SSE stream (#510): one subscription per open project invalidates
+ * the caches an event names, and the signals poll survives only as the
+ * documented fallback while that stream is not healthy.
  */
 
 export type MatrixKeyList = z.infer<typeof zKeyList>;
@@ -364,6 +370,44 @@ export function signalsRequireValuesRefresh(
 }
 
 /**
+ * advisoryInvalidations maps one advisory event (#510) onto exactly the cache
+ * prefixes it names — the event payload is metadata-only, so the mapping is
+ * this mechanical and the pure function is the whole of it:
+ *
+ *  - `revision.published`: the environment advanced. Its values moved, its
+ *    published drafts stopped being pending, and its signals carry the new
+ *    revision and cleared markers. The signals queryFn keeps the ordering
+ *    cascade (`signalsRequireValuesRefresh`), so the values invalidation here
+ *    is direct rather than deferred.
+ *  - `cell.changed`: the named cell moved; the signals refetch decides from
+ *    the revision whether values must follow.
+ *  - `pending.staged`: a draft appeared — the recipient's own (the projection
+ *    blanks other actors) or another principal's write-presence marker. Both
+ *    the draft list and the pending cells render that fact.
+ */
+export function advisoryInvalidations(
+  ref: MatrixRef,
+  event: AdvisoryEvent,
+): readonly (readonly string[])[] {
+  const environmentId = event.environmentId;
+  switch (event.type) {
+    case 'revision.published':
+      return [
+        valuesKey({ ...ref, environment: environmentId }),
+        signalsKey(ref, environmentId),
+        pendingDraftsKey(ref, environmentId),
+      ];
+    case 'cell.changed':
+      return [signalsKey(ref, environmentId)];
+    case 'pending.staged':
+      return [
+        pendingDraftsKey(ref, environmentId),
+        signalsKey(ref, environmentId),
+      ];
+  }
+}
+
+/**
  * The caller's own drafts, as the publish sheet previews them.
  *
  * Previews come from the server (`listPendingDrafts`), bound to the immutable
@@ -452,6 +496,21 @@ export function useMatrixProject(ref: MatrixRef) {
   const queries = useQueryClient();
   const transport = useTransport();
   const environments = useEnvironments(ref.org, ref.project);
+  // The live channel (#510): one advisory stream for the whole project. An
+  // event invalidates exactly the caches its payload names; the connection
+  // state gates the signals fallback poll below. Subscribing here — inside
+  // the same hook that owns the matrix's queries — is what makes the
+  // subscription die with the route and never outlive its ref.
+  const signalsStream = useAdvisoryStream(
+    ref,
+    transport,
+    (event) => {
+      for (const queryKey of advisoryInvalidations(ref, event)) {
+        void queries.invalidateQueries({ queryKey });
+      }
+    },
+    ref.org !== '' && ref.project !== '',
+  );
   const keys = useQuery({
     queryKey: matrixKeysKey(ref),
     queryFn: () => parsed(listKeysOp, { path: ref, ...transport }),
@@ -519,7 +578,12 @@ export function useMatrixProject(ref: MatrixRef) {
         return next;
       },
       select: (value: MatrixEnvironmentSignals) => ({ environmentId: environment.id, value }),
-      refetchInterval: 2_000,
+      // The fallback, not the heartbeat (#510): the advisory stream owns
+      // liveness while it is healthy, and this cadence exists only for a
+      // stream that has not connected or has failed. A healthy stream shows
+      // `false` and the tab holds exactly one events connection, zero
+      // periodic signals requests.
+      refetchInterval: signalsPollInterval(signalsStream),
       retry: false,
     })),
   });


### PR DESCRIPTION
Closes #510.

## What

The matrix SPA subscribed to nothing and polled every environment's signals every 2s — one full read transaction per environment per 2s per open tab (~25 req/s and ~175 queries per 2s at the 50-environment cap). The advisory SSE channel already exists end to end on the server (`WatchProjectEvents`, bounded fan-out in `internal/service/advisory.go`, generated `watchProjectEventsOp`) and had zero consumers.

This PR wires it up:

- **One stream per open matrix** (`web/src/api/advisory.ts`): `useMatrixProject` opens the generated `watchProjectEventsOp` via hey-api's fetch-SSE transport (request interceptors run, so the workspace tier's bearer header rides the stream — native `EventSource` cannot carry one). Route leave aborts the controller; the fetch reader cancels and nothing lingers.
- **Event → invalidation is a pure mapping** (`advisoryInvalidations`): `revision.published` → values + signals + pending drafts of the named environment; `cell.changed` → signals (the existing `signalsRequireValuesRefresh` cascade in the signals queryFn still decides when values follow); `pending.staged` → pending drafts + signals. Events are parsed per payload against the wire shape from `wireAdvisory` — known types strict, unknown types skipped (the channel is additive, advisory-only).
- **The 2s poll is demoted to the documented fallback**: `refetchInterval` reads the connection state — polling only while the stream is `connecting`/`failed`, silent once `healthy`. Reconnection is layered: hey-api's client backs off failed attempts internally; a clean server close (slow-client drop, shutdown) ends the iteration and the wrapper re-subscribes after its own jittered backoff. No replay handling — correctness never depends on delivery.
- The prototype mock answers `/events` with a heartbeat-only stream so the prototype goes healthy instead of reconnect-looping against a 404.

## Acceptance

- [x] Idle open tab holds exactly one SSE connection, zero periodic signals requests while healthy (Playwright request counter, 7s window)
- [x] A publish on a second page reflects in an idle matrix without a reload (no mutation ran on the observer page; the stream is the only delivery path)
- [x] Blocked stream → 2s fallback activates; recovery → polling stops (Playwright route abort + unroute)
- [x] Subscription aborts on client-side route leave (requestfailed on teardown)
- [x] Existing react-query conventions untouched (staleTime 5s, `retry: false`)
- [x] No new unbounded client state; per-hook subscription, abort on unmount

## Verification

- `pnpm --dir web run typecheck` clean
- `pnpm --dir web run test`: 392 tests / 58 files green
- New unit coverage: event parsing (strict known types, unknown types skipped), invalidation mapping, fallback selector, and the stream loop's state machine against a scripted fake op (fake timers)
- Playwright flows (desktop + mobile) run in CI against the real Go binary

Handoff: docs/handoff/510-matrix-advisory-stream.md