### PR TITLE
ci: parallelize the Playwright flow suite and trim its critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,9 @@ jobs:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
     runs-on: ubuntu-latest
+    # On the critical path that web / web-go / no-egress all need; cap it so a
+    # hung Go build or artifact transfer cannot stall the gate at the default 360.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -254,6 +257,19 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Corepack and enable pnpm
         run: ./scripts/ci/install-corepack.sh
+      # pnpm's content-addressed store, shared by both lockfiles (web and
+      # clients/ts). app-build is the SINGLE WRITER: it runs before the browser
+      # legs (which `needs` it) and warms the store they restore. A warm store
+      # turns every later `pnpm install --frozen-lockfile` from a network fetch
+      # into a local hardlink.
+      - name: Restore pnpm store
+        id: pnpm-store
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml', 'clients/ts/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-v1-${{ runner.os }}-
       - name: Verify and build the SPA
         run: ./scripts/ci/build-spa.sh --verify
       - name: Build the release-shaped app
@@ -273,6 +289,16 @@ jobs:
           if-no-files-found: error
           overwrite: true
           retention-days: 1
+      # Single writer, same rule as the Go and Playwright caches: only a trusted
+      # main push publishes the store every later PR run restores.
+      - name: Save pnpm store
+        if: >-
+          success() && steps.pnpm-store.outputs.cache-hit != 'true' &&
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ steps.pnpm-store.outputs.cache-primary-key }}
 
   # Probe the exact release-shaped binary already built for browser validation.
   # Keeping this in the same run removes the standalone workflow's duplicate
@@ -554,36 +580,47 @@ jobs:
       - name: Real Compose delivery round-trip
         run: ./scripts/compose-demo.sh
 
-  # The SPA and its flow suite (#56). One job, because the ordering is the
-  # point: the frontend must be BUILT before Go can embed it, the Go tests must
-  # pass before a browser is worth starting, and the flow registry's closure
-  # check runs first of all — a locked surface without a flow should fail in
-  # seconds, not after a full browser suite has passed.
+  # The SPA and its flow suite (#56). The flows run against the GO BINARY
+  # app-build already produced, so this job no longer builds anything — it boots
+  # instances and drives a browser.
   #
-  # One job, TWO RUNNERS: the flow suite is sharded by viewport project, which
-  # is the only axis that parallelises it without weakening anything. The
-  # harness holds one administrator per run — a TOTP ledger where a code is
-  # single-use per step, a passkey whose signature counter must advance, a
-  # shared browser session flows re-mint — so two workers inside one process
-  # would race all three. Two RUNNERS share none of it: each boots its own pair
-  # of instances, seeds its own tenant, mints its own passkey. And because both
-  # projects run every flow, each shard still executes every claim the registry
-  # makes, so the teardown closure check keeps its full force on both.
+  # PARALLELISED ON TWO AXES: viewport project (desktop / mobile) AND a flow
+  # GROUP. The harness holds one administrator per run — a TOTP ledger where a
+  # code is single-use per step, a passkey whose signature counter must advance,
+  # a shared browser session flows re-mint — so two workers inside one process
+  # would race all three (see playwright.config.ts). But each MATRIX LEG is its
+  # own runner with its own pair of instances, its own seeded tenant and its own
+  # passkey, so splitting the FLOWS across legs races nothing: a leg runs a
+  # subset of the specs, positionally (which the teardown's filter path skips its
+  # per-run execution-closure check for), and the `web-closure` aggregator below
+  # merges every leg's run log and enforces the closure ONCE over the whole set.
+  # A flow that only passes at 1280px has not passed, so every group runs on both
+  # viewports; `fail-fast: false` keeps the broken viewport named.
   #
-  # The matrix stays inside the `web` job rather than becoming a second job:
-  # `needs.web.result` already aggregates the legs, so branch protection and
-  # `check-required-jobs.sh` need no adjustment, and each leg keeps the ordering
-  # above intact instead of starting a browser behind a Go suite that failed.
+  # Adding a flow to e2e/registry.ts REQUIRES adding its spec to one group here —
+  # a flow in no group never runs, and the aggregator fails the build by name.
   web:
     needs: [changes, app-build]
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
     runs-on: ubuntu-latest
+    # A leg runs ~4 flows serially (~3–4 min); the cap is headroom over that, not
+    # the runner default of 360. A browser/MFA-ceremony hang here would otherwise
+    # stall web-closure and the whole gate for up to 6×360 runner-minutes.
+    timeout-minutes: 25
     strategy:
-      # A flow that only passes at 1280px has not passed, so the viewport that
-      # broke must be named — cancelling its sibling would hide half the answer.
       fail-fast: false
       matrix:
         project: [desktop, mobile]
