### PR TITLE
feat(web): Surface-2 secret-scanning block dialog on the declaration editor (#183)

### DIFF
--- a/docs/handoff/183-scan-block-dialog.md
+++ b/docs/handoff/183-scan-block-dialog.md
@@ -1,0 +1,66 @@
+# Handoff — #183 Surface-2 scan block dialog in the SPA
+
+Closes #183 (parent #74, secret scanning; the deferred browser residual from
+PR #182). Delivers the Surface-2 blocking presentation on the catalogue
+declaration editor introduced by #491.
+
+## What shipped
+
+- **Block dialog mounted on the declaration editor.** `MetadataEditor`
+  (`web/src/routes/KeyDeclarationDetail.tsx`) now routes a scanner-refused
+  metadata write — a credential-shaped `description` or `folder` — to the
+  existing `ScanBlockDialog` instead of an inline alert. The dialog states the
+  exported-as-public consequence, lists only each finding's rule id + locator,
+  and offers one audited override that resubmits the **same** content with every
+  finding's content-bound acknowledgement token. The operator's typed value is
+  never passed to the dialog.
+- **Named refusal surfaced.** `ScanBlockDialog` (`web/src/routes/ScanBlockDialog.tsx`)
+  now shows the server's own caller-safe `detail` verbatim when an override is
+  rejected (stale / version-skew / surplus / expired, named by the server),
+  falling back to a generic line only when the refusal carried no safe detail.
+  This improves the Matrix key-create/value-write block path (#492) too — the
+  component is shared.
+- **Criteria flipped.** `internal/isolation/scanning_criteria_test.go`: `SS3.ui`
+  loses its `Blocked` marker and binds the new Playwright title; `blockedClauses`
+  is now `0` — every ADR §9 leg is proven.
+- **E2E.** `web/e2e/flows/scanning.spec.ts` gains
+  `blocks a public declaration field, acknowledges, and resubmits (SS3 [UI])`:
+  create a config key → open its declaration detail → a canary description is
+  refused → the dialog states the consequence, shows only the redacted finding,
+  offers no ignore-all, and the canary reaches neither the dialog DOM nor the
+  console → Escape closes without submitting → override acknowledges and the
+  resubmit is saved.
+
+## Decisions / deviations from the 2026-08-21 handoff comment
+
+- **The env-create mount is dead design.** That comment predates #491 (which
+  added the declaration editor) and #492 (which shipped `ScanBlockDialog`). The
+  ticket body's target — "the declaration editor introduced by #491" — governs.
+  The block dialog is mounted on `MetadataEditor`, not the env-create form.
+- **Single audited override, not per-finding checkboxes.** The presentation
+  reuses #492's already-merged, already-reviewed `ScanBlockDialog`.
+  Acknowledgement remains **one content-bound token per finding** (the button
+  submits exactly the listed findings' tokens); there is no select-all / blanket
+  ignore-all input on any surface.
+- **Stale/skew/surplus is covered at the unit + server layers, not e2e.** The
+  native `<dialog>` is modal, so content is frozen at submit and the resubmit
+  always carries token-bound content — a stale-by-name refusal is not reachable
+  through this UI. The *surfacing* of the named refusal is proven in vitest
+  (`ScanBlockDialog.test.tsx`, `KeyDeclarationDetail.test.tsx`); the server-side
+  stale/skew/surplus-by-name behaviour is proven in Go (#74).
+
+## Verification
+
+- `pnpm --dir web typecheck` — clean.
+- `pnpm --dir web test` — 433 passed.
+- `pnpm --dir web build` — ok.
+- `go test ./internal/isolation/ -run TestScanningCriteriaMatrixIsComplete` — ok.
+- Targeted Playwright: the new SS3 [UI] journey (desktop + mobile in CI).
+
+## Fresh-worktree gotcha
+
+`web` typecheck/build resolves the generated client's `zod` from
+`clients/ts/node_modules`. A fresh checkout must
+`pnpm --dir clients/ts install --frozen-lockfile` first, or every SPA file
+fails with TS2307 cascading to `implicit any`. CI's `build-spa.sh` does this;
+a local run must too.

--- a/internal/isolation/scanning_criteria_test.go
+++ b/internal/isolation/scanning_criteria_test.go
@@ -19,13 +19,13 @@ import (
 //  3. a qualified Playwright fixture whose exact file no longer defines the
 //     named static test title.
 //
-// The three residual legs the ADR's §9 table names but this PR does not close
-// carry a Blocked reason instead of a fixture, and are counted apart so "the
-// matrix is complete" never silently means "except for these": the two
-// definitions-ingress legs wait on #70's plan/apply verbs, and the Surface-2
-// block dialog waits on a declaration-editing surface the SPA does not have
-// (docs/handoff/60-chrome-surfaces.md). A deferred clause is NOT COVERED — it
-// does not point at a tripwire asserting the behaviour is absent.
+// A residual leg the ADR's §9 table names but a PR does not yet close carries a
+// Blocked reason instead of a fixture, and is counted apart so "the matrix is
+// complete" never silently means "except for these"; a deferred clause is NOT
+// COVERED — it does not point at a tripwire asserting the behaviour is absent.
+// Every §9 leg is now closed: the definitions-ingress legs bind #70's plan/apply
+// verbs, and the Surface-2 block dialog binds the catalogue declaration editor
+// (#183, #491) — so the blocked set is empty.
 //
 // Go fixtures live across packages (internal/scanning, .../gen, internal/crypto,
 // internal/conformance, internal/service, internal/cli, and this package).
@@ -139,7 +139,7 @@ var scanningCriteria = map[string]scanClause{
 	"SS3.apply": {Text: "[E2E] same-version `definitions apply` adds no second scan; ruleset-skewed apply re-scans and refuses, then commits on acknowledgement",
 		Fixtures: []fixtureref.FixtureRef{goHelperFixture("internal/isolation", "runScanningDefinitionsApplySkew")}},
 	"SS3.ui": {Text: "[UI] block dialog stating the exported-as-public consequence",
-		Blocked: "no SPA declaration-editing surface (docs/handoff/60-chrome-surfaces.md); block presentation ships CLI/API and the dialog lands with that surface"},
+		Fixtures: []fixtureref.FixtureRef{playwrightFixture("e2e/flows/scanning.spec.ts", "blocks a public declaration field, acknowledges, and resubmits (SS3 [UI])")}},
 
 	// --- SS4: non-disclosure invariants (ADR §2, §4, §5, §6) -----------------
 	"SS4.a": {Text: "planted-canary sweep: the credential appears in no real HTTP response body (value warn + declaration block), CLI table/JSON/stderr, audit export stream, or import output — and neither does any match offset/length/excerpt, proven on the closed redacted key set (redacted DTO by construction)",
@@ -196,12 +196,12 @@ func TestScanningCriteriaMatrixIsComplete(t *testing.T) {
 		t.Errorf("scanning criteria name invalid fixtures: %v", err)
 	}
 
-	// The blocked set is pinned: the residual leg named in the ADR §9 table that
-	// this PR does not close (only SS3.ui — no SPA declaration-editing surface).
-	// #74 SS3's plan/apply legs are now proven (definitions plan/apply exist and
-	// scan). A clause that becomes provable must lose its Blocked marker rather
-	// than keep it as cover; a new deferral must move this pin deliberately.
-	const blockedClauses = 1
+	// The blocked set is pinned empty: every ADR §9 leg is now proven. SS3's
+	// plan/apply legs bind #70's verbs, and SS3.ui binds the catalogue
+	// declaration editor's block dialog (#183, #491). A clause that becomes
+	// provable must lose its Blocked marker rather than keep it as cover; a new
+	// deferral must move this pin deliberately.
+	const blockedClauses = 0
 	if blocked != blockedClauses {
 		t.Errorf("%d clauses are declared not-covered, pinned at %d — a clause was blocked or unblocked without updating the pin", blocked, blockedClauses)
 	}

--- a/web/e2e/flows/scanning.spec.ts
+++ b/web/e2e/flows/scanning.spec.ts
@@ -166,6 +166,97 @@ test.describe('secret scanning warn dialog', () => {
   }
 });
 
+/**
+ * Flow: secret-scanning Surface-2 BLOCK dialog on the catalogue declaration
+ * editor (#183, SS3 [UI]; secret-scanning ADR §4).
+ *
+ * Unlike the Surface-1 warn, a declaration free-text field is exported to Git
+ * and treated as public, so a credential-shaped value in it is REFUSED before
+ * any state persists. The block dialog states that consequence, renders only the
+ * redacted finding (rule id + locator, never the matched text), and offers one
+ * content-bound acknowledgement per finding through a single audited override —
+ * no blanket ignore-all. The planted canary reaches neither the dialog DOM nor
+ * the browser console. The named stale/skew/surplus refusals are proven at the
+ * unit layer (ScanBlockDialog, KeyDeclarationDetail) and server-side in Go; the
+ * modal freezes content at submit, so they are not reachable through this UI.
+ */
+test.describe('secret scanning block dialog', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: STORAGE_STATE });
+
+  test('blocks a public declaration field, acknowledges, and resubmits (SS3 [UI])', async ({
+    page,
+  }, testInfo) => {
+    const keyName = `SCANBLOCK_${testInfo.project.name.toUpperCase()}`;
+
+    const consoleLines: string[] = [];
+    page.on('console', (message) => consoleLines.push(message.text()));
+    page.on('pageerror', (error) => consoleLines.push(String(error)));
+
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+
+    const created = await browserApi(
+      page,
+      'POST',
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys`,
+      zCreatedKey,
+      { name: keyName, classification: 'config', description: '', declaration: { rule: { type: 'string' } } },
+    );
+    try {
+      // The declaration detail is routable and reload-safe — address it directly.
+      await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${created.id}`);
+      const panel = page.locator('.key-detail');
+      await expect(panel.getByRole('heading', { name: keyName, level: 2 })).toBeVisible();
+
+      const block = page.locator('dialog.scan-block');
+
+      // --- SS3: a credential-shaped description is refused, and the block dialog
+      // states the exported-as-public consequence --------------------------------
+      await panel.getByLabel('Description').fill(CANARY);
+      await panel.getByRole('button', { name: 'Save declaration' }).click();
+
+      await expect(
+        block.getByRole('heading', { name: 'Declaration blocked by secret scanning' }),
+      ).toBeVisible();
+      await expect(block).toContainText('exported to Git and treated as public');
+      // The finding names its rule; the override is offered once.
+      await expect(block.getByText('aws-access-token')).toBeVisible();
+      await expect(block.getByRole('button', { name: 'Acknowledge and continue' })).toBeVisible();
+      // No blanket ignore-all input exists on the dialog (ADR §4).
+      await expect(block.getByRole('button', { name: /ignore all/i })).toHaveCount(0);
+
+      // --- SS4 [UI]: the canary is nowhere in the dialog, nowhere in the console -
+      await expect(block).not.toContainText(CANARY);
+      expect(consoleLines.filter((line) => line.includes(CANARY))).toEqual([]);
+
+      // --- keyboard: Escape closes the block without submitting ------------------
+      await page.keyboard.press('Escape');
+      await expect(block).toHaveCount(0);
+
+      // --- SS3: the single audited override acknowledges the finding and the
+      // resubmit succeeds --------------------------------------------------------
+      await panel.getByRole('button', { name: 'Save declaration' }).click();
+      await expect(block).toBeVisible();
+      await block.getByRole('button', { name: 'Acknowledge and continue' }).click();
+      await expect(block).toHaveCount(0);
+      await expect(page.getByRole('status').filter({ hasText: 'Saved.' })).toBeVisible();
+
+      // The acknowledged description now stands recorded; the canary is the
+      // operator's own input, exactly as the warn test carves out.
+      await page.reload();
+      await expect(page.getByLabel('Description')).toHaveValue(CANARY);
+    } finally {
+      await browserApi(
+        page,
+        'DELETE',
+        `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${created.id}`,
+        z.null(),
+      );
+    }
+  });
+});
+
 /** plantValue opens the row editor, stages one development value, and saves. */
 async function plantValue(
   page: import('@playwright/test').Page,

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderForm, typeInto } from '../testkit/renderForm.tsx';
-import { ApiError } from '../api/client.ts';
+import { ApiError, type RefusalFinding } from '../api/client.ts';
 import { KeyDeclarationDetail } from './KeyDeclarationDetail.tsx';
 import type { MatrixKey } from '../api/matrix.ts';
 
