### PR TITLE
feat(web): import a .env file through the WebUI (#495)

### DIFF
--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -811,3 +811,59 @@ test.describe('environment matrix declaration', () => {
     await expect(modal.getByLabel('Key name')).toHaveValue('REQUIRED_EVERYWHERE');
   });
 });
+
+/**
+ * Flow tail: the browser dotenv import wizard (#495).
+ *
+ * A local .env file is read in the browser, its one new key is classified and
+ * typed explicitly, and — targeting only the unprotected development
+ * environment so no step-up is needed — the reviewed import declares the key
+ * and publishes its value. The result names what landed, and the value is a
+ * live (published) matrix cell, not a draft.
+ */
+test.describe('environment matrix dotenv import', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: STORAGE_STATE });
+
+  test('imports a new config key into development and publishes its value', async ({
+    passkeyPage: page,
+  }) => {
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Import .env' }).click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    // The file is read locally; nothing is sent yet.
+    await modal.getByLabel('Dotenv file').setInputFiles({
+      name: 'app.env',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('IMPORTED_FLAG=true\n'),
+    });
+    await expect(modal.getByText('1 value read')).toBeVisible();
+
+    // Target only development; production is protected and would need step-up.
+    await modal.getByRole('checkbox', { name: 'production' }).uncheck();
+    await modal.getByRole('button', { name: 'Review', exact: true }).click();
+
+    // Classify the new key: config (not secret) so its value shows in the cell.
+    await modal.getByRole('checkbox', { name: 'secret' }).uncheck();
+    await expect(modal.getByText('Suggested: boolean')).toBeVisible();
+    await modal.getByLabel('Type').selectOption('boolean');
+    await modal.getByRole('button', { name: 'Review changes' }).click();
+
+    await expect(modal.getByText('1 to import, 1 new key declared')).toBeVisible();
+    await modal.getByRole('button', { name: 'Import', exact: true }).click();
+
+    await expect(modal.getByText('Declared 1 new key: IMPORTED_FLAG')).toBeVisible();
+    await expect(modal.getByRole('list', { name: 'Import results' })).toContainText('imported 1');
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect(modal).toBeHidden();
+
+    // The imported value is a live published cell, not a draft.
+    await expect(
+      page.getByRole('button', { name: /IMPORTED_FLAG in development:/ }),
+    ).toBeVisible();
+  });
+});

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -4,25 +4,29 @@ import {
   createKeyOp,
   getEnvironmentSignalsOp,
   getKeyOp,
+  importValuesOp,
   listKeyGroupsOp,
   listKeysOp,
   listPendingDraftsOp,
+  listValueOccurrencesOp,
   listValuesOp,
   publishPendingChangesOp,
   reclassifyKeyOp,
   setValueOp,
   updateKeyMetadataOp,
 } from '@hikyo/operations';
-import type { KeyPresence, KeyRule } from '@hikyo/client';
+import type { ImportPrecondition, KeyClassification, KeyPresence, KeyRule } from '@hikyo/client';
 import {
   zEnvironmentList,
   zEnvironmentSettings,
   zEnvironmentSignals,
+  zImportValuesResult,
   zKeyList,
   zPendingDraftList,
   zPublishResult,
   zScanFinding,
   zValueList,
+  zValueOccurrenceList,
 } from '@hikyo/zod';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -771,6 +775,85 @@ export function useCreateKey(ref: MatrixRef) {
   });
 }
 
