### PR TITLE
fix(web): don't wall a still-valid session on a revalidation blip (#440)

### DIFF
--- a/web/e2e/flows/shell.spec.ts
+++ b/web/e2e/flows/shell.spec.ts
@@ -311,6 +311,49 @@ test.describe('app chrome', () => {
     await page.unrouteAll({ behavior: 'ignoreErrors' });
   });
 
+  // A still-valid session must survive a transient background revalidation
+  // outage: the server briefly going unreachable for a whoami re-read must not
+  // latch the global reload wall over the working UI (#440).
+  test('holds a still-valid session through a background revalidation outage', async ({ page }) => {
+    await page.goto('/projects');
+    const heading = page.getByRole('heading', { name: 'Projects', level: 1 });
+    const wall = page.getByText('Could not reach the server. Reload once it is back.');
+    await expect(heading).toBeVisible();
+
+    let whoamiDown = true;
+    await page.route('**/api/v1/auth/whoami', async (route) => {
+      if (whoamiDown) {
+        await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.continue();
+    });
+
+    // A peer-tab "session changed" broadcast forces a BLOCKING revalidate — the
+    // path that used to promote the transport error into the latching wall.
+    const failed = page.waitForResponse('**/api/v1/auth/whoami');
+    await page.evaluate(() =>
+      new BroadcastChannel('hikyo-root-auth').postMessage('session-changed'),
+    );
+    await failed;
+
+    // The last-known-good session keeps painting; no reload wall. `heading`
+    // returns only once the failed blocking check has committed back to the
+    // authenticated shell — a reverted fix latches the wall, the heading never
+    // comes back, and this visibility poll times out.
+    await expect(heading).toBeVisible();
+    await expect(wall).toHaveCount(0);
+
+    // When the server returns, the next revalidation recovers cleanly.
+    whoamiDown = false;
+    await page.evaluate(() =>
+      new BroadcastChannel('hikyo-root-auth').postMessage('session-changed'),
+    );
+    await expect(heading).toBeVisible();
+    await expect(wall).toHaveCount(0);
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
   test('fails loud when pruning health cannot be checked', async ({ page }) => {
     await page.route('**/api/v1/instance/retention-health', (route) =>
       route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),

--- a/web/src/app/AuthProvider.test.tsx
+++ b/web/src/app/AuthProvider.test.tsx
@@ -116,6 +116,8 @@ function Probe({
       <output data-testid="operator">
         {auth.identity === null ? '' : String(auth.identity.capabilities.instance_operator)}
       </output>
+      <output data-testid="failure">{auth.failure === null ? '' : 'failed'}</output>
+      <output data-testid="degraded">{auth.degraded === null ? '' : 'degraded'}</output>
       <output data-testid="marker">{String(queries.getQueryData(['marker']) ?? '')}</output>
       <button type="button" onClick={() => void auth.revalidate()}>
         Revalidate
@@ -343,6 +345,129 @@ describe('AuthProvider', () => {
     expect(text(container, 'state')).toContain(`authenticated:${id('ses', '01')}`);
     expect(text(container, 'operator')).toBe('true');
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('latches the reload wall when the very first check has no session to fall back on', async () => {
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockRejectedValueOnce(new Error('server unreachable'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle();
+
+    // No identity was ever held, so the transport failure is the authoritative
+    // answer and App's reload wall is correct.
+    expect(text(container, 'failure')).toBe('failed');
+    expect(text(container, 'degraded')).toBe('');
+  });
+
+  it('keeps a still-valid session painting through a background revalidation blip and recovers', async () => {
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(identity('00', '10')))
+      .mockRejectedValueOnce(new Error('server briefly unreachable'))
+      .mockResolvedValue(json(identity('00', '10')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+
+    // A background revalidation rejects while the session is still valid.
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[0]?.click());
+    await settle();
+
+    // The session keeps painting; the error surfaces only as the non-latching
+    // degraded signal, never the global reload wall.
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+    expect(text(container, 'failure')).toBe('');
+    expect(text(container, 'degraded')).toBe('degraded');
+
+    // The next successful revalidation clears the degraded signal.
+    await act(async () => buttons[0]?.click());
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+    expect(text(container, 'degraded')).toBe('');
+  });
+
+  it('recovers a degraded session on its own through the backoff retry', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi
+        .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+        .mockResolvedValueOnce(json(identity('00', '10')))
+        .mockRejectedValueOnce(new Error('server briefly unreachable'))
+        .mockResolvedValue(json(identity('00', '10')));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const { container } = await renderAuth(
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>,
+      );
+      await settle();
+      expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+
+      // A background BLOCKING revalidate (a peer-tab broadcast or the expiry
+      // timer) fails, degrading the still-valid session.
+      const buttons = container.querySelectorAll('button');
+      await act(async () => buttons[0]?.click());
+      await settle();
+      expect(text(container, 'degraded')).toBe('degraded');
+      expect(text(container, 'failure')).toBe('');
+
+      // No manual revalidation: only the backoff timer fires. Advancing past its
+      // first interval must recover the session on its own — deleting the retry
+      // effect leaves `degraded` set here forever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_100);
+      });
+      await settle();
+      expect(text(container, 'degraded')).toBe('');
+      expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('walls a session whose absolute deadline has passed even when the server is unreachable', async () => {
+    const expired = identity('00', '10');
+    const dead = {
+      ...expired,
+      session: { ...expired.session, absolute_expires_at: '2000-01-01T00:00:00Z' },
+    };
+    const fetchMock = vi
+      .fn<(...args: Parameters<typeof fetch>) => Promise<Response>>()
+      .mockResolvedValueOnce(json(dead))
+      .mockRejectedValueOnce(new Error('server unreachable'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = await renderAuth(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await settle();
+    expect(text(container, 'state')).toContain(`authenticated:${id('ses', '00')}`);
+
+    // The held identity is past its unextendable absolute deadline, so a failed
+    // background revalidation must NOT keep it painting as a degraded-but-valid
+    // session — it is dead regardless of the server, and the wall is correct.
+    const buttons = container.querySelectorAll('button');
+    await act(async () => buttons[0]?.click());
+    await settle();
+    expect(text(container, 'failure')).toBe('failed');
+    expect(text(container, 'degraded')).toBe('');
   });
 
   it('ignores a mutation result captured before a newer session replacement', async () => {

--- a/web/src/app/AuthProvider.tsx
+++ b/web/src/app/AuthProvider.tsx
@@ -43,6 +43,10 @@ type AuthContextValue = {
   readonly state: AuthState;
   readonly identity: WhoAmI | null;
   readonly failure: Error | null;
+  // A transport/5xx/schema error from a BACKGROUND revalidation of a session
+  // that is still held. Unlike `failure` this never latches the reload wall: the
+  // last-known-good session keeps painting and a backed-off retry recovers it.
+  readonly degraded: Error | null;
   readonly captureTransition: () => SessionTransitionGuard;
   readonly acceptSession: (identity: AcceptedIdentity, guard: SessionTransitionGuard) => void;
   readonly endSession: (guard: SessionTransitionGuard) => void;
@@ -60,6 +64,7 @@ type Snapshot = {
   readonly state: AuthState;
   readonly identity: WhoAmI | null;
   readonly failure: Error | null;
+  readonly degraded: Error | null;
   readonly queries: ReturnType<typeof makeQueryClient>;
 };
 
@@ -68,6 +73,8 @@ const CHANNEL_NAME = 'hikyo-root-auth';
 const CHANNEL_MESSAGE = 'session-changed';
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const FOCUS_CHECK_INTERVAL_MS = 1_000;
+const DEGRADED_RETRY_BASE_MS = 1_000;
+const DEGRADED_RETRY_MAX_MS = 30_000;
 
 /** Read root identity without putting it in a session-owned query cache. */
 async function readIdentity(): Promise<WhoAmI | null> {
@@ -79,6 +86,19 @@ async function readIdentity(): Promise<WhoAmI | null> {
     }
     throw error;
   }
+}
+
+/**
+ * Whether a held identity is provably dead regardless of the server. Only the
+ * ABSOLUTE deadline qualifies: it can never be extended, so once it passes the
+ * session is over even if we cannot reach the server to be told so. The idle
+ * deadline is deliberately excluded — a successful revalidation refreshes it, so
+ * a locally-passed idle window during an outage does not PROVE expiry and must
+ * not wall a session the server might still honour.
+ */
+function isDefinitivelyExpired(identity: WhoAmI): boolean {
+  const absolute = Date.parse(identity.session.absolute_expires_at);
+  return Number.isFinite(absolute) && Date.now() >= absolute;
 }
 
 function stateFor(identity: WhoAmI | null): AuthState {
@@ -124,6 +144,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     state: { status: 'checking' },
     identity: null,
     failure: null,
+    degraded: null,
     queries: makeQueryClient(),
   }));
   const snapshotRef = useRef(snapshot);
@@ -131,6 +152,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const transitionRevisionRef = useRef(0);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const lastFocusCheckRef = useRef(0);
+  const degradedRetriesRef = useRef(0);
 
   const commit = useCallback((next: Snapshot) => {
     snapshotRef.current = next;
@@ -158,6 +180,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         transitionRevisionRef.current += 1;
       }
       transitionWorkspaceOwner(identity?.session.id);
+      // A successful settle is the single point that clears a degraded session
+      // and resets its retry backoff.
+      degradedRetriesRef.current = 0;
 
       if (sameSession) {
         commit({
@@ -165,6 +190,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           state: stateFor(identity),
           identity,
           failure: null,
+          degraded: null,
         });
         void current.queries.invalidateQueries();
       } else {
@@ -174,6 +200,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           state: stateFor(identity),
           identity,
           failure: null,
+          degraded: null,
         });
       }
       if (publish) {
@@ -185,7 +212,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const checkSession = useCallback(
     async (mode: SessionCheckMode) => {
-      const blocking = mode !== 'refresh-and-publish';
+      const blocking = mode === 'blocking' || mode === 'blocking-and-publish';
+      const publish = mode === 'blocking-and-publish' || mode === 'refresh-and-publish';
       const request = requestRef.current + 1;
       requestRef.current = request;
       const current = snapshotRef.current;
@@ -195,20 +223,44 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           state:
             current.identity === null ? { status: 'checking' } : { status: 'transitioning' },
           failure: null,
+          degraded: null,
         });
       }
       try {
         const identity = await readIdentity();
         if (requestRef.current === request) {
-          settleIdentity(identity, mode !== 'blocking');
+          settleIdentity(identity, publish);
         }
       } catch (error) {
-        if (requestRef.current === request) {
-          const latest = snapshotRef.current;
+        if (requestRef.current !== request) {
+          return;
+        }
+        const latest = snapshotRef.current;
+        const problem =
+          error instanceof Error ? error : new Error('root authentication check failed');
+        if (latest.identity !== null && !isDefinitivelyExpired(latest.identity)) {
+          // A still-valid session must not be buried under the global reload
+          // wall by a transient background revalidation blip. Keep painting the
+          // last-known-good session and surface the transport error only as the
+          // non-latching `degraded` signal; the backoff effect retries it.
+          degradedRetriesRef.current += 1;
+          commit({
+            ...latest,
+            state: stateFor(latest.identity),
+            failure: null,
+            degraded: problem,
+          });
+        } else {
+          // No usable session in hand — either genuinely session-less (initial
+          // check, or a failing refresh while anonymous) or holding an identity
+          // whose ABSOLUTE deadline has passed, which is dead regardless of the
+          // server. The blocking reload wall is the correct answer; a definitively
+          // expired session must never keep painting authenticated chrome.
           commit({
             ...latest,
             state: blocking ? stateFor(latest.identity) : latest.state,
-            failure: error instanceof Error ? error : new Error('root authentication check failed'),
+            failure: problem,
+            degraded: null,
           });
         }
       }
@@ -377,8 +429,33 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => globalThis.removeEventListener?.('focus', onFocus);
   }, [revalidateOnFocus]);
 
+  // A degraded (still-authenticated) session recovers on its own: a background
+  // retry that backs off while the outage persists. The retry is non-blocking
+  // (never tears the tree down to a spinner) and PUBLISHES on settle, so a
+  // recovery that supersedes a racing post-mutation refresh still notifies peer
+  // tabs rather than swallowing the session change. Each fresh `degraded` error
+  // is a new reference, so this re-arms after every failed retry; a successful
+  // settle clears `degraded` and the cleanup cancels the pending timer.
+  useEffect(() => {
+    if (snapshot.degraded === null) {
+      return;
+    }
+    const attempt = Math.max(0, degradedRetriesRef.current - 1);
+    const delay = Math.min(DEGRADED_RETRY_MAX_MS, DEGRADED_RETRY_BASE_MS * 2 ** Math.min(attempt, 5));
+    const timer = setTimeout(() => void checkSession('refresh-and-publish'), delay);
+    return () => clearTimeout(timer);
+  }, [checkSession, snapshot.degraded]);
+
   useEffect(() => {
     if (snapshot.state.status !== 'authenticated' || snapshot.identity === null) {
+      return;
+    }
+    // Once a check has already failed, the recovery cadence is owned elsewhere:
+    // the degraded backoff retries a still-valid session, and the failure wall
+    // waits for a manual reload. Without this guard the expiry timer, seeing an
+    // already-past deadline, would reschedule a blocking revalidate every second
+    // through an outage — a request storm that also races the degraded backoff.
+    if (snapshot.failure !== null || snapshot.degraded !== null) {
       return;
     }
     const idle = Date.parse(snapshot.identity.session.idle_expires_at);
@@ -389,12 +466,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       : 1_000;
     const timer = setTimeout(() => void revalidate(), delay);
     return () => clearTimeout(timer);
-  }, [revalidate, snapshot.identity, snapshot.state.status]);
+  }, [revalidate, snapshot.degraded, snapshot.failure, snapshot.identity, snapshot.state.status]);
 
   const value = {
     state: snapshot.state,
     identity: snapshot.identity,
     failure: snapshot.failure,
+    degraded: snapshot.degraded,
     captureTransition,
     acceptSession,
     endSession,


### PR DESCRIPTION
Closes #440.

## Problem
A transient **background** revalidation failure latched a global, unrecoverable full-screen "server unreachable" wall over a **still-valid authenticated session**. `AuthProvider` modelled `failure` orthogonally to `AuthState`, and every *blocking* revalidation path — mount, a peer-tab `BroadcastChannel` signal, the idle/absolute expiry timer, a post-mutation refresh — promoted a transport/5xx error into that latching `failure` even while a valid identity was held. Because `readIdentity` maps a 401 to `identity: null`, a thrown error can only mean transport/5xx/schema — never "logged out" — so `App`'s `failure` wall was firing over a working session (self-hosted server restarts, user tabs back, the whole UI is replaced by a reload wall).

> Note on the ticket: #440 cites `onFocus = () => void revalidate()`. That focus path was **already** made quiet (`revalidateOnFocus`) in a prior change, so it no longer latches. The latch was still real via the other blocking paths above — mount, BroadcastChannel, expiry timer, and the non-blocking refresh's catch — which is what this PR fixes.

## Fix (`web/src/app/AuthProvider.tsx`)
The `checkSession` catch now branches on the held identity:

- **Still-valid identity** (present *and* not past its unextendable **absolute** deadline) → keep painting the last-known-good authenticated snapshot. The transport error surfaces only through a new, **non-latching** `degraded` field on the auth context, and a bounded exponential backoff (1s→30s) retries in the background until it recovers. The retry is non-blocking and **publishes** on settle, so a retry that supersedes a racing post-mutation refresh still notifies peer tabs.
- **Session-less, or a definitively-expired identity** (absolute deadline passed → dead regardless of the server) → keep today's blocking reload wall. A definitively expired session must never keep painting authenticated chrome. Idle expiry is deliberately excluded from "definitively expired" because idle is server-refreshable — a locally-passed idle window during an outage does not *prove* expiry.

The expiry timer now stands down while `failure`/`degraded` is set, so an already-past deadline can no longer reschedule a blocking revalidate every second through an outage (a request storm that would also race the backoff).

`App.tsx` is unchanged: its wall now only fires when `failure` is set, which is now only the session-less / definitively-expired case. `degraded` is additive on the context for an optional future banner.

## Tests
- **Unit** (`AuthProvider.test.tsx`): degraded-set-and-recover on a background blip; **automatic** backoff recovery (fake timers, no manual revalidation — deleting the retry effect leaves `degraded` set forever); the absolute-expiry wall; plus the preserved session-less wall.
- **E2e** (`shell.spec.ts`): fail whoami mid-session via a peer-tab broadcast (the blocking path that used to latch), assert the shell keeps painting with no wall, then recover. Passes desktop + mobile. Reverting the fix latches the wall → the heading-visibility poll fails.

## Cross-model review
Native Codex (`gpt-5.6-sol`, high effort), 2 rounds. R1 raised 1 HIGH + 3 MEDIUM (expired-session-stays-authenticated, expiry-timer storm defeating backoff, retry cancelling an authoritative publish, tests not exercising the automatic retry) — all fixed in this PR. R2 verdict: **CLEAN**, no critical regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)