### PR TITLE
feat(web): import K8s, Infisical, Vault/OpenBao through the WebUI (#496)

### DIFF
--- a/docs/handoff/496-import-connectors-webui.md
+++ b/docs/handoff/496-import-connectors-webui.md
@@ -1,0 +1,90 @@
+# #496 — Import K8s / SOPS / Infisical / Vault / OpenBao through the WebUI
+
+Parent: #41. Blocked-by: #495 (merged, PR #540). ADR: `docs/adr/import-paths.md`.
+Builds on the browser `.env` import wizard (#495) and reuses the same two
+server operations (`import.presence`, `value.import`) — **no codegen, no API
+change, no server change.**
+
+## Contract decision (approved by the owner)
+
+Acceptance criterion 1 asks that *every* shipped connector complete "through the
+browser." The locked import-paths ADR blocks a faithful SOPS or live-mode
+browser path in **both** directions:
+
+- **Server-side importers are rejected** ("import stays client-side").
+- **A browser credential prompt is the ADR's explicitly-rejected "interactive
+  prompt per run"** — live connectors authenticate with "the source's own
+  ambient conventions and nothing else," and SOPS uses "the ambient decryption
+  keyring exactly as `sops -d` resolves it." A pasted Vault token, an uploaded
+  kubeconfig, or an age key in a web form is exactly what the ADR refuses.
+
+So the delivered browser scope is the **file-mode connectors whose parse is pure
+and needs no decryption or live network**: Kubernetes Secret manifests, the
+pinned Infisical export, and the Vault/OpenBao JSON Lines capture. **SOPS and all
+live modes are selectable in the picker but routed to the CLI** with the exact
+command and the capture recipe. Widening the browser to those would require an
+ADR amendment (governance procedure) — deliberately out of scope. This boundary
+was chosen with the owner before any parser was written.
+
+The ADR itself blesses the capture-file fallback: "file mode remains available
+everywhere live mode exists — for air-gapped migration and users who prefer the
+artifact." A Vault/OpenBao JSONL capture and a K8s manifest export are exactly
+that, and Infisical is file-only in v1 regardless.
+
+## What ships
+
+- `web/src/routes/import-sources.ts` — pure, React-free connector layer mirroring
+  `internal/importer/{k8s,infisical,vault,names,importer}.go`:
+  - `parseSource(connector, text, {envSlug})` → normalized `{key, sourceName,
+    value, folderPath}[]` plus `renames` and `skipped`, or one content-free
+    refusal. The order of checks mirrors the CLI (file size → parse → per-value
+    bounds → name mapping/collisions).
+  - K8s: multi-doc YAML/JSON via the `yaml` dep (new dependency, pinned
+    `2.9.0`), `data` base64-decoded then `stringData` overlaid (stringData wins),
+    one Secret → one folder named after it, single Secret → environment root.
+  - Infisical: pinned JSON array; flat object routed to the `.env` path; missing
+    `secretPath`/`type` refused; `personal` skipped and listed.
+  - Vault/OpenBao: pinned JSONL; common-prefix stripped to folders; deleted/
+    destroyed skipped; non-string leaves → `json` via a canonical serialization.
+  - **A lossless JSON parser** (numbers kept as their source literal) so a Vault
+    non-string leaf's canonical JSON matches the CLI's exact-number fixtures —
+    native `JSON.parse` would corrupt `9007199254740993` and long decimals.
+  - The `TransformName` rename transform, the `quoteName` safe foreign-name
+    renderer (`safeName`, control/DEL/non-ASCII escaped, 128-byte cap), the
+    post-transform collision hard-stop, and the uniform bounds block (10 MiB
+    file, 50 000 records, 64 KiB value, depth 32).
+- `web/src/routes/ImportWizard.tsx` — generalized from the `.env`-only wizard to
+  a **source picker** (`pick` step) plus the shared classify → review → apply
+  flow, which now threads each connector's `folderPath` into `createKey`
+  (already supported by the op), surfaces renames and source-skips, and shows a
+  CLI-guidance panel for SOPS and live modes. `.env` remains one journey.
+- The matrix trigger button is now **"Import"** (was "Import .env").
+
+## Parity is tested, not asserted
+
+`web/src/routes/import-sources.test.ts` uses the **exact byte content** the Go
+connectors pin in `internal/importer/testdata/*` (k8s single/multi/duplicate/
+collision/binary/wrong-kind/hostile/unmappable/trim, infisical export/flat/
+no-path/no-type/hostile-type, vault capture/numbers/mixed/duplicate). Each
+assertion mirrors what the Go connector maps or refuses, so a divergence shows up
+here (acceptance criterion 6). E2e: a Kubernetes journey rides `flows/matrix.spec.ts`
+beside the `.env` journey (no new registry surface — see
+[[hikyo-new-e2e-surface-ci-grouping]]).
+
+## What is deliberately NOT here
+
+- SOPS decryption in the browser, and live k8s/Vault/OpenBao reads (ADR, above).
+- The mapping template / run-manifest artifacts. The browser preview funnels
+  through `value.import` per environment exactly as #495 did; it does not author
+  the CLI's committable artifacts. The occurrence-token precondition is still
+  built and checked per environment.
+- Cross-environment reconciliation of conflicting per-env sources — a wizard/CLI
+  concern; one source read fans onto the selected environments.
+
+## Verification
+
+- `pnpm --dir web typecheck` — clean.
+- `pnpm --dir web test` — connector parity + wizard + import-state suites pass.
+- `pnpm --dir web build` — clean.
+- Targeted Playwright: the `.env` and Kubernetes import journeys in
+  `flows/matrix.spec.ts`.

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -831,9 +831,12 @@ test.describe('environment matrix dotenv import', () => {
     await page.goto(MATRIX_PATH);
     await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Import .env' }).click();
+    await page.getByRole('button', { name: 'Import', exact: true }).click();
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
+
+    // The wizard opens on the source picker (#496); choose the .env journey.
+    await modal.getByRole('button', { name: /\.env file/ }).click();
 
     // The file is read locally; nothing is sent yet.
     await modal.getByLabel('Dotenv file').setInputFiles({
@@ -865,5 +868,60 @@ test.describe('environment matrix dotenv import', () => {
     await expect(
       page.getByRole('button', { name: /IMPORTED_FLAG in development:/ }),
     ).toBeVisible();
+  });
+});
+
+/**
+ * Flow tail: a browser file-mode connector import (#496).
+ *
+ * A local Kubernetes Secret manifest is read and parsed in the browser (the same
+ * strict mapping the Go connector uses), its one new key classified and declared,
+ * and its base64-decoded value published into the unprotected development
+ * environment through the SAME review/apply flow as the .env journey. This is the
+ * connector half of the shared UI acceptance criterion.
+ */
+test.describe('environment matrix kubernetes import', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: STORAGE_STATE });
+
+  test('imports a Kubernetes Secret entry into development and publishes its value', async ({
+    passkeyPage: page,
+  }) => {
+    await page.goto(MATRIX_PATH);
+    await expect(page.getByRole('heading', { name: 'Environment matrix', level: 1 })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Import', exact: true }).click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole('button', { name: /Kubernetes Secret manifest/ }).click();
+
+    // A single-Secret manifest maps its entries onto the environment root; the
+    // value is `console` (base64 `Y29uc29sZQ==`). Read locally, nothing sent yet.
+    await modal.getByLabel('Kubernetes Secret manifest').setInputFiles({
+      name: 'webapp.yaml',
+      mimeType: 'text/plain',
+      buffer: Buffer.from(
+        'apiVersion: v1\nkind: Secret\nmetadata:\n  name: webapp\ndata:\n  K8S_TOKEN: Y29uc29sZQ==\n',
+      ),
+    });
+    await expect(modal.getByText('1 value read')).toBeVisible();
+
+    await modal.getByRole('checkbox', { name: 'production' }).uncheck();
+    await modal.getByRole('button', { name: 'Review', exact: true }).click();
+
+    // Classify config so the value shows in the cell (K8s defaults to secret).
+    await modal.getByRole('checkbox', { name: 'secret' }).uncheck();
+    await modal.getByRole('button', { name: 'Review changes' }).click();
+
+    await expect(modal.getByText('1 to import, 1 new key declared')).toBeVisible();
+    await modal.getByRole('button', { name: 'Import', exact: true }).click();
+
+    await expect(modal.getByText('Declared 1 new key: K8S_TOKEN')).toBeVisible();
+    await expect(modal.getByRole('list', { name: 'Import results' })).toContainText('imported 1');
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect(modal).toBeHidden();
+
+    await expect(page.getByRole('button', { name: /K8S_TOKEN in development:/ })).toBeVisible();
   });
 });

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router": "8.3.0",
+    "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-router:
         specifier: 8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -53,7 +56,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: 6.1.0
-        version: 6.1.0(vite@8.2.2(@types/node@26.2.0))
+        version: 6.1.0(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0))
       happy-dom:
         specifier: ^20.11.6
         version: 20.11.6
@@ -62,10 +65,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: 8.2.2
-        version: 8.2.2(@types/node@26.2.0)
+        version: 8.2.2(@types/node@26.2.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@types/node@26.2.0)(happy-dom@20.11.6)(vite@8.2.2(@types/node@26.2.0))
+        version: 4.1.11(@types/node@26.2.0)(happy-dom@20.11.6)(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0))
 
 packages:
 
@@ -748,6 +751,11 @@ packages:
       utf-8-validate:
         optional: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -921,10 +929,10 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.2.0))':