+export type ValueOccurrenceList = z.infer<typeof zValueOccurrenceList>;
+export type ImportValuesResult = z.infer<typeof zImportValuesResult>;
+
+/**
+ * useListValueOccurrences is import phase 1 (`import.presence`, #495): a
+ * read-only POST that, for one environment, returns the project's definitions
+ * revision and — per candidate — whether it is declared, whether it is `set`,
+ * and a server-minted OPAQUE occurrence token. Nothing is written and no value
+ * is sent; the token is the only thing that binds this review to the phase-2
+ * write, so a candidate's intended classification/type must be its FINAL one
+ * (an undeclared candidate's token binds that intent, and phase 2 matches it
+ * only once the declaration lands).
+ */
+export function useListValueOccurrences(ref: MatrixRef) {
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: {
+      readonly environment: string;
+      readonly candidates: readonly {
+        readonly name: string;
+        readonly classification: KeyClassification;
+        readonly type: CreateKeyType;
+      }[];
+    }) =>
+      parsed(listValueOccurrencesOp, {
+          path: { ...ref, environment: input.environment },
+          body: {
+            candidates: input.candidates.map((candidate) => ({
+              name: candidate.name,
+              intended_classification: candidate.classification,
+              intended_type: candidate.type,
+            })),
+          },
+          ...transport,
+        }),
+  });
+}
+
+/**
+ * useImportValues is import phase 2 (`value.import`, #495): the strict,
+ * human-only batch write. It is one transaction — an undeclared key rejects the
+ * whole run by name (declare first), a `set` key is skipped unless it is in the
+ * enumerated `overwrite` list, and the `precondition` (revision + the phase-1
+ * tokens) is re-checked inside the write so a state that moved since review
+ * rejects with 409 and writes nothing. On success it republishes, so the same
+ * caches a stage+publish would invalidate are refreshed here.
+ */
+export function useImportValues(ref: MatrixRef) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: {
+      readonly environment: string;
+      readonly entries: readonly { readonly key: string; readonly value: string }[];
+      readonly overwrite: readonly string[];
+      readonly precondition: ImportPrecondition;
+    }) =>
+      parsed(importValuesOp, {
+          path: { ...ref, environment: input.environment },
+          body: {
+            entries: input.entries.map((entry) => ({ key: entry.key, value: entry.value })),
+            ...(input.overwrite.length === 0 ? {} : { overwrite: [...input.overwrite] }),
+            precondition: input.precondition,
+          },
+          ...transport,
+        }),
+    onSuccess: (_result, input) => {
+      const environment = { ...ref, environment: input.environment };
+      return Promise.all([
+        queries.invalidateQueries({ queryKey: valuesKey(environment) }),
+        queries.invalidateQueries({ queryKey: signalsKey(ref, input.environment) }),
+        queries.invalidateQueries({ queryKey: pendingDraftsKey(ref, input.environment) }),
+        queries.invalidateQueries({ queryKey: revisionsKey(environment) }),
+        queries.invalidateQueries({ queryKey: pinsKey(environment) }),
+      ]);
+    },
+  });
+}
+
 export function useReclassifyKey(ref: MatrixRef) {
   const queries = useQueryClient();
   const transport = useTransport();
@@ -1001,7 +1084,7 @@ export function useCopyMatrixConfig(ref: MatrixRef) {
  */
 export function matrixMutationError(
   error: Error,
-  action: 'stage' | 'clear' | 'copy' | 'publish' | 'create',
+  action: 'stage' | 'clear' | 'copy' | 'publish' | 'create' | 'import',
   restorePreviewAttached = false,
 ): string {
   if (error instanceof RestorePreviewSelectionError) {
@@ -1010,8 +1093,14 @@ export function matrixMutationError(
   if (action === 'publish' && restorePreviewAttached && error instanceof ApiError && error.status === 409) {
     return 'Publish refused: the restore preview is stale or missing — stage the restore again from the history drawer.';
   }
-  // `create` declares a key, not a value: its fallbacks read as a declaration.
-  const object = action === 'create' ? 'declare this key' : `${action} this value`;
+  // `create` declares a key and `import` writes a batch; neither reads as a
+  // single value, so both get their own object phrasing in the fallbacks.
+  const object =
+    action === 'create'
+      ? 'declare this key'
+      : action === 'import'
+        ? 'import these values'
+        : `${action} this value`;
   if (error instanceof ApiError) {
     const detailed = callerSafeRefusal(error, action === 'publish' ? 'Publish refused' : 'Refused');
     if (detailed !== null) {
@@ -1024,14 +1113,18 @@ export function matrixMutationError(
         ? 'You do not have permission to publish the selected drafts.'
         : action === 'create'
           ? 'You do not have permission to declare keys in this project.'
-          : `You do not have permission to ${action} this value.`;
+          : action === 'import'
+            ? 'You do not have permission to import values into this environment.'
+            : `You do not have permission to ${action} this value.`;
     }
     if (error.status === 409) {
       return action === 'publish'
         ? 'Publish was refused. Fix the named matrix problems, then retry.'
         : action === 'create'
           ? 'The server refused the declaration; reload the matrix and retry.'
-          : `The server refused this ${action}; reload the matrix and retry.`;
+          : action === 'import'
+            ? 'The reviewed state moved before this import ran — re-review this environment and try again.'
+            : `The server refused this ${action}; reload the matrix and retry.`;
     }
     return action === 'publish'
       ? `The server could not publish the selected drafts (error ${String(error.status)}).`

--- a/web/src/routes/ImportWizard.test.tsx
+++ b/web/src/routes/ImportWizard.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../api/client.ts';
+
+const listOccurrences = vi.fn();
+const createKey = vi.fn();
+const importValues = vi.fn();
+
+vi.mock('../api/matrix.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/matrix.ts')>();
+  return {
+    ...actual,
+    useListValueOccurrences: () => ({ mutateAsync: listOccurrences, isPending: false }),
+    useCreateKey: () => ({ mutateAsync: createKey, isPending: false }),
+    useImportValues: () => ({ mutateAsync: importValues, isPending: false }),
+  };
+});
+
+const { ImportWizard } = await import('./ImportWizard.tsx');
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const environments = [
+  { id: 'env-dev', name: 'development' },
+  { id: 'env-prod', name: 'production' },
+];
+
+// Phase 1a candidates carry the default `secret` intent; 1b carries `config`.
+// The mock uses that to answer 1a with the new key still undeclared and 1b with
+// every declaration landed — the exact transition the wizard depends on.
+function occurrenceList(input: {
+  environment: string;
+  candidates: readonly { name: string; classification: string }[];
+}) {
+  const isBindingRead = input.candidates[0]?.classification === 'config';
+  return {
+    environment_id: input.environment,
+    definitions_revision: 3n,
+    items: input.candidates.map((candidate) => ({
+      name: candidate.name,
+      declared: candidate.name === 'EXISTING' ? true : isBindingRead,
+      set: candidate.name === 'EXISTING' && input.environment === 'env-prod',
+      token: `tok-${candidate.name}-${input.environment}`,
+    })),
+  };
+}
+
+beforeEach(() => {
+  listOccurrences.mockReset().mockImplementation(async (input) => occurrenceList(input));
+  createKey.mockReset().mockResolvedValue({ id: 'key-new' });
+  importValues.mockReset().mockResolvedValue({ imported: ['EXISTING', 'NEW'], skipped: [] });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function render(gitManaged = false) {
+  const onClose = vi.fn();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <ImportWizard
+        matrixRef={{ org: 'acme', project: 'app' }}
+        environments={environments}
+        gitManaged={gitManaged}
+        onClose={onClose}
+      />,
+    );
+  });
+  return { container, onClose };
+}
+
+async function settle(): Promise<void> {
+  for (let round = 0; round < 12; round += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function button(container: HTMLElement, name: string): HTMLButtonElement {
+  const found = [...container.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.trim() === name,
+  );
+  if (found === undefined) {
+    throw new Error(`no button labelled ${name}`);
+  }
+  return found;
+}
+
+async function click(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await settle();
+}
+
+async function selectFile(container: HTMLElement, content: string): Promise<void> {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+  if (input === null) {
+    throw new Error('no file input');
+  }
+  const file = new File([content], 'app.env', { type: 'text/plain' });
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  await act(async () => {
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await settle();
+}
+
+const FILE = 'EXISTING=1\nNEW=hello\n';
+
+// Walk source → classify → review → result, stopping before the final Import.
+async function reachReview(container: HTMLElement): Promise<void> {
+  await selectFile(container, FILE);
+  await click(button(container, 'Review'));
+  await click(button(container, 'Review changes'));
+}
+
+describe('ImportWizard success', () => {
+  it('declares the new key, imports every environment, and reports what landed', async () => {
+    const { container } = await render();
+    await reachReview(container);
+    await click(button(container, 'Import'));
+
+    expect(createKey).toHaveBeenCalledTimes(1);
+    expect(createKey.mock.calls[0]?.[0]).toMatchObject({
+      name: 'NEW',
+      classification: 'secret',
+      rule: { type: 'string' },
+      required: { mode: 'none' },
+      forbidden: { mode: 'none' },
+    });
+    expect(importValues).toHaveBeenCalledTimes(2);
+    const first = importValues.mock.calls[0]?.[0];
+    expect(first.precondition.environment_ids).toEqual(['env-dev']);
+    expect(first.precondition.definitions_revision).toBe(3);
+    expect(first.precondition.occurrences).toHaveLength(2);
+    expect(container.textContent).toContain('Declared 1 new key: NEW');
+    expect(container.textContent).toContain('imported 2');
+  });
+
+  it('sends the token from the binding (config-intent) phase-1 read', async () => {
+    const { container } = await render();
+    await reachReview(container);
+    await click(button(container, 'Import'));
+    const call = importValues.mock.calls[0]?.[0];
+    // env-dev tokens come from the 1b read, so they name the post-declaration state.
+    expect(call.precondition.occurrences).toContainEqual({
+      key: 'NEW',
+      environment_id: 'env-dev',
+      token: 'tok-NEW-env-dev',
+    });
+  });
+});
+
+describe('ImportWizard invalid file', () => {
+  it('blocks Review while any line is invalid (all-or-nothing, matching the server)', async () => {
+    const { container } = await render();
+    // `lower=1` fails the strict upper-snake grammar the Go parser refuses on.
+    await selectFile(container, 'GOOD=1\nlower=2\n');
+    expect(container.textContent).toContain('1 invalid line');
+    expect(container.querySelector('[aria-label="Invalid lines"]')?.textContent).toContain(
+      'Line 2',
+    );
+    expect(button(container, 'Review').disabled).toBe(true);
+    expect(listOccurrences).not.toHaveBeenCalled();
+  });
+});
+
+describe('ImportWizard refusals', () => {
+  it('surfaces an authorization refusal per environment', async () => {
+    importValues.mockRejectedValue(new ApiError(403, 'forbidden'));
+    const { container } = await render();
+    await reachReview(container);
+    await click(button(container, 'Import'));
+    expect(container.textContent).toContain('do not have permission to import');
+  });
+
+  it('quotes a validation refusal detail verbatim', async () => {
+    importValues.mockRejectedValue(new ApiError(400, 'bad request', 'INVALID is not declared'));
+    const { container } = await render();
+    await reachReview(container);
+    await click(button(container, 'Import'));
+    expect(container.textContent).toContain('INVALID is not declared');
+  });
+
+  it('explains a stale-state 409 with a re-review recovery', async () => {
+    importValues.mockRejectedValue(new ApiError(409, 'conflict'));
+    const { container } = await render();
+    await reachReview(container);
+    await click(button(container, 'Import'));
+    expect(container.textContent).toContain('moved before this import ran');
+  });
+});
+
+describe('ImportWizard git-managed', () => {
+  it('skips new-key declaration and imports only declared keys', async () => {
+    importValues.mockResolvedValue({ imported: ['EXISTING'], skipped: [] });
+    const { container } = await render(true);
+    await selectFile(container, FILE);
+    await click(button(container, 'Review'));
+    // The git-managed block names the skipped new keys on the classify step.
+    expect(container.textContent).toContain('cannot be declared here');
+    await click(button(container, 'Review changes'));
+    await click(button(container, 'Import'));
+    expect(createKey).not.toHaveBeenCalled();
+    const sent = importValues.mock.calls[0]?.[0];
+    expect(sent.entries.map((entry: { key: string }) => entry.key)).toEqual(['EXISTING']);
+  });
+});

--- a/web/src/routes/ImportWizard.tsx
+++ b/web/src/routes/ImportWizard.tsx
@@ -1,0 +1,699 @@
+import { useMemo, useRef, useState } from 'react';
+
+import { GIT_DEFINITIONS_NOTICE } from '../api/definitions.ts';
+import { revisionNumber } from '../api/history.ts';
+import {
+  matrixMutationError,
+  useCreateKey,
+  useImportValues,
+  useListValueOccurrences,
+  type MatrixRef,
+  type ValueOccurrenceList,
+} from '../api/matrix.ts';
+import type { KeyClassification } from '@hikyo/client';
+import {
+  indexOccurrences,
+  needsTrim,
+  parseDotenv,
+  planEnvironment,
+  suggestType,
+  type ParseResult,
+  type PrimitiveType,
+} from './import-state.ts';
+import { useModalDialog } from './useModalDialog.ts';
+
+type WizardEnvironment = { readonly id: string; readonly name: string };
+
+/** The primitives the wizard declares a new key as — `enum` is out (see
+ * import-state `PrimitiveType`), so it is the same union `CreateKeyType` minus
+ * `enum`, and every one is a legal `CreateKeyType` for the declare call. */
+const TYPE_CHOICES: readonly PrimitiveType[] = ['string', 'integer', 'boolean', 'url', 'json'];
+
+type Step = 'source' | 'classify' | 'review' | 'result';
+
+/** A new key's operator-chosen declaration, gathered in the classify step. */
+type Declaration = { readonly classification: KeyClassification; readonly type: PrimitiveType };
+
+/** One environment's phase-2 outcome, for the result step. */
+type EnvironmentOutcome = {
+  readonly environmentId: string;
+  readonly name: string;
+  readonly imported: readonly string[];
+  readonly skipped: readonly string[];
+  readonly findingRules: readonly string[];
+  readonly error: string | null;
+};
+
+/**
+ * Browser dotenv import wizard (#495).
+ *
+ * A local .env file is read into memory, parsed with the strict grammar
+ * (`import-state`), and reviewed BEFORE any plaintext leaves the browser: no
+ * value rides a request until the operator starts the reviewed phase-2 write.
+ * New keys are classified explicitly (secret by default) and typed only on an
+ * accepted suggestion, then declared through the shared create path; values are
+ * written per environment through `value.import`, which republishes and refuses
+ * a moved state by name. Nothing here is retained in durable browser storage.
+ */
+export function ImportWizard({
+  matrixRef,
+  environments,
+  gitManaged,
+  onClose,
+}: {
+  matrixRef: MatrixRef;
+  environments: readonly WizardEnvironment[];
+  gitManaged: boolean;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  // Two independent counters guard file reads, and they must not be conflated.
+  // `readSeq` bumps when a selection STARTS: an earlier, slower `file.text()`
+  // that resolves after a later selection is dropped, so the committed contents
+  // always come from the latest selection. `parseVersion` bumps only when a
+  // parse is COMMITTED: `beginReview` pins it and, if a newer file commits
+  // during phase 1a, refuses to advance — otherwise a review begun against a
+  // valid file could stride past the all-or-nothing gate into a newer, invalid
+  // one. A single selection-start counter cannot do both: a Review clicked
+  // between a selection and its commit would pin that pending selection's number.
+  const readSeq = useRef(0);
+  const parseVersion = useRef(0);
+  const occurrences = useListValueOccurrences(matrixRef);
+  const createKey = useCreateKey(matrixRef);
+  const importValues = useImportValues(matrixRef);
+
+  const [step, setStep] = useState<Step>('source');
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [parse, setParse] = useState<ParseResult | null>(null);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(
+    () => new Set(environments.map((environment) => environment.id)),
+  );
+  // Phase-1a presence per selected environment: what the project declares and,
+  // per environment, what is already `set`. Declaration is project-scoped, so
+  // `declared` agrees across environments; `set` is what varies.
+  const [presence, setPresence] = useState<ReadonlyMap<string, ValueOccurrenceList>>(new Map());
+  const [declarations, setDeclarations] = useState<ReadonlyMap<string, Declaration>>(new Map());
+  const [overwrite, setOverwrite] = useState<ReadonlyMap<string, ReadonlySet<string>>>(new Map());
+  const [trimAcks, setTrimAcks] = useState<ReadonlySet<string>>(new Set());
+  const [outcomes, setOutcomes] = useState<readonly EnvironmentOutcome[]>([]);
+  const [declaredKeys, setDeclaredKeys] = useState<readonly string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const busy = occurrences.isPending || createKey.isPending || importValues.isPending;
+  const entries = parse?.entries ?? [];
+
+  // A key is new when the project does not declare it; read from any environment
+  // (declaration is project-scoped). Empty until phase 1a has run.
+  const firstPresence = useMemo(() => {
+    for (const environmentId of selected) {
+      const list = presence.get(environmentId);
+      if (list !== undefined) {
+        return indexOccurrences(list.items);
+      }
+    }
+    return null;
+  }, [presence, selected]);
+
+  const newKeys = useMemo(() => {
+    if (firstPresence === null) {
+      return [];
+    }
+    return entries
+      .map((entry) => entry.key)
+      .filter((name) => {
+        const occurrence = firstPresence.get(name);
+        return occurrence === undefined || !occurrence.declared;
+      });
+  }, [entries, firstPresence]);
+
+  // Git-managed projects declare keys only through `definitions apply`; new keys
+  // cannot be declared here and are dropped from the import (their values would
+  // be rejected by name). Already-declared keys still import their values.
+  const blockedNewKeys = gitManaged ? newKeys : [];
+  const excluded = useMemo(() => new Set(blockedNewKeys), [blockedNewKeys]);
+  const importableEntries = useMemo(
+    () => entries.filter((entry) => !excluded.has(entry.key)),
+    [entries, excluded],
+  );
+
+  const trimOffenders = useMemo(
+    () => importableEntries.filter((entry) => needsTrim(entry.value)),
+    [importableEntries],
+  );
+  const trimSettled = trimOffenders.every((entry) => trimAcks.has(entry.key));
+
+  const selectedEnvironments = environments.filter((environment) => selected.has(environment.id));
+
+  const beginReview = async () => {
+    setError(null);
+    // Pin the committed parse this review began against. If a newer file
+    // commits while phase 1a is in flight, this stale run must not advance to
+    // classify — otherwise it would carry the old file's entries past the
+    // all-or-nothing gate the new (possibly invalid) file has not cleared.
+    const version = parseVersion.current;
+    try {
+      const results = await Promise.all(
+        selectedEnvironments.map(async (environment) => {
+          const list = await occurrences.mutateAsync({
+            environment: environment.id,
+            // Phase 1a only discovers what the project declares; its tokens are
+            // discarded, so a default intent is fine. The binding read is 1b.
+            candidates: entries.map((entry) => ({
+              name: entry.key,
+              classification: 'secret' as const,
+              type: 'string' as const,
+            })),
+          });
+          return [environment.id, list] as const;
+        }),
+      );
+      if (version !== parseVersion.current) {
+        return;
+      }
+      setPresence(new Map(results));
+      // Seed each new key's declaration with the conservative floor: secret, and
+      // type `string`. The suggestion is shown but never preselected.
+      setDeclarations((current) => {
+        const next = new Map(current);
+        for (const [, list] of results) {
+          for (const item of list.items) {
+            if (!item.declared && !next.has(item.name)) {
+              next.set(item.name, { classification: 'secret', type: 'string' });
+            }
+          }
+        }
+        return next;
+      });
+      setStep('classify');
+    } catch (caught) {
+      setError(matrixMutationError(asError(caught), 'import'));
+    }
+  };
+
+  const runImport = async () => {
+    setError(null);
+    // Declare new keys first (skipped entirely on a git-managed project). A
+    // declaration failure drops that key from the import rather than failing the
+    // whole batch by name at phase 2.
+    const declared: string[] = [];
+    const declareFailures: string[] = [];
+    if (!gitManaged) {
+      for (const name of newKeys) {
+        const declaration = declarations.get(name) ?? { classification: 'secret', type: 'string' };
+        try {
+          await createKey.mutateAsync({
+            name,
+            classification: declaration.classification,
+            rule: { type: declaration.type },
+            required: { mode: 'none', environmentIds: [] },
+            forbidden: { mode: 'none', environmentIds: [] },
+          });
+          declared.push(name);
+        } catch (caught) {
+          declareFailures.push(name);
+        }
+      }
+    }
+    setDeclaredKeys(declared);
+    const failedDeclarations = new Set([...excluded, ...declareFailures]);
+
+    const results: EnvironmentOutcome[] = [];
+    for (const environment of selectedEnvironments) {
+      const chosen = overwrite.get(environment.id) ?? new Set<string>();
+      const presenceList = presence.get(environment.id);
+      const index = presenceList === undefined
+        ? indexOccurrences([])
+        : indexOccurrences(presenceList.items);
+      const plan = planEnvironment(importableEntries, index, chosen);
+      // Only keys that will actually be written are sent: a `set` key without an
+      // overwrite is skipped BY OMISSION, exactly as the CLI's values file omits
+      // it — its plaintext never leaves the browser. Report those from the plan,
+      // since the server never sees them.
+      const written = new Set(plan.imported.filter((name) => !failedDeclarations.has(name)));
+      const toSend = importableEntries.filter((entry) => written.has(entry.key));
+      const skippedNames = [
+        ...plan.skipped,
+        ...plan.imported.filter((name) => failedDeclarations.has(name)),
+      ];
+      const base: Omit<EnvironmentOutcome, 'imported' | 'findingRules' | 'error'> = {
+        environmentId: environment.id,
+        name: environment.name,
+        skipped: skippedNames,
+      };
+      if (toSend.length === 0) {
+        results.push({ ...base, imported: [], findingRules: [], error: null });
+        continue;
+      }
+      try {
+        // Phase 1b: re-read now that declarations have landed, so every token
+        // names the exact state phase 2 will re-check inside its transaction.
+        const list = await occurrences.mutateAsync({
+          environment: environment.id,
+          candidates: toSend.map((entry) => ({
+            name: entry.key,
+            classification: 'config' as const,
+            type: 'string' as const,
+          })),
+        });
+        const tokens = indexOccurrences(list.items);
+        const result = await importValues.mutateAsync({
+          environment: environment.id,
+          entries: toSend.map((entry) => ({ key: entry.key, value: entry.value })),
+          // Overwrite consent lists only keys this run carries — naming an
+          // uncarried key is refused, so it is built from `toSend`.
+          overwrite: toSend.map((entry) => entry.key).filter((name) => chosen.has(name)),
+          precondition: {
+            definitions_revision: revisionNumber(list.definitions_revision),
+            environment_ids: [environment.id],
+            occurrences: toSend.flatMap((entry) => {
+              const occurrence = tokens.get(entry.key);
+              return occurrence === undefined
+                ? []
+                : [{ key: entry.key, environment_id: environment.id, token: occurrence.token }];
+            }),
+          },
+        });
+        results.push({
+          ...base,
+          imported: result.imported,
+          // Findings are redacted (rule id + surface + locator, never the value);
+          // the wizard shows only the rule ids, warn-not-block.
+          findingRules: (result.findings ?? []).map((finding) => finding.rule_id),
+          error: null,
+        });
+      } catch (caught) {
+        results.push({
+          ...base,
+          imported: [],
+          findingRules: [],
+          error: matrixMutationError(asError(caught), 'import'),
+        });
+      }
+    }
+    setOutcomes([
+      ...results,
+      ...declareFailures.map((name) => declareFailureOutcome(name)),
+    ]);
+    setStep('result');
+  };
+
+  const toggle = (set: ReadonlySet<string>, id: string): Set<string> => {
+    const next = new Set(set);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    return next;
+  };
+
+  return (
+    <dialog
+      ref={dialog}
+      className="matrix-editor import-wizard"
+      onClose={onClose}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <form method="dialog" onSubmit={(event) => event.preventDefault()}>
+        <div className="matrix-editor__head">
+          <div>
+            <p className="matrix-editor__eyebrow">Import</p>
+            <h2>Import a .env file</h2>
+            <p>Reviewed on this device; values are sent only when you start the import.</p>
+          </div>
+          <button
+            type="button"
+            className="btn matrix-editor__close"
+            aria-label="Close import"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        <p className="notice" role="note">
+          <span aria-hidden="true">⚠</span>
+          <span>
+            The file is read in this browser and reviewed here. Its values are sent only when you
+            start the import, and are never stored by this page.
+          </span>
+        </p>
+
+        {error === null ? null : (
+          <p className="alert" role="alert">
+            <span className="alert__glyph" aria-hidden="true">!</span>
+            <span>{error}</span>
+          </p>
+        )}
+
+        {step === 'source'
+          ? renderSource()
+          : step === 'classify'
+            ? renderClassify()
+            : step === 'review'
+              ? renderReview()
+              : renderResult()}
+      </form>
+    </dialog>
+  );
+
+  function renderSource() {
+    const parseErrors = parse?.errors ?? [];
+    // The server parses the whole file strictly and refuses it entirely on any
+    // bad line; phase 2 only ever sees parsed entries, so the browser must
+    // enforce that same all-or-nothing gate here rather than partially import a
+    // file the Go parser would reject.
+    const canContinue =
+      entries.length > 0 && parseErrors.length === 0 && selected.size > 0 && !busy;
+    return (
+      <>
+        <fieldset>
+          <legend>File</legend>
+          <input
+            type="file"
+            aria-label="Dotenv file"
+            accept=".env,text/plain"
+            onChange={async (event) => {
+              const file = event.target.files?.[0] ?? null;
+              if (file === null) {
+                return;
+              }
+              readSeq.current += 1;
+              const read = readSeq.current;
+              const text = await file.text();
+              // A newer selection started while this file was being read: its
+              // result wins, so drop this stale one entirely.
+              if (read !== readSeq.current) {
+                return;
+              }
+              // Committing a parse advances its version, which invalidates any
+              // in-flight review pinned to the previous one.
+              parseVersion.current += 1;
+              setFileName(file.name);
+              setParse(parseDotenv(text));
+              // A new file is a fresh review: drop every choice made against the
+              // previous one so a stale overwrite or trim ack can never apply to
+              // a value the operator has not seen.
+              setPresence(new Map());
+              setDeclarations(new Map());
+              setOverwrite(new Map());
+              setTrimAcks(new Set());
+              setStep('source');
+            }}
+          />
+          {parse === null ? null : (
+            <p className="import-wizard__summary" role="status">
+              {`${fileName ?? 'file'}: ${String(entries.length)} value${entries.length === 1 ? '' : 's'} read` +
+                (parseErrors.length === 0
+                  ? ''
+                  : `, ${String(parseErrors.length)} invalid line${parseErrors.length === 1 ? '' : 's'} skipped`)}
+            </p>
+          )}
+          {parseErrors.length === 0 ? null : (
+            <>
+              <p className="alert" role="alert">
+                <span className="alert__glyph" aria-hidden="true">!</span>
+                <span>
+                  Fix these lines at the source and choose the file again — the import is
+                  all-or-nothing, so nothing is sent while any line is invalid.
+                </span>
+              </p>
+              <ul className="import-wizard__invalid" aria-label="Invalid lines">
+                {parseErrors.map((invalid) => (
+                  <li key={invalid.line}>{`Line ${String(invalid.line)}: ${invalid.reason}`}</li>
+                ))}
+              </ul>
+            </>
+          )}
+        </fieldset>
+
+        <fieldset>
+          <legend>Target environments</legend>
+          {environments.map((environment) => (
+            <label key={environment.id} className="import-wizard__env">
+              <input
+                type="checkbox"
+                checked={selected.has(environment.id)}
+                onChange={() => setSelected((current) => toggle(current, environment.id))}
+              />
+              {environment.name}
+            </label>
+          ))}
+        </fieldset>
+
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={!canContinue}
+            onClick={beginReview}
+          >
+            {busy ? 'Reading…' : 'Review'}
+          </button>
+        </footer>
+      </>
+    );
+  }
+
+  function renderClassify() {
+    return (
+      <>
+        {gitManaged && newKeys.length > 0 ? (
+          <p className="notice" role="status">
+            <span aria-hidden="true">ℹ</span>
+            <span>
+              {GIT_DEFINITIONS_NOTICE} {`${String(newKeys.length)} new key${newKeys.length === 1 ? '' : 's'} ` +
+                `(${newKeys.join(', ')}) cannot be declared here and will be skipped; already-declared keys still import.`}
+            </span>
+          </p>
+        ) : null}
+
+        {newKeys.length === 0 ? (
+          <p className="import-wizard__summary" role="status">
+            Every key is already declared — no classification needed.
+          </p>
+        ) : (
+          <fieldset disabled={gitManaged}>
+            <legend>Classify new keys</legend>
+            {newKeys.map((name) => {
+              const values = entries
+                .filter((entry) => entry.key === name)
+                .map((entry) => entry.value);
+              const suggestion = suggestType(values);
+              const declaration = declarations.get(name) ?? {
+                classification: 'secret' as const,
+                type: 'string' as const,
+              };
+              return (
+                <div key={name} className="import-wizard__key">
+                  <span className="import-wizard__key-name">{name}</span>
+                  <label className="import-wizard__secret">
+                    <input
+                      type="checkbox"
+                      checked={declaration.classification === 'secret'}
+                      onChange={(event) =>
+                        setDeclarations((current) =>
+                          new Map(current).set(name, {
+                            ...declaration,
+                            classification: event.target.checked ? 'secret' : 'config',
+                          }),
+                        )
+                      }
+                    />
+                    secret
+                  </label>
+                  <label>
+                    Type
+                    <select
+                      value={declaration.type}
+                      onChange={(event) =>
+                        setDeclarations((current) =>
+                          new Map(current).set(name, {
+                            ...declaration,
+                            type: parseType(event.target.value),
+                          }),
+                        )
+                      }
+                    >
+                      {TYPE_CHOICES.map((choice) => (
+                        <option key={choice} value={choice}>
+                          {choice === suggestion && choice !== 'string'
+                            ? `${choice} (suggested)`
+                            : choice}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  {suggestion === 'string' ? null : (
+                    <span className="import-wizard__suggestion">{`Suggested: ${suggestion}`}</span>
+                  )}
+                </div>
+              );
+            })}
+          </fieldset>
+        )}
+
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={() => setStep('source')}>
+            Back
+          </button>
+          <button type="button" className="btn btn--primary" onClick={() => setStep('review')}>
+            Review changes
+          </button>
+        </footer>
+      </>
+    );
+  }
+
+  function renderReview() {
+    const anySendable = importableEntries.length > 0;
+    return (
+      <>
+        {trimOffenders.length === 0 ? null : (
+          <fieldset>
+            <legend>Values with surrounding whitespace</legend>
+            <p className="import-wizard__summary">
+              These values have leading or trailing whitespace. Acknowledge each to import it as
+              written, or fix it at the source.
+            </p>
+            {trimOffenders.map((entry) => (
+              <label key={entry.key} className="import-wizard__env">
+                <input
+                  type="checkbox"
+                  checked={trimAcks.has(entry.key)}
+                  onChange={() => setTrimAcks((current) => toggle(current, entry.key))}
+                />
+                {entry.key}
+              </label>
+            ))}
+          </fieldset>
+        )}
+
+        {selectedEnvironments.map((environment) => {
+          const list = presence.get(environment.id);
+          const index = list === undefined ? indexOccurrences([]) : indexOccurrences(list.items);
+          const plan = planEnvironment(
+            importableEntries,
+            index,
+            overwrite.get(environment.id) ?? new Set<string>(),
+          );
+          return (
+            <fieldset key={environment.id}>
+              <legend>{environment.name}</legend>
+              <p className="import-wizard__summary">
+                {`${String(plan.imported.length)} to import` +
+                  (plan.newKeys.length === 0
+                    ? ''
+                    : `, ${String(plan.newKeys.length)} new key${plan.newKeys.length === 1 ? '' : 's'} declared`) +
+                  (plan.skipped.length === 0
+                    ? ''
+                    : `, ${String(plan.skipped.length)} skipped (already set)`)}
+              </p>
+              {plan.collisions.length === 0 ? null : (
+                <div className="import-wizard__collisions">
+                  <span>Overwrite already-set values:</span>
+                  {plan.collisions.map((name) => (
+                    <label key={name} className="import-wizard__env">
+                      <input
+                        type="checkbox"
+                        checked={(overwrite.get(environment.id) ?? new Set()).has(name)}
+                        onChange={() =>
+                          setOverwrite((current) => {
+                            const next = new Map(current);
+                            next.set(environment.id, toggle(current.get(environment.id) ?? new Set(), name));
+                            return next;
+                          })
+                        }
+                      />
+                      {name}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </fieldset>
+          );
+        })}
+
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={() => setStep('classify')}>
+            Back
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={!anySendable || !trimSettled || busy}
+            onClick={runImport}
+          >
+            {busy ? 'Importing…' : 'Import'}
+          </button>
+        </footer>
+      </>
+    );
+  }
+
+  function renderResult() {
+    return (
+      <>
+        {declaredKeys.length === 0 ? null : (
+          <p className="import-wizard__summary" role="status">
+            {`Declared ${String(declaredKeys.length)} new key${declaredKeys.length === 1 ? '' : 's'}: ${declaredKeys.join(', ')}.`}
+          </p>
+        )}
+        <ul className="import-wizard__results" aria-label="Import results">
+          {outcomes.map((outcome) => (
+            <li key={outcome.environmentId}>
+              <strong>{outcome.name}</strong>
+              {outcome.error === null ? (
+                <span>
+                  {` imported ${String(outcome.imported.length)}` +
+                    (outcome.skipped.length === 0
+                      ? ''
+                      : `, skipped ${String(outcome.skipped.length)} (${outcome.skipped.join(', ')})`) +
+                    (outcome.findingRules.length === 0
+                      ? ''
+                      : ` — secret-scanning warnings: ${outcome.findingRules.join(', ')}`)}
+                </span>
+              ) : (
+                <span className="import-wizard__error"> {outcome.error}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn btn--primary" onClick={onClose}>
+            Done
+          </button>
+        </footer>
+      </>
+    );
+  }
+}
+
+function parseType(value: string): PrimitiveType {
+  const match = TYPE_CHOICES.find((choice) => choice === value);
+  // The <select> can only emit a declared option; a value outside the set is a
+  // DOM tamper, and the floor is the conservative fallback.
+  return match ?? 'string';
+}
+
+function asError(caught: unknown): Error {
+  return caught instanceof Error ? caught : new Error('import failed');
+}
+
+function declareFailureOutcome(name: string): EnvironmentOutcome {
+  return {
+    environmentId: `declare:${name}`,
+    name: `Declaration of ${name}`,
+    imported: [],
+    skipped: [],
+    findingRules: [],
+    error: 'The key could not be declared, so its values were not imported.',
+  };
+}

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -36,6 +36,7 @@ import {
   type MatrixPendingEntry,
 } from './MatrixPublishSheet.tsx';
 import { ApiError, type RefusalFinding } from '../api/client.ts';
+import { ImportWizard } from './ImportWizard.tsx';
 import { MatrixKeyCreate, type MatrixKeyCreatePayload } from './MatrixKeyCreate.tsx';
 import { MatrixRowEditor } from './MatrixRowEditor.tsx';
 import { ScanBlockDialog } from './ScanBlockDialog.tsx';
@@ -134,6 +135,10 @@ export function Matrix({
   // a group header or `null` from the empty state / a new group.
   const [create, setCreate] = useState<{ readonly folder: string | null } | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
+  // #495: the browser dotenv import wizard, opened from the matrix toolbar. Value
+  // import is not git-gated (only declaration is), so it stays available on a
+  // git-managed project — the wizard itself skips new keys there.
+  const [importOpen, setImportOpen] = useState(false);
   // Surface-2 scanner block (#183): the redacted findings a refused write
   // carried, plus the override that retries it with their acknowledgements.
   const [scanBlock, setScanBlock] = useState<{
@@ -762,6 +767,18 @@ export function Matrix({
             {`Δ ${String(pendingCount)} unpublished edit${pendingCount === 1 ? '' : 's'} · publish…`}
           </button>
         )}
+        {/* #495: import a .env file. Value import is not git-gated, so the entry
+            stays available on a git-managed project; the wizard skips new keys
+            there. Needs at least one environment to target. */}
+        {environments.length > 0 ? (
+          <button
+            type="button"
+            className="btn matrix__import"
+            onClick={() => setImportOpen(true)}
+          >
+            Import .env
+          </button>
+        ) : null}
         {/* env-matrix 31 / #492: the header's primary declare action. Git-managed
             projects disable it and say why — value actions still work. */}
         {environments.length > 0 && !gitManaged ? (
@@ -1221,6 +1238,18 @@ export function Matrix({
             setCreate(null);
           }}
           onCreate={declareKey}
+        />
+      )}
+
+      {!importOpen ? null : (
+        <ImportWizard
+          matrixRef={ref}
+          environments={environments.map((environment) => ({
+            id: environment.id,
+            name: environment.name,
+          }))}
+          gitManaged={gitManaged}
+          onClose={() => setImportOpen(false)}
         />
       )}
 

--- a/web/src/routes/import-state.test.ts
+++ b/web/src/routes/import-state.test.ts
@@ -1,0 +1,142 @@
+import type { ValueOccurrence } from '@hikyo/client';
+import { describe, expect, it } from 'vitest';
+
+import {
+  indexOccurrences,
+  needsTrim,
+  normalizeValue,
+  parseDotenv,
+  planEnvironment,
+  suggestType,
+} from './import-state.ts';
+
+describe('parseDotenv', () => {
+  it('parses assignments in file order with 1-based lines', () => {
+    const { entries, errors } = parseDotenv('A=1\nB=two\n');
+    expect(errors).toEqual([]);
+    expect(entries).toEqual([
+      { key: 'A', value: '1', line: 1 },
+      { key: 'B', value: 'two', line: 2 },
+    ]);
+  });
+
+  it('skips blank lines and leading-# comments only', () => {
+    const { entries } = parseDotenv('\n  # a comment\nA=has#hash\n');
+    // `#` after an unquoted value is part of the value, not an inline comment.
+    expect(entries).toEqual([{ key: 'A', value: 'has#hash', line: 3 }]);
+  });
+
+  it('strips the export keyword but not exportKEY', () => {
+    const { entries } = parseDotenv('export A=1\nEXPORTB=2\n');
+    expect(entries).toEqual([
+      { key: 'A', value: '1', line: 1 },
+      { key: 'EXPORTB', value: '2', line: 2 },
+    ]);
+  });
+
+  it('trims trailing \\r for CRLF files', () => {
+    const { entries } = parseDotenv('A=1\r\nB=2\r\n');
+    expect(entries.map((entry) => entry.value)).toEqual(['1', '2']);
+  });
+
+  it('decodes double-quoted escapes and keeps inner whitespace', () => {
+    const { entries, errors } = parseDotenv('A="a\\nb"\nB="  spaced  "\n');
+    expect(errors).toEqual([]);
+    expect(entries[0]?.value).toBe('a\nb');
+    expect(entries[1]?.value).toBe('  spaced  ');
+  });
+
+  it('treats single quotes as literal', () => {
+    const { entries } = parseDotenv("A='a\\nb'\n");
+    expect(entries[0]?.value).toBe('a\\nb');
+  });
+
+  it('refuses malformed lines by line, collecting all', () => {
+    const { entries, errors } = parseDotenv('NOEQUALS\nlower=1\nA="unterminated\nB=ok\n');
+    expect(entries).toEqual([{ key: 'B', value: 'ok', line: 4 }]);
+    expect(errors.map((error) => error.line)).toEqual([1, 2, 3]);
+    expect(errors[1]?.reason).toContain('upper-snake');
+  });
+
+  it('refuses an unknown escape and content after the closing quote', () => {
+    expect(parseDotenv('A="x\\q"\n').errors[0]?.reason).toContain('unknown escape');
+    expect(parseDotenv('A="x"trailing\n').errors[0]?.reason).toContain('after the closing quote');
+  });
+
+  it('refuses a duplicate key by name, keeping the first', () => {
+    const { entries, errors } = parseDotenv('A=first\nA=second\n');
+    expect(entries).toEqual([{ key: 'A', value: 'first', line: 1 }]);
+    expect(errors[0]?.reason).toContain('already assigned on line 1');
+  });
+});
+
+describe('normalizeValue / needsTrim', () => {
+  it('flags surrounding whitespace', () => {
+    expect(needsTrim(' x')).toBe(true);
+    expect(needsTrim('x ')).toBe(true);
+    expect(needsTrim('x')).toBe(false);
+    expect(normalizeValue('  x  ')).toBe('x');
+  });
+});
+
+describe('suggestType', () => {
+  it('is string for an empty set', () => {
+    expect(suggestType([])).toBe('string');
+  });
+
+  it('suggests boolean only for canonical true/false', () => {
+    expect(suggestType(['true', 'false'])).toBe('boolean');
+    expect(suggestType(['TRUE'])).toBe('string');
+    expect(suggestType(['1'])).toBe('integer');
+  });
+
+  it('suggests integer within int64 and rejects wider magnitudes', () => {
+    expect(suggestType(['0', '-42', '9223372036854775807'])).toBe('integer');
+    expect(suggestType(['9223372036854775808'])).toBe('string');
+    expect(suggestType(['+1'])).toBe('string');
+    expect(suggestType(['0x1f'])).toBe('string');
+  });
+
+  it('suggests json only for objects/arrays, not scalars', () => {
+    expect(suggestType(['{"a":1}'])).toBe('json');
+    expect(suggestType(['[1,2]'])).toBe('json');
+    expect(suggestType(['"scalar"'])).toBe('string');
+  });
+
+  it('suggests a type only when every value satisfies it', () => {
+    expect(suggestType(['1', 'two'])).toBe('string');
+  });
+});
+
+function occurrence(over: Partial<ValueOccurrence> & { name: string }): ValueOccurrence {
+  return { declared: true, set: false, token: `tok-${over.name}`, ...over };
+}
+
+describe('planEnvironment', () => {
+  const entries = [
+    { key: 'NEW', value: 'n', line: 1 },
+    { key: 'ABSENT', value: 'a', line: 2 },
+    { key: 'SET_KEEP', value: 'k', line: 3 },
+    { key: 'SET_OVER', value: 'o', line: 4 },
+  ];
+  const occurrences = indexOccurrences([
+    occurrence({ name: 'NEW', declared: false }),
+    occurrence({ name: 'ABSENT', set: false }),
+    occurrence({ name: 'SET_KEEP', set: true }),
+    occurrence({ name: 'SET_OVER', set: true }),
+  ]);
+
+  it('buckets new, absent, skipped, and overwritten keys', () => {
+    const plan = planEnvironment(entries, occurrences, new Set(['SET_OVER']));
+    expect(plan.newKeys).toEqual(['NEW']);
+    expect(plan.imported).toEqual(['NEW', 'ABSENT', 'SET_OVER']);
+    expect(plan.skipped).toEqual(['SET_KEEP']);
+    expect(plan.collisions).toEqual(['SET_KEEP', 'SET_OVER']);
+  });
+
+  it('skips every set key when no overwrite is chosen', () => {
+    const plan = planEnvironment(entries, occurrences, new Set());
+    expect(plan.imported).toEqual(['NEW', 'ABSENT']);
+    expect(plan.skipped).toEqual(['SET_KEEP', 'SET_OVER']);
+  });
+});

--- a/web/src/routes/import-state.ts
+++ b/web/src/routes/import-state.ts
@@ -1,0 +1,288 @@
+import type { ValueOccurrence } from '@hikyo/client';
+
+/**
+ * Pure, React-free logic for the browser dotenv import wizard (#495).
+ *
+ * The file is parsed in the browser and never leaves it until the reviewed
+ * phase-2 write. Everything here is deterministic and unit-tested so the risky
+ * parts — the dotenv grammar, the type suggestion, the collision/trim buckets —
+ * match the Go importer the CLI drives (`internal/dotenv`, `internal/importer`).
+ * The server re-validates every one of these; the browser mirror exists so the
+ * operator reviews an accurate preview, never so a mismatch can slip a write.
+ */
+
+/** A single KEY=value assignment, with its 1-based source line for the preview. */
+export type ParsedEntry = { readonly key: string; readonly value: string; readonly line: number };
+
+/** A line the strict grammar refused, named for the preview — never its value. */
+export type ParseError = { readonly line: number; readonly reason: string };
+
+export type ParseResult = {
+  readonly entries: readonly ParsedEntry[];
+  readonly errors: readonly ParseError[];
+};
+
+/** The primitive types the wizard can declare a new key as. `enum` is excluded:
+ * it needs member authoring the wizard does not gather and the suggester never
+ * proposes it — declare enum keys through the matrix `+ New key` form. */
+export type PrimitiveType = 'string' | 'integer' | 'boolean' | 'url' | 'json';
+
+/** KeyName contract (openapi `KeyName`): ASCII upper-snake, ≤128 code points. */
+const KEY_NAME = /^[A-Z_][A-Z0-9_]*$/;
+const MAX_KEY_NAME = 128;
+
+/** schema.Normalize is `strings.TrimSpace`; a value that changes under it is the
+ * importer's trim offender and must be acknowledged before it is written. */
+export function normalizeValue(value: string): string {
+  return value.trim();
+}
+
+export function needsTrim(value: string): boolean {
+  return value !== normalizeValue(value);
+}
+
+/**
+ * parseDotenv mirrors `internal/dotenv.Parse`'s grammar exactly, with one
+ * deliberate difference: Parse fails loud on the first bad line, but a review
+ * wizard collects EVERY invalid entry so the operator sees them all at once.
+ * Valid entries are still returned; the strict server parse remains the gate.
+ */
+export function parseDotenv(text: string): ParseResult {
+  const entries: ParsedEntry[] = [];
+  const errors: ParseError[] = [];
+  const firstSeen = new Map<string, number>();
+
+  const lines = text.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNumber = index + 1;
+    // CRLF tolerance: a trailing \r is stripped like the Go reader does.
+    const raw = lines[index]?.replace(/\r$/, '') ?? '';
+    const trimmedLeft = raw.replace(/^[ \t]+/, '');
+    // A blank line, or a comment (only when `#` is the first non-space char).
+    if (trimmedLeft === '' || trimmedLeft.startsWith('#')) {
+      continue;
+    }
+    const assignment = cutExportPrefix(trimmedLeft);
+    const equals = assignment.indexOf('=');
+    if (equals === -1) {
+      errors.push({ line: lineNumber, reason: 'not a KEY=value assignment' });
+      continue;
+    }
+    const key = assignment.slice(0, equals).replace(/[ \t]+$/, '');
+    if (key.length > MAX_KEY_NAME) {
+      errors.push({ line: lineNumber, reason: 'key name is longer than 128 characters' });
+      continue;
+    }
+    if (!KEY_NAME.test(key)) {
+      errors.push({
+        line: lineNumber,
+        reason: 'key name is not upper-snake (`[A-Z_][A-Z0-9_]*`)',
+      });
+      continue;
+    }
+    const firstLine = firstSeen.get(key);
+    if (firstLine !== undefined) {
+      errors.push({
+        line: lineNumber,
+        reason: `key ${key} is already assigned on line ${String(firstLine)}`,
+      });
+      continue;
+    }
+    const parsedValue = parseValue(assignment.slice(equals + 1).replace(/^[ \t]+/, ''));
+    if ('error' in parsedValue) {
+      errors.push({ line: lineNumber, reason: parsedValue.error });
+      continue;
+    }
+    firstSeen.set(key, lineNumber);
+    entries.push({ key, value: parsedValue.value, line: lineNumber });
+  }
+  return { entries, errors };
+}
+
+/** `export ` / `export\t` prefix is stripped; `exportKEY=` (no space) is not the
+ * keyword and passes through untouched. */
+function cutExportPrefix(line: string): string {
+  if (line.startsWith('export ') || line.startsWith('export\t')) {
+    return line.slice('export'.length).replace(/^[ \t]+/, '');
+  }
+  return line;
+}
+
+type ValueResult = { readonly value: string } | { readonly error: string };
+
+function parseValue(rest: string): ValueResult {
+  if (rest === '') {
+    return { value: '' };
+  }
+  if (rest.startsWith('"')) {
+    return parseDoubleQuoted(rest);
+  }
+  if (rest.startsWith("'")) {
+    return parseSingleQuoted(rest);
+  }
+  // Unquoted: the rest of the line with trailing blanks trimmed. A `#` here is
+  // part of the value, not an inline comment.
+  return { value: rest.replace(/[ \t]+$/, '') };
+}
+
+function parseDoubleQuoted(rest: string): ValueResult {
+  let out = '';
+  let index = 1;
+  while (index < rest.length) {
+    const char = rest[index];
+    if (char === '\\') {
+      const next = rest[index + 1];
+      if (next === undefined) {
+        return { error: 'dangling backslash in a double-quoted value' };
+      }
+      const decoded = DOUBLE_ESCAPES[next];
+      if (decoded === undefined) {
+        // The offending character comes from the value, so it is never echoed
+        // into a diagnostic the preview renders — only the class of error is.
+        return { error: 'unknown escape in a double-quoted value' };
+      }
+      out += decoded;
+      index += 2;
+      continue;
+    }
+    if (char === '"') {
+      return onlyTrailingBlank(rest.slice(index + 1))
+        ? { value: out }
+        : { error: 'unexpected content after the closing quote' };
+    }
+    out += char;
+    index += 1;
+  }
+  return { error: 'unterminated double-quoted value' };
+}
+
+const DOUBLE_ESCAPES: Record<string, string> = {
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  '\\': '\\',
+  '"': '"',
+  "'": "'",
+};
+
+function parseSingleQuoted(rest: string): ValueResult {
+  const close = rest.indexOf("'", 1);
+  if (close === -1) {
+    return { error: 'unterminated single-quoted value' };
+  }
+  return onlyTrailingBlank(rest.slice(close + 1))
+    ? { value: rest.slice(1, close) }
+    : { error: 'unexpected content after the closing quote' };
+}
+
+function onlyTrailingBlank(tail: string): boolean {
+  return /^[ \t]*$/.test(tail);
+}
+
+const INT64_MIN = -9223372036854775808n;
+const INT64_MAX = 9223372036854775807n;
+const INTEGER = /^-?[0-9]+$/;
+
+/**
+ * suggestType mirrors `importer.SuggestType`: a type is suggested only when
+ * EVERY value satisfies it, checked in the fixed order boolean → integer → json,
+ * falling back to string (also the floor for an empty set). The suggestion is
+ * only ever displayed — it lands only on an explicit accept.
+ */
+export function suggestType(values: readonly string[]): PrimitiveType {
+  if (values.length === 0) {
+    return 'string';
+  }
+  if (values.every(isBoolean)) {
+    return 'boolean';
+  }
+  if (values.every(isInteger)) {
+    return 'integer';
+  }
+  if (values.every(isJSONObjectOrArray)) {
+    return 'json';
+  }
+  return 'string';
+}
+
+/** Boolean is the canonical `true`/`false` only — `1`, `yes`, `TRUE` are not
+ * coerced (schema TypeBoolean). */
+function isBoolean(value: string): boolean {
+  return value === 'true' || value === 'false';
+}
+
+/** Integer is `-?[0-9]+` within signed 64-bit (schema TypeInteger). */
+function isInteger(value: string): boolean {
+  if (!INTEGER.test(value)) {
+    return false;
+  }
+  const magnitude = BigInt(value);
+  return magnitude >= INT64_MIN && magnitude <= INT64_MAX;
+}
+
+/** JSON suggestion fires only for a single well-formed object or array; scalar
+ * JSON (`4`, `true`, `"x"`) belongs to integer/boolean/string. */
+function isJSONObjectOrArray(value: string): boolean {
+  const trimmed = normalizeValue(value);
+  if (trimmed === '' || (trimmed[0] !== '{' && trimmed[0] !== '[')) {
+    return false;
+  }
+  let doc: unknown;
+  try {
+    doc = JSON.parse(value);
+  } catch {
+    return false;
+  }
+  return typeof doc === 'object' && doc !== null;
+}
+
+/** A key's state for one environment, as phase 1 (`listValueOccurrences`)
+ * observed it, keyed by name for the wizard's lookups. */
+export type OccurrenceIndex = ReadonlyMap<string, ValueOccurrence>;
+
+export function indexOccurrences(items: readonly ValueOccurrence[]): OccurrenceIndex {
+  return new Map(items.map((item) => [item.name, item]));
+}
+
+/** The buckets one environment's import falls into, for the review preview and
+ * for building the phase-2 request. Mirrors `importer.planEnvironment`. */
+export type EnvironmentPlan = {
+  /** Undeclared keys — a declaration must land before phase 2 accepts them. */
+  readonly newKeys: readonly string[];
+  /** Keys phase 2 will write: declared and either absent or an accepted overwrite. */
+  readonly imported: readonly string[];
+  /** Keys already `set` that no overwrite named — phase 2 skips them by name. */
+  readonly skipped: readonly string[];
+  /** Keys already `set` — the overwrite opt-in candidates (superset of chosen). */
+  readonly collisions: readonly string[];
+};
+
+export function planEnvironment(
+  entries: readonly ParsedEntry[],
+  occurrences: OccurrenceIndex,
+  overwrite: ReadonlySet<string>,
+): EnvironmentPlan {
+  const newKeys: string[] = [];
+  const imported: string[] = [];
+  const skipped: string[] = [];
+  const collisions: string[] = [];
+  for (const entry of entries) {
+    const occurrence = occurrences.get(entry.key);
+    if (occurrence === undefined || !occurrence.declared) {
+      newKeys.push(entry.key);
+      imported.push(entry.key);
+      continue;
+    }
+    if (occurrence.set) {
+      collisions.push(entry.key);
+      if (overwrite.has(entry.key)) {
+        imported.push(entry.key);
+      } else {
+        skipped.push(entry.key);
+      }
+      continue;
+    }
+    imported.push(entry.key);
+  }
+  return { newKeys, imported, skipped, collisions };
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4988,3 +4988,88 @@ select {
     min-height: var(--touch);
   }
 }
+
+/* #495 dotenv import wizard. Reuses the .matrix-editor dialog shell; these rules
+   only lay out the wizard's own review lists and per-key controls. */
+.import-wizard fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+}
+
+.import-wizard legend {
+  padding: 0 6px;
+  color: var(--tx-dim);
+  font-size: 12px;
+}
+
+.import-wizard__summary {
+  margin: 0;
+  color: var(--tx-dim);
+  font-size: 13px;
+}
+
+.import-wizard__invalid {
+  margin: 0;
+  padding-inline-start: 18px;
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.import-wizard__env,
+.import-wizard__secret {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: var(--touch);
+}
+
+.import-wizard__key {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding-block: 4px;
+}
+
+.import-wizard__key-name {
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+.import-wizard__key label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.import-wizard__suggestion {
+  color: var(--tx-dim);
+  font-size: 12px;
+}
+
+.import-wizard__collisions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.import-wizard__results {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 13px;
+}
+
+.import-wizard__error {
+  color: var(--danger);
+}


### PR DESCRIPTION
## What

Browser dotenv import wizard on the environment matrix (#495). A local `.env`
file is read in the browser and reviewed before any plaintext leaves it — no
value rides a request until the operator starts the reviewed phase-2 write.

Consumes the existing two-phase import contract (`import.presence` /
`value.import`); **no backend or contract change**, no generated client
hand-edits.

## Journey

1. Pick a file → parsed locally with the strict `internal/dotenv` grammar; every
   invalid line is previewed and the import is all-or-nothing (blocked while any
   line is invalid), matching the Go parser's whole-file refusal.
2. Classify each new key (secret by default); the deterministic type suggestion
   is shown but never preselected — `string` is the default and a suggestion
   lands only on an explicit pick.
3. Review per environment: collisions (overwrite opt-in), skips, trims.
4. Apply: new keys are declared through the shared create path (phase 2 never
   creates keys), then values are written per environment through `value.import`,
   which republishes. Each environment imports independently, so a stale one
   (409) does not abort the rest; the result names what landed, was skipped, and
   which declarations succeeded.

## Contract / decisions

- Phase-2 entries omit `set`-but-not-overwritten values entirely (never sent),
  mirroring the CLI's `planEnvironment`; skips are computed client-side.
- Precondition is sliced per environment; tokens come from a binding phase-1
  read taken after declarations land; `overwrite` lists only carried keys.
- Value import is **not** git-gated — only declaration is, so the wizard stays
  available on a git-managed project and skips new keys there with the git notice.

## Scope cuts (deliberate)

- No connector-source rename/transform: a non-conforming key is shown as an
  invalid entry, not auto-renamed (file import mirrors `internal/dotenv`, which
  is upper-snake-only).
- `enum` is not a wizard new-key type (needs member authoring the wizard does not
  gather, and the suggester never proposes it) — declare enum keys via `+ New key`.
- No new environment creation in the wizard.

## Regenerated artifacts

None — both operations were already in the committed generated client.

## Validation

- `pnpm --dir web typecheck`, `pnpm --dir web test` (456 pass), `pnpm --dir web build` — all green.
- New unit tests: `import-state.test.ts` (dotenv grammar, SuggestType, plan
  buckets) and `ImportWizard.test.tsx` (success, auth/validation/stale refusals,
  git-managed, invalid-file gate).
- Playwright: the success journey rides `matrix.spec.ts` (development only, so
  publish needs no step-up); verified locally on desktop and, on a fresh
  instance, mobile.
- Blocking cross-model (Codex, high effort) review completed; findings fixed.

Closes #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)