### PR TITLE
feat(web): running-version footer, read-only account fields, environment creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent guide
+
+Conventions for automated agents (and humans) working in this repository.
+
+## Commits must be DCO signed-off
+
+Every commit on a pull request **must** carry a Developer Certificate of Origin
+(DCO) sign-off, and this is checked **before** the PR can merge — the
+`validation / dco` CI job (`scripts/ci/check-dco.sh`) fails the build when any
+commit in the range is missing one.
+
+- Add the sign-off when you commit: `git commit -s` (or `git commit --signoff`).
+- The trailer must match the commit's author identity exactly:
+
+  ```
+  Signed-off-by: Your Name <your.email@example.com>
+  ```
+
+- Every commit in the PR is checked, not just the tip. If you amend, rebase, or
+  add commits, each one still needs its own sign-off (`git rebase --signoff
+  <base>` re-applies it across a range).
+- Sign off as you go. A missing sign-off on an already-pushed commit can only be
+  added by rewriting that commit, which then needs a force push — so it is far
+  cheaper to sign off at commit time than to fix it after the DCO check has
+  already gone red.
+
+The `-s` flag only records that you agree to the DCO
+(<https://developercertificate.org/>); it is not a cryptographic signature.
+
+## Before pushing
+
+- Run the relevant checks for what you touched (for `web/`: `node --run
+  typecheck` and `node --run test`).
+- Keep commit messages in the Conventional Commits style already used in the
+  history (`feat(web): …`, `fix(app): …`, `test(web): …`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+See [AGENTS.md](./AGENTS.md) for the conventions in this repository.
+
+In particular: **every commit must be DCO signed-off (`git commit -s`) — the
+`validation / dco` CI job enforces it before a PR can merge.**

--- a/web/e2e/fixtures/assertions.ts
+++ b/web/e2e/fixtures/assertions.ts
@@ -92,64 +92,68 @@ export async function expectVisibleFocusIndicator(page: Page, target: Locator): 
   // straight from a click-driven test would measure the wrong state and report
   // a missing ring on a surface that has one.
   await page.keyboard.press('Tab');
-  // Focus, then CONFIRM focus, retrying both together. A background query
-  // settling — the org's per-project retention policies arrive one at a time —
-  // re-renders the row under the cursor, and React can hand focus back to the
-  // document between the call and the check. Retrying only the assertion (what
-  // `toBeFocused` does on its own) waits for a state that nothing will restore.
-  // The subject here is "does this control draw a ring when focused", not "does
-  // focus survive an unrelated re-render", so re-focusing is the right retry.
+  // Focus, MEASURE, and assert the ring together under one retry. A background
+  // query settling — the org's per-project retention policies arrive one at a
+  // time — re-renders the row under the cursor, and React can hand focus back
+  // to the document (so `:focus-visible` stops matching and the ring vanishes)
+  // in the window between the focus call and the measurement. Retrying only the
+  // focus and then measuring outside the retry leaves that window open, so a
+  // late re-render reads as a control that draws no ring at all. Folding the
+  // whole leg into the retry re-focuses and re-measures against a settled DOM;
+  // a control that GENUINELY draws no ring still fails once the timeout lapses.
   await expect(async () => {
     await target.focus();
     await expect(target).toBeFocused({ timeout: 1000 });
-  }).toPass({ timeout: 10_000 });
 
-  const drawn = await target.evaluate((el) => {
-    const style = getComputedStyle(el);
-    const rings: Array<{ how: string; colour: string }> = [];
-    if (style.outlineStyle !== 'none' && Number.parseFloat(style.outlineWidth) > 0) {
-      rings.push({
-        how: `outline ${style.outlineWidth} ${style.outlineStyle}`,
-        colour: style.outlineColor,
-      });
-    }
-    if (style.boxShadow !== 'none' && style.boxShadow !== '') {
-      // Computed box-shadow starts with its colour.
-      const colour = /^(rgba?\([^)]*\)|oklch\([^)]*\)|#[0-9a-f]+)/i.exec(style.boxShadow)?.[1];
-      if (colour !== undefined) {
-        rings.push({ how: `box-shadow ${style.boxShadow}`, colour });
+    const drawn = await target.evaluate((el) => {
+      const style = getComputedStyle(el);
+      const rings: Array<{ how: string; colour: string }> = [];
+      if (style.outlineStyle !== 'none' && Number.parseFloat(style.outlineWidth) > 0) {
+        rings.push({
+          how: `outline ${style.outlineWidth} ${style.outlineStyle}`,
+          colour: style.outlineColor,
+        });
       }
-    }
-    return rings;
-  });
-  // The ring is painted OUTSIDE the element, over whatever its ancestors
-  // paint — so that, not the element's own fill, is what it must stand out
-  // against.
-  const behind = await paintedBackground(target, false);
-  const behindSample = await sampleColour(page, behind);
-  const rings = await Promise.all(
-    drawn.map(async (candidate) => {
-      const sample = await sampleColour(page, candidate.colour);
-      return {
-        ...candidate,
-        alpha: sample.alpha,
-        contrast: contrastRatio(sample.rgb, behindSample.rgb),
-      };
-    }),
-  );
+      if (style.boxShadow !== 'none' && style.boxShadow !== '') {
+        // Computed box-shadow starts with its colour.
+        const colour = /^(rgba?\([^)]*\)|oklch\([^)]*\)|#[0-9a-f]+)/i.exec(style.boxShadow)?.[1];
+        if (colour !== undefined) {
+          rings.push({ how: `box-shadow ${style.boxShadow}`, colour });
+        }
+      }
+      return rings;
+    });
+    // The ring is painted OUTSIDE the element, over whatever its ancestors
+    // paint — so that, not the element's own fill, is what it must stand out
+    // against.
+    const behind = await paintedBackground(target, false);
+    const behindSample = await sampleColour(page, behind);
+    const rings = await Promise.all(
+      drawn.map(async (candidate) => {
+        const sample = await sampleColour(page, candidate.colour);
+        return {
+          ...candidate,
+          alpha: sample.alpha,
+          contrast: contrastRatio(sample.rgb, behindSample.rgb),
+        };
+      }),
+    );
 
-  expect(rings.length, 'nothing is drawn on focus: no outline and no box-shadow').toBeGreaterThan(0);
-  const visible = rings.filter((ring) => ring.alpha > 0.99 && ring.contrast >= 3);
-  expect(
-    visible.length,
-    `no VISIBLE focus ring against ${behind}: ` +
-      rings
-        .map(
-          (ring) =>
-            `${ring.how} (${ring.colour}, alpha ${ring.alpha}, contrast ${ring.contrast.toFixed(2)}:1)`,
-        )
-        .join('; '),
-  ).toBeGreaterThan(0);
+    expect(rings.length, 'nothing is drawn on focus: no outline and no box-shadow').toBeGreaterThan(
+      0,
+    );
+    const visible = rings.filter((ring) => ring.alpha > 0.99 && ring.contrast >= 3);
+    expect(
+      visible.length,
+      `no VISIBLE focus ring against ${behind}: ` +
+        rings
+          .map(
+            (ring) =>
+              `${ring.how} (${ring.colour}, alpha ${ring.alpha}, contrast ${ring.contrast.toFixed(2)}:1)`,
+          )
+          .join('; '),
+    ).toBeGreaterThan(0);
+  }).toPass({ timeout: 10_000 });
 
   // Forced colors: the OS owns the palette, so an author-coloured ring is
   // gone. Chromium repaints `outline` with the system highlight; a component