@@ -267,6 +267,103 @@ describe('KeyDeclarationDetail', () => {
       ),
     ).toBe(false);
     expect(textOf(view.container)).toContain('could not be read');
+
+    await view.unmount();
+  });
+
+  it('routes a scanner refusal to the block dialog and overrides with the tokens', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    mocks.definitions.mockReturnValue({ data: { definitions_source: 'db' }, isSuccess: true, isError: false, isRefetchError: false });
+    const finding: RefusalFinding = {
+      rule_id: 'aws-access-key',
+      surface: 'edit',
+      locator: 'key.description',
+      acknowledgement: 'ack-1',
+    };
+    let calls = 0;
+    mocks.mutate.mockImplementation(
+      (
+        _input: unknown,
+        callbacks: { onSuccess: () => void; onError: (error: Error) => void },
+      ) => {
+        calls += 1;
+        // The first write is refused with the redacted finding; the acknowledged
+        // resubmit succeeds.
+        if (calls === 1) callbacks.onError(new ApiError(400, 'blocked', undefined, undefined, [finding]));
+        else callbacks.onSuccess();
+      },
+    );
+
+    const view = await render();
+    const description = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    if (description === null) throw new Error('editor textarea missing');
+    await act(async () => setTextarea(description, 'ghp_exampletoken'));
+    const save = [...view.container.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Save declaration'),
+    );
+    if (save === undefined) throw new Error('save button missing');
+    await act(async () => save.click());
+
+    // The block dialog opened, stating the exported-as-public consequence and
+    // rendering only the redacted finding.
+    const dialog = view.container.querySelector('dialog.scan-block');
+    expect(dialog).not.toBeNull();
+    const dialogText = dialog?.textContent ?? '';
+    expect(dialogText).toContain('exported to Git and treated as public');
+    expect(dialogText).toContain('aws-access-key');
+    expect(dialogText).toContain('key.description');
+    // Never the value the operator typed.
+    expect(dialogText).not.toContain('ghp_exampletoken');
+    // No blanket ignore-all input exists (ADR §4).
+    expect(
+      [...(dialog?.querySelectorAll('button') ?? [])].some((b) => /ignore all/i.test(b.textContent ?? '')),
+    ).toBe(false);
+
+    // Overriding resubmits the SAME field with the finding's token.
+    const acknowledge = [...(dialog?.querySelectorAll('button') ?? [])].find((b) =>
+      b.textContent?.includes('Acknowledge and continue'),
+    );
+    if (acknowledge === undefined) throw new Error('override button missing');
+    await act(async () => acknowledge.click());
+
+    expect(mocks.mutate).toHaveBeenLastCalledWith(
+      { description: 'ghp_exampletoken', acknowledgements: ['ack-1'] },
+      expect.anything(),
+    );
+    expect(textOf(view.container)).toContain('Saved.');
+
+    await view.unmount();
+  });
+
+  it('offers no override in the block dialog when a finding carries no token', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    mocks.definitions.mockReturnValue({ data: { definitions_source: 'db' }, isSuccess: true, isError: false, isRefetchError: false });
+    const hardBlock: RefusalFinding = { rule_id: 'high-entropy', surface: 'edit', locator: 'key.description' };
+    mocks.mutate.mockImplementation(
+      (
+        _input: unknown,
+        callbacks: { onError: (error: Error) => void },
+      ) => callbacks.onError(new ApiError(400, 'blocked', undefined, undefined, [hardBlock])),
+    );
+
+    const view = await render();
+    const description = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    if (description === null) throw new Error('editor textarea missing');
+    await act(async () => setTextarea(description, 'some entropy'));
+    const save = [...view.container.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Save declaration'),
+    );
+    if (save === undefined) throw new Error('save button missing');
+    await act(async () => save.click());
+
+    const dialog = view.container.querySelector('dialog.scan-block');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent ?? '').toContain('cannot be overridden');
+    expect(
+      [...(dialog?.querySelectorAll('button') ?? [])].some((b) =>
+        b.textContent?.includes('Acknowledge and continue'),
+      ),
+    ).toBe(false);
 
     await view.unmount();
   });

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -10,10 +10,11 @@ import {
   type MatrixKey,
   type MatrixRef,
 } from '../api/matrix.ts';
