### PR TITLE
feat(web): edit declaration rules, metadata, folders, and groups (#493)

### DIFF
--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -599,6 +599,10 @@ const zKeyRead = z.object({
       .object({ min_length: z.number().optional(), pattern: z.string().optional() })
       .optional(),
   }),
+  presence: z.object({
+    required_in: z.object({ mode: z.string() }),
+    forbidden_in: z.object({ mode: z.string() }),
+  }),
 });
 function keyDetailKeyName(projectName: string): string {
   return `CATALOGUE_${projectName.toUpperCase()}`;
@@ -695,6 +699,17 @@ test.describe('catalogue declaration detail', () => {
     await panel.getByLabel('Required in').selectOption('all');
     await expect(panel.locator('.key-detail__presence-impact')).toContainText('Newly required in');
     await panel.getByLabel('Required in').selectOption('none');
+
+    // Commit a value-safe presence change (the key holds no values, so
+    // forbidding it everywhere is satisfiable) and verify it persisted through
+    // the API — the client preview alone would not prove the write carried it.
+    await panel.getByLabel('Forbidden in').selectOption('all');
+    await panel.getByRole('button', { name: 'Save value rules & presence' }).click();
+    await expect(panel.getByRole('status').filter({ hasText: 'Saved.' })).toBeVisible();
+    expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).presence.forbidden_in.mode).toBe('all');
+    await panel.getByLabel('Forbidden in').selectOption('none');
+    await panel.getByRole('button', { name: 'Save value rules & presence' }).click();
+    await expect(panel.getByRole('status').filter({ hasText: 'Saved.' })).toBeVisible();
 
     // #183/#493: a credential-shaped pattern is blocked; overriding commits it.
     const consoleLines: string[] = [];

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -588,6 +588,18 @@ test.describe('environment matrix', () => {
  * other flows assert on untouched.
  */
 const zCreatedKey = z.object({ id: z.string() });
+// AWS's own documented EXAMPLE access-key id: matched by the aws-access-token
+// rule and non-live by construction (same canary the S1 scanning flow uses).
+const CANARY = 'AKIAIOSFODNN7EXAMPLE';
+const zKeyRead = z.object({
+  name: z.string(),
+  group_id: z.string(),
+  declaration: z.object({
+    rule: z
+      .object({ min_length: z.number().optional(), pattern: z.string().optional() })
+      .optional(),
+  }),
+});
 function keyDetailKeyName(projectName: string): string {
   return `CATALOGUE_${projectName.toUpperCase()}`;
 }
@@ -662,6 +674,110 @@ test.describe('catalogue declaration detail', () => {
     await expect(page.getByRole('link', { name: /revision history/i })).toBeVisible();
     await page.getByRole('link', { name: 'Close key declaration' }).click();
     await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+  });
+
+  test('edits value rules and presence, previews impact, and blocks a scanned pattern', async ({
+    page,
+  }) => {
+    const keyPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${keyId}`;
+    const token = await fixtureBearer('rules edit');
+    await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${keyId}`);
+    const panel = page.locator('.key-detail');
+    await expect(panel.getByRole('heading', { name: 'Edit value rules & presence' })).toBeVisible();
+
+    // A valid rule edit commits and is durable.
+    await panel.getByLabel('Minimum length').fill('3');
+    await panel.getByRole('button', { name: 'Save value rules & presence' }).click();
+    await expect(panel.getByRole('status').filter({ hasText: 'Saved.' })).toBeVisible();
+    expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).declaration.rule?.min_length).toBe(3);
+
+    // Criterion 3: the before/after impact names the affected environments.
+    await panel.getByLabel('Required in').selectOption('all');
+    await expect(panel.locator('.key-detail__presence-impact')).toContainText('Newly required in');
+    await panel.getByLabel('Required in').selectOption('none');
+
+    // #183/#493: a credential-shaped pattern is blocked; overriding commits it.
+    const consoleLines: string[] = [];
+    page.on('console', (message) => consoleLines.push(message.text()));
+    page.on('pageerror', (error) => consoleLines.push(String(error)));
+    await panel.getByLabel('Pattern (RE2, anchored)').fill(CANARY);
+    await panel.getByRole('button', { name: 'Save value rules & presence' }).click();
+    const block = page.locator('dialog.scan-block');
+    await expect(block).toBeVisible();
+    await expect(block.getByText('aws-access-token')).toBeVisible();
+    // SS4: the canary reaches neither the dialog markup nor the console.
+    expect(await block.evaluate((el) => el.outerHTML)).not.toContain(CANARY);
+    expect(consoleLines.filter((line) => line.includes(CANARY))).toEqual([]);
+    await block.getByRole('button', { name: 'Acknowledge and continue' }).click();
+    await expect(block).toHaveCount(0);
+    expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).declaration.rule?.pattern).toBe(CANARY);
+  });
+
+  test('sets and clears the key’s group membership', async ({ page }, testInfo) => {
+    const token = await fixtureBearer('group membership');
+    const group = await fixtureApiCall(
+      token,
+      'POST',
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/key-groups`,
+      zCreatedKey,
+      { name: `catgrp-${testInfo.project.name}` },
+    );
+    const keyPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${keyId}`;
+    try {
+      await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${keyId}`);
+      const groupSelect = page.getByLabel('Key group');
+      await groupSelect.selectOption(group.id);
+      await expect(page.getByRole('status').filter({ hasText: 'Group updated.' })).toBeVisible();
+      expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).group_id).toBe(group.id);
+
+      await groupSelect.selectOption('');
+      await expect(page.getByRole('status').filter({ hasText: 'Group updated.' })).toBeVisible();
+      expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).group_id).toBe('');
+    } finally {
+      await fixtureApiCall(
+        token,
+        'DELETE',
+        `/api/v1/orgs/${seed.org}/projects/${seed.project}/key-groups/${group.id}`,
+        z.object({}),
+      );
+    }
+  });
+
+  test('manages folder and key-group lifecycle from the matrix', async ({ page }, testInfo) => {
+    const suffix = testInfo.project.name.toLowerCase();
+    const folderPath = `catflow-${suffix}`;
+    const groupName = `catflow ${suffix}`;
+    await page.goto(MATRIX_PATH);
+    await page.getByRole('button', { name: 'Folders & groups' }).click();
+    const dialog = page.locator('dialog.catalogue-manage');
+    await expect(dialog.getByRole('heading', { name: 'Folders & groups' })).toBeVisible();
+
+    await dialog.getByLabel('New folder path').fill(folderPath);
+    await dialog.getByRole('button', { name: 'Add folder' }).click();
+    await expect(dialog.getByText(`Folder ${folderPath} created.`)).toBeVisible();
+
+    await dialog.getByLabel('New group name').fill(groupName);
+    await dialog.getByRole('button', { name: 'Add group' }).click();
+    await expect(dialog.getByText(`Group ${groupName} created.`)).toBeVisible();
+
+    // Clean up through the same lifecycle controls; a row is addressed by its
+    // input's accessible name (its identity lives in an input value).
+    const folderInput = dialog.getByLabel(`Folder path for ${folderPath}`);
+    await folderInput.locator('xpath=ancestor::li').getByRole('button', { name: 'Delete' }).click();
+    await folderInput
+      .locator('xpath=ancestor::li')
+      .getByRole('button', { name: 'Confirm delete' })
+      .click();
+    await expect(folderInput).toHaveCount(0);
+
+    const groupInput = dialog.getByLabel(`Name for group ${groupName}`);
+    await groupInput.locator('xpath=ancestor::li').getByRole('button', { name: 'Delete' }).click();
+    await groupInput
+      .locator('xpath=ancestor::li')
+      .getByRole('button', { name: 'Confirm delete' })
+      .click();
+    await expect(groupInput).toHaveCount(0);
+    await expect(dialog).toBeVisible();
   });
 
   test('keeps a stale or missing key recoverable', async ({ page }) => {

--- a/web/src/api/catalogue.test.ts
+++ b/web/src/api/catalogue.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError, type RefusalFinding } from './client.ts';
+import {
+  catalogueRefusalText,
+  environmentsUnder,
+  presenceImpact,
+  presenceImpactIsEmpty,
+  scanFindings,
+  type PresenceRulesLike,
+} from './catalogue.ts';
+
+const envs = ['env_a', 'env_b', 'env_c'];
+
+const presence = (
+  required: PresenceRulesLike['required_in'],
+  forbidden: PresenceRulesLike['forbidden_in'] = { mode: 'none' },
+): PresenceRulesLike => ({ required_in: required, forbidden_in: forbidden });
+
+const finding: RefusalFinding = {
+  rule_id: 'aws-access-token',
+  surface: 'edit',
+  locator: 'key.declaration.pattern',
+  acknowledgement: 'tok_1',
+};
+
+/** Build a scanner-block refusal the way client.ts's `refusal` would. */
+function scanRefusal(findings: readonly RefusalFinding[]): ApiError {
+  return new ApiError(400, 'x', undefined, undefined, findings);
+}
+
+describe('environmentsUnder', () => {
+  it('expands `all` to every environment and `none` to nothing', () => {
+    expect(environmentsUnder({ mode: 'all' }, envs)).toEqual(envs);
+    expect(environmentsUnder({ mode: 'none' }, envs)).toEqual([]);
+  });
+
+  it('intersects `explicit` with the environments that still exist', () => {
+    expect(
+      environmentsUnder({ mode: 'explicit', environment_ids: ['env_b', 'env_gone'] }, envs),
+    ).toEqual(['env_b']);
+  });
+});
+
+describe('presenceImpact', () => {
+  it('names the environments a required rule newly covers', () => {
+    const impact = presenceImpact(presence({ mode: 'none' }), presence({ mode: 'all' }), envs);
+    expect(impact.requiredAdded).toEqual(envs);
+    expect(impact.requiredRemoved).toEqual([]);
+    expect(presenceImpactIsEmpty(impact)).toBe(false);
+  });
+
+  it('reports both directions across required and forbidden', () => {
+    const before = presence(
+      { mode: 'explicit', environment_ids: ['env_a'] },
+      { mode: 'explicit', environment_ids: ['env_c'] },
+    );
+    const after = presence({ mode: 'explicit', environment_ids: ['env_b'] }, { mode: 'none' });
+    const impact = presenceImpact(before, after, envs);
+    expect(impact.requiredAdded).toEqual(['env_b']);
+    expect(impact.requiredRemoved).toEqual(['env_a']);
+    expect(impact.forbiddenRemoved).toEqual(['env_c']);
+    expect(impact.forbiddenAdded).toEqual([]);
+  });
+
+  it('is empty when nothing changes', () => {
+    const same = presence({ mode: 'all' });
+    expect(presenceImpactIsEmpty(presenceImpact(same, same, envs))).toBe(true);
+  });
+});
+
+describe('scanFindings', () => {
+  it('returns the findings on a scanner refusal', () => {
+    expect(scanFindings(scanRefusal([finding]))).toEqual([finding]);
+  });
+
+  it('is null for a plain refusal, an empty findings array, and a non-ApiError', () => {
+    expect(scanFindings(new ApiError(400, 'x'))).toBeNull();
+    expect(scanFindings(scanRefusal([]))).toBeNull();
+    expect(scanFindings(new Error('boom'))).toBeNull();
+  });
+});
+
+describe('catalogueRefusalText', () => {
+  it('quotes the server caller-safe detail verbatim', () => {
+    expect(
+      catalogueRefusalText(new ApiError(400, 'x', 'key "PORT" fails its integer rule'), 'update the rules'),
+    ).toBe('Refused: key "PORT" fails its integer rule');
+  });
+
+  it('names the action for permission, missing, and concurrency refusals', () => {
+    expect(catalogueRefusalText(new ApiError(403, 'x'), 'delete the folder')).toContain(
+      'permission to delete the folder',
+    );
+    expect(catalogueRefusalText(new ApiError(404, 'x'), 'rename the group')).toContain(
+      'no longer exists',
+    );
+    expect(catalogueRefusalText(new ApiError(409, 'x'), 'update the rules')).toContain(
+      'concurrent edit',
+    );
+  });
+});

--- a/web/src/api/catalogue.ts
+++ b/web/src/api/catalogue.ts
@@ -1,0 +1,333 @@
+import type { KeyDeclaration, KeyPresenceRules } from '@hikyo/client';
+import {
+  createFolderOp,
+  createKeyGroupOp,
+  deleteFolderOp,
+  deleteKeyGroupOp,
+  listFoldersOp,
+  listKeyGroupsOp,
+  renameFolderOp,
+  renameKeyGroupOp,
+  setKeyGroupOp,
+  updateKeyDeclarationOp,
+} from '@hikyo/operations';
+import { zFolderList, zKeyGroupList } from '@hikyo/zod';
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import type { z } from 'zod';
+
+import { ApiError, ok, parsed, type RefusalFinding } from './client.ts';
+import { callerSafeRefusal } from './history.ts';
+import {
+  foldersKey,
+  matrixGroupsKey,
+  matrixKeyKey,
+  matrixKeysKey,
+  type MatrixRef,
+} from './keys.ts';
+import { useTransport } from './transport.tsx';
+
+/**
+ * The declaration-catalogue writes #493 adds on top of #491's read/metadata
+ * foundation (`useKey`, `useUpdateKeyMetadata` in matrix.ts): value-rule and
+ * presence edits, key rename/delete and group membership, and folder and
+ * key-group lifecycle.
+ *
+ * Every write here is a Surface-2 scanning chokepoint (#74/#183) — a rule
+ * change, a folder or group name — so its request carries `acknowledgements`
+ * and its refusal can arrive with redacted findings on `ApiError.findings`. No
+ * secret value is ever read to edit a declaration: the whole surface builds on
+ * `key.get` and the list endpoints alone.
+ */
+
+export type { KeyDeclaration, KeyPresenceRules } from '@hikyo/client';
+export type Folder = z.infer<typeof zFolderList>['items'][number];
+export type KeyGroup = z.infer<typeof zKeyGroupList>['items'][number];
+
+type Acknowledgeable = { readonly acknowledgements?: readonly string[] };
+
+function ackBody(input: Acknowledgeable): { acknowledgements?: string[] } {
+  return input.acknowledgements === undefined || input.acknowledgements.length === 0
+    ? {}
+    : { acknowledgements: [...input.acknowledgements] };
+}
+
+/**
+ * scanFindings returns the Surface-2 findings a refusal carries, or null when
+ * the error is anything else. `ApiError.findings` is always an array (empty for
+ * a non-scanner refusal), so an empty list reads as null and callers branch
+ * cleanly.
+ */
+export function scanFindings(error: unknown): readonly RefusalFinding[] | null {
+  if (error instanceof ApiError && error.findings.length > 0) {
+    return error.findings;
+  }
+  return null;
+}
+
+export type CatalogueAction =
+  | 'update the rules'
+  | 'change the group'
+  | 'create the folder'
+  | 'rename the folder'
+  | 'delete the folder'
+  | 'create the group'
+  | 'rename the group'
+  | 'delete the group';
+
+/**
+ * catalogueRefusalText renders a catalogue-write refusal in the caller's own
+ * words. A caller-safe server detail (a presence veto, an invalid rule, a
+ * duplicate path) is shown verbatim; the uniform 403/404/409 refusals fall back
+ * to fixed sentences. A scanner block is handled by the caller through
+ * {@link scanFindings}, never here.
+ */
+export function catalogueRefusalText(error: unknown, action: CatalogueAction): string {
+  if (error instanceof ApiError) {
+    const detailed = callerSafeRefusal(error, 'Refused');
+    if (detailed !== null) {
+      return detailed;
+    }
+    if (error.status === 403) {
+      return `You do not have permission to ${action} in this project.`;
+    }
+    if (error.status === 404) {
+      return 'This no longer exists — reload the catalogue to see its current state.';
+    }
+    if (error.status === 409) {
+      return `The server refused this change to avoid overwriting a concurrent edit; reload and ${action} again.`;
+    }
+    return `The server could not ${action} (error ${String(error.status)}).`;
+  }
+  return `The server could not ${action}.`;
+}
+
+/** Every cache a declaration change on one key can move. */
+function invalidateKey(
+  queries: ReturnType<typeof useQueryClient>,
+  ref: MatrixRef,
+  key: string,
+): Promise<unknown> {
+  return Promise.all([
+    queries.invalidateQueries({ queryKey: matrixKeyKey(ref, key) }),
+    queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+    queries.invalidateQueries({ queryKey: matrixGroupsKey(ref) }),
+    queries.invalidateQueries({ queryKey: foldersKey(ref) }),
+  ]);
+}
+
+export function useUpdateKeyDeclaration(ref: MatrixRef, key: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (
+      input: Acknowledgeable & {
+        readonly declaration: KeyDeclaration;
+        readonly presence: KeyPresenceRules;
+      },
+    ) =>
+      parsed(updateKeyDeclarationOp, {
+        path: { ...ref, key },
+        body: { declaration: input.declaration, presence: input.presence, ...ackBody(input) },
+        ...transport,
+      }),
+    onSuccess: () => invalidateKey(queries, ref, key),
+  });
+}
+
+export function useSetKeyGroup(ref: MatrixRef, key: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: { readonly groupId: string }) =>
+      parsed(setKeyGroupOp, {
+        path: { ...ref, key },
+        body: { group_id: input.groupId },
+        ...transport,
+      }),
+    onSuccess: () => invalidateKey(queries, ref, key),
+  });
+}
+
+export function useFolders(ref: MatrixRef): UseQueryResult<z.infer<typeof zFolderList>> {
+  const transport = useTransport();
+  return useQuery({
+    queryKey: foldersKey(ref),
+    queryFn: () => parsed(listFoldersOp, { path: ref, ...transport }),
+    enabled: ref.org !== '' && ref.project !== '',
+    retry: false,
+  });
+}
+
+export function useKeyGroups(ref: MatrixRef): UseQueryResult<z.infer<typeof zKeyGroupList>> {
+  const transport = useTransport();
+  return useQuery({
+    queryKey: matrixGroupsKey(ref),
+    queryFn: () => parsed(listKeyGroupsOp, { path: ref, ...transport }),
+    enabled: ref.org !== '' && ref.project !== '',
+    retry: false,
+  });
+}
+
+function invalidateFolders(
+  queries: ReturnType<typeof useQueryClient>,
+  ref: MatrixRef,
+): Promise<unknown> {
+  return Promise.all([
+    queries.invalidateQueries({ queryKey: foldersKey(ref) }),
+    queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+  ]);
+}
+
+export function useCreateFolder(ref: MatrixRef) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: Acknowledgeable & { readonly path: string }) =>
+      parsed(createFolderOp, {
+        path: ref,
+        body: { path: input.path, ...ackBody(input) },
+        ...transport,
+      }),
+    onSuccess: () => invalidateFolders(queries, ref),
+  });
+}
+
+export function useRenameFolder(ref: MatrixRef, folder: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: Acknowledgeable & { readonly path: string }) =>
+      parsed(renameFolderOp, {
+        path: { ...ref, folder },
+        body: { path: input.path, ...ackBody(input) },
+        ...transport,
+      }),
+    onSuccess: () => invalidateFolders(queries, ref),
+  });
+}
+
+export function useDeleteFolder(ref: MatrixRef, folder: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: () => ok(deleteFolderOp, { path: { ...ref, folder }, ...transport }),
+    onSuccess: () => invalidateFolders(queries, ref),
+  });
+}
+
+function invalidateGroups(
+  queries: ReturnType<typeof useQueryClient>,
+  ref: MatrixRef,
+): Promise<unknown> {
+  return Promise.all([
+    queries.invalidateQueries({ queryKey: matrixGroupsKey(ref) }),
+    queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+  ]);
+}
+
+export function useCreateKeyGroup(ref: MatrixRef) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: Acknowledgeable & { readonly name: string }) =>
+      parsed(createKeyGroupOp, {
+        path: ref,
+        body: { name: input.name, ...ackBody(input) },
+        ...transport,
+      }),
+    onSuccess: () => invalidateGroups(queries, ref),
+  });
+}
+
+export function useRenameKeyGroup(ref: MatrixRef, group: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: Acknowledgeable & { readonly name: string }) =>
+      parsed(renameKeyGroupOp, {
+        path: { ...ref, group },
+        body: { name: input.name, ...ackBody(input) },
+        ...transport,
+      }),
+    onSuccess: () => invalidateGroups(queries, ref),
+  });
+}
+
+export function useDeleteKeyGroup(ref: MatrixRef, group: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: () => ok(deleteKeyGroupOp, { path: { ...ref, group }, ...transport }),
+    onSuccess: () => invalidateGroups(queries, ref),
+  });
+}
+
+// --- presence impact (criterion 3: affected environments before commit) -----
+
+export type PresenceMode = KeyPresenceRules['required_in']['mode'];
+
+export type PresenceRuleLike = {
+  readonly mode: PresenceMode;
+  readonly environment_ids?: readonly string[] | undefined;
+};
+export type PresenceRulesLike = {
+  readonly required_in: PresenceRuleLike;
+  readonly forbidden_in: PresenceRuleLike;
+};
+
+/**
+ * environmentsUnder resolves a presence rule to the concrete environment id set
+ * it covers: `all` is symbolic and covers every environment, `none` covers
+ * nothing, `explicit` covers its listed ids intersected with those that exist.
+ */
+export function environmentsUnder(
+  rule: PresenceRuleLike,
+  environmentIds: readonly string[],
+): readonly string[] {
+  switch (rule.mode) {
+    case 'all':
+      return environmentIds;
+    case 'none':
+      return [];
+    case 'explicit': {
+      const listed = new Set(rule.environment_ids ?? []);
+      return environmentIds.filter((id) => listed.has(id));
+    }
+  }
+}
+
+export type PresenceImpact = {
+  readonly requiredAdded: readonly string[];
+  readonly requiredRemoved: readonly string[];
+  readonly forbiddenAdded: readonly string[];
+  readonly forbiddenRemoved: readonly string[];
+};
+
+/** presenceImpact is the before/after of a presence edit as concrete env sets. */
+export function presenceImpact(
+  before: PresenceRulesLike,
+  after: PresenceRulesLike,
+  environmentIds: readonly string[],
+): PresenceImpact {
+  const requiredBefore = new Set(environmentsUnder(before.required_in, environmentIds));
+  const requiredAfter = new Set(environmentsUnder(after.required_in, environmentIds));
+  const forbiddenBefore = new Set(environmentsUnder(before.forbidden_in, environmentIds));
+  const forbiddenAfter = new Set(environmentsUnder(after.forbidden_in, environmentIds));
+  return {
+    requiredAdded: environmentIds.filter((id) => requiredAfter.has(id) && !requiredBefore.has(id)),
+    requiredRemoved: environmentIds.filter((id) => requiredBefore.has(id) && !requiredAfter.has(id)),
+    forbiddenAdded: environmentIds.filter((id) => forbiddenAfter.has(id) && !forbiddenBefore.has(id)),
+    forbiddenRemoved: environmentIds.filter(
+      (id) => forbiddenBefore.has(id) && !forbiddenAfter.has(id),
+    ),
+  };
+}
+
+export function presenceImpactIsEmpty(impact: PresenceImpact): boolean {
+  return (
+    impact.requiredAdded.length === 0 &&
+    impact.requiredRemoved.length === 0 &&
+    impact.forbiddenAdded.length === 0 &&
+    impact.forbiddenRemoved.length === 0
+  );
+}

--- a/web/src/api/catalogue.ts
+++ b/web/src/api/catalogue.ts
@@ -55,10 +55,12 @@ function ackBody(input: Acknowledgeable): { acknowledgements?: string[] } {
  * scanFindings returns the Surface-2 findings a refusal carries, or null when
  * the error is anything else. `ApiError.findings` is always an array (empty for
  * a non-scanner refusal), so an empty list reads as null and callers branch
- * cleanly.
+ * cleanly. A 404 NEVER opens a findings dialog even if one somehow rode it —
+ * that would leak existence through the uniform missing-resource mask — matching
+ * the foundation's own `scanBlockFrom` guard.
  */
 export function scanFindings(error: unknown): readonly RefusalFinding[] | null {
-  if (error instanceof ApiError && error.findings.length > 0) {
+  if (error instanceof ApiError && error.status !== 404 && error.findings.length > 0) {
     return error.findings;
   }
   return null;

--- a/web/src/api/keys.ts
+++ b/web/src/api/keys.ts
@@ -25,6 +25,8 @@ export const matrixKeyKey = (ref: MatrixRef, key: string) =>
   [...matrixKeysKey(ref), 'key', key] as const;
 export const matrixGroupsKey = (ref: MatrixRef) =>
   ['matrix-groups', ref.org, ref.project] as const;
+export const foldersKey = (ref: MatrixRef) =>
+  ['folders', ref.org, ref.project] as const;
 export const signalsMatrixKey = (ref: MatrixRef) =>
   ['matrix-signals', ref.org, ref.project] as const;
 export const signalsKey = (ref: MatrixRef, environment: string) =>

--- a/web/src/routes/CatalogueManageDialog.tsx
+++ b/web/src/routes/CatalogueManageDialog.tsx
@@ -1,0 +1,432 @@
+import { useId, useState } from 'react';
+
+import type { RefusalFinding } from '../api/client.ts';
+import {
+  catalogueRefusalText,
+  scanFindings,
+  useCreateFolder,
+  useCreateKeyGroup,
+  useDeleteFolder,
+  useDeleteKeyGroup,
+  useFolders,
+  useKeyGroups,
+  useRenameFolder,
+  useRenameKeyGroup,
+  type CatalogueAction,
+  type Folder,
+  type KeyGroup,
+} from '../api/catalogue.ts';
+import { GIT_DEFINITIONS_NOTICE, useDefinitionsSettings } from '../api/definitions.ts';
+import type { MatrixRef } from '../api/keys.ts';
+import { Alert, Done } from './Sections.tsx';
+import { ScanBlockDialog } from './ScanBlockDialog.tsx';
+import { useModalDialog } from './useModalDialog.ts';
+
+type ScanBlockState = {
+  readonly findings: readonly RefusalFinding[];
+  readonly onOverride: ((tokens: readonly string[]) => Promise<void>) | null;
+};
+
+/** Route a refused catalogue write: a scanner block opens the dialog, else null. */
+function toScanBlock(
+  error: unknown,
+  retry: (tokens: readonly string[]) => Promise<void>,
+): ScanBlockState | null {
+  const findings = scanFindings(error);
+  if (findings === null) return null;
+  return {
+    findings,
+    onOverride: findings.every((finding) => finding.acknowledgement !== undefined) ? retry : null,
+  };
+}
+
+/**
+ * CatalogueManageDialog is the folder and key-group lifecycle surface (#493).
+ *
+ * Folders and groups are project-scoped organisation, not per-key facts, so
+ * they live here — reachable from the matrix, including its empty state, which
+ * is what makes the lifecycle complete from an empty project. A folder is a
+ * namespace label that owns no value and blocks no key; a group couples keys
+ * and dissolves without deleting them. Both names are Surface-2 scanning
+ * ingresses (#74), so create/rename route through the shared block dialog.
+ */
+export function CatalogueManageDialog({
+  refData,
+  onClose,
+}: {
+  refData: MatrixRef;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  const folders = useFolders(refData);
+  const groups = useKeyGroups(refData);
+  const definitions = useDefinitionsSettings(refData.org, refData.project);
+  const readOnly = definitions.data?.definitions_source === 'git';
+
+  return (
+    <dialog className="matrix-editor catalogue-manage" ref={dialog} onClose={onClose}>
+      <div className="matrix-editor__head">
+        <div>
+          <h2>Folders &amp; groups</h2>
+          <p>Organise the catalogue: folders are namespace labels, groups couple related keys.</p>
+        </div>
+        <button
+          type="button"
+          className="btn matrix-editor__close"
+          aria-label="Close folders and groups"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+
+      {readOnly ? <Alert>{GIT_DEFINITIONS_NOTICE}</Alert> : null}
+
+      <section className="catalogue-manage__section" aria-labelledby="catalogue-folders">
+        <h3 id="catalogue-folders">Folders</h3>
+        {folders.isPending ? <p role="status">Loading folders…</p> : null}
+        {folders.isError ? <Alert>Folders could not be read.</Alert> : null}
+        {folders.data !== undefined && folders.data.items.length === 0 ? (
+          <p role="status" className="catalogue-manage__empty">
+            No folders yet.
+          </p>
+        ) : null}
+        <ul className="catalogue-manage__list">
+          {(folders.data?.items ?? []).map((folder) => (
+            <FolderRow key={folder.id} refData={refData} folder={folder} readOnly={readOnly} />
+          ))}
+        </ul>
+        {readOnly ? null : <CreateFolder refData={refData} />}
+      </section>
+
+      <section className="catalogue-manage__section" aria-labelledby="catalogue-groups">
+        <h3 id="catalogue-groups">Key groups</h3>
+        {groups.isPending ? <p role="status">Loading groups…</p> : null}
+        {groups.isError ? <Alert>Key groups could not be read.</Alert> : null}
+        {groups.data !== undefined && groups.data.items.length === 0 ? (
+          <p role="status" className="catalogue-manage__empty">
+            No groups yet. Create one, then add keys to it from each key’s detail page.
+          </p>
+        ) : null}
+        <ul className="catalogue-manage__list">
+          {(groups.data?.items ?? []).map((group) => (
+            <GroupRow key={group.id} refData={refData} group={group} readOnly={readOnly} />
+          ))}
+        </ul>
+        {readOnly ? null : <CreateKeyGroup refData={refData} />}
+      </section>
+    </dialog>
+  );
+}
+
+/** A create/rename form's scanning-block state and the retry that clears it. */
+function useNameWrite(action: CatalogueAction) {
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+  const [scanBlock, setScanBlock] = useState<ScanBlockState | null>(null);
+  const run = (
+    attempt: (acknowledgements: readonly string[]) => Promise<void>,
+    okText: string,
+  ): void => {
+    setRefusal(null);
+    setDone(null);
+    void attempt([])
+      .then(() => setDone(okText))
+      .catch((error: unknown) => {
+        const block = toScanBlock(error, (tokens) =>
+          attempt(tokens).then(() => {
+            setDone(okText);
+            setScanBlock(null);
+          }),
+        );
+        if (block !== null) {
+          setScanBlock(block);
+          return;
+        }
+        setRefusal(catalogueRefusalText(error, action));
+      });
+  };
+  return { refusal, done, scanBlock, closeScanBlock: () => setScanBlock(null), run };
+}
+
+function CreateFolder({ refData }: { refData: MatrixRef }) {
+  const create = useCreateFolder(refData);
+  const write = useNameWrite('create the folder');
+  const id = useId();
+  const [path, setPath] = useState('');
+  const trimmed = path.trim();
+  return (
+    <form
+      className="catalogue-manage__create"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (trimmed === '') return;
+        write.run(
+          (acknowledgements) =>
+            new Promise<void>((resolve, reject) =>
+              create.mutate(
+                { path: trimmed, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+                { onSuccess: () => resolve(), onError: (error) => reject(error) },
+              ),
+            ).then(() => setPath('')),
+          `Folder ${trimmed} created.`,
+        );
+      }}
+    >
+      <label className="visually-hidden" htmlFor={id}>
+        New folder path
+      </label>
+      <input
+        id={id}
+        className="mono"
+        value={path}
+        placeholder="app/db"
+        disabled={create.isPending}
+        onChange={(event) => setPath(event.currentTarget.value)}
+      />
+      <button type="submit" className="btn btn--primary" disabled={create.isPending || trimmed === ''}>
+        Add folder
+      </button>
+      {write.refusal === null ? null : <Alert>{write.refusal}</Alert>}
+      {write.done === null ? null : <Done>{write.done}</Done>}
+      {write.scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Folder name blocked by secret scanning"
+          intro="A folder name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          findings={write.scanBlock.findings}
+          onOverride={write.scanBlock.onOverride}
+          onClose={write.closeScanBlock}
+        />
+      )}
+    </form>
+  );
+}
+
+function FolderRow({
+  refData,
+  folder,
+  readOnly,
+}: {
+  refData: MatrixRef;
+  folder: Folder;
+  readOnly: boolean;
+}) {
+  const rename = useRenameFolder(refData, folder.id);
+  const remove = useDeleteFolder(refData, folder.id);
+  const write = useNameWrite('rename the folder');
+  const [path, setPath] = useState(folder.path);
+  const [confirming, setConfirming] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const trimmed = path.trim();
+  const busy = rename.isPending || remove.isPending;
+  return (
+    <li className="catalogue-manage__row">
+      <div className="catalogue-manage__row-main">
+        <input
+          className="mono"
+          aria-label={`Folder path for ${folder.path}`}
+          value={path}
+          disabled={readOnly || busy}
+          onChange={(event) => setPath(event.currentTarget.value)}
+        />
+        <button
+          type="button"
+          className="btn"
+          disabled={readOnly || busy || trimmed === '' || trimmed === folder.path}
+          onClick={() =>
+            write.run(
+              (acknowledgements) =>
+                new Promise<void>((resolve, reject) =>
+                  rename.mutate(
+                    { path: trimmed, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+                    { onSuccess: () => resolve(), onError: (error) => reject(error) },
+                  ),
+                ),
+              `Folder renamed to ${trimmed}.`,
+            )
+          }
+        >
+          Rename
+        </button>
+        {confirming ? (
+          <button
+            type="button"
+            className="btn btn--danger"
+            disabled={busy}
+            onClick={() => {
+              setDeleteError(null);
+              remove.mutate(undefined, {
+                onError: (error) => setDeleteError(catalogueRefusalText(error, 'delete the folder')),
+              });
+            }}
+          >
+            Confirm delete
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn"
+            disabled={readOnly || busy}
+            onClick={() => setConfirming(true)}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+      {write.refusal === null ? null : <Alert>{write.refusal}</Alert>}
+      {deleteError === null ? null : <Alert>{deleteError}</Alert>}
+      {write.done === null ? null : <Done>{write.done}</Done>}
+      {write.scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Folder name blocked by secret scanning"
+          intro="A folder name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          findings={write.scanBlock.findings}
+          onOverride={write.scanBlock.onOverride}
+          onClose={write.closeScanBlock}
+        />
+      )}
+    </li>
+  );
+}
+
+function CreateKeyGroup({ refData }: { refData: MatrixRef }) {
+  const create = useCreateKeyGroup(refData);
+  const write = useNameWrite('create the group');
+  const id = useId();
+  const [name, setName] = useState('');
+  const trimmed = name.trim();
+  return (
+    <form
+      className="catalogue-manage__create"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (trimmed === '') return;
+        write.run(
+          (acknowledgements) =>
+            new Promise<void>((resolve, reject) =>
+              create.mutate(
+                { name: trimmed, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+                { onSuccess: () => resolve(), onError: (error) => reject(error) },
+              ),
+            ).then(() => setName('')),
+          `Group ${trimmed} created.`,
+        );
+      }}
+    >
+      <label className="visually-hidden" htmlFor={id}>
+        New group name
+      </label>
+      <input
+        id={id}
+        value={name}
+        placeholder="database"
+        disabled={create.isPending}
+        onChange={(event) => setName(event.currentTarget.value)}
+      />
+      <button type="submit" className="btn btn--primary" disabled={create.isPending || trimmed === ''}>
+        Add group
+      </button>
+      {write.refusal === null ? null : <Alert>{write.refusal}</Alert>}
+      {write.done === null ? null : <Done>{write.done}</Done>}
+      {write.scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Group name blocked by secret scanning"
+          intro="A group name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          findings={write.scanBlock.findings}
+          onOverride={write.scanBlock.onOverride}
+          onClose={write.closeScanBlock}
+        />
+      )}
+    </form>
+  );
+}
+
+function GroupRow({
+  refData,
+  group,
+  readOnly,
+}: {
+  refData: MatrixRef;
+  group: KeyGroup;
+  readOnly: boolean;
+}) {
+  const rename = useRenameKeyGroup(refData, group.id);
+  const remove = useDeleteKeyGroup(refData, group.id);
+  const write = useNameWrite('rename the group');
+  const [name, setName] = useState(group.name);
+  const [confirming, setConfirming] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const trimmed = name.trim();
+  const busy = rename.isPending || remove.isPending;
+  return (
+    <li className="catalogue-manage__row">
+      <div className="catalogue-manage__row-main">
+        <input
+          aria-label={`Name for group ${group.name}`}
+          value={name}
+          disabled={readOnly || busy}
+          onChange={(event) => setName(event.currentTarget.value)}
+        />
+        <span className="catalogue-manage__meta">
+          {String(group.members.length)} {group.members.length === 1 ? 'key' : 'keys'}
+          {group.inert ? <span className="catalogue-manage__inert"> · inert</span> : null}
+        </span>
+        <button
+          type="button"
+          className="btn"
+          disabled={readOnly || busy || trimmed === '' || trimmed === group.name}
+          onClick={() =>
+            write.run(
+              (acknowledgements) =>
+                new Promise<void>((resolve, reject) =>
+                  rename.mutate(
+                    { name: trimmed, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+                    { onSuccess: () => resolve(), onError: (error) => reject(error) },
+                  ),
+                ),
+              `Group renamed to ${trimmed}.`,
+            )
+          }
+        >
+          Rename
+        </button>
+        {confirming ? (
+          <button
+            type="button"
+            className="btn btn--danger"
+            disabled={busy}
+            onClick={() => {
+              setDeleteError(null);
+              remove.mutate(undefined, {
+                onError: (error) => setDeleteError(catalogueRefusalText(error, 'delete the group')),
+              });
+            }}
+          >
+            Confirm delete
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn"
+            disabled={readOnly || busy}
+            onClick={() => setConfirming(true)}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+      {write.refusal === null ? null : <Alert>{write.refusal}</Alert>}
+      {deleteError === null ? null : <Alert>{deleteError}</Alert>}
+      {write.done === null ? null : <Done>{write.done}</Done>}
+      {write.scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Group name blocked by secret scanning"
+          intro="A group name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          findings={write.scanBlock.findings}
+          onOverride={write.scanBlock.onOverride}
+          onClose={write.closeScanBlock}
+        />
+      )}
+    </li>
+  );
+}

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -35,6 +35,24 @@ vi.mock('../api/definitions.ts', async (importActual) => {
   return { ...actual, useDefinitionsSettings: () => mocks.definitions() };
 });
 
+// The #493 editors (rules/presence, group) call catalogue hooks; stub them so
+// this suite exercises the foundation without live fetches (the pure helpers —
+// presenceImpact, catalogueRefusalText — stay real).
+vi.mock('../api/catalogue.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/catalogue.ts')>();
+  return {
+    ...actual,
+    useUpdateKeyDeclaration: () => ({ mutate: vi.fn(), isPending: false }),
+    useSetKeyGroup: () => ({ mutate: vi.fn(), isPending: false }),
+    useKeyGroups: () => ({
+      data: { items: [], count: 0 },
+      isSuccess: true,
+      isError: false,
+      isPending: false,
+    }),
+  };
+});
+
 vi.mock('../api/transport.tsx', async (importActual) => {
   const actual = await importActual<typeof import('../api/transport.tsx')>();
   return { ...actual, useWorkspaceContext: () => null };
@@ -683,6 +701,23 @@ describe('KeyDeclarationDetail', () => {
     const text = textOf(view.container);
     expect(text).toContain('empty not allowed');
     expect(text).toContain('{"type":"object"}');
+
+    await view.unmount();
+  });
+
+  it('renders the #493 editor for an int64-bounded rule without crashing', async () => {
+    // The read model infers integer bounds as bigint; the DeclarationEditor's
+    // reset signature must tolerate them (a plain JSON.stringify would throw).
+    const boundedKey: MatrixKey = {
+      ...record,
+      declaration: { rule: { type: 'integer', min: 1n, max: 9_007_199_254_740_993n } },
+      presence: { required_in: { mode: 'none' }, forbidden_in: { mode: 'none' } },
+    };
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: boundedKey });
+    mocks.definitions.mockReturnValue({ data: { definitions_source: 'db' }, isSuccess: true, isError: false, isRefetchError: false });
+
+    const view = await render();
+    expect(textOf(view.container)).toContain('Edit value rules & presence');
 
     await view.unmount();
   });

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -1330,6 +1330,10 @@ function DeclarationEditor({
   const [refusal, setRefusal] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [scanBlock, setScanBlock] = useState<ScanBlockState | null>(null);
+  // Whether the user has actually touched the rule draft. A declaration with no
+  // rule seeds a synthetic string draft for the form; without this flag a
+  // presence-only save would fabricate that rule the user never chose.
+  const [ruleDirty, setRuleDirty] = useState(false);
 
   // Re-seed only when the SERVER's declaration/presence actually change (a
   // concurrent edit), keyed on a bigint-safe content signature — an unrelated
@@ -1345,6 +1349,7 @@ function DeclarationEditor({
     );
     setPresence(presenceDraftFrom(record.presence));
     setInvalid(null);
+    setRuleDirty(false);
     // `done` is deliberately NOT reset here: the successful-save refetch changes
     // these signatures, and clearing it would wipe the "Saved." it just set.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- content signatures stand in for the objects
@@ -1362,7 +1367,11 @@ function DeclarationEditor({
     setDone(false);
     let declaration: KeyDeclaration;
     try {
-      if (isAnyOf) {
+      if (isAnyOf || !ruleDirty) {
+        // The rule was not touched (any_of, a rule-less declaration, or a
+        // presence-only edit): preserve the EXISTING declaration exactly rather
+        // than rebuild it from the seeded draft. This also keeps an int64 bound
+        // exact instead of re-parsing it, and never fabricates a rule.
         declaration = declarationToWrite(record.declaration);
       } else {
         const result = buildRule(ruleDraft);
@@ -1408,6 +1417,7 @@ function DeclarationEditor({
   // successful-save refetch reseeds without clearing it (the effect leaves it).
   const editRule = (next: RuleDraft): void => {
     setRuleDraft(next);
+    setRuleDirty(true);
     setDone(false);
   };
   const editPresence = (updater: (current: PresenceDraft) => PresenceDraft): void => {

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -1352,8 +1352,11 @@ function DeclarationEditor({
     setRuleDirty(false);
     // `done` is deliberately NOT reset here: the successful-save refetch changes
     // these signatures, and clearing it would wipe the "Saved." it just set.
+    // `keyId` is a dep so navigating to ANOTHER key always re-seeds, even when
+    // the two keys' declaration/presence signatures happen to be identical —
+    // otherwise a stale dirty draft could be written into the new key.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- content signatures stand in for the objects
-  }, [declSignature, presSignature]);
+  }, [keyId, declSignature, presSignature]);
 
   const envIds = useMemo(() => environments.map((environment) => environment.id), [environments]);
   const proposedPresence = buildPresence(presence);

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -1,6 +1,18 @@
-import { useEffect, useId, useRef, useState, type ReactNode, type RefObject } from 'react';
+import type { KeyRule } from '@hikyo/client';
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { generatePath, Link, useNavigate } from 'react-router';
 
+import {
+  catalogueRefusalText,
+  presenceImpact,
+  presenceImpactIsEmpty,
+  useKeyGroups,
+  useSetKeyGroup,
+  useUpdateKeyDeclaration,
+  type KeyDeclaration,
+  type KeyPresenceRules,
+  type PresenceMode,
+} from '../api/catalogue.ts';
 import { GIT_DEFINITIONS_NOTICE, useDefinitionsSettings } from '../api/definitions.ts';
 import { historyHref } from '../api/history.ts';
 import {
@@ -298,6 +310,13 @@ function KeyDeclarationBody({
       {editable ? (
         <>
           <MetadataEditor refData={refData} keyId={keyId} record={record} />
+          <DeclarationEditor
+            refData={refData}
+            keyId={keyId}
+            record={record}
+            environments={environments}
+          />
+          <GroupEditor refData={refData} keyId={keyId} record={record} />
           <RenameKey refData={refData} keyId={keyId} record={record} />
           <ReclassifyKey
             refData={refData}
@@ -1055,5 +1074,666 @@ function ConfirmDialog({
         </button>
       </div>
     </dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// #493 editors — value rules, presence, and group membership. They extend the
+// #491/#494 foundation, reusing its ScanBlockDialog and scanBlockFrom helper.
+// ---------------------------------------------------------------------------
+
+const RULE_TYPES = ['string', 'integer', 'boolean', 'enum', 'url', 'json'] as const;
+type RuleType = (typeof RULE_TYPES)[number];
+type ReadRule = NonNullable<MatrixKey['declaration']['rule']>;
+
+/**
+ * A JSON signature that tolerates bigint. The read model infers int64 bounds
+ * (min/max) as bigint, and a plain JSON.stringify throws on those — so a bound
+ * integer declaration would crash the panel. A tag keeps a bigint distinct from
+ * the same-digit number so the signature never conflates them.
+ */
+function stableSignature(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) =>
+    typeof entry === 'bigint' ? `${entry.toString()}n` : entry,
+  );
+}
+
+/** Raised when an int64 bound cannot cross into a JS number without loss. */
+class UnsafeBoundError extends Error {}
+
+/**
+ * boundToNumber crosses the read model's bigint bound into the write model's
+ * number EXACTLY or not at all — an int64 outside the safe-integer range would
+ * round silently, so it fails loudly rather than writing a corrupted rule.
+ */
+function boundToNumber(bound: bigint): number {
+  const asNumber = Number(bound);
+  if (!Number.isSafeInteger(asNumber) || BigInt(asNumber) !== bound) {
+    throw new UnsafeBoundError(
+      "This key's integer bounds are outside the range the browser can edit safely. Edit its rules with `hikyo definitions`.",
+    );
+  }
+  return asNumber;
+}
+
+function ruleToWrite(rule: ReadRule): KeyRule {
+  return {
+    type: rule.type,
+    ...(rule.min_length === undefined ? {} : { min_length: rule.min_length }),
+    ...(rule.max_length === undefined ? {} : { max_length: rule.max_length }),
+    ...(rule.pattern === undefined ? {} : { pattern: rule.pattern }),
+    ...(rule.allow_empty === undefined ? {} : { allow_empty: rule.allow_empty }),
+    ...(rule.min === undefined ? {} : { min: boundToNumber(rule.min) }),
+    ...(rule.max === undefined ? {} : { max: boundToNumber(rule.max) }),
+    ...(rule.members === undefined ? {} : { members: [...rule.members] }),
+    ...(rule.schemes === undefined ? {} : { schemes: [...rule.schemes] }),
+    ...(rule.json_schema === undefined ? {} : { json_schema: rule.json_schema }),
+  };
+}
+
+/** The existing declaration as a writable value — used when only presence changes. */
+function declarationToWrite(declaration: MatrixKey['declaration']): KeyDeclaration {
+  if (declaration.rule !== undefined) {
+    return { rule: ruleToWrite(declaration.rule) };
+  }
+  if (declaration.any_of !== undefined) {
+    return { any_of: declaration.any_of.map(ruleToWrite) };
+  }
+  return {};
+}
+
+type RuleDraft = {
+  readonly type: RuleType;
+  readonly minLength: string;
+  readonly maxLength: string;
+  readonly pattern: string;
+  readonly allowEmpty: boolean;
+  readonly min: string;
+  readonly max: string;
+  readonly members: string;
+  readonly schemes: string;
+  readonly jsonSchema: string;
+};
+
+function ruleDraftFrom(rule: ReadRule | { type: RuleType }): RuleDraft {
+  const full = rule as Partial<ReadRule> & { type: RuleType };
+  return {
+    type: full.type,
+    minLength: full.min_length === undefined ? '' : String(full.min_length),
+    maxLength: full.max_length === undefined ? '' : String(full.max_length),
+    pattern: full.pattern ?? '',
+    allowEmpty: full.allow_empty ?? false,
+    min: full.min === undefined ? '' : String(full.min),
+    max: full.max === undefined ? '' : String(full.max),
+    members: (full.members ?? []).join('\n'),
+    schemes: (full.schemes ?? []).join(', '),
+    jsonSchema: full.json_schema ?? '',
+  };
+}
+
+/** Parse a bounded integer field, or report why it cannot. */
+function parseBound(label: string, raw: string): { value?: number; error?: string } {
+  const trimmed = raw.trim();
+  if (trimmed === '') return {};
+  if (!/^-?\d+$/.test(trimmed)) return { error: `${label} must be a whole number.` };
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value)) {
+    return { error: `${label} is too large — keep it within ±9,007,199,254,740,991.` };
+  }
+  return { value };
+}
+
+/** Build a writable rule from the draft, or the first reason it is not valid yet. */
+function buildRule(draft: RuleDraft): { rule?: KeyRule; error?: string } {
+  const rule: KeyRule = { type: draft.type };
+  switch (draft.type) {
+    case 'string': {
+      const min = parseBound('Minimum length', draft.minLength);
+      if (min.error !== undefined) return { error: min.error };
+      const max = parseBound('Maximum length', draft.maxLength);
+      if (max.error !== undefined) return { error: max.error };
+      if (min.value !== undefined) rule.min_length = min.value;
+      if (max.value !== undefined) rule.max_length = max.value;
+      if (draft.pattern.trim() !== '') rule.pattern = draft.pattern;
+      if (draft.allowEmpty) rule.allow_empty = true;
+      break;
+    }
+    case 'integer': {
+      const min = parseBound('Minimum', draft.min);
+      if (min.error !== undefined) return { error: min.error };
+      const max = parseBound('Maximum', draft.max);
+      if (max.error !== undefined) return { error: max.error };
+      if (min.value !== undefined) rule.min = min.value;
+      if (max.value !== undefined) rule.max = max.value;
+      break;
+    }
+    case 'enum': {
+      const members = draft.members
+        .split('\n')
+        .map((member) => member.trim())
+        .filter((member) => member !== '');
+      if (members.length === 0) return { error: 'An enum needs at least one member.' };
+      rule.members = members;
+      break;
+    }
+    case 'url': {
+      const schemes = draft.schemes
+        .split(',')
+        .map((scheme) => scheme.trim())
+        .filter((scheme) => scheme !== '');
+      if (schemes.length > 0) rule.schemes = schemes;
+      break;
+    }
+    case 'json': {
+      if (draft.jsonSchema.trim() !== '') rule.json_schema = draft.jsonSchema;
+      break;
+    }
+    case 'boolean':
+      break;
+  }
+  return { rule };
+}
+
+type PresenceDraft = {
+  readonly requiredMode: PresenceMode;
+  readonly requiredIds: ReadonlySet<string>;
+  readonly forbiddenMode: PresenceMode;
+  readonly forbiddenIds: ReadonlySet<string>;
+};
+
+function presenceDraftFrom(presence: MatrixKey['presence']): PresenceDraft {
+  return {
+    requiredMode: presence.required_in.mode,
+    requiredIds: new Set(presence.required_in.environment_ids ?? []),
+    forbiddenMode: presence.forbidden_in.mode,
+    forbiddenIds: new Set(presence.forbidden_in.environment_ids ?? []),
+  };
+}
+
+function presenceRuleValue(mode: PresenceMode, ids: ReadonlySet<string>) {
+  return mode === 'explicit' ? { mode, environment_ids: [...ids] } : { mode };
+}
+
+function buildPresence(draft: PresenceDraft): KeyPresenceRules {
+  return {
+    required_in: presenceRuleValue(draft.requiredMode, draft.requiredIds),
+    forbidden_in: presenceRuleValue(draft.forbiddenMode, draft.forbiddenIds),
+  };
+}
+
+function toggleId(ids: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  const next = new Set(ids);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
+/**
+ * Toggle is a pressed-state button, not a checkbox: a native checkbox cannot
+ * meet the 44px coarse-pointer touch floor without distortion, and this panel
+ * is asserted at a phone viewport. The on-state carries a ✓ so it never depends
+ * on colour alone (DESIGN.md), and it reuses `.settings-tag`, which the touch
+ * and focus gates already cover.
+ */
+function Toggle({
+  label,
+  on,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  on: boolean;
+  disabled: boolean;
+  onChange: (on: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`settings-tag${on ? ' settings-tag--on' : ''}`}
+      aria-pressed={on}
+      disabled={disabled}
+      onClick={() => onChange(!on)}
+    >
+      {on ? '✓ ' : ''}
+      {label}
+    </button>
+  );
+}
+
+/**
+ * DeclarationEditor edits the value rules and presence — one endpoint, one save
+ * (#493). `any_of` alternatives are shown read-only with a pointer to
+ * `hikyo definitions`; a single rule is fully editable. The before/after impact
+ * names the environments a presence change adds or drops, and the server's
+ * atomic refusal (surfaced verbatim) catches an invalid draft before commit.
+ */
+function DeclarationEditor({
+  refData,
+  keyId,
+  record,
+  environments,
+}: {
+  refData: MatrixRef;
+  keyId: string;
+  record: MatrixKey;
+  environments: readonly Environment[];
+}) {
+  const update = useUpdateKeyDeclaration(refData, keyId);
+  const isAnyOf = record.declaration.any_of !== undefined;
+  const singleRule = record.declaration.rule;
+
+  const [ruleDraft, setRuleDraft] = useState<RuleDraft>(() =>
+    singleRule === undefined ? ruleDraftFrom({ type: 'string' }) : ruleDraftFrom(singleRule),
+  );
+  const [presence, setPresence] = useState<PresenceDraft>(() => presenceDraftFrom(record.presence));
+  const [invalid, setInvalid] = useState<string | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [scanBlock, setScanBlock] = useState<ScanBlockState | null>(null);
+
+  // Re-seed only when the SERVER's declaration/presence actually change (a
+  // concurrent edit), keyed on a bigint-safe content signature — an unrelated
+  // sibling save (metadata, group, rename) refetches the record but leaves
+  // these signatures untouched, so an in-progress edit here is preserved.
+  const declSignature = stableSignature(record.declaration);
+  const presSignature = stableSignature(record.presence);
+  useEffect(() => {
+    setRuleDraft(
+      record.declaration.rule === undefined
+        ? ruleDraftFrom({ type: 'string' })
+        : ruleDraftFrom(record.declaration.rule),
+    );
+    setPresence(presenceDraftFrom(record.presence));
+    setInvalid(null);
+    // `done` is deliberately NOT reset here: the successful-save refetch changes
+    // these signatures, and clearing it would wipe the "Saved." it just set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- content signatures stand in for the objects
+  }, [declSignature, presSignature]);
+
+  const envIds = useMemo(() => environments.map((environment) => environment.id), [environments]);
+  const proposedPresence = buildPresence(presence);
+  const impact = presenceImpact(record.presence, proposedPresence, envIds);
+  const envName = (id: string): string =>
+    environments.find((environment) => environment.id === id)?.name ?? id;
+
+  const submit = (): void => {
+    setInvalid(null);
+    setRefusal(null);
+    setDone(false);
+    let declaration: KeyDeclaration;
+    try {
+      if (isAnyOf) {
+        declaration = declarationToWrite(record.declaration);
+      } else {
+        const result = buildRule(ruleDraft);
+        if (result.error !== undefined || result.rule === undefined) {
+          setInvalid(result.error ?? 'The rule is incomplete.');
+          return;
+        }
+        declaration = { rule: result.rule };
+      }
+    } catch (error) {
+      setInvalid(error instanceof Error ? error.message : 'This declaration cannot be edited here.');
+      return;
+    }
+    const attempt = (acknowledgements: readonly string[]): Promise<void> =>
+      new Promise((resolve, reject) => {
+        update.mutate(
+          {
+            declaration,
+            presence: proposedPresence,
+            ...(acknowledgements.length === 0 ? {} : { acknowledgements }),
+          },
+          { onSuccess: () => resolve(), onError: (error) => reject(error) },
+        );
+      });
+    void attempt([])
+      .then(() => setDone(true))
+      .catch((error: unknown) => {
+        const block = scanBlockFrom(error, (tokens) =>
+          attempt(tokens).then(() => {
+            setDone(true);
+            setScanBlock(null);
+          }),
+        );
+        if (block !== null) {
+          setScanBlock(block);
+          return;
+        }
+        setRefusal(catalogueRefusalText(error, 'update the rules'));
+      });
+  };
+
+  // Any draft change clears "Saved." so it never sits over an unsaved edit; the
+  // successful-save refetch reseeds without clearing it (the effect leaves it).
+  const editRule = (next: RuleDraft): void => {
+    setRuleDraft(next);
+    setDone(false);
+  };
+  const editPresence = (updater: (current: PresenceDraft) => PresenceDraft): void => {
+    setPresence(updater);
+    setDone(false);
+  };
+
+  return (
+    <form
+      className="key-detail__editor"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <h3>Edit value rules &amp; presence</h3>
+
+      {isAnyOf ? (
+        <p className="key-detail__rules-note">
+          This key declares alternatives (<span className="mono">any_of</span>). Edit the
+          alternatives with <span className="mono">hikyo definitions</span>; presence stays editable
+          here.
+        </p>
+      ) : (
+        <RuleFields draft={ruleDraft} disabled={update.isPending} onChange={editRule} />
+      )}
+
+      <fieldset className="key-detail__presence-editor" disabled={update.isPending}>
+        <legend>Presence</legend>
+        <PresenceControl
+          label="Required in"
+          hint="Where a value must resolve to set. `all` covers environments created later."
+          mode={presence.requiredMode}
+          ids={presence.requiredIds}
+          environments={environments}
+          onMode={(mode) => editPresence((current) => ({ ...current, requiredMode: mode }))}
+          onToggle={(id) =>
+            editPresence((current) => ({ ...current, requiredIds: toggleId(current.requiredIds, id) }))
+          }
+        />
+        <PresenceControl
+          label="Forbidden in"
+          hint="Where a value must be absent."
+          mode={presence.forbiddenMode}
+          ids={presence.forbiddenIds}
+          environments={environments}
+          onMode={(mode) => editPresence((current) => ({ ...current, forbiddenMode: mode }))}
+          onToggle={(id) =>
+            editPresence((current) => ({
+              ...current,
+              forbiddenIds: toggleId(current.forbiddenIds, id),
+            }))
+          }
+        />
+      </fieldset>
+
+      <div className="key-detail__presence-impact" aria-live="polite">
+        <p className="key-detail__presence-impact-title">Before → after</p>
+        {presenceImpactIsEmpty(impact) ? (
+          <p>Presence unchanged.</p>
+        ) : (
+          <ul className="key-detail__presence-impact-list">
+            {impact.requiredAdded.length > 0 ? (
+              <li>Newly required in: {impact.requiredAdded.map(envName).join(', ')}</li>
+            ) : null}
+            {impact.requiredRemoved.length > 0 ? (
+              <li>No longer required in: {impact.requiredRemoved.map(envName).join(', ')}</li>
+            ) : null}
+            {impact.forbiddenAdded.length > 0 ? (
+              <li>Newly forbidden in: {impact.forbiddenAdded.map(envName).join(', ')}</li>
+            ) : null}
+            {impact.forbiddenRemoved.length > 0 ? (
+              <li>No longer forbidden in: {impact.forbiddenRemoved.map(envName).join(', ')}</li>
+            ) : null}
+          </ul>
+        )}
+        <p className="key-detail__presence-impact-note">
+          The save is atomic: if a value already set in a newly-forbidden environment, or a required
+          environment left unset, would become invalid, the server refuses the whole change and
+          names it — nothing commits until it is valid.
+        </p>
+      </div>
+
+      {invalid === null ? null : <Alert>{invalid}</Alert>}
+      {refusal === null ? null : <Alert>{refusal}</Alert>}
+      {done ? <Done>Saved.</Done> : null}
+
+      <button type="submit" className="btn btn--primary" disabled={update.isPending}>
+        {update.isPending ? 'Saving…' : 'Save value rules & presence'}
+      </button>
+
+      {scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Declaration blocked by secret scanning"
+          intro={`This field is exported to Git and treated as public. Saving ${record.name}’s rules was refused because it looks like it carries secret material.`}
+          findings={scanBlock.findings}
+          onOverride={scanBlock.onOverride}
+          onClose={() => setScanBlock(null)}
+        />
+      )}
+    </form>
+  );
+}
+
+function RuleFields({
+  draft,
+  disabled,
+  onChange,
+}: {
+  draft: RuleDraft;
+  disabled: boolean;
+  onChange: (next: RuleDraft) => void;
+}) {
+  const set = <K extends keyof RuleDraft>(field: K, value: RuleDraft[K]): void =>
+    onChange({ ...draft, [field]: value });
+  return (
+    <fieldset className="key-detail__rule-editor" disabled={disabled}>
+      <legend>Value rule</legend>
+      <label className="field">
+        <span>Type</span>
+        <select
+          className="mono"
+          value={draft.type}
+          onChange={(event) => set('type', event.currentTarget.value as RuleType)}
+        >
+          {RULE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+      {draft.type === 'string' ? (
+        <>
+          <label className="field">
+            <span>Minimum length</span>
+            <input
+              inputMode="numeric"
+              value={draft.minLength}
+              onChange={(event) => set('minLength', event.currentTarget.value)}
+            />
+          </label>
+          <label className="field">
+            <span>Maximum length</span>
+            <input
+              inputMode="numeric"
+              value={draft.maxLength}
+              onChange={(event) => set('maxLength', event.currentTarget.value)}
+            />
+          </label>
+          <label className="field">
+            <span>Pattern (RE2, anchored)</span>
+            <input
+              className="mono"
+              value={draft.pattern}
+              onChange={(event) => set('pattern', event.currentTarget.value)}
+            />
+          </label>
+          <Toggle
+            label="Allow empty value"
+            on={draft.allowEmpty}
+            disabled={disabled}
+            onChange={(on) => set('allowEmpty', on)}
+          />
+        </>
+      ) : null}
+      {draft.type === 'integer' ? (
+        <>
+          <label className="field">
+            <span>Minimum</span>
+            <input
+              inputMode="numeric"
+              value={draft.min}
+              onChange={(event) => set('min', event.currentTarget.value)}
+            />
+          </label>
+          <label className="field">
+            <span>Maximum</span>
+            <input
+              inputMode="numeric"
+              value={draft.max}
+              onChange={(event) => set('max', event.currentTarget.value)}
+            />
+          </label>
+        </>
+      ) : null}
+      {draft.type === 'enum' ? (
+        <label className="field">
+          <span>Members (one per line)</span>
+          <textarea
+            className="mono"
+            rows={4}
+            value={draft.members}
+            onChange={(event) => set('members', event.currentTarget.value)}
+          />
+        </label>
+      ) : null}
+      {draft.type === 'url' ? (
+        <label className="field">
+          <span>Allowed schemes (comma-separated)</span>
+          <input
+            className="mono"
+            placeholder="https, http"
+            value={draft.schemes}
+            onChange={(event) => set('schemes', event.currentTarget.value)}
+          />
+        </label>
+      ) : null}
+      {draft.type === 'json' ? (
+        <label className="field">
+          <span>JSON Schema (2020-12)</span>
+          <textarea
+            className="mono"
+            rows={6}
+            value={draft.jsonSchema}
+            onChange={(event) => set('jsonSchema', event.currentTarget.value)}
+          />
+        </label>
+      ) : null}
+    </fieldset>
+  );
+}
+
+function PresenceControl({
+  label,
+  hint,
+  mode,
+  ids,
+  environments,
+  onMode,
+  onToggle,
+}: {
+  label: string;
+  hint: string;
+  mode: PresenceMode;
+  ids: ReadonlySet<string>;
+  environments: readonly Environment[];
+  onMode: (mode: PresenceMode) => void;
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <div className="key-detail__presence-control">
+      <label className="field">
+        <span>{label}</span>
+        <select value={mode} onChange={(event) => onMode(event.currentTarget.value as PresenceMode)}>
+          <option value="none">none</option>
+          <option value="all">all</option>
+          <option value="explicit">explicit</option>
+        </select>
+      </label>
+      <p className="key-detail__hint">{hint}</p>
+      {mode === 'explicit' ? (
+        environments.length === 0 ? (
+          <p className="key-detail__state" role="status">
+            This project has no environments yet.
+          </p>
+        ) : (
+          <div className="key-detail__presence-envs">
+            {environments.map((environment) => (
+              <Toggle
+                key={environment.id}
+                label={environment.name}
+                on={ids.has(environment.id)}
+                disabled={false}
+                onChange={() => onToggle(environment.id)}
+              />
+            ))}
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * GroupEditor sets or clears a key's group membership (#493). Membership is
+ * coupling — a schema change — but not a scanning ingress, so a refusal stays
+ * inline. Changing the selection commits immediately.
+ */
+function GroupEditor({
+  refData,
+  keyId,
+  record,
+}: {
+  refData: MatrixRef;
+  keyId: string;
+  record: MatrixKey;
+}) {
+  const groups = useKeyGroups(refData);
+  const setGroup = useSetKeyGroup(refData, keyId);
+  const id = useId();
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  return (
+    <section className="key-detail__section" aria-labelledby={`${id}-group`}>
+      <h3 id={`${id}-group`}>Group membership</h3>
+      <label className="field">
+        <span>Key group</span>
+        <select
+          value={record.group_id}
+          disabled={setGroup.isPending || !groups.isSuccess}
+          onChange={(event) => {
+            const groupId = event.currentTarget.value;
+            setRefusal(null);
+            setDone(false);
+            setGroup.mutate(
+              { groupId },
+              {
+                onSuccess: () => setDone(true),
+                onError: (error) => setRefusal(catalogueRefusalText(error, 'change the group')),
+              },
+            );
+          }}
+        >
+          <option value="">(no group)</option>
+          {(groups.data?.items ?? []).map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {groups.isError ? <Alert>The project’s key groups could not be read.</Alert> : null}
+      {refusal === null ? null : <Alert>{refusal}</Alert>}
+      {done ? <Done>Group updated.</Done> : null}
+    </section>
   );
 }

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -31,6 +31,7 @@ import {
   type ValueCell,
 } from '../api/values.ts';
 import { HistoryDrawer } from './HistoryDrawer.tsx';
+import { CatalogueManageDialog } from './CatalogueManageDialog.tsx';
 import { KeyDeclarationDetail } from './KeyDeclarationDetail.tsx';
 import type { HistoryCurrentCell } from './history-state.ts';
 import {
@@ -141,6 +142,8 @@ export function Matrix({
   // import is not git-gated (only declaration is), so it stays available on a
   // git-managed project — the wizard itself skips new keys there.
   const [importOpen, setImportOpen] = useState(false);
+  // #493: the folder & key-group lifecycle dialog.
+  const [manageOpen, setManageOpen] = useState(false);
   // Surface-2 scanner block (#183): the redacted findings a refused write
   // carried, plus the override that retries it with their acknowledgements.
   const [scanBlock, setScanBlock] = useState<{
@@ -802,6 +805,11 @@ export function Matrix({
             Import
           </button>
         ) : null}
+        {/* #493: folder & key-group lifecycle. Project-scoped organisation in its
+            own dialog, reachable here and from the empty state. */}
+        <button type="button" className="btn matrix__manage" onClick={() => setManageOpen(true)}>
+          Folders &amp; groups
+        </button>
         {/* env-matrix 31 / #492: the header's primary declare action. Git-managed
             projects disable it and say why — value actions still work. */}
         {environments.length > 0 && !gitManaged ? (
@@ -909,6 +917,9 @@ export function Matrix({
                     }}
                   >
                     Declare first key
+                  </button>
+                  <button type="button" className="btn" onClick={() => setManageOpen(true)}>
+                    Folders &amp; groups
                   </button>
                 </div>
               )}
@@ -1274,6 +1285,10 @@ export function Matrix({
           gitManaged={gitManaged}
           onClose={() => setImportOpen(false)}
         />
+      )}
+
+      {!manageOpen ? null : (
+        <CatalogueManageDialog refData={ref} onClose={() => setManageOpen(false)} />
       )}
 
       {scanBlock === null ? null : (

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5134,3 +5134,150 @@ select {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* #493 editors: value rules, presence, impact. Extends #491/#494 key-detail. */
+.key-detail__rule-editor,
+.key-detail__presence-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--panel-line);
+  border-radius: var(--radius-container);
+}
+
+.key-detail__rule-editor legend,
+.key-detail__presence-editor legend {
+  padding: 0 4px;
+  color: var(--tx-faint);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.key-detail__presence-control {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.key-detail__presence-envs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.key-detail__hint {
+  margin: 0;
+  color: var(--tx-dim);
+  font-size: 12px;
+}
+
+.key-detail__presence-impact {
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-container);
+  background: var(--bg);
+  font-size: 13px;
+  color: var(--tx-dim);
+}
+
+.key-detail__presence-impact-title {
+  margin: 0 0 6px;
+  color: var(--tx-faint);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.key-detail__presence-impact-list {
+  margin: 0 0 6px;
+  padding-left: 18px;
+  overflow-wrap: anywhere;
+}
+
+.key-detail__presence-impact-note {
+  margin: 0;
+}
+
+.settings-tag--on {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* #493 folder & key-group lifecycle dialog. Reuses .matrix-editor for the
+   dialog shell, backdrop, head, and close. */
+.catalogue-manage {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.catalogue-manage__section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.catalogue-manage__section h3 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.catalogue-manage__empty {
+  margin: 0;
+  color: var(--tx-dim);
+  font-size: 13px;
+}
+
+.catalogue-manage__list,
+.catalogue-manage__create {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.catalogue-manage__list {
+  flex-direction: column;
+}
+
+.catalogue-manage__create {
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.catalogue-manage__row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.catalogue-manage__row-main {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.catalogue-manage__row-main input,
+.catalogue-manage__create input {
+  flex: 1 1 12ch;
+  min-height: var(--touch);
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  background: var(--bg);
+  color: var(--tx);
+}
+
+.catalogue-manage__meta {
+  font-size: 12px;
+  color: var(--tx-dim);
+}
+
+.catalogue-manage__inert {
+  color: var(--tx-faint);
+}


### PR DESCRIPTION
Closes #493. Rebuilt on top of the now-merged foundation: **#491** (declaration detail + metadata editor) and **#183** (Surface-2 block dialog) landed on main while this was in flight, so this PR now *extends* that foundation instead of duplicating it.

## What this adds (on top of #491/#183)
On the key-detail panel, database-managed projects only:
- **Value-rule editor** for a single rule (type + type-specific constraints: string length/pattern/allow-empty, integer min/max, enum members, url schemes, json schema). `any_of` stays read-only with a pointer to `hikyo definitions`.
- **Presence editor** (required/forbidden: all/none/explicit) with a **before/after impact** naming the affected environments; the server's atomic refusal catches an invalid draft before commit.
- **Group membership**, **key rename**, and typed-confirm **delete**.
- Rule/rename writes (and folder/group names) route a scanner refusal through the existing **`ScanBlockDialog`**; int64 bounds cross to `number` only when exact.

Project-scoped **folder and key-group lifecycle** (create/rename/delete) lives in a matrix-hosted dialog reachable from the header and the empty state — complete from an empty project.

Touch-first: booleans and explicit-environment selection use pressed-state buttons (not native checkboxes) to hold the 44px coarse-pointer floor the key-detail pinned assertion enforces.

## Reuse / no duplication
Reuses `KeyDeclarationDetail`, `useKey`, `useUpdateKeyMetadata` (matrix.ts), and `ScanBlockDialog` from main. New API writes live in `web/src/api/catalogue.ts`. No generated-client or migration changes.

## Validation
- `pnpm --dir web typecheck` clean; `pnpm --dir web test` 469 passing; `pnpm --dir web build` clean.
- `matrix.spec.ts` key-detail flow extended (rules/presence + impact, Surface-2 block with API-verified commit, group membership, rename+delete, folder + key-group lifecycle) — green on **desktop and mobile**, including the pinned accessibility/touch assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)