### PR TITLE
feat(web): rename, reclassify, and delete keys in the WebUI (#494)

### DIFF
--- a/docs/handoff/494-key-lifecycle-webui.md
+++ b/docs/handoff/494-key-lifecycle-webui.md
@@ -1,0 +1,93 @@
+# #494 Browser key lifecycle — rename, reclassify, delete — handoff
+
+Status: FEATURE-COMPLETE for the ticket's scope. Web-only; no contract or
+migration change. The `renameKey`, `reclassifyKey` and `deleteKey` operations
+and their Zod already existed in the generated client — **nothing was
+regenerated**. Blocked-by #491 (PR #535, detail + editor foundation) and #183
+(PR #541, scan block dialog) are both merged; this extends that foundation.
+
+## What shipped
+
+The three remaining lifecycle actions on the catalogue declaration detail
+(`web/src/routes/KeyDeclarationDetail.tsx`), each rendered only in the editable
+(`definitions_source === 'db'`) branch beside the existing metadata editor:
+
+- **Rename** (`RenameKey`, `useRenameKey`): identity is the immutable id, so no
+  reference breaks; the name is Git-exported/public, so the same Surface-2
+  scanning block the metadata editor uses attaches here (redacted findings +
+  audited override with the same-content resubmit). Collisions and any other
+  refusal surface inline via `keyLifecycleRefusalText`.
+- **Reclassify** (`ReclassifyKey`, broadened `useReclassifyKey`): offers only the
+  opposite direction (the server 400s a same-classification no-op anyway) behind
+  a native-`<dialog>` confirm rendering that direction's distinct consequences.
+  - Tightening (`config` → `secret`): re-secures occurrences, drops config
+    scanning dismissals. No reveal.
+  - Declassifying (`secret` → `config`): a disclosure. The server enforces it
+    (CapReveal @ project + MFA session assurance; there is **no per-request
+    reveal token** and no env reveal window — the CLI does nothing client-side
+    either). The UI states the disclosure + second-factor requirement, attempts
+    the ceremony, and maps refusals: **403 → reauthenticate**, **404 → the
+    uniform missing-key sentence**. The 404 branch is deliberately identical to
+    every other 404 because a distinguishable message would turn the reveal gate
+    into the existence/permission oracle it exists to close. On success the
+    response's Surface-1 warnings for re-materialised occurrences render redacted
+    (rule id + locator).
+- **Delete** (`DeleteKey`, `useDeleteKey`): an impact preview of the affected
+  environments (delivered value / unpublished draft) plus the shared
+  `<TypedNameConfirm>` danger-zone gate. On success it navigates back to the
+  matrix (no stale key route). **No value is ever shown.**
+
+### Impact preview
+
+Assembled in `Matrix.tsx` (`keyDetailImpact`/`keyDetailImpactReady`) from the
+cells the matrix already holds, via the pure `assembleKeyImpact`. Only
+value-free environment-id lists cross into the detail surface — never a cell (a
+config `ValueCell` can carry material). Destructive actions stay disabled until
+the preview is ready (fail-closed), so a preview never understates its blast
+radius.
+
+## Load-bearing gotcha: delete invalidation must be `exact`
+
+`matrixKeyKey(ref, key) === [...matrixKeysKey(ref), 'key', key]` — the single-key
+query key is the list key plus a suffix. A **non-exact** `invalidateQueries` on
+`matrixKeysKey` therefore ALSO matches the still-mounted single-key query and
+re-fetches the just-deleted key: a guaranteed 404 that rejects the mutation's
+`onSuccess` promise and, with it, the caller's navigate-to-matrix — the surface
+gets stranded on the deleted-key error state. `useDeleteKey` invalidates the
+list with `{ exact: true }` and never touches `matrixKeyKey`; the stale
+single-key cache is dropped on unmount. Regression test:
+`web/src/api/matrix-hook.test.tsx` ("refreshes the list without re-fetching the
+deleted single key"). Rename/reclassify keep the detail open, so their non-exact
+list invalidation cascading into the single key is harmless (returns 200).
+
+## Registry / CI wiring
+
+- E2E rides `web/e2e/flows/matrix.spec.ts` (describe "catalogue declaration
+  lifecycle"), reusing the `key-detail` surface — a new spec file would never run
+  on its own PR (the merge gate loads `ci.yml` group spec lists from the base
+  branch; see #491 handoff and `docs/handoff/491-catalogue-declaration-detail.md`).
+  The journey creates a throwaway config key, renames it, tightens it to secret,
+  then deletes it. Declassification's reveal gate and Surface-1 warnings are
+  covered by the component tests, which drive the refusal shapes deterministically.
+- Prototype dev server (`web/prototype/mock-api.ts`) gained `PUT /keys/{id}/name`,
+  `PUT /keys/{id}/classification`, and `DELETE /keys/{id}`.
+
+## Verification
+
+- `pnpm --dir web typecheck` — clean.
+- `pnpm --dir web test` — 469 passed (new: rename, rename-scan-block,
+  declassify+warnings, declassify-403-reauth, declassify-404-mask, tighten,
+  delete+typed-confirm+nav, delete-fail-closed, and the delete-invalidation hook
+  guard).
+- `pnpm --dir web build` — clean.
+- Empirical (prototype + Playwright): rename and delete verified end-to-end
+  against the mock; the reclassify confirm dialog is exercised by vitest (the dev
+  prototype's `StrictMode` double-invokes the layout effect and leaves any
+  conditionally-mounted native `<dialog>` closed, affecting every dialog, not a
+  bug in this change; production e2e has no `StrictMode`).
+
+## Deliberately out of scope (later tickets, per #491 handoff)
+
+- Rules/presence editing (`updateKeyDeclaration`) and deprecation toggling.
+- `ScanWarnDialog`'s one-click reclassify-as-secret on the matrix is untouched —
+  it already uses the dedicated ceremony endpoint.

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -723,6 +723,91 @@ test.describe('catalogue declaration detail', () => {
 });
 
 /**
+ * Flow: the browser key lifecycle — rename, reclassify, delete (#494).
+ *
+ * Rides this spec for the same merge-gate reason the detail surface does (it
+ * reuses the `key-detail` surface). One serial journey over one throwaway config
+ * key: rename it (identity survives, the heading follows the new name),
+ * reclassify config → secret through its confirm ceremony (tightening needs no
+ * reveal), then delete it behind the typed-name confirm and land back on the
+ * matrix with no route left pointing at the key. Declassification's reveal gate
+ * and its Surface-1 warnings are covered by the component tests, which can drive
+ * the refusal shapes deterministically.
+ */
+test.describe('catalogue declaration lifecycle', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: STORAGE_STATE });
+
+  test('renames, reclassifies, and deletes a key from the detail surface', async ({
+    page,
+  }, testInfo) => {
+    const startName = `LIFECYCLE_${testInfo.project.name.toUpperCase()}`;
+    const renamed = `${startName}_RENAMED`;
+    const token = await fixtureBearer('lifecycle fixture');
+    const created = await fixtureApiCall(
+      token,
+      'POST',
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys`,
+      zCreatedKey,
+      {
+        name: startName,
+        classification: 'config',
+        folder_path: 'lifecycle',
+        description: '',
+        declaration: { rule: { type: 'string' } },
+      },
+    );
+    const keyId = created.id;
+    let deleted = false;
+    try {
+      await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${keyId}`);
+      const panel = page.locator('.key-detail');
+      await expect(page.getByRole('heading', { name: startName, level: 2 })).toBeVisible();
+
+      // Rename: identity is the id, so the URL is unchanged and the heading
+      // follows the new name once the query is invalidated.
+      await panel.getByLabel('Name').fill(renamed);
+      await panel.getByRole('button', { name: 'Rename key' }).click();
+      await expectStatusIsTextAndAria(
+        page,
+        page.getByRole('status').filter({ hasText: 'Renamed.' }),
+      );
+      await expect(page.getByRole('heading', { name: renamed, level: 2 })).toBeVisible();
+
+      // Reclassify config → secret through the confirm ceremony. Tightening
+      // discloses nothing and needs no reveal.
+      await panel.getByRole('button', { name: 'Reclassify as secret…' }).click();
+      const dialog = page.locator('dialog.matrix-editor');
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', { name: 'Reclassify as secret', exact: true }).click();
+      await expectStatusIsTextAndAria(
+        page,
+        page.getByRole('status').filter({ hasText: 'Reclassified as secret.' }),
+      );
+      await expect(panel).toContainText('🔒 secret');
+
+      // Delete behind the typed-name confirm, then land on the matrix with the
+      // key route gone.
+      await panel.getByLabel('Confirm the key name to delete it').fill(renamed);
+      await panel.getByRole('button', { name: 'Delete key' }).click();
+      await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+      await expect(page).not.toHaveURL(new RegExp(`/matrix/keys/${keyId}$`));
+      deleted = true;
+    } finally {
+      if (!deleted) {
+        const cleanup = await fixtureBearer('lifecycle cleanup');
+        await fixtureApiCall(
+          cleanup,
+          'DELETE',
+          `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${keyId}`,
+          z.object({}),
+        ).catch(() => undefined);
+      }
+    }
+  });
+});
+
+/**
  * Flow: declaring a new key from the browser (#492).
  *
  * Runs after the edit/publish suite and as the last describe in the file, so

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -765,8 +765,10 @@ test.describe('catalogue declaration lifecycle', () => {
       await expect(page.getByRole('heading', { name: startName, level: 2 })).toBeVisible();
 
       // Rename: identity is the id, so the URL is unchanged and the heading
-      // follows the new name once the query is invalidated.
-      await panel.getByLabel('Name').fill(renamed);
+      // follows the new name once the query is invalidated. `exact` because
+      // getByLabel is case-insensitive substring — plain 'Name' also matches the
+      // delete surface's "Confirm the key name to delete it".
+      await panel.getByLabel('Name', { exact: true }).fill(renamed);
       await panel.getByRole('button', { name: 'Rename key' }).click();
       await expectStatusIsTextAndAria(
         page,

--- a/web/prototype/mock-api.ts
+++ b/web/prototype/mock-api.ts
@@ -15,6 +15,8 @@ import {
   zSetDefinitionsSettingsRequest,
   zSetProjectRetentionRequest,
   zSetValueRequest,
+  zReclassifyKeyRequest,
+  zRenameKeyRequest,
   zUpdateKeyMetadataRequest,
 } from '../../clients/ts/src/generated/zod.gen.ts';
 import type { Key } from '../../clients/ts/src/generated/types.gen.ts';
@@ -1214,7 +1216,7 @@ function mockApi(request: IncomingMessage, response: ServerResponse): boolean | 
   // an edit here shows through on the matrix and survives a prototype reload —
   // the same in-memory persistence the create handler above relies on.
   const keyDetailMatch = new RegExp(`^${projectRoot}/keys/([^/]+)$`).exec(path);
-  if (keyDetailMatch !== null && (method === 'GET' || method === 'PATCH')) {
+  if (keyDetailMatch !== null && (method === 'GET' || method === 'PATCH' || method === 'DELETE')) {
     const reference = keyDetailMatch[1];
     const key = reference === undefined ? undefined : keyByReference(reference);
     if (key === undefined) {
@@ -1223,6 +1225,14 @@ function mockApi(request: IncomingMessage, response: ServerResponse): boolean | 
     }
     if (method === 'GET') {
       send(response, 200, key);
+      return true;
+    }
+    if (method === 'DELETE') {
+      // #494: remove the key from the same in-memory catalogue the list serves,
+      // so the matrix reflects the deletion (and a re-open 404s) after nav back.
+      const index = keys.indexOf(key);
+      if (index !== -1) keys.splice(index, 1);
+      send(response, 204);
       return true;
     }
     return body(request).then((raw) => {
@@ -1235,6 +1245,40 @@ function mockApi(request: IncomingMessage, response: ServerResponse): boolean | 
       if (input.deprecated !== undefined) key.deprecated = input.deprecated;
       if (input.deprecation_note !== undefined) key.deprecation_note = input.deprecation_note;
       if (input.classification !== undefined) key.classification = input.classification;
+      send(response, 200, key);
+      return true;
+    });
+  }
+
+  // #494: rename and reclassify are dedicated sub-resources, mutating the same
+  // in-memory catalogue. Reclassify carries no reveal ceremony in the prototype
+  // (there is no session assurance to check here); a real declassification's
+  // Surface-1 warnings are exercised by the component tests, not the mock.
+  const keyNameMatch = new RegExp(`^${projectRoot}/keys/([^/]+)/name$`).exec(path);
+  if (keyNameMatch !== null && method === 'PUT') {
+    const key = keyNameMatch[1] === undefined ? undefined : keyByReference(keyNameMatch[1]);
+    if (key === undefined) {
+      send(response, 404, { error: { code: 'not_found' } });
+      return true;
+    }
+    return body(request).then((raw) => {
+      const input = zRenameKeyRequest.parse(JSON.parse(raw));
+      key.name = input.name;
+      send(response, 200, key);
+      return true;
+    });
+  }
+  const keyClassificationMatch = new RegExp(`^${projectRoot}/keys/([^/]+)/classification$`).exec(path);
+  if (keyClassificationMatch !== null && method === 'PUT') {
+    const key =
+      keyClassificationMatch[1] === undefined ? undefined : keyByReference(keyClassificationMatch[1]);
+    if (key === undefined) {
+      send(response, 404, { error: { code: 'not_found' } });
+      return true;
+    }
+    return body(request).then((raw) => {
+      const input = zReclassifyKeyRequest.parse(JSON.parse(raw));
+      key.classification = input.classification;
       send(response, 200, key);
       return true;
     });

--- a/web/src/api/matrix-hook.test.tsx
+++ b/web/src/api/matrix-hook.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useMatrixProject } from './matrix.ts';
+import { useDeleteKey, useKey, useMatrixProject } from './matrix.ts';
 import { pendingDraftsKey, signalsKey, valuesKey } from './keys.ts';
 
 const ref = { org: 'org_a', project: 'project_a' };
@@ -117,6 +117,95 @@ describe('useMatrixProject query ownership', () => {
     }
   });
 });
+
+describe('useDeleteKey invalidation', () => {
+  it('refreshes the list without re-fetching the deleted single key', async () => {
+    // matrixKeyKey is matrixKeysKey plus a suffix, so a non-exact list
+    // invalidation would re-fetch the still-mounted single-key query — a
+    // guaranteed 404 that would reject onSuccess and strand the navigate. The
+    // hook invalidates the list `exact`, so the single key is never re-read here.
+    const requests: { method: string; path: string }[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
+        const path = new URL(url, 'http://localhost').pathname;
+        requests.push({ method, path });
+        if (method === 'DELETE') {
+          return Promise.resolve(new Response(null, { status: 204 }));
+        }
+        const body = path.endsWith(`/keys/${keyId}`)
+          ? keyRecord
+          : { items: [], count: 0, schema_revision: 1 };
+        return Promise.resolve(
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let deleteFn: (() => void) | null = null;
+
+    function DeleteHarness() {
+      const key = useKey(ref, keyId);
+      const remove = useDeleteKey(ref, keyId);
+      deleteFn = () => remove.mutate();
+      return <span>{key.data?.name ?? 'pending'}</span>;
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={client}>
+            <DeleteHarness />
+          </QueryClientProvider>,
+        );
+      });
+      await settleTasks();
+      // The single key loaded once.
+      expect(container.textContent).toBe('LOG_LEVEL');
+      expect(requests.filter((r) => r.method === 'GET' && r.path.endsWith(`/keys/${keyId}`))).toHaveLength(1);
+
+      requests.length = 0;
+      await act(async () => deleteFn?.());
+      await settleTasks();
+
+      // The DELETE ran; the deleted single key was NOT re-fetched afterwards.
+      expect(requests.some((r) => r.method === 'DELETE' && r.path.endsWith(`/keys/${keyId}`))).toBe(true);
+      expect(
+        requests.some((r) => r.method === 'GET' && r.path.endsWith(`/keys/${keyId}`)),
+      ).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      client.clear();
+    }
+  });
+});
+
+const keyRecord = {
+  id: keyId,
+  org_id: environmentBase.org_id,
+  project_id: environmentBase.project_id,
+  name: 'LOG_LEVEL',
+  folder_path: 'app',
+  classification: 'config' as const,
+  description: '',
+  deprecated: false,
+  deprecation_note: '',
+  declaration: { rule: { type: 'string' } },
+  presence: { required_in: { mode: 'none' }, forbidden_in: { mode: 'none' } },
+  group_id: 'app',
+  created_at: '2026-08-22T08:00:00Z',
+};
 
 function MatrixRows() {
   const matrix = useMatrixProject(ref);

--- a/web/src/api/matrix.test.ts
+++ b/web/src/api/matrix.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ApiError } from './client.ts';
 import {
+  assembleKeyImpact,
   assembleMatrixEnvironmentRows,
   bindMatrixEnvironmentQueries,
   type MatrixEnvironmentQuery,
+  matrixImpactReady,
   matrixPublishValidation,
   matrixMutationError,
   forgetRestorePreviews,
@@ -398,5 +400,36 @@ describe('pending draft preview boundary', () => {
         count: 1,
       }),
     ).toThrow('secret pending drafts must remain unrevealed');
+  });
+});
+
+describe('key lifecycle impact boundary', () => {
+  it('reduces per-environment occupancy to value-free id lists', () => {
+    expect(
+      assembleKeyImpact([
+        { environmentId: 'env_a', set: true, pending: false },
+        { environmentId: 'env_b', set: false, pending: true },
+        { environmentId: 'env_c', set: false, pending: false },
+      ]),
+    ).toEqual({ setEnvironmentIds: ['env_a'], pendingEnvironmentIds: ['env_b'] });
+  });
+
+  it('is ready only when every row is fully ready, and fails closed otherwise', () => {
+    const ready = { values: { status: 'ready' as const }, signals: { status: 'ready' as const } };
+    // The empty project (env list loaded, no rows) is legitimately ready.
+    expect(matrixImpactReady(true, [])).toBe(true);
+    expect(matrixImpactReady(false, [])).toBe(false);
+    expect(matrixImpactReady(true, [ready, ready])).toBe(true);
+    // A row whose values errored or went stale must NOT count as ready — that is
+    // the fail-closed property that keeps a preview from understating its reach.
+    expect(
+      matrixImpactReady(true, [ready, { values: { status: 'error' }, signals: { status: 'ready' } }]),
+    ).toBe(false);
+    expect(
+      matrixImpactReady(true, [{ values: { status: 'ready' }, signals: { status: 'stale' } }]),
+    ).toBe(false);
+    expect(
+      matrixImpactReady(true, [{ values: { status: 'pending' }, signals: { status: 'ready' } }]),
+    ).toBe(false);
   });
 });

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -12,6 +12,8 @@ import {
   listValuesOp,
   publishPendingChangesOp,
   reclassifyKeyOp,
+  deleteKeyOp,
+  renameKeyOp,
   setValueOp,
   updateKeyMetadataOp,
 } from '@hikyo/operations';
@@ -37,7 +39,7 @@ import {
   useAdvisoryStream,
   type AdvisoryEvent,
 } from './advisory.ts';
-import { ApiError, parsed } from './client.ts';
+import { ApiError, ok, parsed } from './client.ts';
 import { callerSafeRefusal } from './history.ts';
 import {
   invalidateAfterCopy,
@@ -864,8 +866,153 @@ export function useReclassifyKey(ref: MatrixRef) {
           body: { classification: input.classification },
           ...transport,
         }),
-    onSuccess: () => queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+    // Reclassification moves how every occurrence of the key is HANDLED, not
+    // just the catalogue lock: declassifying (`secret` → `config`)
+    // re-materialises the value under ordinary config read, and tightening
+    // (`config` → `secret`) drops the key's config dismissals and re-secures the
+    // cells. Both change what the value/signals/pending views must show, so the
+    // whole matrix is invalidated alongside the single-key detail and the list —
+    // the metadata-only edit's narrow key+list invalidation is not enough here.
+    onSuccess: (_result, input) =>
+      Promise.all([
+        queries.invalidateQueries({ queryKey: matrixKeyKey(ref, input.key) }),
+        queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+        queries.invalidateQueries({ queryKey: valuesMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: signalsMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: pendingMatrixKey(ref) }),
+      ]),
   });
+}
+
+/**
+ * useRenameKey renames a key by its immutable id (#494). Identity is that id, so
+ * no stored reference breaks — but the DELIVERED payload's key set changes,
+ * which is a content-affecting schema change and advances the schema revision.
+ * `acknowledgements` carries Surface-2 override tokens because the new name is
+ * exported to Git and treated as public, so the scanner can refuse it exactly as
+ * it refuses a free-text declaration field. The single-key detail, the project
+ * key list and the groups (whose membership is recorded by NAME) are all
+ * invalidated so the new name shows everywhere it appears.
+ */
+export function useRenameKey(ref: MatrixRef, key: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: (input: { readonly name: string; readonly acknowledgements?: readonly string[] }) =>
+      parsed(renameKeyOp, {
+          path: { ...ref, key },
+          body: {
+            name: input.name,
+            ...(input.acknowledgements === undefined || input.acknowledgements.length === 0
+              ? {}
+              : { acknowledgements: [...input.acknowledgements] }),
+          },
+          ...transport,
+        }),
+    onSuccess: () =>
+      Promise.all([
+        queries.invalidateQueries({ queryKey: matrixKeyKey(ref, key) }),
+        queries.invalidateQueries({ queryKey: matrixKeysKey(ref) }),
+        queries.invalidateQueries({ queryKey: matrixGroupsKey(ref) }),
+      ]),
+  });
+}
+
+/**
+ * useDeleteKey removes a key declaration, its explicit presence rows and its
+ * group membership (#494).
+ *
+ * It deliberately does NOT invalidate the single-key detail cache, and the list
+ * invalidation is `exact` for a load-bearing reason: `matrixKeyKey` is
+ * `matrixKeysKey` plus a suffix, so a non-exact list invalidation would ALSO
+ * match the still-mounted single-key query and re-fetch the now-deleted key.
+ * That 404 would reject this `onSuccess` promise and, with it, the caller's
+ * navigate-to-matrix — leaving the surface stranded on the deleted key. `exact`
+ * refreshes only the list; the surface navigates away and the stale single-key
+ * cache is dropped on unmount (a later visit re-fetches to the recoverable
+ * deleted-key state). The key vanishes from the whole matrix, so its per-
+ * environment views are invalidated too — none of those keys is a prefix of the
+ * single-key query, so they do not cascade.
+ */
+export function useDeleteKey(ref: MatrixRef, key: string) {
+  const queries = useQueryClient();
+  const transport = useTransport();
+  return useMutation({
+    mutationFn: () => ok(deleteKeyOp, { path: { ...ref, key }, ...transport }),
+    onSuccess: () =>
+      Promise.all([
+        queries.invalidateQueries({ queryKey: matrixKeysKey(ref), exact: true }),
+        queries.invalidateQueries({ queryKey: matrixGroupsKey(ref) }),
+        queries.invalidateQueries({ queryKey: valuesMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: signalsMatrixKey(ref) }),
+        queries.invalidateQueries({ queryKey: pendingMatrixKey(ref) }),
+      ]),
+  });
+}
+
+/** One key's cross-environment lifecycle impact: the environments whose value
+ *  the action moves (a set occurrence) or whose pending draft it disturbs. Only
+ *  environment IDs cross this boundary — never a value cell, which for a config
+ *  key can carry material the detail surface must never hold (#491). */
+export type KeyImpact = {
+  readonly setEnvironmentIds: readonly string[];
+  readonly pendingEnvironmentIds: readonly string[];
+};
+
+/** assembleKeyImpact reduces the per-environment occupancy of ONE key into the
+ *  two id lists a delete/reclassify preview shows. Pure over booleans the caller
+ *  extracts from the matrix cells, so no cell (hence no value) reaches it. */
+export function assembleKeyImpact(
+  cells: readonly {
+    readonly environmentId: string;
+    readonly set: boolean;
+    readonly pending: boolean;
+  }[],
+): KeyImpact {
+  return {
+    setEnvironmentIds: cells.filter((cell) => cell.set).map((cell) => cell.environmentId),
+    pendingEnvironmentIds: cells.filter((cell) => cell.pending).map((cell) => cell.environmentId),
+  };
+}
+
+/**
+ * keyLifecycleRefusalText renders a rename/reclassify/delete refusal in the
+ * caller's words, and — this is the security-sensitive part — WITHOUT ever
+ * turning the reveal gate into an oracle.
+ *
+ * A caller-safe server detail is quoted verbatim (a rename collision names the
+ * clashing key; a Surface-2 block names its rule id and locator). Otherwise:
+ *  - 403 on a declassification is the one place a step-up may be named, because
+ *    the server discloses the assurance requirement ONLY to a caller who already
+ *    holds the reveal grant; every other 403 is a plain permission refusal.
+ *  - 404 is the uniform missing-key sentence. For a declassification it ALSO
+ *    masks "you do not hold reveal on this key" — the gate is a one-bit oracle
+ *    the instant the UI says anything else, so this stays identical to every
+ *    other 404.
+ */
+export function keyLifecycleRefusalText(
+  error: Error,
+  action: 'rename' | 'reclassify' | 'declassify' | 'delete',
+): string {
+  if (error instanceof ApiError) {
+    const detailed = callerSafeRefusal(error, 'Refused');
+    if (detailed !== null) {
+      return detailed;
+    }
+    if (error.status === 403) {
+      return action === 'declassify'
+        ? 'Declassifying a secret needs a recent second-factor sign-in. Reauthenticate, then try again.'
+        : `You do not have permission to ${action} this key in this project.`;
+    }
+    if (error.status === 404) {
+      return 'This key no longer exists. Return to the matrix and reopen it.';
+    }
+    if (error.status === 409) {
+      return `The server refused this ${action}; reload the key and retry.`;
+    }
+    return `The server could not ${action} this key (error ${String(error.status)}).`;
+  }
+  return `The server could not ${action} this key.`;
 }
 
 /** One key declaration, as the catalogue detail surface (#491) reads it. */

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -976,6 +976,25 @@ export function assembleKeyImpact(
 }
 
 /**
+ * matrixImpactReady reports whether a key's impact preview can be trusted enough
+ * to arm a destructive action. It fails CLOSED: every environment row's values
+ * AND signals must be fully `ready` — an `error` row has no data and a `stale`
+ * row may be outdated, either of which would silently drop an affected
+ * environment from the preview and understate the blast radius. The empty case
+ * (a project with no environments) is legitimately ready once the environment
+ * list itself has loaded.
+ */
+export function matrixImpactReady(
+  environmentsLoaded: boolean,
+  rows: readonly { readonly values: { readonly status: MatrixQueryStatus }; readonly signals: { readonly status: MatrixQueryStatus } }[],
+): boolean {
+  return (
+    environmentsLoaded &&
+    rows.every((row) => row.values.status === 'ready' && row.signals.status === 'ready')
+  );
+}
+
+/**
  * keyLifecycleRefusalText renders a rename/reclassify/delete refusal in the
  * caller's words, and — this is the security-sensitive part — WITHOUT ever
  * turning the reveal gate into an oracle.
@@ -995,17 +1014,23 @@ export function keyLifecycleRefusalText(
   action: 'rename' | 'reclassify' | 'declassify' | 'delete',
 ): string {
   if (error instanceof ApiError) {
-    const detailed = callerSafeRefusal(error, 'Refused');
-    if (detailed !== null) {
-      return detailed;
+    // 404 is handled FIRST and its wording is the one canonical constant: for a
+    // declassification a 404 ALSO masks "you do not hold reveal on this key",
+    // and ANY variance — a caller-safe detail smuggled onto the 404, or copy
+    // that differs from the ordinary missing-key line — is exactly the
+    // existence/permission oracle the reveal gate exists to close. So a 404
+    // never consults `callerSafeRefusal`.
+    if (error.status === 404) {
+      return KEY_GONE_REFUSAL;
     }
     if (error.status === 403) {
       return action === 'declassify'
         ? 'Declassifying a secret needs a recent second-factor sign-in. Reauthenticate, then try again.'
         : `You do not have permission to ${action} this key in this project.`;
     }
-    if (error.status === 404) {
-      return 'This key no longer exists. Return to the matrix and reopen it.';
+    const detailed = callerSafeRefusal(error, 'Refused');
+    if (detailed !== null) {
+      return detailed;
     }
     if (error.status === 409) {
       return `The server refused this ${action}; reload the key and retry.`;
@@ -1014,6 +1039,11 @@ export function keyLifecycleRefusalText(
   }
   return `The server could not ${action} this key.`;
 }
+
+/** The one missing-key sentence every key refusal shares. A single constant so
+ *  no surface can render a distinguishable 404 that would turn the reveal gate
+ *  into an existence oracle. */
+export const KEY_GONE_REFUSAL = 'This key no longer exists. Return to the matrix and reopen it.';
 
 /** One key declaration, as the catalogue detail surface (#491) reads it. */
 export type MatrixKey = MatrixKeyList['items'][number];