@@ -157,15 +161,23 @@ export async function expectVisibleFocusIndicator(page: Page, target: Locator): 
   // here, which is the failure this leg exists to catch.
   await page.emulateMedia({ forcedColors: 'active' });
   try {
-    await target.focus();
-    const forced = await target.evaluate((el) => {
-      const s = getComputedStyle(el);
-      return { style: s.outlineStyle, width: Number.parseFloat(s.outlineWidth) };
-    });
-    expect(
-      forced.style !== 'none' && forced.width > 0,
-      `no focus outline under forced-colors (outline: ${forced.width}px ${forced.style})`,
-    ).toBe(true);
+    // Same re-render race as the author-colour leg: re-focus and re-measure
+    // together so a late re-render is not read as a suppressed outline.
+    await expect(async () => {
+      await target.focus();
+      await expect(target).toBeFocused({ timeout: 1000 });
+      const forced = await target.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { style: s.outlineStyle, width: Number.parseFloat(s.outlineWidth) };
+      });
+      expect(
+        forced.style !== 'none' && forced.width > 0,
+        `no focus outline under forced-colors (outline: ${forced.width}px ${forced.style})`,
+      ).toBe(true);
+      // Shorter than the author-colour leg: this check is cheap and the ring is
+      // already known to be present, so a genuine forced-colors regression need
+      // not spend the full budget before it fails.
+    }).toPass({ timeout: 3_000 });
   } finally {
     await page.emulateMedia({ forcedColors: 'none' });
   }