+  '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.2(@types/node@26.2.0)
+      vite: 8.2.2(@types/node@26.2.0)(yaml@2.9.0)
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -935,13 +943,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.2.0)
+      vite: 8.2.2(@types/node@26.2.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -1178,7 +1186,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  vite@8.2.2(@types/node@26.2.0):
+  vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -1188,11 +1196,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       fsevents: 2.3.3
+      yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@26.2.0)(happy-dom@20.11.6)(vite@8.2.2(@types/node@26.2.0)):
+  vitest@4.1.11(@types/node@26.2.0)(happy-dom@20.11.6)(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -1209,7 +1218,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.2.0)
+      vite: 8.2.2(@types/node@26.2.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
@@ -1225,5 +1234,7 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.21.3: {}
+
+  yaml@2.9.0: {}
 
   zod@4.4.3: {}

--- a/web/src/routes/ImportWizard.test.tsx
+++ b/web/src/routes/ImportWizard.test.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '../api/client.ts';
+import { MAX_FILE_BYTES } from './import-sources.ts';
 
 const listOccurrences = vi.fn();
 const createKey = vi.fn();
@@ -119,8 +120,20 @@ async function selectFile(container: HTMLElement, content: string): Promise<void
 
 const FILE = 'EXISTING=1\nNEW=hello\n';
 
-// Walk source → classify → review → result, stopping before the final Import.
+// The wizard opens on the source picker (#496); the `.env` journey is one row.
+async function pickDotenv(container: HTMLElement): Promise<void> {
+  const source = [...container.querySelectorAll('button')].find((candidate) =>
+    candidate.textContent?.includes('.env file'),
+  );
+  if (source === undefined) {
+    throw new Error('no .env source in the picker');
+  }
+  await click(source);
+}
+
+// Walk pick → source → classify → review, stopping before the final Import.
 async function reachReview(container: HTMLElement): Promise<void> {
+  await pickDotenv(container);
   await selectFile(container, FILE);
   await click(button(container, 'Review'));
   await click(button(container, 'Review changes'));
@@ -166,6 +179,7 @@ describe('ImportWizard success', () => {
 describe('ImportWizard invalid file', () => {
   it('blocks Review while any line is invalid (all-or-nothing, matching the server)', async () => {
     const { container } = await render();
+    await pickDotenv(container);
     // `lower=1` fails the strict upper-snake grammar the Go parser refuses on.
     await selectFile(container, 'GOOD=1\nlower=2\n');
     expect(container.textContent).toContain('1 invalid line');
@@ -174,6 +188,28 @@ describe('ImportWizard invalid file', () => {
     );
     expect(button(container, 'Review').disabled).toBe(true);
     expect(listOccurrences).not.toHaveBeenCalled();
+  });
+
+  it('clears a prior valid parse when an oversized file is then selected', async () => {
+    const { container } = await render();
+    await pickDotenv(container);
+    await selectFile(container, 'GOOD=1\n');
+    expect(button(container, 'Review').disabled).toBe(false);
+
+    // Selecting an oversized file must invalidate the earlier importable parse,
+    // not merely show an error while Review stays enabled.
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (input === null) throw new Error('no file input');
+    const big = new File(['x'], 'big.env', { type: 'text/plain' });
+    Object.defineProperty(big, 'size', { value: MAX_FILE_BYTES + 1, configurable: true });
+    Object.defineProperty(input, 'files', { value: [big], configurable: true });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await settle();
+
+    expect(container.textContent).toContain('exceeds');
+    expect(button(container, 'Review').disabled).toBe(true);
   });
 });
 
@@ -207,6 +243,7 @@ describe('ImportWizard git-managed', () => {
   it('skips new-key declaration and imports only declared keys', async () => {
     importValues.mockResolvedValue({ imported: ['EXISTING'], skipped: [] });
     const { container } = await render(true);
+    await pickDotenv(container);
     await selectFile(container, FILE);
     await click(button(container, 'Review'));
     // The git-managed block names the skipped new keys on the classify step.

--- a/web/src/routes/ImportWizard.tsx
+++ b/web/src/routes/ImportWizard.tsx
@@ -20,6 +20,7 @@ import {
   type ParseResult,
   type PrimitiveType,
 } from './import-state.ts';
+import { MAX_FILE_BYTES, parseSource, type FileConnector } from './import-sources.ts';
 import { useModalDialog } from './useModalDialog.ts';
 
 type WizardEnvironment = { readonly id: string; readonly name: string };
@@ -29,7 +30,52 @@ type WizardEnvironment = { readonly id: string; readonly name: string };
  * `enum`, and every one is a legal `CreateKeyType` for the declare call. */
 const TYPE_CHOICES: readonly PrimitiveType[] = ['string', 'integer', 'boolean', 'url', 'json'];
 
-type Step = 'source' | 'classify' | 'review' | 'result';
+type Step = 'pick' | 'source' | 'classify' | 'review' | 'result';
+
+/**
+ * The import journeys the picker offers (#496). File-mode Kubernetes, Infisical,
+ * Vault and OpenBao complete in the browser through the shared review/apply flow
+ * below; `.env` is the #495 journey. SOPS (its only mode needs decryption keys)
+ * and every live mode (ambient kubeconfig / Vault client conventions) cannot run
+ * in the browser without the import-paths ADR's rejected server-side importer or
+ * credential prompt, so they are selectable but routed to the CLI with guidance.
+ */
+type Journey =
+  | { readonly kind: 'dotenv' }
+  | { readonly kind: 'file'; readonly connector: FileConnector }
+  | { readonly kind: 'cli'; readonly source: CliSource };
+
+type CliSource = 'sops' | 'k8s-live' | 'vault-live';
+
+type JourneyOption = {
+  readonly id: string;
+  readonly label: string;
+  readonly hint: string;
+  readonly journey: Journey;
+};
+
+/** The picker rows, in offer order. Vault and OpenBao share one JSONL parser, so
+ * one browser row covers both; each connector the ADR ships is selectable. */
+const JOURNEYS: readonly JourneyOption[] = [
+  { id: 'dotenv', label: '.env file', hint: 'KEY=value pairs', journey: { kind: 'dotenv' } },
+  { id: 'k8s', label: 'Kubernetes Secret manifest', hint: 'YAML/JSON export', journey: { kind: 'file', connector: 'k8s' } },
+  { id: 'infisical', label: 'Infisical export', hint: 'infisical export --format=json', journey: { kind: 'file', connector: 'infisical' } },
+  { id: 'vault', label: 'Vault / OpenBao capture', hint: 'JSON Lines capture', journey: { kind: 'file', connector: 'vault' } },
+  { id: 'sops', label: 'SOPS file', hint: 'Decrypts with your keyring — CLI', journey: { kind: 'cli', source: 'sops' } },
+  { id: 'k8s-live', label: 'Kubernetes (live)', hint: 'kubeconfig — CLI', journey: { kind: 'cli', source: 'k8s-live' } },
+  { id: 'vault-live', label: 'Vault / OpenBao (live)', hint: 'client conventions — CLI', journey: { kind: 'cli', source: 'vault-live' } },
+];
+
+/** A source-agnostic entry the shared classify/review/apply flow works on: the
+ * canonical KEY, the folder it declares under, its source name (for the rename
+ * surface) and the exact value phase 2 writes. `.env` and every connector
+ * normalize onto this shape. */
+type WorkingEntry = {
+  readonly key: string;
+  readonly sourceName: string;
+  readonly value: string;
+  readonly folderPath: string;
+};
 
 /** A new key's operator-chosen declaration, gathered in the classify step. */
 type Declaration = { readonly classification: KeyClassification; readonly type: PrimitiveType };
@@ -44,16 +90,43 @@ type EnvironmentOutcome = {
   readonly error: string | null;
 };
 
+const CLI_GUIDANCE: Record<CliSource, { readonly title: string; readonly body: string; readonly command: string }> = {
+  sops: {
+    title: 'Import a SOPS file with the CLI',
+    body:
+      'SOPS import decrypts with your ambient keyring (age, GPG, KMS). Decryption keys cannot be handled in the ' +
+      'browser, so run it on a machine with your keyring:',
+    command: 'hikyo import --from sops --file <file> --project <project> --environment <environment>',
+  },
+  'k8s-live': {
+    title: 'Import from a live cluster with the CLI',
+    body:
+      'A live Kubernetes read uses your ambient kubeconfig, which the browser cannot present. Run it where your ' +
+      'kubeconfig lives, or capture a manifest and import the file here:',
+    command:
+      'hikyo import --from k8s --live --namespace <ns> [--name <secret>] --project <project> --environment <environment>',
+  },
+  'vault-live': {
+    title: 'Import from a live Vault/OpenBao with the CLI',
+    body:
+      'A live Vault/OpenBao read uses your ambient client configuration and token, which the browser cannot ' +
+      'present. Run it where your client is configured, or capture a JSONL file and import it here:',
+    command:
+      'hikyo import --from vault --live --mount <mount> [--path <prefix>] --project <project> --environment <environment>',
+  },
+};
+
 /**
- * Browser dotenv import wizard (#495).
+ * Browser import wizard (#495 `.env`; #496 file-mode connectors).
  *
- * A local .env file is read into memory, parsed with the strict grammar
- * (`import-state`), and reviewed BEFORE any plaintext leaves the browser: no
- * value rides a request until the operator starts the reviewed phase-2 write.
- * New keys are classified explicitly (secret by default) and typed only on an
- * accepted suggestion, then declared through the shared create path; values are
- * written per environment through `value.import`, which republishes and refuses
- * a moved state by name. Nothing here is retained in durable browser storage.
+ * A local file is read into memory, parsed on this device (`import-state` for
+ * `.env`, `import-sources` for the connectors), and reviewed BEFORE any
+ * plaintext leaves the browser: no value rides a request until the operator
+ * starts the reviewed phase-2 write. New keys are classified explicitly (secret
+ * by default) and typed only on an accepted suggestion, then declared through
+ * the shared create path (carrying each connector's folder); values are written
+ * per environment through `value.import`, which republishes and refuses a moved
+ * state by name. Nothing here is retained in durable browser storage.
  */
 export function ImportWizard({
   matrixRef,
@@ -82,9 +155,14 @@ export function ImportWizard({
   const createKey = useCreateKey(matrixRef);
   const importValues = useImportValues(matrixRef);
 
-  const [step, setStep] = useState<Step>('source');
+  const [step, setStep] = useState<Step>('pick');
+  const [journey, setJourney] = useState<Journey | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+  // `.env` carries its own parse (with per-line errors); the connectors carry a
+  // normalized entry set plus what they renamed and skipped, or one refusal.
   const [parse, setParse] = useState<ParseResult | null>(null);
+  const [source, setSource] = useState<ConnectorSource | null>(null);
+  const [envSlug, setEnvSlug] = useState('');
   const [selected, setSelected] = useState<ReadonlySet<string>>(
     () => new Set(environments.map((environment) => environment.id)),
   );
@@ -100,7 +178,30 @@ export function ImportWizard({
   const [error, setError] = useState<string | null>(null);
 
   const busy = occurrences.isPending || createKey.isPending || importValues.isPending;
-  const entries = parse?.entries ?? [];
+
+  // The one shape everything downstream reads. `.env` folders onto the root and
+  // is its own source name; the connectors carry their mapped folder and rename.
+  const entries: readonly WorkingEntry[] = useMemo(() => {
+    if (journey?.kind === 'dotenv') {
+      return (parse?.entries ?? []).map((entry) => ({
+        key: entry.key,
+        sourceName: entry.key,
+        value: entry.value,
+        folderPath: '',
+      }));
+    }
+    return source?.entries ?? [];
+  }, [journey, parse, source]);
+
+  const renames = source?.renames ?? [];
+  const sourceSkipped = source?.skipped ?? [];
+  const folderByKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const entry of entries) {
+      map.set(entry.key, entry.folderPath);
+    }
+    return map;
+  }, [entries]);
 
   // A key is new when the project does not declare it; read from any environment
   // (declaration is project-scoped). Empty until phase 1a has run.
@@ -143,6 +244,13 @@ export function ImportWizard({
   const trimSettled = trimOffenders.every((entry) => trimAcks.has(entry.key));
 
   const selectedEnvironments = environments.filter((environment) => selected.has(environment.id));
+
+  const resetChoices = () => {
+    setPresence(new Map());
+    setDeclarations(new Map());
+    setOverwrite(new Map());
+    setTrimAcks(new Set());
+  };
 
   const beginReview = async () => {
     setError(null);
@@ -194,7 +302,7 @@ export function ImportWizard({
     setError(null);
     // Declare new keys first (skipped entirely on a git-managed project). A
     // declaration failure drops that key from the import rather than failing the
-    // whole batch by name at phase 2.
+    // whole batch by name at phase 2. Each new key carries its connector folder.
     const declared: string[] = [];
     const declareFailures: string[] = [];
     if (!gitManaged) {
@@ -205,6 +313,7 @@ export function ImportWizard({
             name,
             classification: declaration.classification,
             rule: { type: declaration.type },
+            folderPath: folderByKey.get(name) ?? '',
             required: { mode: 'none', environmentIds: [] },
             forbidden: { mode: 'none', environmentIds: [] },
           });
@@ -307,6 +416,24 @@ export function ImportWizard({
     return next;
   };
 
+  const chooseJourney = (chosen: Journey) => {
+    setError(null);
+    // Switching journeys invalidates any file read still in flight from the
+    // previous one, so its late-resolving contents cannot land under the new
+    // journey (the same guard `renderFileSource`/dotenv reads use per selection).
+    readSeq.current += 1;
+    parseVersion.current += 1;
+    setJourney(chosen);
+    setFileName(null);
+    setParse(null);
+    setSource(null);
+    setEnvSlug('');
+    resetChoices();
+    setStep('source');
+  };
+
+  const heading = journeyHeading(journey);
+
   return (
     <dialog
       ref={dialog}
@@ -322,7 +449,7 @@ export function ImportWizard({
         <div className="matrix-editor__head">
           <div>
             <p className="matrix-editor__eyebrow">Import</p>
-            <h2>Import a .env file</h2>
+            <h2>{heading}</h2>
             <p>Reviewed on this device; values are sent only when you start the import.</p>
           </div>
           <button
@@ -335,13 +462,15 @@ export function ImportWizard({
           </button>
         </div>
 
-        <p className="notice" role="note">
-          <span aria-hidden="true">⚠</span>
-          <span>
-            The file is read in this browser and reviewed here. Its values are sent only when you
-            start the import, and are never stored by this page.
-          </span>
-        </p>
+        {step !== 'pick' && journey?.kind !== 'cli' ? (
+          <p className="notice" role="note">
+            <span aria-hidden="true">⚠</span>
+            <span>
+              The file is read in this browser and reviewed here. Its values are sent only when you
+              start the import, and are never stored by this page.
+            </span>
+          </p>
+        ) : null}
 
         {error === null ? null : (
           <p className="alert" role="alert">
@@ -350,25 +479,101 @@ export function ImportWizard({
           </p>
         )}
 
-        {step === 'source'
-          ? renderSource()
-          : step === 'classify'
-            ? renderClassify()
-            : step === 'review'
-              ? renderReview()
-              : renderResult()}
+        {step === 'pick'
+          ? renderPick()
+          : step === 'source'
+            ? renderSource()
+            : step === 'classify'
+              ? renderClassify()
+              : step === 'review'
+                ? renderReview()
+                : renderResult()}
       </form>
     </dialog>
   );
 
+  function renderPick() {
+    return (
+      <>
+        <fieldset>
+          <legend>Choose a source</legend>
+          <ul className="import-wizard__sources" aria-label="Import sources">
+            {JOURNEYS.map((option) => (
+              <li key={option.id}>
+                <button
+                  type="button"
+                  className="btn import-wizard__source"
+                  onClick={() => chooseJourney(option.journey)}
+                >
+                  <span className="import-wizard__source-label">{option.label}</span>
+                  <span className="import-wizard__source-hint">{option.hint}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+        </footer>
+      </>
+    );
+  }
+
   function renderSource() {
+    if (journey?.kind === 'cli') {
+      return renderCliGuidance(journey.source);
+    }
+    if (journey?.kind === 'dotenv') {
+      return renderDotenvSource();
+    }
+    if (journey?.kind === 'file') {
+      return renderFileSource(journey.connector);
+    }
+    return null;
+  }
+
+  function renderCliGuidance(cliSource: CliSource) {
+    const guidance = CLI_GUIDANCE[cliSource];
+    return (
+      <>
+        <fieldset>
+          <legend>{guidance.title}</legend>
+          <p className="import-wizard__summary">{guidance.body}</p>
+          <pre className="import-wizard__command" aria-label="CLI command">
+            <code>{guidance.command}</code>
+          </pre>
+        </fieldset>
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={() => setStep('pick')}>
+            Back
+          </button>
+          <button type="button" className="btn btn--primary" onClick={onClose}>
+            Close
+          </button>
+        </footer>
+      </>
+    );
+  }
+
+  function commitReset() {
+    // A new file is a fresh review: drop every choice made against the previous
+    // one so a stale overwrite or trim ack can never apply to a value the
+    // operator has not seen.
+    resetChoices();
+    setStep('source');
+  }
+
+  function renderDotenvSource() {
     const parseErrors = parse?.errors ?? [];
+    const dotenvEntries = parse?.entries ?? [];
     // The server parses the whole file strictly and refuses it entirely on any
     // bad line; phase 2 only ever sees parsed entries, so the browser must
     // enforce that same all-or-nothing gate here rather than partially import a
     // file the Go parser would reject.
     const canContinue =
-      entries.length > 0 && parseErrors.length === 0 && selected.size > 0 && !busy;
+      dotenvEntries.length > 0 && parseErrors.length === 0 && selected.size > 0 && !busy;
     return (
       <>
         <fieldset>
@@ -384,6 +589,19 @@ export function ImportWizard({
               }
               readSeq.current += 1;
               const read = readSeq.current;
+              // Refuse an oversized selection by size before reading it in, and
+              // CLEAR the prior parse so a still-valid earlier file cannot be
+              // imported while this oversized one is selected (bump parseVersion
+              // to invalidate any in-flight review, matching the connector path).
+              if (file.size > MAX_FILE_BYTES) {
+                parseVersion.current += 1;
+                setFileName(file.name);
+                setParse(null);
+                resetChoices();
+                setStep('source');
+                setError(`the file exceeds the ${String(MAX_FILE_BYTES)}-byte per-file cap`);
+                return;
+              }
               const text = await file.text();
               // A newer selection started while this file was being read: its
               // result wins, so drop this stale one entirely.
@@ -395,19 +613,13 @@ export function ImportWizard({
               parseVersion.current += 1;
               setFileName(file.name);
               setParse(parseDotenv(text));
-              // A new file is a fresh review: drop every choice made against the
-              // previous one so a stale overwrite or trim ack can never apply to
-              // a value the operator has not seen.
-              setPresence(new Map());
-              setDeclarations(new Map());
-              setOverwrite(new Map());
-              setTrimAcks(new Set());
-              setStep('source');
+              setSource(null);
+              commitReset();
             }}
           />
           {parse === null ? null : (
             <p className="import-wizard__summary" role="status">
-              {`${fileName ?? 'file'}: ${String(entries.length)} value${entries.length === 1 ? '' : 's'} read` +
+              {`${fileName ?? 'file'}: ${String(dotenvEntries.length)} value${dotenvEntries.length === 1 ? '' : 's'} read` +
                 (parseErrors.length === 0
                   ? ''
                   : `, ${String(parseErrors.length)} invalid line${parseErrors.length === 1 ? '' : 's'} skipped`)}
@@ -430,24 +642,10 @@ export function ImportWizard({
             </>
           )}
         </fieldset>
-
-        <fieldset>
-          <legend>Target environments</legend>
-          {environments.map((environment) => (
-            <label key={environment.id} className="import-wizard__env">
-              <input
-                type="checkbox"
-                checked={selected.has(environment.id)}
-                onChange={() => setSelected((current) => toggle(current, environment.id))}
-              />
-              {environment.name}
-            </label>
-          ))}
-        </fieldset>
-
+        {renderTargets()}
         <footer className="matrix-editor__actions">
-          <button type="button" className="btn" onClick={onClose}>
-            Cancel
+          <button type="button" className="btn" onClick={() => setStep('pick')}>
+            Back
           </button>
           <button
             type="button"
@@ -459,6 +657,125 @@ export function ImportWizard({
           </button>
         </footer>
       </>
+    );
+  }
+
+  function renderFileSource(connector: FileConnector) {
+    const needsSlug = connector === 'infisical';
+    const refusal = source?.refusal ?? null;
+    const canContinue =
+      source !== null && source.refusal === null && source.entries.length > 0 && selected.size > 0 && !busy;
+    const readFile = async (file: File, slug: string) => {
+      readSeq.current += 1;
+      const read = readSeq.current;
+      // Refuse an oversized selection by size BEFORE reading it into memory, so a
+      // multi-gigabyte file cannot exhaust the tab before the connector's own
+      // per-file cap would fire (which only runs after `file.text()`).
+      if (file.size > MAX_FILE_BYTES) {
+        parseVersion.current += 1;
+        setFileName(file.name);
+        setParse(null);
+        setSource({
+          entries: [],
+          renames: [],
+          skipped: [],
+          refusal: `the file exceeds the ${String(MAX_FILE_BYTES)}-byte per-file cap`,
+        });
+        commitReset();
+        return;
+      }
+      const text = await file.text();
+      if (read !== readSeq.current) {
+        return;
+      }
+      parseVersion.current += 1;
+      setFileName(file.name);
+      setParse(null);
+      setSource(toConnectorSource(parseSource(connector, text, { envSlug: slug })));
+      commitReset();
+    };
+    return (
+      <>
+        <fieldset>
+          <legend>{FILE_HINTS[connector].legend}</legend>
+          {needsSlug ? (
+            <label className="import-wizard__slug">
+              Source environment slug
+              <input
+                type="text"
+                aria-label="Source environment slug"
+                value={envSlug}
+                placeholder="prod"
+                onChange={(event) => setEnvSlug(event.target.value)}
+              />
+            </label>
+          ) : null}
+          <input
+            type="file"
+            aria-label={FILE_HINTS[connector].inputLabel}
+            accept={FILE_HINTS[connector].accept}
+            disabled={needsSlug && envSlug.trim() === ''}
+            onChange={async (event) => {
+              const file = event.target.files?.[0] ?? null;
+              if (file === null) {
+                return;
+              }
+              await readFile(file, envSlug.trim());
+            }}
+          />
+          {needsSlug && envSlug.trim() === '' ? (
+            <p className="import-wizard__summary" role="status">
+              Name the source environment slug before choosing the export.
+            </p>
+          ) : null}
+          {source === null ? null : refusal !== null ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">!</span>
+              <span>{refusal}</span>
+            </p>
+          ) : (
+            <p className="import-wizard__summary" role="status">
+              {`${fileName ?? 'file'}: ${String(source.entries.length)} value${source.entries.length === 1 ? '' : 's'} read` +
+                (source.renames.length === 0
+                  ? ''
+                  : `, ${String(source.renames.length)} renamed`) +
+                (source.skipped.length === 0 ? '' : `, ${String(source.skipped.length)} skipped`)}
+            </p>
+          )}
+        </fieldset>
+        {renderTargets()}
+        <footer className="matrix-editor__actions">
+          <button type="button" className="btn" onClick={() => setStep('pick')}>
+            Back
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={!canContinue}
+            onClick={beginReview}
+          >
+            {busy ? 'Reading…' : 'Review'}
+          </button>
+        </footer>
+      </>
+    );
+  }
+
+  function renderTargets() {
+    return (
+      <fieldset>
+        <legend>Target environments</legend>
+        {environments.map((environment) => (
+          <label key={environment.id} className="import-wizard__env">
+            <input
+              type="checkbox"
+              checked={selected.has(environment.id)}
+              onChange={() => setSelected((current) => toggle(current, environment.id))}
+            />
+            {environment.name}
+          </label>
+        ))}
+      </fieldset>
     );
   }
 
@@ -475,6 +792,17 @@ export function ImportWizard({
           </p>
         ) : null}
 
+        {renames.length === 0 ? null : (
+          <fieldset>
+            <legend>Renamed to the canonical grammar</legend>
+            <ul className="import-wizard__renames" aria-label="Renamed keys">
+              {renames.map((rename) => (
+                <li key={rename.from}>{`${rename.from} → ${rename.to}`}</li>
+              ))}
+            </ul>
+          </fieldset>
+        )}
+
         {newKeys.length === 0 ? (
           <p className="import-wizard__summary" role="status">
             Every key is already declared — no classification needed.
@@ -487,13 +815,17 @@ export function ImportWizard({
                 .filter((entry) => entry.key === name)
                 .map((entry) => entry.value);
               const suggestion = suggestType(values);
+              const folder = folderByKey.get(name) ?? '';
               const declaration = declarations.get(name) ?? {
                 classification: 'secret' as const,
                 type: 'string' as const,
               };
               return (
                 <div key={name} className="import-wizard__key">
-                  <span className="import-wizard__key-name">{name}</span>
+                  <span className="import-wizard__key-name">
+                    {name}
+                    {folder === '' ? null : <span className="import-wizard__key-folder">{` · ${folder}`}</span>}
+                  </span>
                   <label className="import-wizard__secret">
                     <input
                       type="checkbox"
@@ -556,6 +888,13 @@ export function ImportWizard({
     const anySendable = importableEntries.length > 0;
     return (
       <>
+        {sourceSkipped.length === 0 ? null : (
+          <p className="import-wizard__summary" role="status">
+            {`${String(sourceSkipped.length)} entr${sourceSkipped.length === 1 ? 'y' : 'ies'} skipped at the source ` +
+              `(personal overrides or deleted): ${sourceSkipped.join(', ')}`}
+          </p>
+        )}
+
         {trimOffenders.length === 0 ? null : (
           <fieldset>
             <legend>Values with surrounding whitespace</legend>
@@ -674,6 +1013,51 @@ export function ImportWizard({
       </>
     );
   }
+}
+
+/** The connector parse, held in wizard state: either the mapped entries (with
+ * their renames and skips) or a single content-free refusal. */
+type ConnectorSource = {
+  readonly entries: readonly WorkingEntry[];
+  readonly renames: readonly { readonly from: string; readonly to: string }[];
+  readonly skipped: readonly string[];
+  readonly refusal: string | null;
+};
+
+function toConnectorSource(result: ReturnType<typeof parseSource>): ConnectorSource {
+  if (!result.ok) {
+    return { entries: [], renames: [], skipped: [], refusal: result.reason };
+  }
+  return {
+    entries: result.entries.map((entry) => ({
+      key: entry.key,
+      sourceName: entry.sourceName,
+      value: entry.value,
+      folderPath: entry.folderPath,
+    })),
+    renames: result.renames,
+    skipped: result.skipped,
+    refusal: null,
+  };
+}
+
+const FILE_HINTS: Record<FileConnector, { legend: string; inputLabel: string; accept: string }> = {
+  k8s: { legend: 'Kubernetes Secret manifest', inputLabel: 'Kubernetes Secret manifest', accept: '.yaml,.yml,.json,text/plain' },
+  infisical: { legend: 'Infisical export', inputLabel: 'Infisical export', accept: '.json,application/json' },
+  vault: { legend: 'Vault / OpenBao JSON Lines capture', inputLabel: 'Vault capture', accept: '.jsonl,.json,text/plain' },
+};
+
+function journeyHeading(journey: Journey | null): string {
+  if (journey === null) {
+    return 'Import into this project';
+  }
+  if (journey.kind === 'dotenv') {
+    return 'Import a .env file';
+  }
+  if (journey.kind === 'file') {
+    return `Import ${FILE_HINTS[journey.connector].legend}`;
+  }
+  return CLI_GUIDANCE[journey.source].title;
 }
 
 function parseType(value: string): PrimitiveType {

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -776,7 +776,7 @@ export function Matrix({
             className="btn matrix__import"
             onClick={() => setImportOpen(true)}
           >
-            Import .env
+            Import
           </button>
         ) : null}
         {/* env-matrix 31 / #492: the header's primary declare action. Git-managed

--- a/web/src/routes/import-sources.test.ts
+++ b/web/src/routes/import-sources.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSource, transformName, safeName, type SourceParse } from './import-sources.ts';
+
+/**
+ * Parity tests for the browser file-mode connectors (#496). The fixtures are
+ * the exact byte content the Go connectors pin in
+ * `internal/importer/testdata/*`; the assertions mirror what those connectors
+ * map or refuse, so a divergence between this preview and the CLI shows up here
+ * (acceptance criterion "equivalent browser and CLI choices produce
+ * semantically identical plans and results").
+ */
+
+function ok(result: SourceParse): Extract<SourceParse, { ok: true }> {
+  if (!result.ok) {
+    throw new Error(`expected ok, got refusal: ${result.reason}`);
+  }
+  return result;
+}
+
+function refusal(result: SourceParse): string {
+  if (result.ok) {
+    throw new Error('expected a refusal, got ok');
+  }
+  return result.reason;
+}
+
+describe('transformName', () => {
+  it('preserves an already-valid name byte-for-byte', () => {
+    expect(transformName('DB_URL')).toEqual({ target: 'DB_URL' });
+  });
+
+  it('uppercases lowercase ASCII and maps -, ., /, \\ to underscore', () => {
+    expect(transformName('db-host')).toEqual({ target: 'DB_HOST' });
+    expect(transformName('db.host')).toEqual({ target: 'DB_HOST' });
+    expect(transformName('a/b')).toEqual({ target: 'A_B' });
+  });
+
+  it('prefixes a leading digit with one underscore', () => {
+    expect(transformName('9lives')).toEqual({ target: '_9LIVES' });
+  });
+
+  it('hard-stops on a byte outside the documented transform', () => {
+    expect(transformName('has space')).toEqual({ error: true });
+    expect(transformName('a=b')).toEqual({ error: true });
+    expect(transformName('café')).toEqual({ error: true });
+    expect(transformName('')).toEqual({ error: true });
+  });
+});
+
+describe('safeName', () => {
+  it('escapes control bytes so a hostile name cannot inject terminal escapes', () => {
+    const rendered = safeName('A\x1b[2J\x1b]0;pwned\x07B');
+    expect(rendered).not.toContain('\x1b');
+    expect(rendered).not.toContain('\x07');
+    expect(rendered).toContain('\\x1b');
+  });
+
+  it('escapes non-ASCII runes and caps the shown length', () => {
+    expect(safeName('caf\u00e9')).toBe('"caf\\u00e9"');
+  });
+});
+
+describe('k8s connector', () => {
+  it('maps a single Secret onto the environment root (no folder)', () => {
+    const { entries, renames, skipped } = ok(
+      parseSource('k8s', 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: solo\n  resourceVersion: "1"\ndata:\n  ALPHA: YWxwaGE=\n  BETA: YmV0YQ==\n'),
+    );
+    expect(entries).toEqual([
+      { key: 'ALPHA', sourceName: 'ALPHA', value: 'alpha', folderPath: '' },
+      { key: 'BETA', sourceName: 'BETA', value: 'beta', folderPath: '' },
+    ]);
+    expect(renames).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it('folders multiple Secrets, overlays stringData, and surfaces renames', () => {
+    const manifest = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: app-db',
+      '  namespace: prod',
+      '  resourceVersion: "8821"',
+      'type: Opaque',
+      'data:',
+      '  DB_PASSWORD: czNjcjN0',
+      '  db-host: ZGIuaW50ZXJuYWw=',
+      '  DB_PORT: NTQzMg==',
+      'stringData:',
+      '  DB_PASSWORD: overlaid-wins',
+      '---',
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: app-api',
+      '  namespace: prod',
+      '  resourceVersion: "8822"',
+      'data:',
+      '  API_KEY: c2tfbGl2ZV9hYmM=',
+      '---',
+      '',
+    ].join('\n');
+    const { entries, renames } = ok(parseSource('k8s', manifest));
+    expect(entries).toEqual([
+      { key: 'API_KEY', sourceName: 'API_KEY', value: 'sk_live_abc', folderPath: 'app-api' },
+      { key: 'DB_HOST', sourceName: 'db-host', value: 'db.internal', folderPath: 'app-db' },
+      // stringData wins over data for DB_PASSWORD (admission merge).
+      { key: 'DB_PASSWORD', sourceName: 'DB_PASSWORD', value: 'overlaid-wins', folderPath: 'app-db' },
+      { key: 'DB_PORT', sourceName: 'DB_PORT', value: '5432', folderPath: 'app-db' },
+    ]);
+    expect(renames).toEqual([{ from: 'db-host', to: 'DB_HOST' }]);
+  });
+
+  it('refuses a duplicate key within one Secret', () => {
+    expect(refusal(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: dup\ndata:\n  A: eA==\n  A: eQ==\n'))).toMatch(
+      /more than once/,
+    );
+  });
+
+  it('refuses a post-transform collision', () => {
+    expect(
+      refusal(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: coll\ndata:\n  db-host: eA==\n  db.host: eQ==\n')),
+    ).toMatch(/collision/);
+  });
+
+  it('refuses a binary (non-UTF-8) value by name', () => {
+    const reason = refusal(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: bin\ndata:\n  BLOB: AAECAw==\n'));
+    expect(reason).toMatch(/not UTF-8/);
+    expect(reason).toContain('BLOB');
+  });
+
+  it('refuses a wrong kind without echoing the field value', () => {
+    const reason = refusal(
+      parseSource('k8s', '{"kind": "\\u001b[2J\\u001b]0;pwned\\u0007 sk_live_KINDLEAK", "metadata": {"name": "x"}, "data": {"A": "eA=="}}'),
+    );
+    expect(reason).toMatch(/`kind` is not `Secret`/);
+    expect(reason).not.toContain('sk_live_KINDLEAK');
+  });
+
+  it('refuses unpadded/whitespace base64 the strict Go decoder would reject', () => {
+    // `YQ` is `atob`-decodable to "a" but is not valid StdEncoding (no padding).
+    expect(refusal(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: s\ndata:\n  TOKEN: YQ\n'))).toMatch(/valid base64/);
+  });
+
+  it('accepts base64 wrapped across lines (Go skips CR/LF)', () => {
+    // A JSON manifest whose data value carries an embedded newline, as a YAML
+    // block scalar would; Go's decoder skips it, so the browser must too.
+    const { entries } = ok(parseSource('k8s', '{"kind":"Secret","metadata":{"name":"s"},"data":{"TOKEN":"YQ==\\n"}}'));
+    expect(entries[0]?.value).toBe('a');
+  });
+
+  it('refuses an unmappable name', () => {
+    expect(refusal(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: bad\ndata:\n  "has space": eA==\n'))).toMatch(
+      /outside the documented transform/,
+    );
+  });
+
+  it('preserves a value the write-time trim would alter (acknowledged later)', () => {
+    // CERT decodes to "-----BEGIN-----\n"; the connector keeps it verbatim, the
+    // wizard's trim acknowledgement handles it.
+    const { entries } = ok(parseSource('k8s', 'kind: Secret\nmetadata:\n  name: trim\ndata:\n  CERT: LS0tLUJFR0lOLS0tLQo=\n'));
+    expect(entries[0]?.value).toBe('----BEGIN----\n');
+  });
+});
+
+describe('infisical connector', () => {
+  const exportJson = JSON.stringify([
+    { key: 'DB_URL', workspace: 'ws_1', value: 'postgres://x', type: 'shared', _id: 'sec_1', secretPath: '/db' },
+    { key: 'api-key', workspace: 'ws_1', value: 'sk_live_x', type: 'shared', _id: 'sec_2', secretPath: '/db' },
+    { key: 'MY_OVERRIDE', workspace: 'ws_1', value: 'personal', type: 'personal', _id: 'sec_3', secretPath: '/db' },
+  ]);
+
+  it('maps shared secrets to folders, skips personal overrides, surfaces renames', () => {
+    const { entries, renames, skipped } = ok(parseSource('infisical', exportJson, { envSlug: 'prod' }));
+    expect(entries).toEqual([
+      { key: 'API_KEY', sourceName: 'api-key', value: 'sk_live_x', folderPath: 'db' },
+      { key: 'DB_URL', sourceName: 'DB_URL', value: 'postgres://x', folderPath: 'db' },
+    ]);
+    expect(renames).toEqual([{ from: 'api-key', to: 'API_KEY' }]);
+    // Skipped names are rendered through safeName (quoted, escaped, capped).
+    expect(skipped).toEqual(['"MY_OVERRIDE"']);
+  });
+
+  it('requires the source env slug', () => {
+    expect(refusal(parseSource('infisical', exportJson))).toMatch(/source environment slug/);
+  });
+
+  it('refuses a flat (dotenv-shaped) export and points at the .env path', () => {
+    expect(refusal(parseSource('infisical', '{"DB_URL":"postgres://x","API_KEY":"sk_live_x"}', { envSlug: 'prod' }))).toMatch(
+      /\.env import/,
+    );
+  });
+
+  it('refuses an entry without secretPath (no folder provenance)', () => {
+    expect(
+      refusal(parseSource('infisical', '[{"key":"DB_URL","value":"postgres://x","type":"shared"}]', { envSlug: 'prod' })),
+    ).toMatch(/secretPath/);
+  });
+
+  it('refuses an entry without type (personal overrides resolved)', () => {
+    expect(
+      refusal(parseSource('infisical', '[{"key":"DB_URL","value":"postgres://x","secretPath":"/"}]', { envSlug: 'prod' })),
+    ).toMatch(/`type`/);
+  });
+
+  it('refuses a case-variant duplicate member (fold-collision, matching the CLI)', () => {
+    expect(
+      refusal(parseSource('infisical', '[{"key":"DB_URL","Key":"other","value":"x","type":"shared","secretPath":"/"}]', { envSlug: 'prod' })),
+    ).toMatch(/more than once/);
+  });
+
+  it('refuses a non-string value instead of coercing it to an empty secret', () => {
+    expect(
+      refusal(parseSource('infisical', '[{"key":"API_KEY","value":123,"type":"shared","secretPath":"/"}]', { envSlug: 'prod' })),
+    ).toMatch(/pinned JSON array/);
+  });
+
+  it('refuses a non-string value even on a personal (skipped) entry', () => {
+    expect(
+      refusal(parseSource('infisical', '[{"key":"X","value":123,"type":"personal","secretPath":"/"}]', { envSlug: 'prod' })),
+    ).toMatch(/pinned JSON array/);
+  });
+
+  it('refuses a hostile type without echoing its value', () => {
+    const reason = refusal(
+      parseSource('infisical', '[{"key": "DB_URL", "value": "x", "type": "\\u001b[2J\\u001b]0;pwned\\u0007 sk_live_TYPELEAK", "secretPath": "/"}]', {
+        envSlug: 'prod',
+      }),
+    );
+    expect(reason).toMatch(/neither `shared` nor `personal`/);
+    expect(reason).not.toContain('sk_live_TYPELEAK');
+  });
+});
+
+describe('vault/openbao connector', () => {
+  it('strips the common prefix to folders, skips deleted, canonicalizes json leaves', () => {
+    const capture = [
+      '{"path":"apps/db/main","mount":"secret","engine_version":2,"secret_version":4,"deleted":false,"destroyed":false,"data":{"DB_URL":"postgres://fixture","OPTIONS":{"pool":5,"ssl":true}}}',
+      '{"path":"apps/old","mount":"secret","engine_version":2,"secret_version":8,"deleted":true,"destroyed":false,"data":{}}',
+      '{"path":"apps/top","mount":"secret","engine_version":2,"secret_version":2,"deleted":false,"destroyed":false,"data":{"API_KEY":"top-secret"}}',
+    ].join('\n');
+    const { entries, skipped } = ok(parseSource('vault', capture));
+    expect(entries).toEqual([
+      { key: 'API_KEY', sourceName: 'API_KEY', value: 'top-secret', folderPath: 'top' },
+      { key: 'DB_URL', sourceName: 'DB_URL', value: 'postgres://fixture', folderPath: 'db/main' },
+      // Non-string leaf → canonical JSON (sorted keys, no spaces), type json.
+      { key: 'OPTIONS', sourceName: 'OPTIONS', value: '{"pool":5,"ssl":true}', folderPath: 'db/main' },
+    ]);
+    expect(skipped).toEqual(['"apps/old"']);
+  });
+
+  it('preserves number literals exactly (no JSON.parse precision loss)', () => {
+    const capture =
+      '{"path":"apps/numbers","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"DECIMAL":0.12345678901234567890123456789,"LARGE_INTEGER":9007199254740993}}';
+    const { entries } = ok(parseSource('vault', capture));
+    expect(entries).toEqual([
+      { key: 'DECIMAL', sourceName: 'DECIMAL', value: '0.12345678901234567890123456789', folderPath: '' },
+      { key: 'LARGE_INTEGER', sourceName: 'LARGE_INTEGER', value: '9007199254740993', folderPath: '' },
+    ]);
+  });
+
+  it('refuses a mixed mount or engine version in one file', () => {
+    const capture = [
+      '{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"X":"1"}}',
+      '{"path":"b","mount":"secret","engine_version":2,"secret_version":1,"deleted":false,"destroyed":false,"data":{"Y":"2"}}',
+    ].join('\n');
+    expect(refusal(parseSource('vault', capture))).toMatch(/one mount and one KV engine version/);
+  });
+
+  it('refuses a duplicate mount+path record', () => {
+    const capture = [
+      '{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"X":"1"}}',
+      '{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"Y":"2"}}',
+    ].join('\n');
+    expect(refusal(parseSource('vault', capture))).toMatch(/more than once/);
+  });
+
+  it('refuses a bare kv-get response (unexpected field) with a pointer to the recipe', () => {
+    expect(refusal(parseSource('vault', '{"request_id":"abc","data":{"X":"1"}}'))).toMatch(/unexpected field|capture record/);
+  });
+
+  it('refuses a non-object data field (a JSON number is not a map)', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":1,"deleted":true,"destroyed":false,"data":1}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/omits required data/);
+  });
+
+  it('refuses a secret_version beyond signed 64-bit range', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":2,"secret_version":9223372036854775808,"deleted":false,"destroyed":false,"data":{"X":"1"}}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/positive secret_version/);
+  });
+
+  it('substitutes U+FFFD for a lone surrogate, matching Go encoding/json', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"OPTS":{"n":"\\ud800"}}}';
+    const { entries } = ok(parseSource('vault', capture));
+    expect(entries[0]?.value).toBe('{"n":"\uFFFD"}');
+  });
+
+  it('refuses a non-integer secret_version (Go int field)', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":2,"secret_version":1.5,"deleted":false,"destroyed":false,"data":{"X":"1"}}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/positive secret_version/);
+  });
+
+  it('refuses a leading-zero number literal (strict JSON)', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":01,"deleted":false,"destroyed":false,"data":{"X":"1"}}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/malformed|engine_version/);
+  });
+
+  it('refuses an unescaped control character inside a JSON string', () => {
+    const capture = '{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"X":"a\tb"}}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/control character/);
+  });
+
+  it('does not let a __proto__ member pollute validation', () => {
+    // `__proto__` is an own key on a null-prototype object → an unexpected field.
+    const capture = '{"__proto__":{"deleted":false,"destroyed":false,"data":{"X":"1"}},"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"X":"1"}}';
+    expect(refusal(parseSource('vault', capture))).toMatch(/unexpected field/);
+  });
+
+  it('refuses a deeply nested leaf at the depth bound instead of overflowing the stack', () => {
+    // A leaf nested far past depth 32; a bounded refusal, never a RangeError.
+    const nested = `${'['.repeat(200)}1${']'.repeat(200)}`;
+    const capture = `{"path":"a","mount":"secret","engine_version":1,"deleted":false,"destroyed":false,"data":{"DEEP":${nested}}}`;
+    expect(refusal(parseSource('vault', capture))).toMatch(/depth bound/);
+  });
+});

--- a/web/src/routes/import-sources.ts
+++ b/web/src/routes/import-sources.ts
@@ -1,0 +1,1065 @@
+import { parseAllDocuments } from 'yaml';
+
+/**
+ * Pure, React-free connector layer for the browser import wizard (#496).
+ *
+ * #495 taught the wizard to read a local `.env` file; this module extends the
+ * same client-side, review-before-transfer journey to the shipped FILE-mode
+ * connectors: Kubernetes Secret manifests, the pinned Infisical export, and the
+ * Vault/OpenBao JSON Lines capture. Each turns foreign bytes into a normalized
+ * record set that feeds the shared classify/collision/apply flow unchanged.
+ *
+ * Everything here mirrors the Go connectors the CLI drives
+ * (`internal/importer/{k8s,infisical,vault,names,importer}.go`) so the browser
+ * preview matches the plan the CLI would author for the same choices (ADR
+ * `docs/adr/import-paths.md`; acceptance criterion "equivalent browser and CLI
+ * choices produce semantically identical plans and results"). The server
+ * re-validates every byte on `value.import`; this mirror exists so the operator
+ * reviews an accurate preview, never so a mismatch can slip a write.
+ *
+ * Two invariants carried over verbatim from the Go framework:
+ *
+ *   - EVERY FOREIGN BYTE IS SECRET UNTIL CLASSIFIED. No refusal here carries
+ *     source content — messages name keys, paths, bounds and codes, never a
+ *     value fragment or a parser's echo. Foreign NAMES are rendered only through
+ *     `safeName` (control bytes escaped, length-capped), the single safe
+ *     renderer, because the ADR requires errors to name keys.
+ *   - WORK IS BOUNDED. File size, record count, per-value size and name length
+ *     are checked while parsing; exceeding one fails loud, naming the bound.
+ *
+ * SOPS (its only mode needs decryption keys) and every live mode (ambient
+ * kubeconfig / Vault client conventions) stay on the CLI: the import-paths ADR
+ * rejects both server-side importers and a browser credential prompt, so those
+ * connectors are surfaced in the picker but routed to the CLI with guidance.
+ */
+
+/** The file-mode connectors the browser can complete. `dotenv` stays in the
+ * wizard's own `import-state` module; these three are this file's subject. */
+export type FileConnector = 'k8s' | 'infisical' | 'vault';
+
+// The uniform bounds, mirroring the one block at the top of
+// `internal/importer/importer.go`. Values match main; a refusal names the bound.
+/** Per-file cap (`importer.MaxFileBytes`); exported so the wizard can refuse an
+ * oversized selection by `file.size` BEFORE reading it into memory. */
+export const MAX_FILE_BYTES = 10 << 20;
+const MAX_DECODED_BYTES = 50 << 20;
+const MAX_RECORDS = 50000;
+const MAX_VALUE_BYTES = 65536;
+const MAX_KEY_NAME_BYTES = 128;
+const MAX_DEPTH = 32;
+/** How much of a foreign NAME any message renders, after escaping. */
+const MAX_SHOWN_NAME_BYTES = 128;
+
+/** KeyName grammar (`schema.CheckKeyName`): ASCII upper-snake, ≤128 bytes. */
+const KEY_NAME = /^[A-Z_][A-Z0-9_]*$/;
+
+/** One normalized leaf: a target key under a folder, with its source name for
+ * the rename surface. `value` is the exact bytes phase 2 will write. */
+export type SourceEntry = {
+  readonly key: string;
+  readonly sourceName: string;
+  readonly value: string;
+  readonly folderPath: string;
+};
+
+/** A surfaced rename (source name → canonical KEY); nothing is renamed unseen. */
+export type SourceRename = { readonly from: string; readonly to: string };
+
+/** The connector's result: a set of entries plus what it skipped and renamed,
+ * OR an all-or-nothing refusal naming keys/paths/bounds (never content). */
+export type SourceParse =
+  | {
+      readonly ok: true;
+      readonly entries: readonly SourceEntry[];
+      readonly renames: readonly SourceRename[];
+      readonly skipped: readonly string[];
+    }
+  | { readonly ok: false; readonly reason: string };
+
+/** A pre-mapping record, as a connector `Read` emits it. `binary` marks a value
+ * whose decoded bytes are not UTF-8 (a K8s Secret can hold arbitrary bytes);
+ * `byteLength` is the exact decoded size the per-value bound checks. */
+type SourceRecord = {
+  readonly folder: readonly string[];
+  readonly sourceName: string;
+  readonly value: string;
+  readonly byteLength: number;
+  readonly binary: boolean;
+};
+
+/** A refusal, thrown by the connectors and caught at the boundary. Carries only
+ * the content-free message the ADR permits. */
+class Refusal extends Error {}
+
+function refuse(message: string): never {
+  throw new Refusal(message);
+}
+
+/** UTF-8 byte length — Go's `len(string)`, which the value/name bounds use. */
+const ENCODER = new TextEncoder();
+function byteLength(value: string): number {
+  return ENCODER.encode(value).length;
+}
+
+/**
+ * The run budget, mirroring `importer.Budget`: it charges EVERY leaf a connector
+ * decodes — record count and decoded bytes — while parsing, so resource
+ * exhaustion is impossible before a result exists and a skipped leaf still costs
+ * its slot (`b.Record`/`b.Bytes` in the Go connectors). Exceeding a bound fails
+ * loud, naming it.
+ */
+type Budget = { record: () => void; bytes: (count: number) => void };
+
+function newBudget(): Budget {
+  let records = 0;
+  let decoded = 0;
+  return {
+    record() {
+      records += 1;
+      if (records > MAX_RECORDS) {
+        refuse(`the source holds more than the ${MAX_RECORDS}-record cap`);
+      }
+    },
+    bytes(count) {
+      decoded += count;
+      if (decoded > MAX_DECODED_BYTES) {
+        refuse(`the source decodes to more than the ${MAX_DECODED_BYTES}-byte cap`);
+      }
+    },
+  };
+}
+
+/**
+ * safeName is THE ONLY way foreign text is rendered by this module — the mirror
+ * of Go's `quoteName`. Control bytes, DEL and the quote/backslash are escaped so
+ * a hostile source name (literally `"\x1b[2J\x1b]0;pwned\x07"`) cannot smuggle
+ * terminal escapes or markup into a message; the length cap runs after escaping,
+ * so the budget is on what is shown. React escapes the DOM, but a refusal string
+ * also reaches logs and copy, so the escaping is load-bearing, not tidy.
+ */
+export function safeName(value: string): string {
+  let out = '"';
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (char === '"') {
+      out += '\\"';
+    } else if (char === '\\') {
+      out += '\\\\';
+    } else if (char === '\n') {
+      out += '\\n';
+    } else if (char === '\t') {
+      out += '\\t';
+    } else if (char === '\r') {
+      out += '\\r';
+    } else if (code < 0x20 || code === 0x7f) {
+      out += `\\x${code.toString(16).padStart(2, '0')}`;
+    } else if (code > 0x7f) {
+      // Non-ASCII is escaped rather than passed through, matching Go %q's
+      // treatment of foreign runes.
+      out += code > 0xffff
+        ? `\\U${code.toString(16).padStart(8, '0')}`
+        : `\\u${code.toString(16).padStart(4, '0')}`;
+    } else {
+      out += char;
+    }
+  }
+  out += '"';
+  return out.length <= MAX_SHOWN_NAME_BYTES ? out : `${out.slice(0, MAX_SHOWN_NAME_BYTES)}..."`;
+}
+
+function recordPath(record: SourceRecord): string {
+  if (record.folder.length === 0) {
+    return safeName(record.sourceName);
+  }
+  return safeName([...record.folder, record.sourceName].join('/'));
+}
+
+/**
+ * transformName maps a source name onto the canonical grammar, mirroring
+ * `importer.TransformName`. The asymmetry is the whole design: a name already
+ * valid is preserved byte-for-byte (a transform on a valid name is a silent
+ * rename); an invalid name goes through ONE documented transform; anything that
+ * transform cannot resolve is a hard stop requiring an explicit rename.
+ *
+ * The documented transform, in full: lowercase ASCII → uppercase; `-`, `.`, `/`,
+ * `\` → `_`; a leading digit takes one leading `_`. Everything else — a space,
+ * `=`, `:`, any non-ASCII — is unmappable.
+ */
+export function transformName(source: string): { readonly target: string } | { readonly error: true } {
+  if (KEY_NAME.test(source) && byteLength(source) <= MAX_KEY_NAME_BYTES) {
+    return { target: source };
+  }
+  if (source === '') {
+    return { error: true };
+  }
+  if (byteLength(source) > MAX_KEY_NAME_BYTES) {
+    return { error: true };
+  }
+  let out = '';
+  const chars = [...source];
+  for (let i = 0; i < chars.length; i += 1) {
+    const char = chars[i] ?? '';
+    const code = char.codePointAt(0) ?? 0;
+    if (char >= 'a' && char <= 'z') {
+      out += char.toUpperCase();
+    } else if ((char >= 'A' && char <= 'Z') || char === '_') {
+      out += char;
+    } else if (char >= '0' && char <= '9') {
+      // A leading digit cannot open a name; one underscore is the documented,
+      // deterministic, surfaced resolution.
+      out += i === 0 ? `_${char}` : char;
+    } else if (char === '-' || char === '.' || char === '/' || char === '\\') {
+      out += '_';
+    } else {
+      // Space, `=`, `:`, any non-ASCII rune (`code > 0x7f`): outside the mapping.
+      void code;
+      return { error: true };
+    }
+  }
+  return KEY_NAME.test(out) ? { target: out } : { error: true };
+}
+
+// ── Lossless JSON ──────────────────────────────────────────────────────────
+//
+// Native `JSON.parse` mangles numbers: `9007199254740993` becomes `…992`, and a
+// long decimal loses precision. The Vault connector's non-string leaves become
+// `json`-typed values through a canonical serialization the CLI pins with
+// exact-number fixtures, so a value that round-trips through `JSON.parse` would
+// diverge from the CLI and be stored wrong. This tiny parser keeps numbers as
+// their source literal, rejects duplicate object members (the CLI's
+// `rejectDuplicateMembers`) and rejects trailing content, so one line of the
+// capture is exactly one record.
+
+/** A number kept as its exact source literal. A class (not a `{__num}` object)
+ * so it can never be confused with a genuine JSON object that has a `__num`
+ * member. */
+class JsonNumber {
+  constructor(readonly literal: string) {}
+}
+type JsonValue = string | boolean | null | JsonNumber | JsonValue[] | { [key: string]: JsonValue };
+
+function isJsonNumber(value: unknown): value is JsonNumber {
+  return value instanceof JsonNumber;
+}
+
+/** A JSON field that is present and non-null but not a string — what Go's typed
+ * `json.Unmarshal` into a `string`/`*string` field refuses. Absent or null is
+ * allowed (Go leaves the zero value / nil). */
+function mistyped(field: JsonValue | undefined): boolean {
+  return field !== undefined && field !== null && typeof field !== 'string';
+}
+
+function isJsonObject(value: unknown): value is { [key: string]: JsonValue } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof JsonNumber);
+}
+
+function parseJsonLossless(text: string): JsonValue {
+  const parser = new JsonParser(text);
+  const value = parser.parseValue();
+  parser.skipWhitespace();
+  if (!parser.atEnd()) {
+    refuse('the JSON carries trailing content after its value');
+  }
+  return value;
+}
+
+class JsonParser {
+  private i = 0;
+  private depth = 0;
+  constructor(private readonly s: string) {}
+
+  atEnd(): boolean {
+    return this.i >= this.s.length;
+  }
+
+  skipWhitespace(): void {
+    while (this.i < this.s.length && ' \t\n\r'.includes(this.s[this.i] ?? '')) {
+      this.i += 1;
+    }
+  }
+
+  parseValue(): JsonValue {
+    this.skipWhitespace();
+    const char = this.s[this.i];
+    // Bound nesting the way `importer.normalizeTree` does (depth 32). Without
+    // this a deeply nested leaf would recurse until the JS stack overflows — an
+    // uncaught error, not a loud refusal at the bound.
+    if (char === '{' || char === '[') {
+      this.depth += 1;
+      if (this.depth > MAX_DEPTH) {
+        refuse(`the JSON nests deeper than the ${MAX_DEPTH}-level depth bound`);
+      }
+      const value = char === '{' ? this.parseObject() : this.parseArray();
+      this.depth -= 1;
+      return value;
+    }
+    if (char === '"') return this.parseString();
+    if (char === '-' || (char !== undefined && char >= '0' && char <= '9')) return this.parseNumber();
+    if (this.s.startsWith('true', this.i)) return this.take('true', true);
+    if (this.s.startsWith('false', this.i)) return this.take('false', false);
+    if (this.s.startsWith('null', this.i)) return this.take('null', null);
+    return refuse('the JSON is malformed');
+  }
+
+  private take<T extends JsonValue>(literal: string, value: T): T {
+    this.i += literal.length;
+    return value;
+  }
+
+  private parseObject(): { [key: string]: JsonValue } {
+    this.i += 1;
+    // A null-prototype object: a member literally named `__proto__` becomes an
+    // ordinary own key rather than mutating the prototype (prototype pollution),
+    // and it then shows up in `Object.keys` for the unknown-field checks.
+    const out: { [key: string]: JsonValue } = Object.create(null);
+    // Duplicate detection is case-insensitive, matching Go's `foldJSONMember`:
+    // `encoding/json` matches struct fields case-insensitively, so `{"a":1,"A":2}`
+    // is a last-value-wins ambiguity the CLI refuses, and the browser must too.
+    const seen = new Set<string>();
+    this.skipWhitespace();
+    if (this.s[this.i] === '}') {
+      this.i += 1;
+      return out;
+    }
+    for (;;) {
+      this.skipWhitespace();
+      if (this.s[this.i] !== '"') refuse('the JSON object is malformed');
+      const key = this.parseString();
+      const folded = key.toLowerCase();
+      if (seen.has(folded)) {
+        refuse(`a JSON object declares the member ${safeName(key)} more than once`);
+      }
+      seen.add(folded);
+      this.skipWhitespace();
+      if (this.s[this.i] !== ':') refuse('the JSON object is malformed');
+      this.i += 1;
+      out[key] = this.parseValue();
+      this.skipWhitespace();
+      const next = this.s[this.i];
+      if (next === ',') {
+        this.i += 1;
+        continue;
+      }
+      if (next === '}') {
+        this.i += 1;
+        return out;
+      }
+      return refuse('the JSON object is malformed');
+    }
+  }
+
+  private parseArray(): JsonValue[] {
+    this.i += 1;
+    const out: JsonValue[] = [];
+    this.skipWhitespace();
+    if (this.s[this.i] === ']') {
+      this.i += 1;
+      return out;
+    }
+    for (;;) {
+      out.push(this.parseValue());
+      this.skipWhitespace();
+      const next = this.s[this.i];
+      if (next === ',') {
+        this.i += 1;
+        continue;
+      }
+      if (next === ']') {
+        this.i += 1;
+        return out;
+      }
+      return refuse('the JSON array is malformed');
+    }
+  }
+
+  private parseString(): string {
+    this.i += 1;
+    let out = '';
+    while (this.i < this.s.length) {
+      const char = this.s[this.i] ?? '';
+      if (char === '"') {
+        this.i += 1;
+        return JsonParser.replaceLoneSurrogates(out);
+      }
+      if (char === '\\') {
+        const esc = this.s[this.i + 1] ?? '';
+        if (esc === 'u') {
+          const hex = this.s.slice(this.i + 2, this.i + 6);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) refuse('the JSON string has a bad \\u escape');
+          out += String.fromCharCode(parseInt(hex, 16));
+          this.i += 6;
+          continue;
+        }
+        const simple: Record<string, string> = {
+          '"': '"', '\\': '\\', '/': '/', b: '\b', f: '\f', n: '\n', r: '\r', t: '\t',
+        };
+        const decoded = simple[esc];
+        if (decoded === undefined) refuse('the JSON string has a bad escape');
+        out += decoded;
+        this.i += 2;
+        continue;
+      }
+      // A literal control byte inside a string is invalid JSON; the Go decoder
+      // rejects it, so an unescaped tab or newline must not be accepted here.
+      if ((char.codePointAt(0) ?? 0) < 0x20) {
+        refuse('the JSON string holds an unescaped control character');
+      }
+      out += char;
+      this.i += 1;
+    }
+    return refuse('the JSON string is unterminated');
+  }
+
+  // Go's `encoding/json` substitutes U+FFFD for an unpaired UTF-16 surrogate
+  // (from a lone `\uD800`-class escape), so a structured value's canonical JSON
+  // matches the CLI byte-for-byte. A valid surrogate PAIR is left intact.
+  private static replaceLoneSurrogates(value: string): string {
+    return value.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '\uFFFD');
+  }
+
+  private parseNumber(): JsonNumber {
+    const start = this.i;
+    if (this.s[this.i] === '-') this.i += 1;
+    while (this.i < this.s.length && /[0-9]/.test(this.s[this.i] ?? '')) this.i += 1;
+    if (this.s[this.i] === '.') {
+      this.i += 1;
+      while (this.i < this.s.length && /[0-9]/.test(this.s[this.i] ?? '')) this.i += 1;
+    }
+    if (this.s[this.i] === 'e' || this.s[this.i] === 'E') {
+      this.i += 1;
+      if (this.s[this.i] === '+' || this.s[this.i] === '-') this.i += 1;
+      while (this.i < this.s.length && /[0-9]/.test(this.s[this.i] ?? '')) this.i += 1;
+    }
+    const literal = this.s.slice(start, this.i);
+    // Strict JSON number grammar: no leading zero (`01`), a fraction and an
+    // exponent each require at least one digit. The Go decoder rejects the rest.
+    if (!/^-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?$/.test(literal)) {
+      refuse('the JSON number is malformed');
+    }
+    return new JsonNumber(literal);
+  }
+}
+
+/**
+ * canonicalJson is THE deterministic conversion for non-scalar leaves, mirroring
+ * `importer.canonicalJSON`: object members ordered by key, HTML escaping OFF
+ * (`<`, `>`, `&` survive — JS `JSON.stringify` already leaves them), no
+ * indentation, no trailing newline, and number literals preserved exactly. A
+ * SOPS array and a Vault object serialize identically through it.
+ */
+function canonicalJson(value: JsonValue): string {
+  if (isJsonNumber(value)) {
+    return value.literal;
+  }
+  if (typeof value === 'string') {
+    return encodeJsonString(value);
+  }
+  if (value === null || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  // Go's `encoding/json` sorts map keys by UTF-8 byte order, which equals
+  // Unicode code-point order; JS `<` sorts by UTF-16 code units, which disagrees
+  // above U+FFFF. Compare by code point so a structured value serializes exactly
+  // as the CLI does.
+  const members = Object.entries(value).sort(([a], [b]) => compareCodePoints(a, b));
+  return `{${members.map(([key, child]) => `${encodeJsonString(key)}:${canonicalJson(child)}`).join(',')}}`;
+}
+
+/** JSON string encoding matching Go's encoder with HTML escaping off: `<`, `>`,
+ * `&` survive, but the line separators U+2028/U+2029 are escaped (Go always
+ * escapes them; JS `JSON.stringify` does not). */
+function encodeJsonString(value: string): string {
+  return JSON.stringify(value).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+}
+
+/** Compares two strings by Unicode code point (== UTF-8 byte order). */
+function compareCodePoints(a: string, b: string): number {
+  const ca = [...a];
+  const cb = [...b];
+  for (let i = 0; i < ca.length && i < cb.length; i += 1) {
+    const pa = ca[i]?.codePointAt(0) ?? 0;
+    const pb = cb[i]?.codePointAt(0) ?? 0;
+    if (pa !== pb) return pa - pb;
+  }
+  return ca.length - cb.length;
+}
+
+// ── Kubernetes Secret manifests ─────────────────────────────────────────────
+
+/**
+ * Parses one or more Kubernetes Secret manifests (YAML or JSON, multi-document
+ * `---` streams included), mirroring `k8s.go`'s file mode. `data` is
+ * base64-decoded, then `stringData` is overlaid and STRINGDATA WINS (Kubernetes'
+ * own admission merge). One Secret → one folder named after it. A wrong `kind`,
+ * a duplicate key within one mapping, and a missing name are refused; the
+ * decoded value's UTF-8/NUL and size checks run uniformly afterwards.
+ */
+function readK8s(text: string, budget: Budget): SourceRecord[] {
+  // `uniqueKeys` refuses a mapping that declares a key twice; the lib's default
+  // `maxAliasCount` (100) caps YAML alias expansion so a billion-laughs bomb
+  // fails loud rather than in the allocator.
+  const documents = parseAllDocuments(text, { uniqueKeys: true });
+  const records: SourceRecord[] = [];
+  const names: string[] = [];
+  documents.forEach((doc, index) => {
+    const where = `document ${index}`;
+    if (doc.errors.length > 0) {
+      const duplicate = doc.errors.find((error) => error.code === 'DUPLICATE_KEY');
+      if (duplicate !== undefined) {
+        refuse(`a key is declared more than once in one mapping (${where})`);
+      }
+      const alias = doc.errors.find((error) => /alias/i.test(error.message));
+      if (alias !== undefined) {
+        refuse(`the ${where} expands beyond the alias/decoded-size bound`);
+      }
+      refuse(`the ${where} is not parseable as YAML or JSON`);
+    }
+    let object: unknown;
+    try {
+      object = doc.toJS();
+    } catch (caught) {
+      if (caught instanceof Error && /alias/i.test(caught.message)) {
+        refuse(`the ${where} expands beyond the alias/decoded-size bound`);
+      }
+      refuse(`the ${where} is not parseable as YAML or JSON`);
+    }
+    // An empty document — a trailing `---` — is skipped, as `kubectl` emits them.
+    if (object === null || object === undefined) {
+      return;
+    }
+    if (!isObject(object)) {
+      refuse(`the ${where} is not shaped like a Kubernetes Secret manifest`);
+    }
+    const manifest = object;
+    const kind = manifest.kind;
+    if (kind !== 'Secret') {
+      // The refused value is NOT echoed: `kind` is a foreign field a document
+      // can fill with a token or an escape sequence. Naming the field says all.
+      refuse(`the ${where}'s \`kind\` is not \`Secret\`; this connector reads Kubernetes Secret manifests only`);
+    }
+    const metadata = isObject(manifest.metadata) ? manifest.metadata : {};
+    const name = typeof metadata.name === 'string' ? metadata.name : '';
+    if (name === '') {
+      refuse(`the Secret in ${where} carries no metadata.name; one Secret maps onto one folder named after it`);
+    }
+    names.push(name);
+    const merged = new Map<string, { value: string; byteLength: number; binary: boolean }>();
+    const data = manifest.data;
+    if (data !== undefined && data !== null) {
+      if (!isObject(data)) {
+        refuse(`the Secret ${safeName(name)} in ${where} is not shaped like a Kubernetes Secret manifest`);
+      }
+      for (const dataKey of Object.keys(data).sort()) {
+        const encoded = data[dataKey];
+        if (typeof encoded !== 'string') {
+          refuse(`the Secret ${safeName(name)} \`data\` entry ${safeName(dataKey)} is not a base64 string`);
+        }
+        const decoded = decodeK8sData(name, dataKey, encoded);
+        // Charge the DECODED bytes, matching Go's `b.Bytes(len(raw))` after
+        // base64 decoding — the file cap alone does not bound base64 expansion.
+        budget.bytes(decoded.byteLength);
+        merged.set(dataKey, decoded);
+      }
+    }
+    const stringData = manifest.stringData;
+    if (stringData !== undefined && stringData !== null) {
+      if (!isObject(stringData)) {
+        refuse(`the Secret ${safeName(name)} in ${where} is not shaped like a Kubernetes Secret manifest`);
+      }
+      for (const stringKey of Object.keys(stringData).sort()) {
+        const raw = stringData[stringKey];
+        if (typeof raw !== 'string') {
+          refuse(`the Secret ${safeName(name)} \`stringData\` entry ${safeName(stringKey)} is not a string`);
+        }
+        budget.bytes(byteLength(raw));
+        // stringData wins, silently and correctly — the admission merge.
+        merged.set(stringKey, { value: raw, byteLength: byteLength(raw), binary: raw.includes('\u0000') });
+      }
+    }
+    for (const key of [...merged.keys()].sort()) {
+      const leaf = merged.get(key);
+      if (leaf === undefined) continue;
+      budget.record();
+      records.push({ folder: [name], sourceName: key, value: leaf.value, byteLength: leaf.byteLength, binary: leaf.binary });
+    }
+  });
+  if (records.length === 0) {
+    refuse('the file holds no Kubernetes Secret manifest with any entry');
+  }
+  return records;
+}
+
+/** Decodes one `data` value from base64 and classifies its bytes. A K8s Secret
+ * can hold arbitrary bytes; a value that is not UTF-8 text (or carries NUL) is
+ * marked binary and refused by name in the uniform value check. */
+function decodeK8sData(
+  secret: string,
+  key: string,
+  encoded: string,
+): { value: string; byteLength: number; binary: boolean } {
+  // Go's `base64.StdEncoding.DecodeString` is strict on the alphabet, requires
+  // correct `=` padding, and a length that is a multiple of 4 — but it DOES skip
+  // `\r`/`\n` (a YAML block scalar can wrap base64 across lines). `atob` is
+  // otherwise too forgiving (accepts unpadded input, ignores all whitespace), so
+  // strip only CR/LF, then validate strictly, or the browser would decode bytes
+  // the CLI refuses (and vice versa).
+  const cleaned = encoded.replace(/[\r\n]/g, '');
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(cleaned) || cleaned.length % 4 !== 0) {
+    refuse(`the Secret ${safeName(secret)} \`data\` entry ${safeName(key)} is not valid base64`);
+  }
+  let bytes: Uint8Array;
+  try {
+    const binaryString = atob(cleaned);
+    bytes = Uint8Array.from(binaryString, (char) => char.charCodeAt(0));
+  } catch {
+    refuse(`the Secret ${safeName(secret)} \`data\` entry ${safeName(key)} is not valid base64`);
+  }
+  let value = '';
+  let binary = bytes.includes(0);
+  try {
+    value = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    binary = true;
+  }
+  return { value, byteLength: bytes.length, binary };
+}
+
+// ── Infisical pinned export ─────────────────────────────────────────────────
+
+const INFISICAL_MINIMUM_VERSION = 'v0.43.0';
+
+/**
+ * Parses the pinned Infisical export (`infisical export --format=json`),
+ * mirroring `infisical.go`. A JSON array of `{key,value,type,secretPath,_id}`;
+ * `secretPath` maps onto a folder chain. A flat object is a dotenv export
+ * wearing JSON and is routed to the `.env` path; an entry without `secretPath`
+ * (no folder provenance) or without `type` (personal overrides already resolved)
+ * is refused; `type: "personal"` entries are skipped and listed by name.
+ */
+function readInfisical(text: string, budget: Budget): { records: SourceRecord[]; skipped: string[] } {
+  const trimmed = text.trim();
+  if (trimmed === '') {
+    refuse('the Infisical export is empty');
+  }
+  if (trimmed[0] !== '[') {
+    refuse(
+      'this is not the pinned structured export (a JSON array): a flattened export carries no folder or ' +
+        'override provenance — export it with `infisical export --format=json --env <slug> --path <path>` (' +
+        `${INFISICAL_MINIMUM_VERSION} or newer), or route the flattened form through the .env import instead`,
+    );
+  }
+  const parsed = parseJsonLossless(trimmed);
+  if (!Array.isArray(parsed)) {
+    refuse('the export is not the pinned JSON array of secret entries');
+  }
+  if (parsed.length === 0) {
+    refuse('the export holds no secrets');
+  }
+  const records: SourceRecord[] = [];
+  const skipped: string[] = [];
+  parsed.forEach((raw, index) => {
+    const where = `entry ${index}`;
+    if (!isJsonObject(raw)) {
+      refuse(`the ${where} is not a secret object`);
+    }
+    const entry = raw;
+    // Mirror Go's typed `json.Unmarshal`: a field present with the wrong JSON
+    // type refuses the WHOLE export (before mapping and before the personal-skip
+    // branch), never coerces. Coercing a non-string `value` to `""` — the
+    // pre-fix behaviour — declared and imported an empty secret where the CLI
+    // refuses the file.
+    if (mistyped(entry.key) || mistyped(entry.value) || mistyped(entry.type) ||
+        mistyped(entry.secretPath) || mistyped(entry['_id'])) {
+      refuse(`the ${where} is not the pinned JSON array of secret entries`);
+    }
+    // Charge every entry before the personal-skip branch (Go's `b.Record` per
+    // entry): a skipped override still costs its record slot.
+    budget.record();
+    const key = typeof entry.key === 'string' ? entry.key : '';
+    if (key === '') {
+      refuse(`the ${where} carries no \`key\``);
+    }
+    const named = `key ${safeName(key)}`;
+    if (!('secretPath' in entry) || typeof entry.secretPath !== 'string') {
+      refuse(`the ${named} carries no \`secretPath\`: this export has no folder provenance and cannot be mapped`);
+    }
+    if (!('type' in entry) || typeof entry.type !== 'string') {
+      refuse(
+        `the ${named} carries no \`type\`: personal overrides are indistinguishable from shared secrets, ` +
+          'so this export has already resolved them into values',
+      );
+    }
+    const type = entry.type;
+    if (type === 'personal') {
+      skipped.push(safeName(key));
+      return;
+    }
+    if (type !== 'shared') {
+      // `type` is a foreign enum-shaped field; its value is not echoed.
+      refuse(`the ${named}'s \`type\` is neither \`shared\` nor \`personal\``);
+    }
+    const value = typeof entry.value === 'string' ? entry.value : '';
+    budget.bytes(byteLength(value));
+    const folder = infisicalFolder(named, entry.secretPath);
+    if (folder.length > MAX_DEPTH) {
+      refuse(`the ${named} folder path exceeds the ${MAX_DEPTH}-level depth bound`);
+    }
+    records.push({ folder, sourceName: key, value, byteLength: byteLength(value), binary: value.includes('\u0000') });
+  });
+  if (records.length === 0) {
+    refuse('every entry in the export is a personal override; there is no shared secret to import');
+  }
+  skipped.sort();
+  return { records, skipped };
+}
+
+/** Maps `secretPath` onto a folder chain; `/` is the root and maps onto none. */
+function infisicalFolder(where: string, path: string): string[] {
+  if (!path.startsWith('/')) {
+    refuse(`the ${where} \`secretPath\` is not absolute; the pinned export spells folder paths from the root`);
+  }
+  return path.split('/').filter((segment) => segment !== '');
+}
+
+// ── Vault / OpenBao JSON Lines capture ──────────────────────────────────────
+
+/**
+ * Parses the pinned Vault/OpenBao JSON Lines capture, mirroring `vault.go`'s
+ * file mode. One object per line: `{path,mount,engine_version,secret_version?,
+ * deleted,destroyed,data}`. Path segments below the common prefix become a
+ * folder chain; non-string field values become `json` leaves through the
+ * canonical serialization; deleted/destroyed records are skipped by name. One
+ * capture file must describe one mount and one engine version.
+ */
+function readVault(text: string, budget: Budget): { records: SourceRecord[]; skipped: string[] } {
+  type Capture = {
+    path: string;
+    mount: string;
+    engineVersion: number;
+    secretVersion: number | null;
+    deleted: boolean;
+    destroyed: boolean;
+    data: { [key: string]: JsonValue };
+  };
+  const captures: Capture[] = [];
+  const seen = new Set<string>();
+  const lines = text.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = (lines[index] ?? '').trim();
+    if (raw === '') continue;
+    const where = `line ${index + 1}`;
+    const parsed = parseJsonLossless(raw);
+    if (!isJsonObject(parsed)) {
+      refuse(
+        `the ${where} is not one pinned Vault/OpenBao capture record; see ` +
+          'docs/handoff/69-import-live-connectors.md#vaultopenbao-capture-recipe',
+      );
+    }
+    const capture = validateVaultCapture(parsed, where);
+    const identity = `${capture.mount}\u0000${capture.path}`;
+    if (seen.has(identity)) {
+      refuse(`the capture file declares this mount and canonical secret path more than once (${where})`);
+    }
+    seen.add(identity);
+    if (pathSegments(capture.path).length > MAX_DEPTH) {
+      refuse(`the ${where} secret path exceeds the ${MAX_DEPTH}-level depth bound`);
+    }
+    // Charge every record now (Go charges in this first pass): a deleted/
+    // destroyed record costs one slot, a live one costs a slot per data field —
+    // so a capture of 50 000 deleted records cannot walk past the record cap.
+    if (capture.deleted || capture.destroyed) {
+      budget.record();
+    } else {
+      for (const _field of Object.keys(capture.data)) {
+        void _field;
+        budget.record();
+      }
+    }
+    captures.push(capture);
+  }
+  if (captures.length === 0) {
+    refuse('the file holds no Vault/OpenBao JSON Lines capture record');
+  }
+  captures.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const mount = captures[0]?.mount ?? '';
+  const version = captures[0]?.engineVersion ?? 0;
+  for (const capture of captures) {
+    if (capture.mount !== mount || capture.engineVersion !== version) {
+      refuse('one capture file must describe one mount and one KV engine version');
+    }
+  }
+  const prefix = commonPathPrefix(captures.map((capture) => pathSegments(capture.path)));
+  const records: SourceRecord[] = [];
+  const skipped: string[] = [];
+  for (const capture of captures) {
+    if (capture.deleted || capture.destroyed) {
+      skipped.push(safeName(capture.path));
+      continue;
+    }
+    const folder = pathSegments(stripPrefix(capture.path, prefix));
+    for (const [name, field] of Object.entries(capture.data).sort(([a], [b]) => compareCodePoints(a, b))) {
+      const value = typeof field === 'string' ? field : canonicalJson(field);
+      budget.bytes(byteLength(value));
+      records.push({ folder, sourceName: name, value, byteLength: byteLength(value), binary: value.includes('\u0000') });
+    }
+  }
+  if (records.length === 0) {
+    refuse('the capture holds no current Vault/OpenBao KV field');
+  }
+  return { records, skipped };
+}
+
+function validateVaultCapture(
+  raw: Record<string, JsonValue>,
+  where: string,
+): {
+  path: string;
+  mount: string;
+  engineVersion: number;
+  secretVersion: number | null;
+  deleted: boolean;
+  destroyed: boolean;
+  data: { [key: string]: JsonValue };
+} {
+  const known = new Set(['path', 'mount', 'engine_version', 'secret_version', 'deleted', 'destroyed', 'data']);
+  for (const field of Object.keys(raw)) {
+    if (!known.has(field)) {
+      refuse(`the ${where} carries an unexpected field ${safeName(field)}`);
+    }
+  }
+  const missing: string[] = [];
+  if (!('deleted' in raw) || typeof raw.deleted !== 'boolean') missing.push('deleted');
+  if (!('destroyed' in raw) || typeof raw.destroyed !== 'boolean') missing.push('destroyed');
+  // `isJsonObject`, not the generic `isObject`: a `JsonNumber` is a class
+  // instance and would pass `isObject`, letting `"data":1` slip through (Go's
+  // typed decode into a map refuses the whole file).
+  if (!('data' in raw) || !isJsonObject(raw.data)) missing.push('data');
+  if (missing.length > 0) {
+    refuse(`the ${where} capture record omits required ${missing.join(', ')}`);
+  }
+  const mount = typeof raw.mount === 'string' ? raw.mount : '';
+  if (mount === '' || mount.includes('/')) {
+    refuse(`the ${where} capture record carries no single mount name`);
+  }
+  const path = typeof raw.path === 'string' ? raw.path : '';
+  if (!canonicalSourcePath(path)) {
+    refuse(`the ${where} capture record carries no canonical secret path`);
+  }
+  // engine_version and secret_version are Go `int` fields: a fractional or
+  // exponent literal (`1.5`, `2e0`) cannot unmarshal into `int` and is refused.
+  const engineVersion = isJsonNumber(raw.engine_version) ? asInteger(raw.engine_version) : null;
+  if (engineVersion !== 1 && engineVersion !== 2) {
+    refuse(`the ${where} capture record's engine_version is neither 1 nor 2`);
+  }
+  const secretVersion = isJsonNumber(raw.secret_version) ? asInteger(raw.secret_version) : null;
+  if (engineVersion === 1 && 'secret_version' in raw) {
+    refuse(`a KV v1 capture record carries a v2 secret_version (${where})`);
+  }
+  if (engineVersion === 2 && (secretVersion === null || secretVersion < 1)) {
+    refuse(`a KV v2 capture record carries no positive secret_version (${where})`);
+  }
+  const data = isJsonObject(raw.data) ? raw.data : {};
+  const deleted = raw.deleted === true;
+  const destroyed = raw.destroyed === true;
+  if (!deleted && !destroyed && Object.keys(data).length === 0) {
+    refuse(`a current capture record carries no data fields (${where})`);
+  }
+  return { path, mount, engineVersion, secretVersion, deleted, destroyed, data };
+}
+
+const INT64_MIN = -9223372036854775808n;
+const INT64_MAX = 9223372036854775807n;
+
+/** A JSON number as a Go `int`: the exact integer, or null if the literal is
+ * fractional, has an exponent, or overflows signed 64-bit — all of which
+ * `json.Unmarshal` into `int` refuses. */
+function asInteger(number: JsonNumber): number | null {
+  if (!/^-?[0-9]+$/.test(number.literal)) {
+    return null;
+  }
+  const magnitude = BigInt(number.literal);
+  if (magnitude < INT64_MIN || magnitude > INT64_MAX) {
+    return null;
+  }
+  return Number(magnitude);
+}
+
+function pathSegments(value: string): string[] {
+  const trimmed = value.replace(/^\/+/, '').replace(/\/+$/, '');
+  return trimmed === '' ? [] : trimmed.split('/');
+}
+
+function canonicalSourcePath(value: string): boolean {
+  const segments = pathSegments(value);
+  if (segments.length === 0 || segments.join('/') !== value) {
+    return false;
+  }
+  return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+function commonPathPrefix(paths: string[][]): string {
+  if (paths.length === 0) return '';
+  let prefix = [...(paths[0] ?? [])];
+  for (const candidate of paths.slice(1)) {
+    let i = 0;
+    while (i < prefix.length && i < candidate.length && prefix[i] === candidate[i]) i += 1;
+    prefix = prefix.slice(0, i);
+  }
+  return prefix.join('/');
+}
+
+function stripPrefix(path: string, prefix: string): string {
+  return prefix !== '' && path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+// ── Mapping, bounds, and the boundary ───────────────────────────────────────
+
+/** Validates one target folder path, mirroring `targetFolderPath`: no empty or
+ * reserved segment, no surrounding whitespace, no separator inside a segment. */
+function targetFolderPath(folder: readonly string[]): string {
+  for (const segment of folder) {
+    if (segment === '' || segment === '.' || segment === '..' || segment.trim() !== segment || segment.includes('/')) {
+      refuse(`a folder path segment in ${safeName(folder.join('/'))} is empty, reserved, or malformed`);
+    }
+  }
+  return folder.join('/');
+}
+
+/**
+ * mapRecords runs the rename transform and the post-transform collision check
+ * over every record, mirroring `plan.go`'s `mapRecords`. Every offender is
+ * collected before refusing — an unmappable or colliding name is one fix in one
+ * edit, not one run each. `k8s` collapses a single-Secret folder onto the
+ * environment root; other connectors carry their folder chain.
+ */
+function mapRecords(
+  connector: FileConnector,
+  records: readonly SourceRecord[],
+): { entries: SourceEntry[]; renames: SourceRename[] } {
+  const rootCollapse = connector === 'k8s' && singleSourceFolder(records);
+  const rows: SourceEntry[] = [];
+  const renames: SourceRename[] = [];
+  const unmappable: string[] = [];
+  const collisions: string[] = [];
+  const origin = new Map<string, string>();
+  for (const record of records) {
+    const sourcePath = recordPath(record);
+    const transformed = transformName(record.sourceName);
+    if ('error' in transformed) {
+      unmappable.push(sourcePath);
+      continue;
+    }
+    const target = transformed.target;
+    if (target !== record.sourceName) {
+      renames.push({ from: record.sourceName, to: target });
+    }
+    const prior = origin.get(target);
+    if (prior !== undefined) {
+      collisions.push(`${prior} and ${sourcePath} both map onto ${safeName(target)}`);
+      continue;
+    }
+    origin.set(target, sourcePath);
+    const folderPath = rootCollapse ? '' : targetFolderPath(record.folder);
+    rows.push({ key: target, sourceName: record.sourceName, value: record.value, folderPath });
+  }
+  if (unmappable.length > 0) {
+    unmappable.sort();
+    refuse(
+      `${unmappable.length} source name(s) fall outside the documented transform; rename each explicitly at ` +
+        `the source or import through the CLI: ${unmappable.join(', ')}`,
+    );
+  }
+  if (collisions.length > 0) {
+    collisions.sort();
+    refuse(`${collisions.length} post-transform collision(s); resolve each with an explicit rename: ${collisions.join('; ')}`);
+  }
+  rows.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  renames.sort((a, b) => (a.from < b.from ? -1 : a.from > b.from ? 1 : 0));
+  return { entries: rows, renames };
+}
+
+function singleSourceFolder(records: readonly SourceRecord[]): boolean {
+  const seen = new Set<string>();
+  for (const record of records) {
+    seen.add(record.folder.join('/'));
+    if (seen.size > 1) return false;
+  }
+  return seen.size === 1;
+}
+
+/** The uniform per-value bound and UTF-8/NUL rule, mirroring `validateResult`:
+ * both name every offending key at once. */
+function validateRecords(records: readonly SourceRecord[]): void {
+  if (records.length > MAX_RECORDS) {
+    refuse(`the source holds ${records.length} records, over the ${MAX_RECORDS}-record cap`);
+  }
+  const oversized: string[] = [];
+  const binary: string[] = [];
+  for (const record of records) {
+    if (record.byteLength > MAX_VALUE_BYTES) {
+      oversized.push(recordPath(record));
+    } else if (record.binary) {
+      binary.push(recordPath(record));
+    }
+  }
+  if (oversized.length > 0) {
+    refuse(`${oversized.length} value(s) exceed the ${MAX_VALUE_BYTES}-byte per-value cap: ${oversized.join(', ')}`);
+  }
+  if (binary.length > 0) {
+    refuse(
+      `${binary.length} value(s) are not UTF-8 text (invalid encoding or a NUL byte); Hikyo values are UTF-8 text: ` +
+        binary.join(', '),
+    );
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * parseSource is the boundary: it runs the named connector over the file text
+ * and returns the normalized entries, renames and skips — or a single
+ * content-free refusal. Infisical requires its source env slug; the others take
+ * none. The order of checks mirrors the CLI: file size → parse → per-value
+ * bounds → name mapping and collisions.
+ */
+export function parseSource(
+  connector: FileConnector,
+  text: string,
+  options: { readonly envSlug?: string } = {},
+): SourceParse {
+  try {
+    if (byteLength(text) > MAX_FILE_BYTES) {
+      refuse(`the file exceeds the ${MAX_FILE_BYTES}-byte per-file cap`);
+    }
+    const budget = newBudget();
+    let records: SourceRecord[];
+    let skipped: string[] = [];
+    if (connector === 'k8s') {
+      records = readK8s(text, budget);
+    } else if (connector === 'infisical') {
+      if (options.envSlug === undefined || options.envSlug === '') {
+        refuse('an Infisical import names its source slice: choose the source environment slug');
+      }
+      const result = readInfisical(text, budget);
+      records = result.records;
+      skipped = result.skipped;
+    } else {
+      const result = readVault(text, budget);
+      records = result.records;
+      skipped = result.skipped;
+    }
+    validateRecords(records);
+    const { entries, renames } = mapRecords(connector, records);
+    return { ok: true, entries, renames, skipped };
+  } catch (caught) {
+    if (caught instanceof Refusal) {
+      return { ok: false, reason: caught.message };
+    }
+    throw caught;
+  }
+}

--- a/web/src/routes/import-state.ts
+++ b/web/src/routes/import-state.ts
@@ -258,7 +258,9 @@ export type EnvironmentPlan = {
 };
 
 export function planEnvironment(
-  entries: readonly ParsedEntry[],
+  // Only the key is read; `.env` passes `ParsedEntry`, the connectors pass their
+  // own richer entry — both carry `key`, which is all bucketing needs.
+  entries: readonly { readonly key: string }[],
   occurrences: OccurrenceIndex,
   overwrite: ReadonlySet<string>,
 ): EnvironmentPlan {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5072,3 +5072,65 @@ select {
 .import-wizard__error {
   color: var(--danger);
 }
+
+.import-wizard__sources {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.import-wizard__source {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  min-height: var(--touch);
+  padding: 10px 12px;
+  text-align: start;
+}
+
+.import-wizard__source-label {
+  font-weight: 600;
+}
+
+.import-wizard__source-hint {
+  color: var(--tx-dim);
+  font-size: 12px;
+}
+
+.import-wizard__slug {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-block-end: 8px;
+  font-size: 13px;
+}
+
+.import-wizard__renames {
+  margin: 0;
+  padding-inline-start: 18px;
+  color: var(--tx-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.import-wizard__key-folder {
+  color: var(--tx-dim);
+  font-weight: 400;
+}
+
+.import-wizard__command {
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raise), var(--tx) 8%);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}


### PR DESCRIPTION
Closes #496. Extends the browser import journey (#495, `.env`) to the shipped **file-mode** connectors — Kubernetes Secret manifests, the pinned Infisical export, and the Vault/OpenBao JSON Lines capture — reusing the same review → classify → collision → apply UI and the **same two server operations** (`import.presence`, `value.import`). No codegen, no API change, no server change, no migration.

## Contract decision (approved by the owner)

Acceptance criterion 1 ("every shipped connector through the browser") cannot be met literally for **SOPS** and **live** modes: the locked import-paths ADR rejects *both* server-side importers **and** a browser credential prompt (live connectors use "the source's own ambient conventions and nothing else"; SOPS uses "the ambient decryption keyring exactly as `sops -d` resolves it"). So those are **selectable in the picker but routed to the CLI** with the exact command/capture recipe; widening the browser to them needs an ADR amendment (out of scope). Detail: `docs/handoff/496-import-connectors-webui.md`. The ADR itself blesses the capture-file fallback ("file mode remains available everywhere live mode exists").

Under that boundary, **4 of 5 connectors complete in the browser** (Vault + OpenBao share one JSONL parser).

## What ships

- `web/src/routes/import-sources.ts` — pure connector layer mirroring `internal/importer/{k8s,infisical,vault,names,importer}.go`: the rename transform, the safe foreign-name renderer, post-transform collision, a **lossless JSON parser** (exact number literals, so a Vault structured leaf's canonical JSON matches the CLI byte-for-byte), and the uniform bounds/budget (10 MiB file, 50 MiB decoded, 50 000 records, 64 KiB value, depth 32) charged during parse.
- `web/src/routes/ImportWizard.tsx` — generalized from `.env`-only into a source picker + the shared flow, threading each connector's folder into `createKey`, surfacing renames/skips, and the SOPS/live CLI-guidance panel.
- New dependency: `yaml@2.9.0` (K8s manifests are YAML; untrusted parse → known lib over hand-rolled, bounds enforced around it).

## Parity is tested, not asserted

`import-sources.test.ts` uses the exact byte content of `internal/importer/testdata/*`; assertions mirror what the Go connectors map or refuse (stringData-wins overlay, single-Secret→root, base64 CR/LF handling, non-string-value refusal, `__proto__`/lone-surrogate/leading-zero/control-char/int64-range edge cases, case-fold duplicate members). A Kubernetes journey rides `flows/matrix.spec.ts` beside the `.env` journey (no new registry surface).

## Validation

- `pnpm --dir web typecheck` — clean.
- `pnpm --dir web test` — 499 passed (66 files), incl. the new connector parity + wizard suites.
- `pnpm --dir web build` — clean.
- Playwright, `flows/matrix.spec.ts` (`-g import`): desktop 2/2, mobile 2/2 (fresh instance per project, as CI runs them).
- Cross-model review (native Codex `gpt-5.6-sol`, high): R1 (5 findings) → R2 (4 findings) → **R3 CLEAN**.

Regenerated artifacts: none (both ops pre-existed in the committed client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)