@@ -1087,15 +1117,17 @@ export function useUpdateKeyMetadata(ref: MatrixRef, key: string) {
  */
 export function keyMetadataRefusalText(error: Error): string {
   if (error instanceof ApiError) {
+    // 404 first and canonical, for the same anti-oracle reason as
+    // keyLifecycleRefusalText: a 404 never consults the caller-safe detail.
+    if (error.status === 404) {
+      return KEY_GONE_REFUSAL;
+    }
     const detailed = callerSafeRefusal(error, 'Refused');
     if (detailed !== null) {
       return detailed;
     }
     if (error.status === 403) {
       return 'You do not have permission to edit this key in this project.';
-    }
-    if (error.status === 404) {
-      return 'This key no longer exists. Return to the matrix and reopen it.';
     }
     if (error.status === 409) {
       return 'The server refused this edit; reload the key and retry.';

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderForm, typeInto } from '../testkit/renderForm.tsx';
 import { ApiError, type RefusalFinding } from '../api/client.ts';
 import { KeyDeclarationDetail } from './KeyDeclarationDetail.tsx';
-import type { MatrixKey } from '../api/matrix.ts';
+import { KEY_GONE_REFUSAL, type MatrixKey } from '../api/matrix.ts';
 
 const mocks = vi.hoisted(() => ({
   key: vi.fn(),
@@ -211,7 +211,7 @@ describe('KeyDeclarationDetail', () => {
     const view = await render();
     const text = textOf(view.container);
 
-    expect(text).toContain('no longer exists');
+    expect(text).toContain(KEY_GONE_REFUSAL);
     expect(
       [...view.container.querySelectorAll('a')].some((a) => a.textContent?.includes('Back to the matrix')),
     ).toBe(true);
@@ -444,7 +444,7 @@ describe('KeyDeclarationDetail', () => {
 
     expect(view.container.querySelector('dialog.scan-block')).toBeNull();
     const text = textOf(view.container);
-    expect(text).toContain('no longer exists');
+    expect(text).toContain(KEY_GONE_REFUSAL);
     expect(text).not.toContain('aws-access-key');
 
     await view.unmount();
@@ -590,7 +590,7 @@ describe('KeyDeclarationDetail', () => {
     await act(async () => dialogButton(view.container, 'Reclassify as config').click());
 
     const text = textOf(view.container);
-    expect(text).toContain('no longer exists');
+    expect(text).toContain(KEY_GONE_REFUSAL);
     // The gate must not become an oracle: neither the server detail nor any
     // reveal/permission wording may surface on a 404.
     expect(text).not.toContain('requires reveal');

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => ({
   key: vi.fn(),
   definitions: vi.fn(),
   mutate: vi.fn(),
+  rename: vi.fn(),
+  reclassify: vi.fn(),
+  deleteKey: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock('../api/matrix.ts', async (importActual) => {
@@ -20,6 +24,9 @@ vi.mock('../api/matrix.ts', async (importActual) => {
     ...actual,
     useKey: () => mocks.key(),
     useUpdateKeyMetadata: () => ({ mutate: mocks.mutate, isPending: false }),
+    useRenameKey: () => ({ mutate: mocks.rename, isPending: false }),
+    useReclassifyKey: () => ({ mutate: mocks.reclassify, isPending: false }),
+    useDeleteKey: () => ({ mutate: mocks.deleteKey, isPending: false }),
   };
 });
 
@@ -31,6 +38,11 @@ vi.mock('../api/definitions.ts', async (importActual) => {
 vi.mock('../api/transport.tsx', async (importActual) => {
   const actual = await importActual<typeof import('../api/transport.tsx')>();
   return { ...actual, useWorkspaceContext: () => null };
+});
+
+vi.mock('react-router', async (importActual) => {
+  const actual = await importActual<typeof import('react-router')>();
+  return { ...actual, useNavigate: () => mocks.navigate };
 });
 
 const environments = [
@@ -71,13 +83,20 @@ const record: MatrixKey = {
   created_at: '2026-08-24T08:00:00Z',
 };
 
-function render() {
+const noImpact = { setEnvironmentIds: [], pendingEnvironmentIds: [] } as const;
+
+function render(
+  impact: { setEnvironmentIds: readonly string[]; pendingEnvironmentIds: readonly string[] } = noImpact,
+  impactReady = true,
+) {
   return renderForm(
     <MemoryRouter initialEntries={['/orgs/org_a/projects/project_a/matrix/keys/key_a']}>
       <KeyDeclarationDetail
         refData={{ org: 'org_a', project: 'project_a' }}
         keyId="key_a"
         environments={environments}
+        impact={impact}
+        impactReady={impactReady}
         openerRef={{ current: null }}
       />
     </MemoryRouter>,
@@ -92,7 +111,40 @@ beforeEach(() => {
   mocks.key.mockReset();
   mocks.definitions.mockReset();
   mocks.mutate.mockReset();
+  mocks.rename.mockReset();
+  mocks.reclassify.mockReset();
+  mocks.deleteKey.mockReset();
+  mocks.navigate.mockReset();
 });
+
+/** The db-managed, editable source mode the lifecycle actions require. */
+function dbMode() {
+  mocks.definitions.mockReturnValue({
+    data: { definitions_source: 'db' },
+    isSuccess: true,
+    isError: false,
+    isRefetchError: false,
+  });
+}
+
+function buttonBy(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')].find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (button === undefined) throw new Error(`button "${text}" missing`);
+  return button;
+}
+
+/** The confirm dialog's action button, matched EXACTLY so it is never confused
+ *  with the section trigger whose label is a superset ("…config…"). */
+function dialogButton(container: HTMLElement, text: string): HTMLButtonElement {
+  const dialog = container.querySelector('dialog.matrix-editor');
+  const button = [...(dialog?.querySelectorAll('button') ?? [])].find(
+    (candidate) => candidate.textContent === text,
+  );
+  if (button === undefined) throw new Error(`dialog button "${text}" missing`);
+  return button;
+}
 
 describe('KeyDeclarationDetail', () => {
   it('renders every declaration field and, in db mode, the editor', async () => {
@@ -364,6 +416,220 @@ describe('KeyDeclarationDetail', () => {
         b.textContent?.includes('Acknowledge and continue'),
       ),
     ).toBe(false);
+
+    await view.unmount();
+  });
+
+  it('renames a key and reports it', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    mocks.rename.mockImplementation((_input: unknown, cb: { onSuccess: () => void }) =>
+      cb.onSuccess(),
+    );
+
+    const view = await render();
+    const nameInput = [...view.container.querySelectorAll('input.mono')].find(
+      (input) => (input as HTMLInputElement).value === 'DATABASE_URL',
+    ) as HTMLInputElement | undefined;
+    if (nameInput === undefined) throw new Error('name input missing');
+    await act(async () => typeInto(nameInput, 'DATABASE_DSN'));
+    await act(async () => buttonBy(view.container, 'Rename key').click());
+
+    expect(mocks.rename).toHaveBeenCalledWith({ name: 'DATABASE_DSN' }, expect.anything());
+    expect(textOf(view.container)).toContain('Renamed.');
+
+    await view.unmount();
+  });
+
+  it('routes a scanner refusal on rename to the block dialog and overrides', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    const finding: RefusalFinding = {
+      rule_id: 'aws-access-key',
+      surface: 'edit',
+      locator: 'key.name',
+      acknowledgement: 'ack-name',
+    };
+    let calls = 0;
+    mocks.rename.mockImplementation(
+      (_input: unknown, cb: { onSuccess: () => void; onError: (error: Error) => void }) => {
+        calls += 1;
+        if (calls === 1) cb.onError(new ApiError(400, 'blocked', undefined, undefined, [finding]));
+        else cb.onSuccess();
+      },
+    );
+
+    const view = await render();
+    const nameInput = [...view.container.querySelectorAll('input.mono')].find(
+      (input) => (input as HTMLInputElement).value === 'DATABASE_URL',
+    ) as HTMLInputElement | undefined;
+    if (nameInput === undefined) throw new Error('name input missing');
+    await act(async () => typeInto(nameInput, 'AKIAEXAMPLE'));
+    await act(async () => buttonBy(view.container, 'Rename key').click());
+
+    const dialog = view.container.querySelector('dialog.scan-block');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent ?? '').toContain('aws-access-key');
+    expect(dialog?.textContent ?? '').not.toContain('AKIAEXAMPLE');
+
+    const acknowledge = [...(dialog?.querySelectorAll('button') ?? [])].find((b) =>
+      b.textContent?.includes('Acknowledge and continue'),
+    );
+    if (acknowledge === undefined) throw new Error('override button missing');
+    await act(async () => acknowledge.click());
+
+    expect(mocks.rename).toHaveBeenLastCalledWith(
+      { name: 'AKIAEXAMPLE', acknowledgements: ['ack-name'] },
+      expect.anything(),
+    );
+    expect(textOf(view.container)).toContain('Renamed.');
+
+    await view.unmount();
+  });
+
+  it('declassifies through a disclosure confirm and renders the Surface-1 warnings', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    mocks.reclassify.mockImplementation(
+      (input: { classification: string }, cb: { onSuccess: (key: unknown) => void }) => {
+        expect(input.classification).toBe('config');
+        cb.onSuccess({
+          ...record,
+          classification: 'config',
+          findings: [{ rule_id: 'high-entropy', surface: 'value', locator: 'production' }],
+        });
+      },
+    );
+
+    const view = await render({ setEnvironmentIds: ['env_b'], pendingEnvironmentIds: [] });
+    await act(async () => buttonBy(view.container, 'Reclassify as config…').click());
+
+    const dialog = view.container.querySelector('dialog.matrix-editor');
+    expect(dialog).not.toBeNull();
+    const dialogText = dialog?.textContent ?? '';
+    // The disclosure consequence and the second-factor requirement are stated.
+    expect(dialogText).toContain('readable under ordinary config read');
+    expect(dialogText).toContain('second-factor');
+    // The impact preview names the affected environment, never a value.
+    expect(dialogText).toContain('production');
+
+    await act(async () => dialogButton(view.container, 'Reclassify as config').click());
+
+    expect(mocks.reclassify).toHaveBeenCalledWith(
+      { key: 'key_a', classification: 'config' },
+      expect.anything(),
+    );
+    const text = textOf(view.container);
+    expect(text).toContain('Reclassified as config.');
+    // The re-materialised occurrence's warning is shown redacted.
+    expect(text).toContain('high-entropy');
+
+    await view.unmount();
+  });
+
+  it('surfaces the reauth requirement when a declassification is refused for assurance', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    mocks.reclassify.mockImplementation(
+      (_input: unknown, cb: { onError: (error: Error) => void }) =>
+        cb.onError(new ApiError(403, 'forbidden')),
+    );
+
+    const view = await render();
+    await act(async () => buttonBy(view.container, 'Reclassify as config…').click());
+    await act(async () => dialogButton(view.container, 'Reclassify as config').click());
+
+    expect(textOf(view.container)).toContain('second-factor sign-in');
+
+    await view.unmount();
+  });
+
+  it('masks a missing reveal grant as a uniform not-found on declassify', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    mocks.reclassify.mockImplementation(
+      (_input: unknown, cb: { onError: (error: Error) => void }) =>
+        cb.onError(new ApiError(404, 'not found')),
+    );
+
+    const view = await render();
+    await act(async () => buttonBy(view.container, 'Reclassify as config…').click());
+    await act(async () => dialogButton(view.container, 'Reclassify as config').click());
+
+    const text = textOf(view.container);
+    expect(text).toContain('no longer exists');
+    // The gate must not become an oracle: no reveal/permission wording here.
+    expect(text.toLowerCase()).not.toContain('reveal');
+    expect(text.toLowerCase()).not.toContain('permission');
+
+    await view.unmount();
+  });
+
+  it('tightens config to secret with its own consequence, no reveal', async () => {
+    const configKey: MatrixKey = { ...record, classification: 'config' };
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: configKey });
+    dbMode();
+    mocks.reclassify.mockImplementation(
+      (input: { classification: string }, cb: { onSuccess: (key: unknown) => void }) => {
+        expect(input.classification).toBe('secret');
+        cb.onSuccess({ ...configKey, classification: 'secret' });
+      },
+    );
+
+    const view = await render();
+    await act(async () => buttonBy(view.container, 'Reclassify as secret…').click());
+    const dialog = view.container.querySelector('dialog.matrix-editor');
+    expect(dialog?.textContent ?? '').toContain('dismissals are dropped');
+    // Tightening does not disclose, so it names no second-factor requirement.
+    expect((dialog?.textContent ?? '').toLowerCase()).not.toContain('second-factor');
+
+    await act(async () => dialogButton(view.container, 'Reclassify as secret').click());
+    expect(textOf(view.container)).toContain('Reclassified as secret.');
+
+    await view.unmount();
+  });
+
+  it('previews impact and deletes behind a typed confirm, then returns to the matrix', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    mocks.deleteKey.mockImplementation((_input: unknown, cb: { onSuccess: () => void }) =>
+      cb.onSuccess(),
+    );
+
+    const view = await render({ setEnvironmentIds: ['env_b'], pendingEnvironmentIds: ['env_a'] });
+    const deleteSection = view.container.querySelector('.danger-zone');
+    expect(deleteSection).not.toBeNull();
+    const text = textOf(view.container);
+    // The impact names both the delivering and the drafting environment.
+    expect(text).toContain('production');
+    expect(text).toContain('development');
+
+    // The delete stays disabled until the exact name is typed.
+    const del = buttonBy(view.container, 'Delete key');
+    expect(del.disabled).toBe(true);
+    const confirmInput = deleteSection?.querySelector('input') as HTMLInputElement;
+    await act(async () => typeInto(confirmInput, 'DATABASE_URL'));
+    expect(buttonBy(view.container, 'Delete key').disabled).toBe(false);
+    await act(async () => buttonBy(view.container, 'Delete key').click());
+
+    expect(mocks.deleteKey).toHaveBeenCalledWith(undefined, expect.anything());
+    expect(mocks.navigate).toHaveBeenCalledWith(expect.stringContaining('/matrix'));
+
+    await view.unmount();
+  });
+
+  it('fails closed: delete cannot arm while the impact is still loading', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+
+    const view = await render(noImpact, false);
+    expect(textOf(view.container)).toContain('Checking which environments this affects');
+    // No expected name while impact is unknown, so the confirm input is disabled.
+    const deleteSection = view.container.querySelector('.danger-zone');
+    const confirmInput = deleteSection?.querySelector('input') as HTMLInputElement;
+    expect(confirmInput.disabled).toBe(true);
+    // The reclassify-as-config trigger is also disabled without a ready preview.
+    expect(buttonBy(view.container, 'Reclassify as config…').disabled).toBe(true);
 
     await view.unmount();
   });

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -547,9 +547,12 @@ describe('KeyDeclarationDetail', () => {
   it('masks a missing reveal grant as a uniform not-found on declassify', async () => {
     mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
     dbMode();
+    // A 404 that even CARRIES a caller-safe detail must still render the uniform
+    // missing-key sentence — a detailed or otherwise distinguishable 404 would be
+    // the existence/reveal oracle the gate exists to close.
     mocks.reclassify.mockImplementation(
       (_input: unknown, cb: { onError: (error: Error) => void }) =>
-        cb.onError(new ApiError(404, 'not found')),
+        cb.onError(new ApiError(404, 'not found', 'key requires reveal to declassify')),
     );
 
     const view = await render();
@@ -558,7 +561,9 @@ describe('KeyDeclarationDetail', () => {
 
     const text = textOf(view.container);
     expect(text).toContain('no longer exists');
-    // The gate must not become an oracle: no reveal/permission wording here.
+    // The gate must not become an oracle: neither the server detail nor any
+    // reveal/permission wording may surface on a 404.
+    expect(text).not.toContain('requires reveal');
     expect(text.toLowerCase()).not.toContain('reveal');
     expect(text.toLowerCase()).not.toContain('permission');
 

--- a/web/src/routes/KeyDeclarationDetail.test.tsx
+++ b/web/src/routes/KeyDeclarationDetail.test.tsx
@@ -420,6 +420,36 @@ describe('KeyDeclarationDetail', () => {
     await view.unmount();
   });
 
+  it('never opens the scan block on a 404, even one carrying findings (no oracle)', async () => {
+    mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
+    dbMode();
+    const finding: RefusalFinding = {
+      rule_id: 'aws-access-key',
+      surface: 'edit',
+      locator: 'key.description',
+      acknowledgement: 'ack-x',
+    };
+    // A 404 must be canonicalized BEFORE findings are considered: a 404 carrying
+    // findings must render the uniform sentence, never the block dialog.
+    mocks.mutate.mockImplementation(
+      (_input: unknown, cb: { onError: (error: Error) => void }) =>
+        cb.onError(new ApiError(404, 'not found', undefined, undefined, [finding])),
+    );
+
+    const view = await render();
+    const description = view.container.querySelector<HTMLTextAreaElement>('textarea');
+    if (description === null) throw new Error('editor textarea missing');
+    await act(async () => setTextarea(description, 'changed'));
+    await act(async () => buttonBy(view.container, 'Save declaration').click());
+
+    expect(view.container.querySelector('dialog.scan-block')).toBeNull();
+    const text = textOf(view.container);
+    expect(text).toContain('no longer exists');
+    expect(text).not.toContain('aws-access-key');
+
+    await view.unmount();
+  });
+
   it('renames a key and reports it', async () => {
     mocks.key.mockReturnValue({ isPending: false, isError: false, data: record });
     dbMode();

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { generatePath, Link, useNavigate } from 'react-router';
 
 import { GIT_DEFINITIONS_NOTICE, useDefinitionsSettings } from '../api/definitions.ts';
 import { historyHref } from '../api/history.ts';
 import {
+  keyLifecycleRefusalText,
   keyMetadataRefusalText,
+  useDeleteKey,
   useKey,
+  useReclassifyKey,
+  useRenameKey,
   useUpdateKeyMetadata,
+  type KeyImpact,
   type MatrixKey,
   type MatrixRef,
 } from '../api/matrix.ts';
@@ -15,7 +20,8 @@ import { useWorkspaceContext, withRemote } from '../api/transport.tsx';
 import type { EnvironmentList } from '../api/values.ts';
 import { surfaceById } from '../app/navigation.ts';
 import { ScanBlockDialog } from './ScanBlockDialog.tsx';
-import { Alert, Done } from './Sections.tsx';
+import { Alert, Done, TypedNameConfirm } from './Sections.tsx';
+import { useModalDialog } from './useModalDialog.ts';
 
 type Environment = EnvironmentList['items'][number];
 
@@ -42,11 +48,23 @@ export function KeyDeclarationDetail({
   refData,
   keyId,
   environments,
+  impact,
+  impactReady,
   openerRef,
 }: {
   refData: MatrixRef;
   keyId: string;
   environments: readonly Environment[];
+  /**
+   * This key's cross-environment occupancy, assembled by the matrix from the
+   * cells it already holds (#494). It is value-free by construction — only the
+   * ids of the environments a lifecycle action would disturb — and drives the
+   * delete/reclassify impact previews. `impactReady` is false while the matrix
+   * rows are still loading, and the destructive actions stay disabled until it
+   * is true so a preview never understates what an action affects (fail-closed).
+   */
+  impact: KeyImpact;
+  impactReady: boolean;
   openerRef: RefObject<HTMLAnchorElement | null>;
 }) {
   const navigate = useNavigate();
@@ -138,12 +156,15 @@ export function KeyDeclarationDetail({
           keyId={keyId}
           record={key.data}
           environments={environments}
+          impact={impact}
+          impactReady={impactReady}
           editable={editable}
           gitManaged={gitManaged}
           sourceResolved={definitions.isSuccess}
           sourceFailed={sourceUntrusted}
           gitProvenance={definitions.data?.last_apply}
           historyPath={historyPath}
+          matrixPath={matrixPath}
         />
       )}
     </aside>
@@ -179,17 +200,22 @@ function KeyDeclarationBody({
   keyId,
   record,
   environments,
+  impact,
+  impactReady,
   editable,
   gitManaged,
   sourceResolved,
   sourceFailed,
   gitProvenance,
   historyPath,
+  matrixPath,
 }: {
   refData: MatrixRef;
   keyId: string;
   record: MatrixKey;
   environments: readonly Environment[];
+  impact: KeyImpact;
+  impactReady: boolean;
   editable: boolean;
   gitManaged: boolean;
   sourceResolved: boolean;
@@ -198,6 +224,7 @@ function KeyDeclarationBody({
     | { commit?: string; ref?: string; actor?: string; applied_by: string }
     | undefined;
   historyPath: string;
+  matrixPath: string;
 }) {
   const environmentName = (id: string) =>
     environments.find((environment) => environment.id === id)?.name ?? id;
@@ -266,7 +293,27 @@ function KeyDeclarationBody({
       </p>
 
       {editable ? (
-        <MetadataEditor refData={refData} keyId={keyId} record={record} />
+        <>
+          <MetadataEditor refData={refData} keyId={keyId} record={record} />
+          <RenameKey refData={refData} keyId={keyId} record={record} />
+          <ReclassifyKey
+            refData={refData}
+            keyId={keyId}
+            record={record}
+            impact={impact}
+            impactReady={impactReady}
+            environmentName={environmentName}
+          />
+          <DeleteKey
+            refData={refData}
+            keyId={keyId}
+            record={record}
+            impact={impact}
+            impactReady={impactReady}
+            environmentName={environmentName}
+            matrixPath={matrixPath}
+          />
+        </>
       ) : gitManaged ? (
         <section className="key-detail__section" aria-labelledby="key-detail-git">
           <h3 id="key-detail-git">Declarations are read-only</h3>
@@ -533,5 +580,454 @@ function MetadataEditor({
         />
       )}
     </form>
+  );
+}
+
+type ScanBlockState = {
+  readonly findings: readonly RefusalFinding[];
+  readonly onOverride: ((tokens: readonly string[]) => Promise<void>) | null;
+};
+
+/** scanBlockFrom turns a scanner-refused write into the block dialog's state:
+ *  the redacted findings, and an override only when every finding carries a
+ *  token. `resubmit` re-runs the SAME content with those tokens (each token is
+ *  bound to the content that produced it). Returns null for any non-scanner
+ *  refusal, which the caller shows inline instead. */
+function scanBlockFrom(
+  error: unknown,
+  resubmit: (tokens: readonly string[]) => Promise<void>,
+): ScanBlockState | null {
+  if (!(error instanceof ApiError) || error.findings.length === 0) {
+    return null;
+  }
+  const findings = error.findings;
+  return {
+    findings,
+    onOverride: findings.every((finding) => finding.acknowledgement !== undefined)
+      ? (tokens) => resubmit(tokens)
+      : null,
+  };
+}
+
+/**
+ * RenameKey changes the key's name. Identity is the immutable id, so nothing
+ * that references the key breaks — but the delivered payload's key set changes,
+ * an advertised schema change. The new name is exported to Git and treated as
+ * public, so the same Surface-2 scanning block the metadata editor carries
+ * attaches here: a refused rename renders the redacted finding and offers the
+ * audited override. A collision or any other refusal stays inline in the
+ * server's own caller-safe words.
+ */
+function RenameKey({
+  refData,
+  keyId,
+  record,
+}: {
+  refData: MatrixRef;
+  keyId: string;
+  record: MatrixKey;
+}) {
+  const rename = useRenameKey(refData, keyId);
+  const [name, setName] = useState(record.name);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [scanBlock, setScanBlock] = useState<ScanBlockState | null>(null);
+
+  // Reload the field when the record's name changes underneath (a concurrent
+  // rename, or this rename's own success invalidating the query) so the form
+  // never re-submits a name that is already applied.
+  useEffect(() => {
+    setName(record.name);
+  }, [record.name]);
+
+  const dirty = name !== record.name && name !== '';
+
+  const submit = () => {
+    if (!dirty) return;
+    setRefusal(null);
+    setDone(false);
+    const attempt = (acknowledgements: readonly string[]): Promise<void> =>
+      new Promise((resolve, reject) => {
+        rename.mutate(
+          { name, ...(acknowledgements.length === 0 ? {} : { acknowledgements }) },
+          { onSuccess: () => resolve(), onError: (error) => reject(error) },
+        );
+      });
+    void attempt([])
+      .then(() => setDone(true))
+      .catch((error: unknown) => {
+        const block = scanBlockFrom(error, (tokens) =>
+          attempt(tokens).then(() => {
+            setDone(true);
+            setScanBlock(null);
+          }),
+        );
+        if (block !== null) {
+          setScanBlock(block);
+          return;
+        }
+        setRefusal(
+          keyLifecycleRefusalText(error instanceof Error ? error : new Error('rename failed'), 'rename'),
+        );
+      });
+  };
+
+  return (
+    <form
+      className="key-detail__editor"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <h3>Rename key</h3>
+      <p className="key-detail__public-note">
+        The name is part of the delivered payload and is exported to Git — treat it as public. The
+        key’s identity does not change, so nothing that references it breaks.
+      </p>
+      <label className="field">
+        <span>Name</span>
+        <input
+          className="mono"
+          value={name}
+          disabled={rename.isPending}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </label>
+
+      {refusal === null ? null : <Alert>{refusal}</Alert>}
+      {done ? <Done>Renamed.</Done> : null}
+
+      <button type="submit" className="btn btn--primary" disabled={rename.isPending || !dirty}>
+        {rename.isPending ? 'Renaming…' : 'Rename key'}
+      </button>
+
+      {scanBlock === null ? null : (
+        <ScanBlockDialog
+          title="Rename blocked by secret scanning"
+          intro={`The name is exported to Git and treated as public. Renaming ${record.name} was refused because the new name looks like it carries secret material.`}
+          findings={scanBlock.findings}
+          onOverride={scanBlock.onOverride}
+          onClose={() => setScanBlock(null)}
+        />
+      )}
+    </form>
+  );
+}
+
+/**
+ * ReclassifyKey runs the reclassification ceremony in the one direction that is
+ * available — a `secret` key can only become `config`, a `config` key only
+ * `secret` — and renders that direction's distinct consequences before
+ * committing.
+ *
+ * Tightening (`config` → `secret`) re-secures every occurrence and drops the
+ * key's config-scanning dismissals. Declassifying (`secret` → `config`) is a
+ * disclosure: the value becomes readable under ordinary config read, so the
+ * server requires a recent second factor. The UI cannot pre-check that — the
+ * server is the source of truth — so it states the requirement, attempts the
+ * ceremony, and on refusal surfaces the reauth need (403) or the uniform
+ * missing-key sentence (404, which also masks a missing reveal grant). On a
+ * successful declassification the response's Surface-1 warnings for the
+ * re-materialised occurrences are rendered redacted (rule id + locator).
+ */
+function ReclassifyKey({
+  refData,
+  keyId,
+  record,
+  impact,
+  impactReady,
+  environmentName,
+}: {
+  refData: MatrixRef;
+  keyId: string;
+  record: MatrixKey;
+  impact: KeyImpact;
+  impactReady: boolean;
+  environmentName: (id: string) => string;
+}) {
+  const reclassify = useReclassifyKey(refData);
+  const target: 'secret' | 'config' = record.classification === 'secret' ? 'config' : 'secret';
+  const declassify = target === 'config';
+  const [confirming, setConfirming] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [warnings, setWarnings] = useState<readonly RefusalFinding[]>([]);
+
+  const run = () => {
+    setRefusal(null);
+    setDone(false);
+    setWarnings([]);
+    reclassify.mutate(
+      { key: keyId, classification: target },
+      {
+        onSuccess: (key) => {
+          setConfirming(false);
+          setDone(true);
+          // Only a declassification carries Surface-1 warnings, for the
+          // occurrences re-materialised as config; a tightening carries none.
+          setWarnings(declassify ? (key.findings ?? []) : []);
+        },
+        onError: (error: unknown) => {
+          setConfirming(false);
+          setRefusal(
+            keyLifecycleRefusalText(
+              error instanceof Error ? error : new Error('reclassify failed'),
+              declassify ? 'declassify' : 'reclassify',
+            ),
+          );
+        },
+      },
+    );
+  };
+
+  return (
+    <section className="key-detail__section" aria-labelledby="key-detail-reclassify">
+      <h3 id="key-detail-reclassify">Reclassify</h3>
+      <p>
+        This key is classified{' '}
+        <strong>{record.classification === 'secret' ? '🔒 secret' : 'config'}</strong>.
+      </p>
+
+      {refusal === null ? null : <Alert>{refusal}</Alert>}
+      {done ? (
+        <Done>
+          {declassify ? 'Reclassified as config.' : 'Reclassified as secret.'}
+        </Done>
+      ) : null}
+
+      {warnings.length === 0 ? null : (
+        <div className="key-detail__section" aria-label="Declassification scanning warnings">
+          <p className="key-detail__public-note">
+            Now readable as config, these occurrences look like they carry secret material. Review
+            them — nothing is blocked.
+          </p>
+          <ul className="key-detail__findings">
+            {warnings.map((finding, index) => (
+              <li key={`${finding.rule_id}:${finding.locator}:${String(index)}`}>
+                <span className="mono">{finding.rule_id}</span> at{' '}
+                <span className="mono">{finding.locator}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <button
+        type="button"
+        className="btn"
+        disabled={reclassify.isPending || (declassify && !impactReady)}
+        onClick={() => {
+          setDone(false);
+          setConfirming(true);
+        }}
+      >
+        {declassify ? 'Reclassify as config…' : 'Reclassify as secret…'}
+      </button>
+
+      {confirming ? (
+        <ConfirmDialog
+          title={declassify ? 'Reclassify this secret as config?' : 'Reclassify this key as secret?'}
+          confirmLabel={declassify ? 'Reclassify as config' : 'Reclassify as secret'}
+          busy={reclassify.isPending}
+          danger={declassify}
+          onConfirm={run}
+          onClose={() => setConfirming(false)}
+        >
+          {declassify ? (
+            <>
+              <p>
+                The value becomes readable under ordinary config read in every environment that
+                holds it. This is a disclosure and cannot be undone by re-securing the key later —
+                anything already served as config has been served.
+              </p>
+              <p>
+                It requires a recent second-factor sign-in; if you have not reauthenticated lately
+                you will be asked to before it can proceed.
+              </p>
+            </>
+          ) : (
+            <p>
+              Every occurrence is re-secured and handled as a secret, and the key’s existing
+              config-scanning dismissals are dropped — a value that looks secret will warn again.
+            </p>
+          )}
+          <ImpactPreview
+            impact={impact}
+            impactReady={impactReady}
+            environmentName={environmentName}
+          />
+        </ConfirmDialog>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * DeleteKey removes the declaration, its explicit presence rows and its group
+ * membership. It previews exactly which environments the deletion disturbs
+ * (a delivered value, or an unpublished draft) and gates the act behind typing
+ * the key's name — the same danger-zone confirm the project and org deletions
+ * use — WITHOUT ever revealing a value. On success it returns to the matrix, so
+ * no route is left pointing at the deleted key.
+ */
+function DeleteKey({
+  refData,
+  keyId,
+  record,
+  impact,
+  impactReady,
+  environmentName,
+  matrixPath,
+}: {
+  refData: MatrixRef;
+  keyId: string;
+  record: MatrixKey;
+  impact: KeyImpact;
+  impactReady: boolean;
+  environmentName: (id: string) => string;
+  matrixPath: string;
+}) {
+  const navigate = useNavigate();
+  const remove = useDeleteKey(refData, keyId);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  const confirmDelete = () => {
+    setRefusal(null);
+    remove.mutate(undefined, {
+      // Navigate FIRST so the useKey observer unmounts before anything could
+      // re-fetch the now-deleted key: the AC's "no stale key route" is exactly
+      // this ordering. The hook's own onSuccess refreshes the matrix lists.
+      onSuccess: () => {
+        void navigate(matrixPath);
+      },
+      onError: (error: unknown) => {
+        setRefusal(
+          keyLifecycleRefusalText(error instanceof Error ? error : new Error('delete failed'), 'delete'),
+        );
+      },
+    });
+  };
+
+  return (
+    <section className="key-detail__section" aria-labelledby="key-detail-delete">
+      <h3 id="key-detail-delete">Delete key</h3>
+      <p>
+        Removes the declaration, its presence rules and its group membership across the whole
+        project. No value is shown, and this cannot be undone.
+      </p>
+      <ImpactPreview impact={impact} impactReady={impactReady} environmentName={environmentName} />
+
+      {refusal === null ? null : <Alert>{refusal}</Alert>}
+
+      <TypedNameConfirm
+        label="Confirm the key name to delete it"
+        // Fail closed: no typed target until the impact is loaded, so a delete
+        // cannot be armed while the preview still understates what it affects.
+        expect={impactReady ? record.name : null}
+        action="Delete key"
+        hint={
+          <>
+            Type <span className="mono">{record.name}</span> to enable deletion.
+          </>
+        }
+        busy={remove.isPending}
+        onConfirm={confirmDelete}
+      />
+    </section>
+  );
+}
+
+/** ImpactPreview lists the environments a lifecycle action disturbs — a
+ *  delivered value or an unpublished draft — by name, never by value. Until the
+ *  matrix rows load it says so, and the caller keeps the action disabled. */
+function ImpactPreview({
+  impact,
+  impactReady,
+  environmentName,
+}: {
+  impact: KeyImpact;
+  impactReady: boolean;
+  environmentName: (id: string) => string;
+}) {
+  if (!impactReady) {
+    return (
+      <p className="key-detail__state" role="status">
+        Checking which environments this affects…
+      </p>
+    );
+  }
+  const set = impact.setEnvironmentIds;
+  const pending = impact.pendingEnvironmentIds;
+  return (
+    <ul className="key-detail__impact">
+      <li>
+        {set.length === 0
+          ? 'No environment currently delivers a value for this key.'
+          : `Delivers a value in ${String(set.length)} ${set.length === 1 ? 'environment' : 'environments'}: ${set.map(environmentName).join(', ')}.`}
+      </li>
+      {pending.length === 0 ? null : (
+        <li>
+          {`Unpublished drafts touch ${String(pending.length)} ${pending.length === 1 ? 'environment' : 'environments'}: ${pending.map(environmentName).join(', ')}.`}
+        </li>
+      )}
+    </ul>
+  );
+}
+
+/**
+ * ConfirmDialog is the native-`<dialog>` confirm the reclassification ceremony
+ * opens. Native so the platform gives the focus trap, the inert backdrop and
+ * Escape — and so the aside's Escape guard (which only collapses the panel when
+ * no dialog owns the top layer) generalises to it without a per-dialog change.
+ */
+function ConfirmDialog({
+  title,
+  confirmLabel,
+  busy,
+  danger,
+  onConfirm,
+  onClose,
+  children,
+}: {
+  title: string;
+  confirmLabel: string;
+  busy: boolean;
+  danger: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const dialog = useModalDialog();
+  return (
+    <dialog className="matrix-editor" ref={dialog} onClose={onClose}>
+      <div className="matrix-editor__head">
+        <div>
+          <h2>{title}</h2>
+        </div>
+        <button
+          type="button"
+          className="btn matrix-editor__close"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+      {children}
+      <div className="matrix-editor__actions">
+        <button
+          type="button"
+          className={danger ? 'btn btn--danger' : 'btn btn--primary'}
+          disabled={busy}
+          onClick={onConfirm}
+        >
+          {busy ? 'Working…' : confirmLabel}
+        </button>
+        <button type="button" className="btn" disabled={busy} onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
   );
 }

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { generatePath, Link, useNavigate } from 'react-router';
 
 import { GIT_DEFINITIONS_NOTICE, useDefinitionsSettings } from '../api/definitions.ts';
@@ -751,19 +751,26 @@ function ReclassifyKey({
   const declassify = target === 'config';
   const [confirming, setConfirming] = useState(false);
   const [refusal, setRefusal] = useState<string | null>(null);
-  const [done, setDone] = useState(false);
+  // The success text is derived from the DIRECTION THAT RAN, captured here, not
+  // from the live `declassify`: the mutation invalidates the key, the record
+  // refetches with the new classification, and `declassify` flips — which would
+  // otherwise flip the persistent "Reclassified as …" message to the wrong verb.
+  const [doneClassification, setDoneClassification] = useState<'secret' | 'config' | null>(null);
   const [warnings, setWarnings] = useState<readonly RefusalFinding[]>([]);
 
   const run = () => {
+    // Fail closed: never submit while the impact preview is not trustworthy, even
+    // if it went unready after the dialog opened (a concurrent invalidation).
+    if (!impactReady) return;
     setRefusal(null);
-    setDone(false);
+    setDoneClassification(null);
     setWarnings([]);
     reclassify.mutate(
       { key: keyId, classification: target },
       {
         onSuccess: (key) => {
           setConfirming(false);
-          setDone(true);
+          setDoneClassification(target);
           // Only a declassification carries Surface-1 warnings, for the
           // occurrences re-materialised as config; a tightening carries none.
           setWarnings(declassify ? (key.findings ?? []) : []);
@@ -790,11 +797,11 @@ function ReclassifyKey({
       </p>
 
       {refusal === null ? null : <Alert>{refusal}</Alert>}
-      {done ? (
+      {doneClassification === null ? null : (
         <Done>
-          {declassify ? 'Reclassified as config.' : 'Reclassified as secret.'}
+          {doneClassification === 'config' ? 'Reclassified as config.' : 'Reclassified as secret.'}
         </Done>
-      ) : null}
+      )}
 
       {warnings.length === 0 ? null : (
         <div className="key-detail__section" aria-label="Declassification scanning warnings">
@@ -816,9 +823,11 @@ function ReclassifyKey({
       <button
         type="button"
         className="btn"
-        disabled={reclassify.isPending || (declassify && !impactReady)}
+        // Fail closed in BOTH directions: tightening drops the key's config
+        // dismissals, so its impact preview matters as much as a declassification's.
+        disabled={reclassify.isPending || !impactReady}
         onClick={() => {
-          setDone(false);
+          setDoneClassification(null);
           setConfirming(true);
         }}
       >
@@ -830,6 +839,10 @@ function ReclassifyKey({
           title={declassify ? 'Reclassify this secret as config?' : 'Reclassify this key as secret?'}
           confirmLabel={declassify ? 'Reclassify as config' : 'Reclassify as secret'}
           busy={reclassify.isPending}
+          // If the impact preview goes unready while the dialog is open, keep the
+          // confirm disabled — the preview shows "Checking…" and must not be
+          // actioned against a stale blast radius.
+          confirmDisabled={!impactReady}
           danger={declassify}
           onConfirm={run}
           onClose={() => setConfirming(false)}
@@ -985,6 +998,7 @@ function ConfirmDialog({
   title,
   confirmLabel,
   busy,
+  confirmDisabled = false,
   danger,
   onConfirm,
   onClose,
@@ -993,17 +1007,19 @@ function ConfirmDialog({
   title: string;
   confirmLabel: string;
   busy: boolean;
+  confirmDisabled?: boolean;
   danger: boolean;
   onConfirm: () => void;
   onClose: () => void;
   children: ReactNode;
 }) {
   const dialog = useModalDialog();
+  const titleId = useId();
   return (
-    <dialog className="matrix-editor" ref={dialog} onClose={onClose}>
+    <dialog className="matrix-editor" ref={dialog} aria-labelledby={titleId} onClose={onClose}>
       <div className="matrix-editor__head">
         <div>
-          <h2>{title}</h2>
+          <h2 id={titleId}>{title}</h2>
         </div>
         <button
           type="button"
@@ -1019,7 +1035,7 @@ function ConfirmDialog({
         <button
           type="button"
           className={danger ? 'btn btn--danger' : 'btn btn--primary'}
-          disabled={busy}
+          disabled={busy || confirmDisabled}
           onClick={onConfirm}
         >
           {busy ? 'Working…' : confirmLabel}

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -4,6 +4,7 @@ import { generatePath, Link, useNavigate } from 'react-router';
 import { GIT_DEFINITIONS_NOTICE, useDefinitionsSettings } from '../api/definitions.ts';
 import { historyHref } from '../api/history.ts';
 import {
+  KEY_GONE_REFUSAL,
   keyLifecycleRefusalText,
   keyMetadataRefusalText,
   useDeleteKey,
@@ -175,11 +176,13 @@ export function KeyDeclarationDetail({
  * A load failure that stays recoverable: a deleted or renamed-away key (404) is
  * a stale link, not a dead end, so it names the state and offers the way back;
  * a refusal (403) quotes the server; anything else is reported with its status.
+ * The 404 uses the ONE canonical missing-key sentence every key 404 shares — a
+ * surface that worded it differently would be a distinguishable existence signal.
  */
 function KeyLoadError({ error, matrixPath }: { error: Error; matrixPath: string }) {
   const message =
     error instanceof ApiError && error.status === 404
-      ? 'This key no longer exists — it may have been deleted or renamed. Its link is stale.'
+      ? KEY_GONE_REFUSAL
       : error instanceof ApiError && error.status === 403
         ? 'You are not permitted to view this key.'
         : error instanceof ApiError
@@ -509,8 +512,11 @@ function MetadataEditor({
       .catch((error: unknown) => {
         // A scanner block carries findings; route them to the block dialog,
         // which shows ONLY the redacted rule id + locator and offers an audited
-        // override. Any other refusal stays inline in its own words.
-        if (error instanceof ApiError && error.findings.length > 0) {
+        // override. Any other refusal stays inline in its own words. A 404 is
+        // canonicalized to the uniform missing-key sentence BEFORE findings are
+        // considered — a 404 that carried findings must never render details, or
+        // it becomes the existence oracle the reveal gate closes.
+        if (error instanceof ApiError && error.status !== 404 && error.findings.length > 0) {
           const findings = error.findings;
           setScanBlock({
             findings,
@@ -597,7 +603,11 @@ function scanBlockFrom(
   error: unknown,
   resubmit: (tokens: readonly string[]) => Promise<void>,
 ): ScanBlockState | null {
-  if (!(error instanceof ApiError) || error.findings.length === 0) {
+  // A 404 is canonicalized to the uniform missing-key refusal by the caller and
+  // must NEVER open a findings dialog, even if one somehow rode a 404 — that
+  // would leak existence through the reveal mask. Only a genuine scan refusal
+  // (which carries findings on a non-404) becomes a block.
+  if (!(error instanceof ApiError) || error.status === 404 || error.findings.length === 0) {
     return null;
   }
   const findings = error.findings;

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -7,6 +7,7 @@ import { historyHref } from '../api/history.ts';
 import { useWorkspaceContext, withRemote } from '../api/transport.tsx';
 import { surfaceById } from '../app/navigation.ts';
 import {
+  assembleKeyImpact,
   matrixPublishValidation,
   matrixMutationError,
   pendingConfigPreview,
@@ -286,6 +287,31 @@ export function Matrix({
     }
     return drafts;
   }, [environmentRows]);
+
+  // The open key's cross-environment lifecycle impact (#494), assembled here
+  // from cells the matrix already holds and handed to the detail surface as
+  // value-free id lists — a config value cell can carry material the detail
+  // must never receive, so only the booleans (set / pending) cross. It stays
+  // "not ready" until the environment list and every row's values+signals have
+  // loaded, so the delete/reclassify previews never understate what an action
+  // touches (fail-closed, the surface's own idiom).
+  const keyDetailImpact = useMemo(() => {
+    if (keyDetailId === undefined || keyDetailId === '') {
+      return { setEnvironmentIds: [], pendingEnvironmentIds: [] };
+    }
+    return assembleKeyImpact(
+      environmentRows.map((row) => ({
+        environmentId: row.environmentId,
+        set: valuesByCell.get(cellID(keyDetailId, row.environmentId))?.set === true,
+        pending: signalsByCell.get(cellID(keyDetailId, row.environmentId))?.pending !== undefined,
+      })),
+    );
+  }, [environmentRows, keyDetailId, signalsByCell, valuesByCell]);
+  const keyDetailImpactReady =
+    matrix.environments.isSuccess &&
+    environmentRows.every(
+      (row) => row.values.status !== 'pending' && row.signals.status !== 'pending',
+    );
 
   const stateKeys = useMemo<readonly MatrixStateKey[]>(
     () =>
@@ -1313,6 +1339,8 @@ export function Matrix({
           refData={ref}
           keyId={keyDetailId}
           environments={environments}
+          impact={keyDetailImpact}
+          impactReady={keyDetailImpactReady}
           openerRef={keyDetailOpener}
         />
       )}

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -8,6 +8,7 @@ import { useWorkspaceContext, withRemote } from '../api/transport.tsx';
 import { surfaceById } from '../app/navigation.ts';
 import {
   assembleKeyImpact,
+  matrixImpactReady,
   matrixPublishValidation,
   matrixMutationError,
   pendingConfigPreview,
@@ -307,11 +308,7 @@ export function Matrix({
       })),
     );
   }, [environmentRows, keyDetailId, signalsByCell, valuesByCell]);
-  const keyDetailImpactReady =
-    matrix.environments.isSuccess &&
-    environmentRows.every(
-      (row) => row.values.status !== 'pending' && row.signals.status !== 'pending',
-    );
+  const keyDetailImpactReady = matrixImpactReady(matrix.environments.isSuccess, environmentRows);
 
   const stateKeys = useMemo<readonly MatrixStateKey[]>(
     () =>


### PR DESCRIPTION
Closes #494.

Finishes the browser key lifecycle on the catalogue declaration detail (#491 foundation, #183 scan block — both merged): **rename**, **reclassify** (both directions), and **delete**, each showing its actual impact before committing.

## What's here

- **Rename** — preserves key identity (immutable id), carries the Surface-2 scan block (the name is Git-exported/public) with the same same-content override the metadata editor uses, and surfaces collisions verbatim.
- **Reclassify** — offers only the opposite direction behind a native-`<dialog>` confirm rendering that direction's distinct consequences.
  - Tightening (`config` → `secret`): re-secures occurrences, drops config dismissals. No reveal.
  - Declassifying (`secret` → `config`): a disclosure. The server enforces reveal (CapReveal @ project + MFA session assurance; **no per-request token**). The UI states the requirement, attempts the ceremony, and maps refusals — **403 → reauthenticate**, **404 → the uniform missing-key sentence** (never an existence/permission oracle). Success renders the Surface-1 warnings redacted.
- **Delete** — previews the affected environments/drafts (value-free) + shared typed-name confirm, then returns to the matrix with no stale key route.

## Contract / codegen

None. `renameKey`/`reclassifyKey`/`deleteKey` and their Zod already existed in the generated client — nothing regenerated. No clients were hand-edited, no authorization widened, no refusal weakened, and no secret material is placed in URLs, logs, toasts, DOM diagnostics, or storage.

## Notable decision

`useDeleteKey` invalidates the key list with `exact: true`: `matrixKeyKey` is `matrixKeysKey` plus a suffix, so a non-exact invalidation would re-fetch the just-deleted key (404), reject `onSuccess`, and strand the navigate. Regression test in `web/src/api/matrix-hook.test.tsx`.

## Validation

- `pnpm --dir web typecheck` — clean.
- `pnpm --dir web test` — 469 passed (rename, rename-scan-block, declassify+warnings, declassify-403-reauth, declassify-404-mask, tighten, delete+typed-confirm+nav, delete-fail-closed, delete-invalidation hook guard).
- `pnpm --dir web build` — clean.
- Targeted Playwright for the completed journey rides `flows/matrix.spec.ts` (`key-detail` surface); rename + delete additionally verified end-to-end against the prototype mock.

Handoff: `docs/handoff/494-key-lifecycle-webui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)