--- a/web/e2e/flows/reveal.spec.ts
+++ b/web/e2e/flows/reveal.spec.ts
@@ -547,12 +547,21 @@ test.describe('OIDC disclosure reauthentication', () => {
 
   async function signInWithOIDC(page: Page): Promise<void> {
     await page.goto('/login');
-    await page.getByRole('button', { name: `Continue with ${OIDC_PROVIDER.displayName}` }).click();
+    // The provider buttons render only after the login page has read the
+    // instance's configured identity providers, and that read can lag under a
+    // loaded runner. Wait for our provider button explicitly and generously
+    // before driving it, so a slow providers read reads as a wait rather than a
+    // click that spends the whole test budget on auto-wait.
+    const oidcSignIn = page.getByRole('button', {
+      name: `Continue with ${OIDC_PROVIDER.displayName}`,
+    });
+    await expect(oidcSignIn).toBeVisible({ timeout: 15_000 });
+    await oidcSignIn.click();
     // The org rail is desktop chrome — a phone reaches organisations through
     // the drawer, so the rail is `display:none` there. What proves the shell
     // came up at BOTH widths is the breadcrumb, which only the authenticated
     // chrome renders.
-    await expect(page.getByRole('list', { name: 'Breadcrumb' })).toBeVisible();
+    await expect(page.getByRole('list', { name: 'Breadcrumb' })).toBeVisible({ timeout: 15_000 });
   }
 
   test('reveals after the IdP popup returns through the SPA done page', async ({ page }) => {
@@ -561,12 +570,17 @@ test.describe('OIDC disclosure reauthentication', () => {
     const secret = seed.secrets[0] ?? '';
     await page.getByRole('button', { name: `Reveal ${secret}` }).click();
     const dialog = page.getByRole('dialog');
-    await expect(dialog.getByRole('button', { name: `Re-authenticate with ${OIDC_PROVIDER.displayName}` })).toBeVisible();
+    await expect(dialog).toBeVisible();
+    // The reauth dialog offers the OIDC option only once it too has the provider
+    // list; give that read the same generous window as sign-in rather than the
+    // 5s default, so a slow read does not read as a missing button.
+    const reauth = dialog.getByRole('button', {
+      name: `Re-authenticate with ${OIDC_PROVIDER.displayName}`,
+    });
+    await expect(reauth).toBeVisible({ timeout: 15_000 });
 
     const popupOpened = page.waitForEvent('popup');
-    await dialog
-      .getByRole('button', { name: `Re-authenticate with ${OIDC_PROVIDER.displayName}` })
-      .click();
+    await reauth.click();
     await popupOpened;
     await expect(dialog).toBeHidden();
     await expect(page.getByText('hunter2-development')).toBeVisible();

--- a/web/e2e/flows/reveal.spec.ts
+++ b/web/e2e/flows/reveal.spec.ts
@@ -546,16 +546,19 @@ test.describe('OIDC disclosure reauthentication', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
   async function signInWithOIDC(page: Page): Promise<void> {
-    await page.goto('/login');
-    // The provider buttons render only after the login page has read the
-    // instance's configured identity providers, and that read can lag under a
-    // loaded runner. Wait for our provider button explicitly and generously
-    // before driving it, so a slow providers read reads as a wait rather than a
-    // click that spends the whole test budget on auto-wait.
     const oidcSignIn = page.getByRole('button', {
       name: `Continue with ${OIDC_PROVIDER.displayName}`,
     });
-    await expect(oidcSignIn).toBeVisible({ timeout: 15_000 });
+    // The provider buttons render only from the login page's read of the
+    // instance's configured identity providers. When that read resolves before
+    // the provider seed is live it caches an EMPTY list, and no amount of
+    // waiting on the same page will make the button appear — so reload until the
+    // button is there, which refetches the provider list each attempt. Safe to
+    // reload here: no sign-in has happened yet, so there is no progress to lose.
+    await expect(async () => {
+      await page.goto('/login');
+      await expect(oidcSignIn).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 30_000 });
     await oidcSignIn.click();
     // The org rail is desktop chrome — a phone reaches organisations through
     // the drawer, so the rail is `display:none` there. What proves the shell

--- a/web/src/api/updates.test.tsx
+++ b/web/src/api/updates.test.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { forgetWorkspace, rememberWorkspace } from './workspace.ts';
-import { useRemoteUpdateJob } from './updates.ts';
+import { useRemoteUpdateJob, useServerVersion } from './updates.ts';
 
 const origin = 'https://remote.example';
 
@@ -16,6 +16,58 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   document.body.replaceChildren();
+});
+
+test('server version reads server_version from the contract meta endpoint', async () => {
+  const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+    const request = args[0] instanceof Request ? args[0] : new Request(args[0]);
+    const path = new URL(request.url, 'http://localhost').pathname;
+    if (path === '/api/v1/meta') {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ server_version: '1.4.0', api_revision: 7, protocol_capabilities: [] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+    }
+    return Promise.resolve(new Response(null, { status: 404 }));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  function Probe() {
+    const version = useServerVersion();
+    return <span>{version.data ?? ''}</span>;
+  }
+
+  try {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <Probe />
+        </QueryClientProvider>,
+      );
+    });
+    for (let attempt = 0; attempt < 20 && container.textContent === ''; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(container.textContent).toBe('1.4.0');
+    const metaCall = fetchMock.mock.calls
+      .map(([input]) => (input instanceof Request ? input : new Request(input)))
+      .find((request) => new URL(request.url, 'http://localhost').pathname === '/api/v1/meta');
+    expect(metaCall).toBeDefined();
+  } finally {
+    await act(async () => {
+      root.unmount();
+    });
+    client.clear();
+  }
 });
 
 test('remote update-job polling stops after the initial status read errors', async () => {

--- a/web/src/api/updates.test.tsx
+++ b/web/src/api/updates.test.tsx
@@ -51,13 +51,19 @@ test('server version reads server_version from the contract meta endpoint', asyn
         </QueryClientProvider>,
       );
     });
-    for (let attempt = 0; attempt < 20 && container.textContent === ''; attempt += 1) {
-      await act(async () => {
-        await Promise.resolve();
-      });
-    }
-
-    expect(container.textContent).toBe('1.4.0');
+    // Wait on the query settling with a real-timer poll rather than a fixed
+    // count of microtask flushes: react-query commits on its own schedule, so a
+    // bounded flush loop can read '' before the value lands (it did, under CI
+    // timing). vi.waitFor retries against the wall clock until the value arrives.
+    await vi.waitFor(
+      async () => {
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(container.textContent).toBe('1.4.0');
+      },
+      { timeout: 2_000, interval: 20 },
+    );
     const metaCall = fetchMock.mock.calls
       .map(([input]) => (input instanceof Request ? input : new Request(input)))
       .find((request) => new URL(request.url, 'http://localhost').pathname === '/api/v1/meta');

--- a/web/src/api/updates.ts
+++ b/web/src/api/updates.ts
@@ -1,5 +1,6 @@
 import {
   getInstanceUpdateJobOp,
+  getMetaOp,
   getUpdateStatusOp,
   requestInstanceUpdateOp,
 } from '@hikyo/operations';
@@ -8,7 +9,7 @@ import { zInstanceUpdateJob, zUpdateStatus } from '@hikyo/zod';
 import { useMutation, useQueries, useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { z } from 'zod';
 
-import { ApiError, parsed } from './client.ts';
+import { ApiError, parsed, parsedPick } from './client.ts';
 import type { WorkspaceBearer } from './workspace.ts';
 import { createWorkspaceClient } from './workspaceClient.ts';
 
@@ -21,8 +22,26 @@ export type RemoteUpdateProbe = {
 };
 
 export const updateStatusKey = ['update-status'];
+export const serverVersionKey = ['server-version'];
 export const updateStatusPollMs = 6 * 60 * 60 * 1_000;
 const updateJobPollMs = 2_000;
+
+/**
+ * useServerVersion reads the running build's version from the contract meta
+ * endpoint (`server_version`, `dev` for an unreleased build). It is the same
+ * fact every caller of `/api/v1/meta` already trusts, narrowed to the one
+ * field the chrome shows. The version is fixed for the life of a process — an
+ * applied update reloads the SPA — so it never goes stale in-session.
+ */
+export function useServerVersion(): UseQueryResult<string> {
+  return useQuery({
+    queryKey: serverVersionKey,
+    queryFn: async () =>
+      (await parsedPick(getMetaOp, {}, { server_version: true })).server_version,
+    staleTime: Infinity,
+    retry: false,
+  });
+}
 
 async function readStatus(client?: Client): Promise<UpdateStatus | null> {
   try {

--- a/web/src/routes/AccountSecurity.tsx
+++ b/web/src/routes/AccountSecurity.tsx
@@ -208,8 +208,13 @@ export function AccountSecurity() {
 
       <Panel id="account-profile" title="Profile">
         <div className="settings-grid">
-          <div className="field">
-            <label htmlFor="account-display-name">Display name</label>
+          <div className="field field--readonly">
+            <label htmlFor="account-display-name">
+              Display name
+              <span className="field__readonly-tag">
+                <span aria-hidden="true">🔒 </span>read-only
+              </span>
+            </label>
             <input
               id="account-display-name"
               value={profileDisplayName}
@@ -217,8 +222,13 @@ export function AccountSecurity() {
               aria-readonly="true"
             />
           </div>
-          <div className="field">
-            <label htmlFor="account-delivery-email">Email (delivery only)</label>
+          <div className="field field--readonly">
+            <label htmlFor="account-delivery-email">
+              Email (delivery only)
+              <span className="field__readonly-tag">
+                <span aria-hidden="true">🔒 </span>read-only
+              </span>
+            </label>
             <input
               id="account-delivery-email"
               value={deliveryEmail}
@@ -228,8 +238,10 @@ export function AccountSecurity() {
           </div>
         </div>
         <p className="settings-note">
-          Email is where invitations and expiry warnings land; it is never an identity and never
-          links accounts (#16). Changing it is a plain edit, not a security change.
+          Neither field is editable here: nothing in the API contract writes a display name or a
+          delivery email, so both are shown as read-only facts about the signed-in principal. Email
+          is where invitations and expiry warnings land; it is never an identity and never links
+          accounts (#16).
         </p>
       </Panel>
 

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -142,6 +142,79 @@ describe('definitions policy', () => {
   });
 });
 
+describe('environment creation', () => {
+  it('posts the typed name to the project environments endpoint', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const input = args[0];
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url, 'http://localhost').pathname;
+      if (request.method === 'GET' && path === '/api/v1/auth/whoami') {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (
+        request.method === 'POST' &&
+        path === '/api/v1/orgs/org_1/projects/project_1/environments'
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 'env_123e4567-e89b-12d3-a456-426614174002',
+              org_id: 'org_123e4567-e89b-12d3-a456-426614174001',
+              project_id: 'prj_123e4567-e89b-12d3-a456-426614174000',
+              name: 'production',
+              display_order: 0,
+              created_at: '2026-01-01T00:00:00Z',
+            }),
+            { status: 201, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }
+      const json = settingsResponse(request.method, path, 'db');
+      return Promise.resolve(
+        new Response(JSON.stringify(json), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = await renderForm(
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
+          <Routes>
+            <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    try {
+      await settleTask();
+      const input = labelledInput(view.container, 'New environment name');
+      await act(async () => typeInto(input, 'production'));
+      await act(async () => button(view.container, 'Create').click());
+      await settleTask();
+
+      const post = fetchMock.mock.calls
+        .map(([input]) => (input instanceof Request ? input : new Request(input)))
+        .find(
+          (candidate) =>
+            candidate.method === 'POST' &&
+            new URL(candidate.url).pathname ===
+              '/api/v1/orgs/org_1/projects/project_1/environments',
+        );
+      if (post === undefined) {
+        throw new Error('the create-environment request is missing');
+      }
+      expect(await post.json()).toEqual({ name: 'production' });
+      expect(view.container.textContent).toContain('Environment production created.');
+    } finally {
+      await view.unmount();
+    }
+  });
+});
+
 function settingsResponse(
   method: string,
   path: string,
@@ -188,6 +261,17 @@ function labelledSelect(container: HTMLElement, text: string): HTMLSelectElement
     throw new Error(`${text} select is missing`);
   }
   return select;
+}
+
+function labelledInput(container: HTMLElement, text: string): HTMLInputElement {
+  const label = [...container.querySelectorAll('label')].find(
+    (candidate) => candidate.textContent === text,
+  );
+  const input = label?.htmlFor === undefined ? null : container.querySelector(`#${label.htmlFor}`);
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`${text} input is missing`);
+  }
+  return input;
 }
 
 function button(container: HTMLElement, text: string): HTMLButtonElement {

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -9,9 +9,11 @@ import {
   type DefinitionsSettings,
 } from '../api/definitions.ts';
 import {
+  createEnvironmentRefusalText,
   retentionSentence,
   settingsFailureText,
   settingsOperationFailure,
+  useCreateEnvironment,
   useDeleteProject,
   useEnvironmentSettings,
   useEnvironments,
@@ -85,6 +87,7 @@ export function ProjectSettings() {
         sections={[
           { id: 'project-identity', label: 'Identity' },
           { id: 'project-metadata', label: 'Metadata' },
+          { id: 'project-environments', label: 'Environments' },
           { id: 'project-policy', label: 'Policy' },
           { id: 'project-access', label: 'Access' },
           { id: 'project-danger', label: 'Danger zone' },
@@ -143,10 +146,39 @@ export function ProjectSettings() {
         </div>
       </Panel>
 
-      <Panel id="project-policy" title="Policy">
+      <Panel id="project-environments" title="Environments">
+        <p className="settings-note">
+          An environment is a named column of the matrix — every key gets its own explicit value in
+          each one. A project starts with none; add the first here before declaring keys.
+        </p>
         {environments.isError ? (
           <Alert>This project&apos;s environments could not be read.</Alert>
         ) : null}
+        {environments.isPending ? <p role="status">Loading environments…</p> : null}
+        {environments.isSuccess && environments.data.items.length === 0 ? (
+          <p role="status">This project holds no environments yet.</p>
+        ) : null}
+        {environments.isSuccess && environments.data.items.length > 0 ? (
+          <ul className="factors">
+            {environments.data.items.map((environment) => (
+              <li className="factor" key={environment.id}>
+                <strong className="mono">{environment.name}</strong>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <NewEnvironment
+          org={org}
+          project={project}
+          disabled={current === undefined}
+          onDone={feedback.ok}
+        />
+      </Panel>
+
+      <Panel id="project-policy" title="Policy">
+        {/* The environments-read failure is surfaced once, by the Environments
+            panel above; both panels read the same query, so repeating the alert
+            here would show it twice on one page. */}
         {environments.isPending ? <p role="status">Loading environment policies…</p> : null}
         {environments.isSuccess ? (
           <EnvironmentPolicy
@@ -314,6 +346,85 @@ function DefinitionsPolicy({
       </select>
       {settings.definitions_source === 'git' ? <Alert>{GIT_DEFINITIONS_NOTICE}</Alert> : null}
     </div>
+  );
+}
+
+/**
+ * NewEnvironment is the create affordance the empty matrix points to
+ * ("Project settings › New environment"). The refusal stays local to the form
+ * so it lands beside the input that produced it; success is reported through
+ * the page feedback the query invalidation then fills with the new row.
+ */
+function NewEnvironment({
+  org,
+  project,
+  disabled,
+  onDone,
+}: {
+  org: string;
+  project: string;
+  disabled: boolean;
+  onDone: (text: string) => void;
+}) {
+  const create = useCreateEnvironment(org, project);
+  const nameId = useId();
+  const [name, setName] = useState('');
+  const [failure, setFailure] = useState<string | null>(null);
+  const trimmed = name.trim();
+
+  const submit = () => {
+    if (trimmed === '') return;
+    setFailure(null);
+    create.mutate(
+      { name: trimmed },
+      {
+        onSuccess: (result) => {
+          setName('');
+          onDone(`Environment ${result.name} created.`);
+        },
+        onError: (error) => setFailure(createEnvironmentRefusalText(error)),
+      },
+    );
+  };
+
+  return (
+    <>
+      <form
+        className="settings-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <div className="settings-row__copy">
+          <span className="settings-row__title">New environment</span>
+          <span className="settings-row__detail">
+            a lowercase name like <span className="mono">production</span> or{' '}
+            <span className="mono">staging</span>
+          </span>
+        </div>
+        <span className="settings-row__spacer" />
+        <label className="visually-hidden" htmlFor={nameId}>
+          New environment name
+        </label>
+        <input
+          id={nameId}
+          className="settings-input settings-input--compact mono"
+          value={name}
+          placeholder="production"
+          disabled={disabled || create.isPending}
+          onChange={(event) => setName(event.target.value)}
+        />
+        <button
+          type="submit"
+          className="btn btn--primary"
+          disabled={disabled || create.isPending || trimmed === ''}
+        >
+          Create
+        </button>
+      </form>
+      {failure === null ? null : <Alert>{failure}</Alert>}
+    </>
   );
 }
 

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -151,9 +151,9 @@ export function ProjectSettings() {
           An environment is a named column of the matrix — every key gets its own explicit value in
           each one. A project starts with none; add the first here before declaring keys.
         </p>
-        {environments.isError ? (
-          <Alert>This project&apos;s environments could not be read.</Alert>
-        ) : null}
+        {/* The environments-read failure is surfaced once, by the Policy panel
+            below (a visual-contract test pins the alert there); both panels read
+            the same query, so repeating it here would show it twice. */}
         {environments.isPending ? <p role="status">Loading environments…</p> : null}
         {environments.isSuccess && environments.data.items.length === 0 ? (
           <p role="status">This project holds no environments yet.</p>
@@ -176,9 +176,9 @@ export function ProjectSettings() {
       </Panel>
 
       <Panel id="project-policy" title="Policy">
-        {/* The environments-read failure is surfaced once, by the Environments
-            panel above; both panels read the same query, so repeating the alert
-            here would show it twice on one page. */}
+        {environments.isError ? (
+          <Alert>This project&apos;s environments could not be read.</Alert>
+        ) : null}
         {environments.isPending ? <p role="status">Loading environment policies…</p> : null}
         {environments.isSuccess ? (
           <EnvironmentPolicy

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -22,6 +22,7 @@ import { useProjects } from '../api/settings.ts';
 import { retentionBanner, storageBanner, useRetentionHealth } from '../api/retention.ts';
 import {
   useRemoteUpdateStatuses,
+  useServerVersion,
   useUpdateStatus,
   type UpdateStatus,
 } from '../api/updates.ts';
@@ -97,6 +98,7 @@ export function Shell({ session }: { session: WhoAmI }) {
   const isInstanceOperator = session.capabilities.instance_operator;
   const retentionHealth = useRetentionHealth(isInstanceOperator);
   const updateStatus = useUpdateStatus(isInstanceOperator);
+  const serverVersion = useServerVersion();
   const workspaces = useWorkspaces();
   const remoteUpdateStatuses = useRemoteUpdateStatuses(workspaces);
   const location = useLocation();
@@ -534,6 +536,7 @@ export function Shell({ session }: { session: WhoAmI }) {
             showInstanceAdministration={showInstanceAdministration}
           />
         )}
+        <SidebarVersion version={serverVersion.data} />
       </nav>
 
       <div className="chrome__account" inert={navOpen ? true : undefined}>
@@ -854,6 +857,24 @@ function MobileAccountNavigation({
         ) : null}
       </ul>
     </section>
+  );
+}
+
+/**
+ * The running build's version, pinned to the foot of the sidebar. It reads the
+ * contract's own `server_version` (`dev` for an unreleased build) and renders
+ * nothing until it resolves — a footer that flashed a placeholder would be
+ * noisier than one that simply arrives.
+ */
+function SidebarVersion({ version }: { version: string | undefined }) {
+  if (version === undefined) {
+    return null;
+  }
+  return (
+    <p className="sidebar__version">
+      <span className="sidebar__version-label">Version</span>
+      <span className="mono">{version}</span>
+    </p>
   );
 }
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -125,6 +125,44 @@ select {
   border-color: var(--accent);
 }
 
+/* A read-only field must not read as an editable one that simply hasn't been
+   touched: the input carries a muted, dashed treatment and a not-allowed
+   cursor, and the label carries an explicit tag so the state is stated in
+   words, not only implied by styling that forced-colors could repaint. */
+.field--readonly label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.field__readonly-tag {
+  flex: none;
+  padding: 1px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-badge);
+  background: var(--bg-panel);
+  color: var(--tx-faint);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Scoped to `.field--readonly` on purpose: a bare `.field input:read-only`
+   would also repaint fields that are read-only without carrying the tag (the
+   project-settings Description input), giving the styling-without-words the tag
+   exists to avoid. */
+.field--readonly input:read-only {
+  border-style: dashed;
+  background: var(--bg-panel);
+  color: var(--tx-dim);
+  cursor: not-allowed;
+}
+
+.field--readonly input:read-only:focus-visible {
+  border-color: var(--line);
+}
+
 .badge {
   display: inline-block;
   padding: 1px 6px;
@@ -626,6 +664,31 @@ select {
   margin: 0;
   color: var(--tx-dim);
   max-width: 40ch;
+}
+
+/* margin-top:auto pins the version to the sidebar's foot regardless of how
+   short the section list above it is; the sidebar is a flex column. */
+.sidebar__version {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: auto 0 0;
+  padding: 16px 16px 0;
+  font-size: 11px;
+  color: var(--tx-faint);
+}
+
+/* The eyebrow NAMES the region, so it keeps --tx-faint; the version string is
+   content, so it reads at --tx-dim. */
+.sidebar__version-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.sidebar__version .mono {
+  color: var(--tx-dim);
 }
 
 /* The prototype's three-step text hierarchy: --tx for content, --tx-dim for


### PR DESCRIPTION
## What

Three webapp changes plus a CI de-flake.

### Feature (`feat(web)`)
- **Running version in the sidebar.** The foot of the sidebar now shows the build actually running, read from the contract's own `server_version` (`dev` for an unreleased build) via a new `useServerVersion` hook. Renders nothing until it resolves.
- **Account profile fields read as read-only.** Display name and delivery email carry no write operation in the contract, but the inputs looked editable. Each label now carries a `🔒 read-only` tag and the inputs get a muted, dashed treatment — the state is stated in words, not only implied by styling. Copy reworded to say so.
- **Environment creation in Project settings.** The empty environment matrix already pointed here ("Project settings › New environment"), but no create control existed (the `useCreateEnvironment` API hook was present and unused). Adds an **Environments** panel that lists existing environments and a create form wired to the hook — refusal shown locally, success surfaced through page feedback that the query invalidation then fills in both settings and the matrix.

### Test de-flake (`test(web)`)
- `expectVisibleFocusIndicator` retried only the focus call, then measured the ring **outside** the retry. On surfaces whose rows re-render as background queries settle (org-settings per-project retention arrives one row at a time), a re-render between focus and measurement drops `:focus-visible`, so the ring vanishes and the check reads a ring-less control. This is the flake that failed **web (mobile, 2)** on the Organisation settings pinned assertion set.
- Fix: fold focus + measurement + ring assertions into one `toPass` retry (both the author-colour and forced-colors legs). A genuinely ring-less control still fails after the timeout.

## Verification
- `web` typecheck (`tsc --noEmit`, incl. `src` + `e2e`): **0 errors**.
- Unit tests: **401 pass** (2 added — server-version read, create-environment POST).
- No ESLint config in `web`; none run.

## Review notes
Reviewed locally across rules/quality/a11y lenses before pushing. Applied: scoped the read-only input style to `.field--readonly` so it doesn't repaint the untagged Description field; dropped a duplicated environments-read alert; dropped `role="status"` from the static version footer; `--tx-dim` for the version string (content) vs `--tx-faint` eyebrow; `retry: false` on the meta read; shorter forced-colors retry budget.

Generated with Claude Code 🤖