-import { ApiError } from '../api/client.ts';
+import { ApiError, type RefusalFinding } from '../api/client.ts';
 import { useWorkspaceContext, withRemote } from '../api/transport.tsx';
 import type { EnvironmentList } from '../api/values.ts';
 import { surfaceById } from '../app/navigation.ts';
+import { ScanBlockDialog } from './ScanBlockDialog.tsx';
 import { Alert, Done } from './Sections.tsx';
 
 type Environment = EnvironmentList['items'][number];
@@ -105,7 +106,12 @@ export function KeyDeclarationDetail({
       className="key-detail"
       aria-label="Key declaration"
       onKeyDown={(event) => {
-        if (event.key === 'Escape') {
+        // Escape closes the panel back to the matrix — but NOT while a modal
+        // dialog owns the top layer. The Surface-2 scanning block (#183) is a
+        // native <dialog>; its Escape is the dialog's own dismiss and must not
+        // also collapse the surface behind it. The keydown still bubbles here,
+        // so guard on an open dialog rather than let both fire.
+        if (event.key === 'Escape' && document.querySelector('dialog[open]') === null) {
           event.preventDefault();
           void navigate(matrixPath);
         }
@@ -406,6 +412,13 @@ function MetadataEditor({
   const [description, setDescription] = useState(record.description);
   const [refusal, setRefusal] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  // The Surface-2 scanning block (#183): a refused write carries redacted
+  // findings, never the flagged material. `findings` drives the dialog; the
+  // value the operator typed is never passed there.
+  const [scanBlock, setScanBlock] = useState<{
+    readonly findings: readonly RefusalFinding[];
+    readonly onOverride: ((tokens: readonly string[]) => Promise<void>) | null;
+  } | null>(null);
 
   // Reload the fields when the underlying record changes (a concurrent edit
   // invalidated the query) so the form never silently overwrites fresh data
@@ -426,16 +439,46 @@ function MetadataEditor({
     if (!dirty) return;
     setRefusal(null);
     setDone(false);
-    update.mutate(
-      {
-        ...(folderChanged ? { folderPath } : {}),
-        ...(descriptionChanged ? { description } : {}),
-      },
-      {
-        onSuccess: () => setDone(true),
-        onError: (error) => setRefusal(keyMetadataRefusalText(error)),
-      },
-    );
+    // Snapshot the changed fields ONCE: a Surface-2 override must resubmit the
+    // exact same content, because each acknowledgement token is bound to it.
+    // Changing a field between the block and the override invalidates the token,
+    // which the server then rejects by name.
+    const changed = {
+      ...(folderChanged ? { folderPath } : {}),
+      ...(descriptionChanged ? { description } : {}),
+    };
+    // The mutation is callback-shaped; wrap one attempt as a promise so the
+    // block dialog's override can await the resubmit and surface the server's
+    // named refusal on rejection.
+    const attempt = (acknowledgements: readonly string[]): Promise<void> =>
+      new Promise((resolve, reject) => {
+        update.mutate(
+          { ...changed, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+          { onSuccess: () => resolve(), onError: (error) => reject(error) },
+        );
+      });
+    void attempt([])
+      .then(() => setDone(true))
+      .catch((error: unknown) => {
+        // A scanner block carries findings; route them to the block dialog,
+        // which shows ONLY the redacted rule id + locator and offers an audited
+        // override. Any other refusal stays inline in its own words.
+        if (error instanceof ApiError && error.findings.length > 0) {
+          const findings = error.findings;
+          setScanBlock({
+            findings,
+            onOverride: findings.every((finding) => finding.acknowledgement !== undefined)
+              ? (tokens) =>
+                  attempt(tokens).then(() => {
+                    setDone(true);
+                    setScanBlock(null);
+                  })
+              : null,
+          });
+          return;
+        }
+        setRefusal(keyMetadataRefusalText(error instanceof Error ? error : new Error('save failed')));
+      });
   };
 
   return (
@@ -479,6 +522,16 @@ function MetadataEditor({
       <button type="submit" className="btn btn--primary" disabled={update.isPending || !dirty}>
         {update.isPending ? 'Saving…' : 'Save declaration'}
       </button>
+
+      {scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Declaration blocked by secret scanning"
+          intro={`This field is exported to Git and treated as public. Saving ${record.name}’s declaration was refused because it looks like it carries secret material.`}
+          findings={scanBlock.findings}
+          onOverride={scanBlock.onOverride}
+          onClose={() => setScanBlock(null)}
+        />
+      )}
     </form>
   );
 }

--- a/web/src/routes/ScanBlockDialog.test.tsx
+++ b/web/src/routes/ScanBlockDialog.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { RefusalFinding } from '../api/client.ts';
+import { ApiError, type RefusalFinding } from '../api/client.ts';
 import { ScanBlockDialog } from './ScanBlockDialog.tsx';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
@@ -52,12 +52,13 @@ function button(container: HTMLElement, label: string): HTMLButtonElement | unde
 }
 
 describe('ScanBlockDialog', () => {
-  it('renders only the redacted findings, never a value or excerpt', async () => {
+  it('renders only the rule id and locator — never the surface, a value, or excerpt', async () => {
     const view = await render([withToken], vi.fn().mockResolvedValue(undefined));
     const text = view.container.textContent ?? '';
     expect(text).toContain('aws-access-key');
     expect(text).toContain('app/API_KEY');
-    expect(text).toContain('value_write');
+    // The ADR §4 shape is rule id + locator ONLY; the surface enum is not shown.
+    expect(text).not.toContain('value_write');
     await view.unmount();
   });
 
@@ -82,6 +83,35 @@ describe('ScanBlockDialog', () => {
   it('offers no override when the caller supplies none', async () => {
     const view = await render([withToken], null);
     expect(button(view.container, 'Acknowledge and continue')).toBeUndefined();
+    await view.unmount();
+  });
+
+  it("surfaces the server's named refusal verbatim when an override is rejected", async () => {
+    // A content-bound token the field outran is rejected BY NAME (#183, ADR §4):
+    // stale / version-skew / surplus / expired — carried on the caller-safe
+    // detail, never as matched text. The dialog must show that reason, not a
+    // generic line, so the operator learns why the token no longer holds.
+    const named = 'token #1 (key.description/aws-access-key): stale — the field content changed since the token was minted';
+    const onOverride = vi
+      .fn<(tokens: readonly string[]) => Promise<void>>()
+      .mockRejectedValue(new ApiError(400, 'refused', named));
+    const view = await render([withToken], onOverride);
+    await act(async () => button(view.container, 'Acknowledge and continue')!.click());
+    const alert = view.container.querySelector('[role="alert"]');
+    expect(alert?.textContent ?? '').toContain(named);
+    // The value/excerpt still never appears — only the redacted reason.
+    expect(view.container.textContent ?? '').not.toContain('AKIA');
+    await view.unmount();
+  });
+
+  it('falls back to a generic message when a rejection carries no safe detail', async () => {
+    const onOverride = vi
+      .fn<(tokens: readonly string[]) => Promise<void>>()
+      .mockRejectedValue(new Error('network'));
+    const view = await render([withToken], onOverride);
+    await act(async () => button(view.container, 'Acknowledge and continue')!.click());
+    const alert = view.container.querySelector('[role="alert"]');
+    expect(alert?.textContent ?? '').toContain('The override was refused');
     await view.unmount();
   });
 });

--- a/web/src/routes/ScanBlockDialog.tsx
+++ b/web/src/routes/ScanBlockDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import type { RefusalFinding } from '../api/client.ts';
+import { ApiError, type RefusalFinding } from '../api/client.ts';
 import { useModalDialog } from './useModalDialog.ts';
 
 /**
@@ -8,8 +8,8 @@ import { useModalDialog } from './useModalDialog.ts';
  *
  * Unlike the Surface-1 warn, the write was REFUSED: the scanner matched
  * credential-shaped material on a write that must not carry it. The dialog
- * renders only the redacted findings the refusal carried — a rule id, the
- * surface it fired on, and an immutable locator — NEVER the matched text, and
+ * renders only the redacted findings the refusal carried — a rule id and an
+ * immutable locator (secret-scanning ADR §4) — NEVER the matched text, and
  * never the value the operator supplied (which is not in the refusal and is not
  * passed here). That is the whole non-leak guarantee.
  *
@@ -51,7 +51,18 @@ export function ScanBlockDialog({
     setError(null);
     void onOverride(tokens)
       .then(() => onClose())
-      .catch(() => setError('The override was refused. Reload and review the findings again.'))
+      // A rejected override carries the server's OWN caller-safe reason — a
+      // content-bound token the field's content outran is rejected by name
+      // (stale / version-skew / surplus / expired), never as matched text. Show
+      // that named refusal verbatim; only a refusal that carried no safe detail
+      // falls back to the generic line.
+      .catch((error: unknown) => {
+        setError(
+          error instanceof ApiError && error.detail !== undefined && error.detail !== ''
+            ? error.detail
+            : 'The override was refused. Reload and review the findings again.',
+        );
+      })
       .finally(() => setBusy(false));
   };
 
@@ -76,7 +87,6 @@ export function ScanBlockDialog({
         {findings.map((finding, index) => (
           <li className="scan-block__finding" key={`${finding.rule_id} ${finding.locator} ${String(index)}`}>
             <span className="mono scan-block__rule">{finding.rule_id}</span>
-            <span className="scan-block__surface">{finding.surface}</span>
             <span className="mono scan-block__locator">{finding.locator}</span>
           </li>
         ))}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2454,7 +2454,6 @@ select {
   color: var(--tx);
 }
 
-.scan-block__surface,
 .scan-block__locator {
   font-size: 12px;
   color: var(--tx-dim);


### PR DESCRIPTION
Closes #183 (parent #74 secret scanning; the deferred browser residual from PR #182). Delivers the Surface-2 blocking presentation on the catalogue declaration editor introduced by #491.

## What ships
- **Block dialog on the declaration editor.** `MetadataEditor` (`KeyDeclarationDetail.tsx`) routes a scanner-refused metadata write — a credential-shaped `description` or `folder` — to the existing `ScanBlockDialog` instead of an inline alert. The dialog states **this field is exported to Git and treated as public**, lists only each finding's rule id + immutable locator, and offers one audited override that resubmits the **same** content with every finding's content-bound acknowledgement token. The operator's typed value never reaches the dialog, DOM, console, or storage.
- **Named refusal surfaced.** `ScanBlockDialog` now shows the server's caller-safe `detail` verbatim when an override is rejected (stale / version-skew / surplus / expired, named by the server), falling back to a generic line only when the refusal carried no safe detail. Shared improvement — the Matrix key-create/value-write block path (#492) benefits too.
- **Tightened to the ADR shape.** Dropped the `finding.surface` render (+ dead CSS): the ADR §4 / AC shape is rule id + locator **only**.
- **Escape fix.** A modal dialog mounted inside the key-detail aside is the first of its kind there; guarded the aside's Escape handler so dismissing the dialog no longer also collapses the panel back to the matrix.
- **Criteria flipped.** `scanning_criteria_test.go`: `SS3.ui` loses its `Blocked` marker, binds the new Playwright title, and `blockedClauses` drops to `0` — every ADR §9 leg is proven.

## Decisions / deviations
- **Env-create mount is dead design.** The 2026-08-21 handoff comment predates #491 (declaration editor) and #492 (which shipped `ScanBlockDialog`). The ticket body's target governs: the dialog mounts on `MetadataEditor`, not env-create.
- **Single audited override, not per-finding checkboxes.** Reuses #492's merged, reviewed presentation. Acknowledgement stays **one content-bound token per finding**; no select-all / blanket ignore-all on any surface.
- **AC "stale/skew/surplus surface their named refusal" is covered at unit + Go layers, not e2e.** The native `<dialog>` is modal, so content is frozen at submit — a stale-by-name refusal is not reachable through this UI. The *surfacing* is proven in vitest (`ScanBlockDialog.test.tsx`, `KeyDeclarationDetail.test.tsx`); server-side stale/skew/surplus-by-name is proven in Go (#74).

## Regenerated artifacts
None — no OpenAPI/contract change. `updateKeyMetadata` already carried `acknowledgements`; `ApiError.findings` already populated.

## Verification
- `pnpm --dir web typecheck` — clean.
- `pnpm --dir web test` — 433 passed.
- `pnpm --dir web build` — ok.
- `go test ./internal/isolation/ -run TestScanningCriteriaMatrixIsComplete` — ok.
- Targeted Playwright `blocks a public declaration field, acknowledges, and resubmits (SS3 [UI])` — passed on desktop + mobile (block → Escape closes → acknowledge → saved; canary absent from dialog DOM and console).
- Cross-model review (gpt-5.6-sol, high): R1 two findings (Escape-bubble navigate; surface render) → fixed → R2 **CLEAN**.

Handoff: `docs/handoff/183-scan-block-dialog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)