+        group: [1, 2, 3]
+        # Weight-balanced by test count + MFA-ceremony cost. Every flow in
+        # e2e/registry.ts appears in exactly one group; the aggregator proves it.
+        include:
+          - group: 1
+            specs: e2e/flows/reveal.spec.ts e2e/flows/members.spec.ts e2e/flows/login.spec.ts e2e/flows/scanning.spec.ts
+          - group: 2
+            specs: e2e/flows/settings.spec.ts e2e/flows/history.spec.ts e2e/flows/workspace.spec.ts e2e/flows/matrix.spec.ts
+          - group: 3
+            specs: e2e/flows/shell.spec.ts e2e/flows/instance-admin.spec.ts e2e/flows/machine-access.spec.ts e2e/flows/account.spec.ts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -624,6 +661,16 @@ jobs:
       - name: Install Corepack and enable pnpm
         run: ./scripts/ci/install-corepack.sh
 
+      # Restore the store app-build warmed. Restore only: app-build is the
+      # writer, so both viewport legs hardlink from it and never race a save.
+      - name: Restore pnpm store
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml', 'clients/ts/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-v1-${{ runner.os }}-
+
       # The SPA consumes clients/ts generated sources through aliases, so the
       # generated Zod schemas resolve `zod` from clients/ts's own node_modules
       # — without this install, typecheck and build fail on TS2307.
@@ -635,17 +682,10 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      # The release ships the `ui`-tagged binary, so the shipped shape gets
-      # its own govulncheck pass here; `test` scans the untagged build that
-      # every Go-only change exercises. One leg: the binary is identical.
-      - name: govulncheck (vulnerabilities reachable from the release-shaped binary)
-        if: matrix.project == 'desktop'
-        run: ./scripts/ci/run-go-tool.sh govulncheck -mode=binary ci-artifacts/hikyo-ui
-
-      - name: Go tests (transport, serving rules, browser session)
-        # Restored GOCACHE may contain passing test results. Compile from cache,
-        # but always execute this job's tests against its fresh build.
-        run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
+      # The ui-tagged govulncheck and Go tests that used to run here inline moved
+      # to the `web-go` job so they run CONCURRENTLY with the browser legs rather
+      # than serially inside each of them. Go stays set up above because global
+      # setup still builds the oidctest IdP from source at flow time.
 
       # The browser payload is ~130 MB pulled from cdn.playwright.dev on every
       # leg, and both matrix legs pay it. Only the apt half (`install-deps`)
@@ -667,16 +707,30 @@ jobs:
       # `playwright test` directly, not `pnpm run e2e`: the script rebuilds the
       # SPA so a developer cannot run the flows against a stale bundle, and
       # app-build already supplied this run's exact bundle and binary.
-      - name: Flow suite (${{ matrix.project }})
+      # Positional specs, one group per leg. A positional spec filter makes the
+      # teardown SKIP its per-run execution-closure check (it is a partial run by
+      # design); the `web-closure` job re-checks closure over the merged log.
+      - name: Flow suite (${{ matrix.project }} group ${{ matrix.group }})
         working-directory: web
         env:
           HIKYO_E2E_BINARY: ${{ github.workspace }}/ci-artifacts/hikyo-ui
-        run: pnpm exec playwright test --project=${{ matrix.project }}
+        run: pnpm exec playwright test --project=${{ matrix.project }} ${{ matrix.specs }}
+
+      # Each leg's pinned-assertion run log, for the aggregator to merge. Named
+      # per (project, group) so the six logs never collide on download.
+      - name: Upload flow run log
+        if: success()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flow-log-${{ matrix.project }}-${{ matrix.group }}
+          path: web/e2e/.runs/pinned.log
+          if-no-files-found: error
+          retention-days: 1
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: playwright-traces-${{ matrix.project }}
+          name: playwright-traces-${{ matrix.project }}-${{ matrix.group }}
           path: web/test-results/
           retention-days: 7
       # One leg writes the cache. Both legs compile the same packages against
@@ -685,7 +739,7 @@ jobs:
         if: >-
           success() && steps.web-go-cache.outputs.cache-hit != 'true' &&
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-          matrix.project == 'desktop'
+          matrix.project == 'desktop' && matrix.group == 1
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build
@@ -697,11 +751,97 @@ jobs:
         if: >-
           success() && steps.playwright-browsers.outputs.cache-hit != 'true' &&
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-          matrix.project == 'desktop'
+          matrix.project == 'desktop' && matrix.group == 1
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-browsers.outputs.cache-primary-key }}
+
+  # Flow-registry EXECUTION closure, enforced once over every leg. Splitting the
+  # flows across legs means no single leg runs them all, so the per-leg teardown
+  # check is skipped (positional-spec filter); this job restores its force. It
+  # merges the six legs' run logs and asserts every flow×surface×theme claim ran
+  # for BOTH viewports. `needs: web` so it runs only when all legs passed — a
+  # failed leg already fails the gate, and a partial log here would be a false
+  # negative. No pnpm install: the checker imports only registry.ts and the pure
+  # surface list, so Node's native type stripping runs it with zero deps.
+  web-closure:
+    needs: [changes, web]
+    if: ${{ fromJSON(needs.changes.outputs.plan).web }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Download every leg's flow run log
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: flow-log-*
+          path: flow-logs
+      # Each artifact lands in its own flow-logs/<name>/ dir, so pinned.log names
+      # never collide; concatenation order does not matter to the checker.
+      - name: Merge run logs
+        run: cat flow-logs/flow-log-*/pinned.log > "$GITHUB_WORKSPACE/merged-pinned.log"
+      - name: Enforce flow-registry closure over the merged log
+        working-directory: web
+        run: node e2e/check-closure.ts "$GITHUB_WORKSPACE/merged-pinned.log"
+
+  # The ui-tagged Go coverage the browser suite used to carry inline: the
+  # release-shaped binary's govulncheck pass and the ui-tagged server/webui
+  # tests. Split into its own job so it runs CONCURRENTLY with the two browser
+  # legs instead of serially inside each of them — both legs paid it before, and
+  # neither is browser work. Keyed on the same `web` plan (see the job registry),
+  # so it is planned and required exactly when the browser legs are.
+  web-go:
+    needs: [changes, app-build]
+    if: ${{ fromJSON(needs.changes.outputs.plan).web }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Download the exact app build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: hikyo-app-${{ github.run_id }}
+      - name: Prepare the prebuilt app
+        run: chmod +x ci-artifacts/hikyo-ui
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: go-mod-v2-${{ runner.os }}-
+      - name: Select runner cache ABI
+        id: runner-cache-abi
+        run: ./scripts/ci/export-runner-cache-abi.sh
+      - name: Restore web Go cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: |
+            go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
+      # The release ships the `ui`-tagged binary, so the shipped shape gets its
+      # own govulncheck pass here; `test` scans the untagged build that every
+      # Go-only change exercises. The binary is app-build's exact artifact.
+      - name: govulncheck (vulnerabilities reachable from the release-shaped binary)
+        run: ./scripts/ci/run-go-tool.sh govulncheck -mode=binary ci-artifacts/hikyo-ui
+      - name: Go tests (transport, serving rules, browser session)
+        # Restored GOCACHE may contain passing test results. Compile from cache,
+        # but always execute against a fresh build.
+        run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
 
   test:
     needs: changes
@@ -1296,6 +1436,8 @@ jobs:
       - supply-chain-checks
       - test
       - web
+      - web-closure
+      - web-go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/ci/check-required-jobs_test.sh
+++ b/scripts/ci/check-required-jobs_test.sh
@@ -63,7 +63,9 @@ all_success='{
 	"release-snapshot":{"result":"success"},
 	"supply-chain-checks":{"result":"success"},
 	"test":{"result":"success"},
-	"web":{"result":"success"}
+	"web":{"result":"success"},
+	"web-closure":{"result":"success"},
+	"web-go":{"result":"success"}
 }'
 
 docs_plan=$(printf '%s' "$all_plan" | jq 'map_values(false) | .docs = true')
@@ -80,7 +82,9 @@ docs_success=$(printf '%s' "$all_success" | jq '
 	.["release-snapshot"].result = "skipped" |
 	.["supply-chain-checks"].result = "skipped" |
 	.test.result = "skipped" |
-	.web.result = "skipped"
+	.web.result = "skipped" |
+	.["web-closure"].result = "skipped" |
+	.["web-go"].result = "skipped"
 ')
 
 expect_accept 'successful full pull request' pull_request "$all_success" "$all_plan"

--- a/scripts/ci/ci-job-registry.json
+++ b/scripts/ci/ci-job-registry.json
@@ -109,6 +109,8 @@
       "plan_jobs": ["compose-demo"]
     },
     "web": {"required_gate": "planned", "plan_jobs": ["web"]},
+    "web-closure": {"required_gate": "planned", "plan_jobs": ["web"]},
+    "web-go": {"required_gate": "planned", "plan_jobs": ["web"]},
     "test": {"required_gate": "planned", "plan_jobs": ["test"]},
     "k8s-e2e": {
       "required_gate": "planned",

--- a/web/e2e/check-closure.ts
+++ b/web/e2e/check-closure.ts
@@ -1,0 +1,34 @@
+/**
+ * Flow-registry closure check over a MERGED run log.
+ *
+ * The `web` job splits the flows across matrix legs, so no single leg runs them
+ * all and each leg's globalTeardown skips the execution-closure check (its run
+ * is a positional-spec partial by design). This script restores that check's
+ * full force in the `web-closure` aggregator job: given the concatenation of
+ * every leg's `.runs/pinned.log`, it runs both halves of the registry gate —
+ * the declarative closure (every locked surface has a flow, every flow's spec
+ * exists) and the execution closure (every flow×surface×theme claim actually
+ * ran, for every viewport project present in the merged log).
+ *
+ * It imports only `registry.ts` and the pure surface list it closes over, so it
+ * needs no dependency install: Node's native type stripping runs it directly.
+ */
+import { readFileSync } from 'node:fs';
+
+import { liveClosureViolations, unexecutedClaims } from './registry.ts';
+
+const logPath = process.argv[2];
+if (logPath === undefined) {
+  process.stderr.write('usage: node e2e/check-closure.ts <merged-run-log>\n');
+  process.exit(2);
+}
+
+const problems = [...liveClosureViolations(), ...unexecutedClaims(readFileSync(logPath, 'utf8'))];
+if (problems.length > 0) {
+  process.stderr.write(`the flow registry is not closed across the sharded run:\n  - ${problems.join('\n  - ')}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  'flow-registry closure: every claim executed for every viewport present in the merged log\n',
+);

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -12,15 +12,19 @@ import { readRunLog, unexecutedClaims } from './registry.ts';
  *
  * It is skipped under `--grep` or a positional spec filter: a filtered run is
  * deliberately partial, and failing it would make the check something people
- * work around instead of with. CI runs unfiltered.
+ * work around instead of with.
  *
- * `--shard` is REFUSED rather than skipped. CI #169 parallelises by viewport
- * project, where each runner still runs every flow and both themes; one runner
- * legitimately sees only one viewport. The run log names each project, so a
- * combined run must close every claim independently for both viewports. A
- * `--shard` run splits the flows themselves, so the log is partial while the
- * run still looks complete. Left alone it would fail as a wall of "claims more
- * than it runs" lines that say nothing about the real cause, so it says it.
+ * CI RELIES ON THAT SKIP. The `web` job splits the flows across matrix legs and
+ * runs each leg with a positional spec list (see .github/workflows/ci.yml), so
+ * each leg is a partial run and skips here — the `web-closure` aggregator job
+ * then merges every leg's run log and runs this same closure over the whole set
+ * (e2e/check-closure.ts). A local unfiltered `pnpm run e2e` still closes here.
+ *
+ * `--shard` is REFUSED rather than skipped. It would split the flows the same
+ * way, but WITHOUT the positional-filter marker, so the log would be partial
+ * while the run still looked complete — a wall of "claims more than it runs"
+ * lines that say nothing about the real cause. The CI split uses positional
+ * specs precisely so the skip is honest; `--shard` is not, so it says so.
  */
 export default function globalTeardown(config: FullConfig): void {
   stopInstance();

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -169,15 +169,17 @@ export function surfacesForFlow(flowID: string): readonly Surface[] {
 // are separate processes, this suite runs with `workers: 1`, and a line per
 // surface-and-theme is a few dozen bytes per run.
 //
-// CI parallelism does not change that. It shards by VIEWPORT project, one
-// runner each (#169), so a legitimate run sees only the project recorded in
-// that shard. A combined run records both. For EVERY project that appears
-// anywhere in the log, every flow/surface/theme claim must appear for that
-// same project; one complete viewport can never conceal a partial second one.
-// ponytail: single-writer append. The shapes that would need merging are a
-// worker split (blocked by the fixture's single administrator, see
-// playwright.config.ts) and a `--shard` split of the flows, which global
-// teardown refuses by name for exactly this reason.
+// CI parallelism does not change what the log MEANS. It splits the flows across
+// matrix legs, one runner per (viewport project, flow group), so each leg's log
+// is partial by design and its teardown skips the execution check. The
+// `web-closure` job concatenates every leg's log and runs `unexecutedClaims`
+// over the whole thing (e2e/check-closure.ts): for EVERY project that appears
+// anywhere in the merged log, every flow/surface/theme claim must appear for
+// that same project, so one complete viewport can never conceal a partial
+// second one. The append stays single-writer PER LEG; the aggregator merges the
+// legs by concatenation, which needs no coordination. A `--shard` split is
+// still refused by global teardown — it fragments the flows without the
+// positional-filter marker the skip is keyed on.
 
 export const RUN_LOG = fileURLToPath(new URL('.runs/pinned.log', import.meta.url));
 

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -25,14 +25,19 @@ import { BASE_URL } from './e2e/fixtures/instance.ts';
  * one process race all three, and each race surfaces as an `unauthenticated`
  * several tests away from its cause.
  *
- * So the suite is parallelised across RUNNERS instead, one per project — see
- * the `web` job's matrix in .github/workflows/ci.yml. Two runners share none of
- * that state: each boots its own instances, seeds its own tenant and mints its
- * own passkey. Both projects run every flow, so a per-project shard still
- * executes every claim in the registry and the teardown closure check stays
- * whole. Sharding any finer (`--shard`) splits the flows themselves and breaks
- * that property; global teardown refuses it by name rather than failing as a
- * pile of unexecuted claims.
+ * So the suite is parallelised across RUNNERS instead — see the `web` job's
+ * matrix in .github/workflows/ci.yml, which fans out over (viewport project ×
+ * flow group). Every runner boots its own instances, seeds its own tenant and
+ * mints its own passkey, so it shares none of that state: splitting the FLOWS
+ * across runners races nothing that two workers in one process would.
+ *
+ * Each leg runs its group's specs positionally, which makes the teardown skip
+ * its per-run execution-closure check (a positional run is partial by design);
+ * the `web-closure` aggregator job then merges every leg's run log and runs the
+ * closure over the whole set, so no claim escapes. Sharding with `--shard`
+ * would split the flows the same way but WITHOUT that positional marker, so the
+ * log would look complete while missing flows — global teardown refuses it by
+ * name rather than failing as a pile of unexecuted claims.
  */
 export default defineConfig({
   testDir: './e2e/flows',


### PR DESCRIPTION
## Why

The browser flow suite is the long pole in CI: ~8 min for mobile and ~10 min for the desktop-shaped `web` leg. This cuts wall-clock without weakening any guarantee or touching the `workers: 1` / single-shared-administrator design.

## What

**1. Split the flows across runners.** The `web` job now fans out over `project × group` — 6 legs (3 desktop + 3 mobile) instead of 2. Each leg boots its own isolated instances and runs ~4 flows serially, so splitting the flows races nothing that two in-process workers would (no shared TOTP ledger / passkey counter / session across runners).

| group | flows |
|---|---|
| 1 | reveal, members, login, scanning |
| 2 | settings, history, workspace, matrix |
| 3 | shell, instance-admin, machine-access, account |

Each leg runs its group positionally, which makes the teardown skip its per-run execution-closure check. A new **`web-closure`** aggregator merges all six legs' run logs and enforces the registry closure once over the whole set — every flow×surface×theme, both viewports (new `web/e2e/check-closure.ts`; zero-dep, run under Node's native type stripping, no `pnpm install`).

**2. Go off the browser critical path.** The ui-tagged `go test` and release-binary `govulncheck` ran inline in every browser leg — serial work that isn't browser work. Moved to a new parallel **`web-go`** job. (`setup-go` stays in `web` because global-setup builds the oidctest IdP from source at flow time.)

**3. Cache the pnpm store.** It was fully uncached (every `setup-node` had `cache: false`). `app-build` is the single writer and warms the content-addressed store before the legs that `needs` it; the web legs restore only.

## Guarantees preserved

- Registry closure is relocated, not weakened: per-leg skip + one aggregate check over the merged log. Add a flow to `registry.ts` but not to a group → `web-closure` fails by name.
- `web-closure` / `web-go` registered in `ci-job-registry.json` + `ci-required.needs`, keyed on the existing `web` plan (same shape as `no-egress`) — branch protection stays exact (18 direct-gate jobs, verified).
- Cache single-writers re-pinned to one leg (desktop, group 1). Added `timeout-minutes` to `web` and `app-build` so a browser/MFA hang can't stall the gate at the 360-min default.

## Expected impact

Browser legs ~8 min → ~3–3.5 min; whole `web` gate ~10 → ~5.5 min. Cost: 6 browser runners + aggregator vs 2 — runner-minutes traded for wall-clock.

## Verification

- Local: `tsc --noEmit` green on `web`; `check-closure.ts` proven on full log (exit 0) and a one-line-short log (exit 1, names the exact gap); group specs cover all 12 registry flows exactly; gate set-equality holds.
- Two isolated code-review passes (CI-workflow correctness + closure-checker TS) — all findings addressed.

Generated with Claude Code 🤖