### PR TITLE
feat(web): manage receiving-side connection credentials in the WebUI (#498)

### DIFF
--- a/web/e2e/flows/workspace.spec.ts
+++ b/web/e2e/flows/workspace.spec.ts
@@ -66,6 +66,40 @@ function card(page: Page) {
   return page.locator('.remote').filter({ hasText: REMOTE_NAME });
 }
 
+/**
+ * revokeConnectionByLabel is best-effort test cleanup: it retires any live
+ * connection credential carrying `label`, from inside B's own origin so the
+ * session cookie and its synchronizer token are both present. It never throws —
+ * a failed cleanup must not mask the assertion that actually failed.
+ */
+async function revokeConnectionByLabel(page: Page, label: string): Promise<void> {
+  await page
+    .evaluate(async (wanted) => {
+      const csrf =
+        document.cookie
+          .split(';')
+          .map((part) => part.trim())
+          .find((part) => part.startsWith('__Host-hikyo-csrf='))
+          ?.slice('__Host-hikyo-csrf='.length) ?? '';
+      const listed = await fetch('/api/v1/instance/connections');
+      if (!listed.ok) return;
+      const body: unknown = await listed.json();
+      const items =
+        typeof body === 'object' && body !== null && 'items' in body
+          ? (body as { items: { id: string; label: string; revoked_at?: string }[] }).items
+          : [];
+      for (const item of items) {
+        if (item.label === wanted && item.revoked_at === undefined) {
+          await fetch(`/api/v1/instance/connections/${item.id}`, {
+            method: 'DELETE',
+            headers: { 'X-Hikyo-CSRF': csrf },
+          });
+        }
+      }
+    }, label)
+    .catch(() => undefined);
+}
+
 test.describe('multi-instance', () => {
   test.use({ storageState: STORAGE_STATE });
 
@@ -105,6 +139,97 @@ test.describe('multi-instance', () => {
     // instance's own.
     await expect(entry.getByText('Identity')).toBeVisible();
     await expect(entry).not.toContainText('not yet observed');
+  });
+
+  /**
+   * The receiving side, end to end (#498). The serving instance's operator
+   * mints a connection credential IN THE UI, a peer presents it at the one
+   * endpoint it may reach — the directory fetch — and it authenticates.
+   * Revoking it through the UI, after the consequence is stated, refuses the
+   * very next presentation.
+   *
+   * It mints its OWN uniquely-labelled credential and never touches the seeded
+   * one every sibling test depends on. The connect-and-refuse legs run through
+   * an EXPLICITLY cookie-less request context, so the credential — not an
+   * ambient session — is provably what authenticates: a no-auth control against
+   * the same endpoint is refused, and only the bearer turns that into a 200,
+   * which is exactly what a peer instance's server-side directory fetch does.
+   *
+   * A `finally` revokes the credential by label whatever happens, so a failure
+   * before the UI revoke neither leaves a live credential nor a usable one in a
+   * retained trace: a revoked value is inert.
+   */
+  test('mints a connection credential in the UI, a peer connects with it, and revocation refuses the next fetch', async ({
+    page,
+    playwright,
+  }) => {
+    await onB(page, '/remotes');
+    const section = page.locator('#connection-credentials');
+    await expect(section).toBeVisible();
+
+    const label = `e2e connection ${Date.now()}`;
+    // A context with no storage state carries no cookies — the only credential
+    // it can present is the bearer set per request.
+    const peer = await playwright.request.newContext();
+    const directory = `${BASE_URL_B}/api/v1/instance/directory`;
+    try {
+      await section.getByLabel('Label').fill(label);
+      await section.getByRole('button', { name: 'Mint credential' }).click();
+
+      const mintDialog = page.getByRole('dialog', { name: /shown exactly once/ });
+      await expect(mintDialog).toBeVisible();
+      const value = (await mintDialog.locator('.machine__token').textContent())?.trim() ?? '';
+      expect(value).not.toBe('');
+
+      // Control: without the credential the same request is refused, proving the
+      // 200 below is the bearer's doing and not an ambient cookie.
+      const anonymous = await peer.get(directory);
+      expect(anonymous.status(), 'the directory fetch is not open without a credential').toBe(401);
+
+      // A peer presents the minted value at the directory fetch — the one
+      // operation an instance-connection credential may reach — and connects.
+      const connected = await peer.get(directory, {
+        headers: { Authorization: `Bearer ${value}` },
+      });
+      expect(connected.status()).toBe(200);
+
+      // The value is display-once: confirm storage, dismiss, and it is gone from
+      // the surface — the inventory shows metadata only.
+      await mintDialog.getByLabel(/I have stored this credential/).check();
+      await mintDialog.getByRole('button', { name: 'Done' }).click();
+      await expect(mintDialog).toBeHidden();
+
+      const row = section.locator('.connection').filter({ hasText: label });
+      await expect(row.getByText('live', { exact: true })).toBeVisible();
+      // The full plaintext must be absent (its prefix_hint legitimately is not).
+      // Asserting on a boolean keeps the value out of any failure diagnostic.
+      const surfaceText = (await section.textContent()) ?? '';
+      expect(surfaceText.includes(value), 'the plaintext value is present in the inventory').toBe(
+        false,
+      );
+
+      // Revocation states the consequence before it commits (AC#4).
+      await row.getByRole('button', { name: `Revoke ${label}` }).click();
+      const revokeDialog = page.getByRole('dialog', { name: new RegExp(`Revoke ${label}`) });
+      await expect(revokeDialog).toContainText('credential rejected');
+      await expect(revokeDialog).toContainText('Active workspace sessions');
+      await expect(revokeDialog).toContainText('unaffected');
+      await revokeDialog.getByRole('button', { name: 'Revoke credential' }).click();
+      await expect(revokeDialog).toBeHidden();
+
+      await expect(row.getByText('revoked', { exact: true })).toBeVisible();
+
+      // The same presentation is now refused — revocation bit at the next fetch.
+      const refused = await peer.get(directory, {
+        headers: { Authorization: `Bearer ${value}` },
+      });
+      expect(refused.status()).toBe(401);
+    } finally {
+      // Revoke by label from within B's own origin (cookies + CSRF available),
+      // whatever state the assertions left the credential in.
+      await revokeConnectionByLabel(page, label);
+      await peer.dispose();
+    }
   });
 
   test('the popup ceremony opens a workspace, and both kill switches close it', async ({

--- a/web/src/api/remotes.ts
+++ b/web/src/api/remotes.ts
@@ -1,15 +1,21 @@
 import {
   addRemoteOp,
   addWorkspaceOriginOp,
+  listInstanceConnectionsOp,
   listMySessionsOp,
   listRemotesOp,
   listWorkspaceOriginsOp,
+  mintInstanceConnectionOp,
   removeRemoteOp,
   removeWorkspaceOriginOp,
   renameRemoteOp,
+  revokeInstanceConnectionOp,
   revokeMySessionOp,
 } from '@hikyo/operations';
 import {
+  zInstanceConnection,
+  zInstanceConnectionList,
+  zMintedInstanceConnection,
   zRemote,
   zRemoteList,
   zSessionList,
@@ -17,9 +23,10 @@ import {
   zWorkspaceOriginList,
 } from '@hikyo/zod';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { useState } from 'react';
 import type { z } from 'zod';
 
-import { ok, parsed } from './client.ts';
+import { ok, parsed, parsedPick } from './client.ts';
 
 /**
  * The multi-instance surfaces' same-origin data (#71).
@@ -44,10 +51,25 @@ export type RemoteList = z.infer<typeof zRemoteList>;
 export type WorkspaceOrigin = z.infer<typeof zWorkspaceOrigin>;
 export type SessionList = z.infer<typeof zSessionList>;
 export type ActiveSession = SessionList['items'][number];
+export type InstanceConnection = z.infer<typeof zInstanceConnection>;
+export type InstanceConnectionList = z.infer<typeof zInstanceConnectionList>;
+/**
+ * The only fields the display-once ceremony reads back. It is a NARROW pick on
+ * purpose: parsing the whole `MintedInstanceConnection` would let a drift in an
+ * unrelated `connection` member throw away the one value nothing in the system
+ * can ever return again — the same discipline the machine-credential mint keeps
+ * (`identities.ts`). The label the operator typed is carried separately, so the
+ * dialog never needs the echoed `connection` object at all.
+ */
+export type MintedConnectionValue = Pick<
+  z.infer<typeof zMintedInstanceConnection>,
+  'value' | 'clamped'
+>;
 
 export const remotesKey = ['remotes'] as const;
 export const originsKey = ['workspace-origins'] as const;
 export const sessionsKey = ['sessions'] as const;
+export const connectionsKey = ['instance-connections'] as const;
 
 /**
  * The directory refresh cadence.
@@ -145,6 +167,100 @@ export function useRemoveWorkspaceOrigin() {
   });
 }
 
+/**
+ * The receiving side's connection credentials (#498).
+ *
+ * These are minted on THIS instance for a peer to hold and present at its
+ * server-side directory fetch — the write-only counterpart to the `credential`
+ * a `useAddRemote` entry consumes over on the viewing instance. The value is
+ * disclosed exactly once at mint and never read back: every hook here trades in
+ * metadata alone, and the plaintext lives only in the mint mutation's own
+ * result until the caller clears it.
+ */
+export function useConnections(): UseQueryResult<InstanceConnectionList> {
+  return useQuery({
+    queryKey: connectionsKey,
+    queryFn: () => parsed(listInstanceConnectionsOp, {}),
+    retry: false,
+  });
+}
+
+export type MintConnectionInput = {
+  readonly label: string;
+  readonly lifetimeSeconds?: number;
+  readonly indefinite?: boolean;
+};
+
+/**
+ * useMintConnection returns the display-once value, and does so WITHOUT a
+ * TanStack mutation on purpose: a mutation caches its `data`, and this data is
+ * an irretrievable plaintext credential that must never outlive the dialog it
+ * is handed to. So the value flows straight back to the caller and touches no
+ * query or mutation cache — the same discipline the machine-credential mint
+ * follows. `lifetime_seconds` and `indefinite` are mutually exclusive at the
+ * contract; the form makes the choice a radio so the both-named 400 is
+ * unreachable from the UI.
+ */
+export function useMintConnection() {
+  const queries = useQueryClient();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const mint = async (input: MintConnectionInput): Promise<MintedConnectionValue> => {
+    setPending(true);
+    setError(null);
+    try {
+      const minted = await parsedPick(
+        mintInstanceConnectionOp,
+        {
+          body: {
+            label: input.label,
+            ...(input.lifetimeSeconds === undefined
+              ? {}
+              : { lifetime_seconds: input.lifetimeSeconds }),
+            ...(input.indefinite === undefined ? {} : { indefinite: input.indefinite }),
+          },
+        },
+        { value: true, clamped: true },
+      );
+      // Disclose FIRST, refresh the inventory second and un-awaited: the value
+      // is irretrievable, so it must reach the guarded dialog the instant the
+      // POST returns, never after a list refetch the operator could interrupt
+      // by reloading with the credential already committed server-side.
+      void queries.invalidateQueries({ queryKey: connectionsKey });
+      return minted;
+    } catch (caught) {
+      // A mint whose response never arrived may still have COMMITTED, so the
+      // inventory is refreshed on the failure path too: a lost-but-live
+      // credential must at least become visible enough to revoke.
+      void queries.invalidateQueries({ queryKey: connectionsKey });
+      setError(caught);
+      throw caught;
+    } finally {
+      setPending(false);
+    }
+  };
+  return { mint, pending, error };
+}
+
+/**
+ * useRevokeConnection retires the credential and its principal. It bites at the
+ * peer's next directory fetch; a double revoke is a 409, surfaced rather than
+ * swallowed so the operator sees an act that did not put a second event on the
+ * trail.
+ */
+export function useRevokeConnection() {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (connection: string) =>
+      ok(revokeInstanceConnectionOp, { path: { connection } }),
+    // Refresh on SETTLE, not just success: a 409 means another tab already
+    // revoked it, so the inventory is stale in exactly that case — refetching
+    // flips the row to revoked and drops its Revoke action rather than leaving
+    // a credential that reads live and cannot be revoked again.
+    onSettled: () => queries.invalidateQueries({ queryKey: connectionsKey }),
+  });
+}
+
 /** useSessions is the caller's OWN active sessions, workspace ones included. */
 export function useSessions(): UseQueryResult<SessionList> {
   return useQuery({
@@ -192,7 +308,7 @@ export function remoteStateText(remote: Remote): string {
     case 'unreachable':
       return 'Unreachable';
     case 'credential-rejected':
-      return 'Credential rejected — this instance is reachable and is refusing our credential. Mint a new one there and re-add the entry.';
+      return 'Credential rejected — this instance is reachable and is refusing our credential. Mint a fresh one on the peer and re-add the entry.';
     case 'pin-mismatch':
       return 'Certificate pin mismatch — the key at that URL is not the one this entry pinned. Do not re-add until you know why.';
     case 'redirect-refused':

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1030,7 +1030,7 @@ function claimText(pin: ClaimPin): string {
  * gate as Escape. Deactivating consumes the sentinel again so Back is not a
  * double-press afterwards.
  */
-function useNavigationGuard(active: boolean, onAttempt: () => void) {
+export function useNavigationGuard(active: boolean, onAttempt: () => void) {
   const attempt = useRef(onAttempt);
   attempt.current = onAttempt;
   useEffect(() => {

--- a/web/src/routes/Remotes.connections.test.tsx
+++ b/web/src/routes/Remotes.connections.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { ConnectionCredentials } from './Remotes.tsx';
+
+const SENTINEL = 'hik_1_cn_SENTINEL_PLAINTEXT';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) {
+    await cleanup();
+  }
+  vi.unstubAllGlobals();
+});
+
+const live = {
+  id: 'icn_11111111-1111-1111-1111-111111111111',
+  principal: 'mch_live',
+  label: 'production peer',
+  kind: 'hikyo-token',
+  prefix_hint: 'hik_1_cn_abc',
+  lifetime: 'finite',
+  expires_at: '2027-01-01T00:00:00Z',
+  created_at: '2026-01-01T00:00:00Z',
+  created_by: 'usr_root',
+  last_used_at: '2026-02-01T00:00:00Z',
+  live: true,
+};
+
+const revoked = {
+  id: 'icn_22222222-2222-2222-2222-222222222222',
+  principal: 'mch_dead',
+  label: 'retired peer',
+  kind: 'hikyo-token',
+  prefix_hint: 'hik_1_cn_xyz',
+  lifetime: 'finite',
+  created_at: '2026-01-01T00:00:00Z',
+  created_by: 'usr_root',
+  revoked_at: '2026-03-01T00:00:00Z',
+  live: false,
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+type Handlers = {
+  list?: readonly unknown[];
+  mint?: () => Response;
+  revoke?: () => Response;
+};
+
+function stubFetch(handlers: Handlers) {
+  const fetchMock = vi.fn((request: RequestInfo | URL) => {
+    const url = request instanceof Request ? request.url : String(request);
+    const method = request instanceof Request ? request.method : 'GET';
+    if (url.endsWith('/api/v1/instance/connections') && method === 'GET') {
+      const items = handlers.list ?? [];
+      return Promise.resolve(jsonResponse({ items, count: items.length }, 200));
+    }
+    if (url.endsWith('/api/v1/instance/connections') && method === 'POST') {
+      return Promise.resolve((handlers.mint ?? (() => jsonResponse(minted(), 201)))());
+    }
+    if (url.includes('/api/v1/instance/connections/') && method === 'DELETE') {
+      return Promise.resolve((handlers.revoke ?? (() => new Response(null, { status: 204 })))());
+    }
+    throw new Error(`unexpected request: ${method} ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function minted(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { value: SENTINEL, connection: live, clamped: false, ...overrides };
+}
+
+async function render(handlers: Handlers) {
+  const fetchMock = stubFetch(handlers);
+  const rendered = await renderForm(<ConnectionCredentials />);
+  cleanups.push(rendered.unmount);
+  await settleTask();
+  return { ...rendered, fetchMock };
+}
+
+function button(container: HTMLElement, text: string): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === text,
+  );
+  if (found === undefined) {
+    throw new Error(`no button labelled "${text}"`);
+  }
+  return found;
+}
+
+function postBody(fetchMock: ReturnType<typeof stubFetch>): Promise<unknown> {
+  const request = fetchMock.mock.calls
+    .map(([candidate]) => candidate)
+    .find((candidate) => candidate instanceof Request && candidate.method === 'POST');
+  if (!(request instanceof Request)) {
+    throw new Error('no POST request was sent');
+  }
+  return request.json();
+}
+
+async function submitMintForm(container: HTMLElement, label: string): Promise<void> {
+  const labelInput = container.querySelector<HTMLInputElement>('#connection-label');
+  if (labelInput === null) {
+    throw new Error('the mint form has no label input');
+  }
+  await act(async () => typeInto(labelInput, label));
+  await act(async () => {
+    button(container, 'Mint credential').click();
+  });
+  await settleTask();
+}
+
+describe('ConnectionCredentials inventory', () => {
+  it('renders bounded metadata and the live/revoked state without plaintext', async () => {
+    const { container } = await render({ list: [live, revoked] });
+
+    expect(container.textContent).toContain('production peer');
+    expect(container.textContent).toContain('retired peer');
+    expect(container.querySelector('.connection__prefix')?.textContent).toContain('hik_1_cn_abc');
+    expect(container.querySelector('[data-state="live"]')?.textContent).toBe('live');
+    expect(container.querySelector('[data-state="revoked"]')?.textContent).toBe('revoked');
+    // A revoked entry offers no revoke button; a live one does.
+    const revokeButtons = Array.from(container.querySelectorAll('button')).filter(
+      (candidate) => candidate.textContent === 'Revoke',
+    );
+    expect(revokeButtons).toHaveLength(1);
+  });
+
+  it('shows the empty state when nothing is minted', async () => {
+    const { container } = await render({ list: [] });
+    expect(container.textContent).toContain('None minted.');
+  });
+});
+
+describe('ConnectionCredentials mint', () => {
+  it('mints with the default lifetime and names no lifetime field', async () => {
+    const { container, fetchMock } = await render({ list: [] });
+    await submitMintForm(container, 'a new peer');
+
+    expect(await postBody(fetchMock)).toEqual({ label: 'a new peer' });
+    expect(container.querySelector('.machine__token')?.textContent).toBe(SENTINEL);
+  });
+
+  it('sends lifetime_seconds when a custom lifetime is chosen, and never indefinite too', async () => {
+    const { container, fetchMock } = await render({ list: [] });
+    await act(async () => {
+      (container.querySelector('#lifetime-custom') as HTMLInputElement).click();
+    });
+    await act(async () => typeInto(container.querySelector('#lifetime-days')!, '7'));
+    await submitMintForm(container, 'weekly peer');
+
+    const body = (await postBody(fetchMock)) as Record<string, unknown>;
+    expect(body).toEqual({ label: 'weekly peer', lifetime_seconds: 7 * 86_400 });
+    expect('indefinite' in body).toBe(false);
+  });
+
+  it('sends indefinite alone when chosen', async () => {
+    const { container, fetchMock } = await render({ list: [] });
+    await act(async () => {
+      (container.querySelector('#lifetime-indefinite') as HTMLInputElement).click();
+    });
+    await submitMintForm(container, 'forever peer');
+
+    const body = (await postBody(fetchMock)) as Record<string, unknown>;
+    expect(body).toEqual({ label: 'forever peer', indefinite: true });
+    expect('lifetime_seconds' in body).toBe(false);
+  });
+
+  it('keeps the value out of the query and mutation caches, and gone from the DOM once stored', async () => {
+    const { container, client } = await render({ list: [] });
+    await submitMintForm(container, 'a new peer');
+
+    // The value lives only in the dialog. It is reset out of the mutation cache
+    // and never entered the query cache.
+    const mutationData = JSON.stringify(
+      client.getMutationCache().getAll().map((mutation) => mutation.state.data),
+    );
+    expect(mutationData).not.toContain(SENTINEL);
+    expect(JSON.stringify(client.getQueryCache().getAll())).not.toContain(SENTINEL);
+
+    // Done is refused until stored is confirmed — the value has no second look.
+    await act(async () => button(container, 'Done').click());
+    await settle();
+    expect(container.querySelector('.machine__token')?.textContent).toBe(SENTINEL);
+    expect(container.textContent).toContain('Confirm you have stored it');
+
+    await act(async () => {
+      (container.querySelector('#connection-stored') as HTMLInputElement).click();
+    });
+    await act(async () => button(container, 'Done').click());
+    await settle();
+    expect(container.querySelector('.machine__token')).toBeNull();
+    expect(container.textContent).not.toContain(SENTINEL);
+  });
+
+  it('refuses a sub-second custom lifetime without sending it to the server', async () => {
+    const { container, fetchMock } = await render({ list: [] });
+    await act(async () => {
+      (container.querySelector('#lifetime-custom') as HTMLInputElement).click();
+    });
+    await act(async () => typeInto(container.querySelector('#lifetime-days')!, '0.000001'));
+    await act(async () => typeInto(container.querySelector('#connection-label')!, 'too small'));
+
+    const mintButton = button(container, 'Mint credential');
+    expect(mintButton.disabled).toBe(true);
+    expect(container.querySelector('#lifetime-days')?.getAttribute('aria-invalid')).toBe('true');
+    await act(async () => mintButton.click());
+    await settleTask();
+    // Only the initial inventory GET ran; no mint POST was sent.
+    expect(fetchMock.mock.calls.every(([c]) => !(c instanceof Request) || c.method === 'GET')).toBe(
+      true,
+    );
+  });
+
+  it('surfaces the both-lifetime / indefinite-disallowed refusal from a 400', async () => {
+    const { container } = await render({
+      list: [],
+      mint: () => new Response(null, { status: 400 }),
+    });
+    await submitMintForm(container, 'bad peer');
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('That mint was refused');
+    expect(container.querySelector('.machine__token')).toBeNull();
+  });
+});
+
+describe('ConnectionCredentials revoke', () => {
+  it('states the active-session and remote-trust consequence before committing', async () => {
+    const { container } = await render({ list: [live] });
+    await act(async () => button(container, 'Revoke').click());
+    await settle();
+
+    const dialog = container.ownerDocument.querySelector('dialog');
+    expect(dialog?.textContent).toContain('credential rejected');
+    expect(dialog?.textContent).toContain('Active workspace sessions');
+    expect(dialog?.textContent).toContain('unaffected');
+  });
+
+  it('reports a double revoke as a 409 rather than a silent success', async () => {
+    const { container } = await render({
+      list: [live],
+      revoke: () => new Response(null, { status: 409 }),
+    });
+    await act(async () => button(container, 'Revoke').click());
+    await settle();
+    await act(async () => button(container, 'Revoke credential').click());
+    await settleTask();
+
+    expect(container.ownerDocument.querySelector('dialog')?.textContent).toContain(
+      'already revoked',
+    );
+  });
+
+  it('closes the dialog on a successful revoke', async () => {
+    const { container } = await render({ list: [live] });
+    await act(async () => button(container, 'Revoke').click());
+    await settle();
+    await act(async () => button(container, 'Revoke credential').click());
+    await settleTask();
+
+    expect(container.ownerDocument.querySelector('dialog')).toBeNull();
+  });
+});

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -1,8 +1,9 @@
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
-import { useMemo, useState, type FormEvent } from 'react';
+import { useMemo, useRef, useState, type FormEvent } from 'react';
 import { generatePath, Link } from 'react-router';
 
 import { ApiError } from '../api/client.ts';
+import { isoDay } from '../api/identities.ts';
 import { useProjects } from '../api/matrix.ts';
 import {
   remoteStateText,
@@ -10,11 +11,16 @@ import {
   stalenessText,
   useAddRemote,
   useAddWorkspaceOrigin,
+  useConnections,
+  useMintConnection,
   useRemotes,
   useRemoveRemote,
   useRemoveWorkspaceOrigin,
   useRenameRemote,
+  useRevokeConnection,
   useWorkspaceOrigins,
+  type InstanceConnection,
+  type MintedConnectionValue,
   type Remote,
 } from '../api/remotes.ts';
 import { useOrgs } from '../api/session.ts';
@@ -33,8 +39,11 @@ import {
   type WorkspaceBearer,
 } from '../api/workspace.ts';
 import { createWorkspaceClient } from '../api/workspaceClient.ts';
+import { writeClipboard } from '../app/clipboard.ts';
 import { makeQueryClient } from '../app/queryClient.ts';
 import { surfaceById } from '../app/navigation.ts';
+import { useNavigationGuard } from './MachineAccess.tsx';
+import { useModalDialog } from './useModalDialog.ts';
 import { useWorkspaceHandoff, workspaceHandoffAction } from './useWorkspaceHandoff.ts';
 
 /**
@@ -82,7 +91,8 @@ export function Remotes() {
         {remotes.isSuccess && remotes.data.items.length === 0 ? (
           <p role="status">
             No remotes yet. Add one below — you will need its URL, its certificate fingerprint and a
-            connection credential minted over there.
+            connection credential, which whoever runs that instance mints from the{' '}
+            <strong>Connection credentials</strong> section of its own Remotes page.
           </p>
         ) : null}
 
@@ -94,6 +104,7 @@ export function Remotes() {
       </section>
 
       <AddRemote />
+      <ConnectionCredentials />
       <OriginAllowlist />
     </>
   );
@@ -177,7 +188,21 @@ function RemoteCard({ remote }: { remote: Remote }) {
             !
           </span>
         )}
-        <span>{remoteStateText(remote)}</span>
+        <span>
+          {remoteStateText(remote)}
+          {/* A rejected credential is fixed on the PEER's own Connection
+              credentials section — link straight to it rather than describe
+              where it lives (AC#1). */}
+          {remote.state === 'credential-rejected' ? (
+            <>
+              {' '}
+              <a href={`${origin}/remotes#connection-credentials`} target="_blank" rel="noreferrer">
+                Manage connection credentials on {origin}
+              </a>
+              .
+            </>
+          ) : null}
+        </span>
       </p>
       {staleness === null ? null : (
         <p className="remote__stale" role="status">
@@ -326,8 +351,12 @@ function RemoteCard({ remote }: { remote: Remote }) {
       {live === undefined ? null : <WorkspacePicker origin={origin} remoteName={remote.name} />}
       {remove.isSuccess ? (
         <p role="status">
-          Removed here. That does <strong>not</strong> revoke the credential — revoke it on the
-          other instance too.
+          Removed here. That does <strong>not</strong> revoke the credential — revoke it in the
+          Connection credentials section of{' '}
+          <a href={`${origin}/remotes#connection-credentials`} target="_blank" rel="noreferrer">
+            {origin}
+          </a>{' '}
+          too.
         </p>
       ) : null}
     </li>
@@ -529,6 +558,514 @@ function OriginAllowlist() {
       </form>
     </section>
   );
+}
+
+/**
+ * The receiving-side credential surface (#498): mint, inventory and revoke the
+ * connection credentials THIS instance issues for a peer to hold.
+ *
+ * It is deliberately NOT the same thing as a directory card. A card is this
+ * instance VIEWING a peer, holding a credential minted over there. This is the
+ * SERVING side: the write-only credentials a peer presents at our own directory
+ * fetch. The two look alike — both say "credential" — so the copy names the
+ * distinction rather than trusting the layout to carry it.
+ */
+/** A minted value paired with the label the operator typed for it. */
+type Disclosed = MintedConnectionValue & { readonly label: string };
+
+export function ConnectionCredentials() {
+  const connections = useConnections();
+  const mint = useMintConnection();
+  const [disclosed, setDisclosed] = useState<Disclosed | null>(null);
+  const [revoking, setRevoking] = useState<InstanceConnection | null>(null);
+
+  const items = connections.data?.items ?? [];
+
+  return (
+    <section className="card" id="connection-credentials" aria-labelledby="connections-title">
+      <h2 id="connections-title">Connection credentials</h2>
+      <p>
+        The credentials <strong>this</strong> instance issues for another to hold. A peer presents
+        one at this instance&apos;s server-side directory fetch — it is the write-only counterpart to
+        the connection credential you paste into <strong>Add a remote</strong> over on the viewing
+        instance. It is <strong>not</strong> a directory card: a card is this instance reading a
+        peer, this is a peer reading us.
+      </p>
+
+      {connections.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            The connection credentials could not be read. It is gated on{' '}
+            <span className="mono">instance-config</span>.
+          </span>
+        </p>
+      ) : null}
+
+      {connections.isSuccess && items.length === 0 ? (
+        <p role="status">
+          None minted. A peer cannot fetch this instance&apos;s directory until you mint one here and
+          hand the value over.
+        </p>
+      ) : null}
+
+      <ul className="connections">
+        {items.map((connection) => (
+          <ConnectionRow
+            key={connection.id}
+            connection={connection}
+            onRevoke={() => setRevoking(connection)}
+          />
+        ))}
+      </ul>
+
+      <MintConnectionForm mint={mint} onMinted={setDisclosed} />
+
+      {disclosed === null ? null : (
+        <ConnectionMintDialog minted={disclosed} onClose={() => setDisclosed(null)} />
+      )}
+      {revoking === null ? null : (
+        <RevokeConnectionDialog connection={revoking} onClose={() => setRevoking(null)} />
+      )}
+    </section>
+  );
+}
+
+/** ConnectionRow is one inventory entry: bounded metadata, no plaintext. */
+function ConnectionRow({
+  connection,
+  onRevoke,
+}: {
+  connection: InstanceConnection;
+  onRevoke: () => void;
+}) {
+  const revokedAt = connection.revoked_at;
+  const revoked = revokedAt !== undefined;
+  const state = revoked ? 'revoked' : connection.live ? 'live' : 'expired';
+  return (
+    <li className="connection">
+      <div className="connection__head">
+        <h3 className="connection__label">{connection.label}</h3>
+        {/* State as text first; the badge colour is decoration on a word. */}
+        <span className="badge" data-state={state}>
+          {state}
+        </span>
+      </div>
+      <p className="mono connection__prefix">{connection.prefix_hint}…</p>
+      <dl className="connection__facts">
+        <dt>Kind</dt>
+        <dd className="mono">{connection.kind}</dd>
+        <dt>Lifetime</dt>
+        <dd>
+          {connection.lifetime === 'indefinite'
+            ? 'indefinite'
+            : connection.expires_at === undefined
+              ? 'finite'
+              : `expires ${isoDay(connection.expires_at)}`}
+        </dd>
+        <dt>Created</dt>
+        <dd>
+          {isoDay(connection.created_at)} by <span className="mono">{connection.created_by}</span>
+        </dd>
+        <dt>Last used</dt>
+        <dd>{connection.last_used_at === undefined ? 'never used' : isoDay(connection.last_used_at)}</dd>
+        {revokedAt === undefined ? null : (
+          <>
+            <dt>Revoked</dt>
+            <dd>{isoDay(revokedAt)}</dd>
+          </>
+        )}
+      </dl>
+      {revoked ? null : (
+        <div className="connection__actions">
+          <button
+            className="btn"
+            type="button"
+            aria-label={`Revoke ${connection.label}`}
+            onClick={onRevoke}
+          >
+            Revoke
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+type LifetimeChoice = 'default' | 'custom' | 'indefinite';
+
+/**
+ * MintConnectionForm names lifetime as a RADIO so the both-named 400 is
+ * unreachable: the contract refuses a request that carries `lifetime_seconds`
+ * and `indefinite` at once, so the UI can only ever send one of them.
+ */
+function MintConnectionForm({
+  mint,
+  onMinted,
+}: {
+  mint: ReturnType<typeof useMintConnection>;
+  onMinted: (result: Disclosed) => void;
+}) {
+  const [label, setLabel] = useState('');
+  const [choice, setChoice] = useState<LifetimeChoice>('default');
+  const [days, setDays] = useState('30');
+
+  // The converted seconds, or null when the custom field is not a positive
+  // whole-second lifetime the contract (minimum 1) would accept. `0.0001` days
+  // rounds to zero and a huge value overflows to non-finite; both are refused
+  // here rather than sent for the server to 400.
+  const customSeconds = customLifetimeSeconds(days);
+  const customInvalid = choice === 'custom' && customSeconds === null;
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = label.trim();
+    if (trimmed === '' || mint.pending || customInvalid) {
+      return;
+    }
+    const input =
+      choice === 'indefinite'
+        ? { label: trimmed, indefinite: true }
+        : choice === 'custom' && customSeconds !== null
+          ? { label: trimmed, lifetimeSeconds: customSeconds }
+          : { label: trimmed };
+    void mint.mint(input).then(
+      (result) => {
+        onMinted({ ...result, label: trimmed });
+        setLabel('');
+        setChoice('default');
+        setDays('30');
+      },
+      () => {
+        // The failure is surfaced from mint.error; nothing to do here.
+      },
+    );
+  };
+
+  return (
+    <form className="form" onSubmit={onSubmit} noValidate>
+      <h3>Mint a credential</h3>
+      <p>
+        The label names the peer for the audit trail. It is descriptive, not enforced — this
+        instance cannot verify who holds the value.
+      </p>
+      {mint.error !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{mintFailureText(mint.error)}</span>
+        </p>
+      ) : null}
+      <div className="field">
+        <label htmlFor="connection-label">Label</label>
+        <input
+          id="connection-label"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          maxLength={200}
+          required
+        />
+      </div>
+      <fieldset className="field">
+        <legend>Lifetime</legend>
+        <div className="chk">
+          <input
+            id="lifetime-default"
+            type="radio"
+            name="lifetime"
+            checked={choice === 'default'}
+            onChange={() => setChoice('default')}
+          />
+          <label htmlFor="lifetime-default">Instance default</label>
+        </div>
+        <div className="chk">
+          <input
+            id="lifetime-custom"
+            type="radio"
+            name="lifetime"
+            checked={choice === 'custom'}
+            onChange={() => setChoice('custom')}
+          />
+          <label htmlFor="lifetime-custom">Expires after</label>
+          <input
+            id="lifetime-days"
+            type="number"
+            min={1}
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            disabled={choice !== 'custom'}
+            aria-invalid={customInvalid}
+            aria-label="Lifetime in days"
+          />
+          <span>days (clamped to the instance ceiling)</span>
+        </div>
+        <div className="chk">
+          <input
+            id="lifetime-indefinite"
+            type="radio"
+            name="lifetime"
+            checked={choice === 'indefinite'}
+            onChange={() => setChoice('indefinite')}
+          />
+          <label htmlFor="lifetime-indefinite">
+            Never expires (only if this instance allows it)
+          </label>
+        </div>
+      </fieldset>
+      <button
+        className="btn btn--primary"
+        type="submit"
+        disabled={mint.pending || label.trim() === '' || customInvalid}
+      >
+        {mint.pending ? 'Minting…' : 'Mint credential'}
+      </button>
+    </form>
+  );
+}
+
+/**
+ * ConnectionMintDialog is the display-once ceremony. The value exists only in
+ * this dialog's props for as long as it is open: copy is best-effort, the
+ * stored-confirmation gates dismissal, and a navigation while unstored is
+ * routed through the same guard as Escape so the one disclosure is not lost to
+ * a Back press or a reload.
+ */
+function ConnectionMintDialog({
+  minted,
+  onClose,
+}: {
+  minted: Disclosed;
+  onClose: () => void;
+}) {
+  const confirmation = useRef<HTMLInputElement>(null);
+  const dialog = useModalDialog(confirmation);
+  const [stored, setStored] = useState(false);
+  const [heldBack, setHeldBack] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const dismiss = () => {
+    if (!stored) {
+      setHeldBack(true);
+      return;
+    }
+    onClose();
+  };
+
+  // Back, reload and tab close must not silently lose a value nothing returns.
+  useNavigationGuard(!stored, dismiss);
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="connection-mint-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        dismiss();
+      }}
+    >
+      <h2 className="ceremony__title" id="connection-mint-title">
+        Connection credential minted — shown exactly once
+      </h2>
+      <p className="ceremony__scope">
+        For <strong>{minted.label}</strong>. Hand this value to that peer; it goes into its{' '}
+        <strong>Add a remote</strong> form as the connection credential.
+      </p>
+      <p className="mono machine__token">{minted.value}</p>
+      {minted.clamped ? (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            The instance lifetime ceiling shortened this credential. It expires earlier than asked
+            for — said now rather than discovered when it dies.
+          </span>
+        </p>
+      ) : null}
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          This value is never retrievable again. The list shows metadata only. Store it in the
+          consuming instance now; if it is lost, revoke this credential and mint a fresh one.
+        </span>
+      </p>
+      <button
+        className="btn"
+        type="button"
+        onClick={async () => {
+          const result = await writeClipboard(minted.value);
+          setCopyStatus(
+            result === 'ok'
+              ? 'Copied. The clipboard is now the only copy outside its target instance.'
+              : 'This browser refused clipboard access, so nothing was copied.',
+          );
+        }}
+      >
+        Copy to clipboard
+      </button>
+      {copyStatus === null ? null : (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            ⧉
+          </span>
+          <span>{copyStatus}</span>
+        </p>
+      )}
+      <div className="field chk">
+        <input
+          id="connection-stored"
+          type="checkbox"
+          ref={confirmation}
+          checked={stored}
+          onChange={(event) => {
+            setStored(event.target.checked);
+            if (event.target.checked) {
+              setHeldBack(false);
+            }
+          }}
+        />
+        <label htmlFor="connection-stored">I have stored this credential in its target instance.</label>
+      </div>
+      {heldBack ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>Confirm you have stored it — there is no second look at this value.</span>
+        </p>
+      ) : null}
+      <div className="ceremony__actions">
+        <button className="btn btn--primary" type="button" onClick={dismiss}>
+          Done
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * RevokeConnectionDialog states the consequence before it commits (AC#4).
+ *
+ * Revocation retires the credential and its principal. It does NOT touch
+ * workspace sessions — those are governed by the origin allowlist, not this
+ * credential — so the copy says exactly what it does and does not do, and a
+ * double revoke surfaces the 409 rather than pretending a second act happened.
+ */
+function RevokeConnectionDialog({
+  connection,
+  onClose,
+}: {
+  connection: InstanceConnection;
+  onClose: () => void;
+}) {
+  const cancel = useRef<HTMLButtonElement>(null);
+  const dialog = useModalDialog(cancel);
+  const revoke = useRevokeConnection();
+
+  const run = () => {
+    revoke.mutate(connection.id, { onSuccess: onClose });
+  };
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="connection-revoke-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!revoke.isPending) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="connection-revoke-title">
+        Revoke {connection.label}?
+      </h2>
+      <p className="ceremony__scope">
+        The credential and its principal are retired together. The peer holding it loses this
+        instance&apos;s directory fetch at its <strong>next</strong> presentation — its card over
+        there flips to <span className="mono">credential rejected</span>. Active workspace sessions
+        are <strong>unaffected</strong>: those follow the origin allowlist, not this credential.
+      </p>
+      {revoke.isError ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{revokeFailureText(revoke.error)}</span>
+        </p>
+      ) : null}
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          onClick={run}
+          disabled={revoke.isPending}
+        >
+          {revoke.isPending ? 'Revoking…' : 'Revoke credential'}
+        </button>
+        <button
+          className="btn"
+          type="button"
+          ref={cancel}
+          onClick={onClose}
+          disabled={revoke.isPending}
+        >
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * customLifetimeSeconds converts the days field to seconds, or null when the
+ * result is not a lifetime the contract accepts. The contract's floor is one
+ * second; the field's floor is one day, so this also mirrors `min={1}`. It
+ * refuses fractional-day inputs that round below a second and any value large
+ * enough to overflow a safe integer.
+ */
+function customLifetimeSeconds(days: string): number | null {
+  const parsed = Number(days);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return null;
+  }
+  const seconds = Math.round(parsed * 86_400);
+  return Number.isSafeInteger(seconds) && seconds >= 1 ? seconds : null;
+}
+
+function mintFailureText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return 'That mint was refused: the label must be present, and a finite lifetime and “never expires” cannot both be named. “Never expires” also requires this instance to allow indefinite credentials.';
+      case 429:
+        return 'Too many attempts right now. Wait a moment and try again.';
+      default:
+        return `The credential could not be minted (server error ${error.status}).`;
+    }
+  }
+  return 'The credential could not be minted: the server could not be reached, or it answered something this client does not understand.';
+}
+
+function revokeFailureText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 409:
+        return 'This credential was already revoked — nothing more to do, and no second event recorded.';
+      case 429:
+        return 'Too many attempts right now. Wait a moment and try again.';
+      default:
+        return `The credential could not be revoked (server error ${error.status}).`;
+    }
+  }
+  return 'The credential could not be revoked: the server could not be reached, or it answered something this client does not understand.';
 }
 
 /**

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3105,6 +3105,7 @@ select {
 .remotes,
 .origins,
 .sessions,
+.connections,
 .remote__orgs {
   list-style: none;
   margin: 12px 0 0;
@@ -3114,25 +3115,29 @@ select {
   gap: 12px;
 }
 
-.remote {
+.remote,
+.connection {
   padding: 16px;
   border: 1px solid var(--line);
   border-radius: var(--radius-container);
   background: var(--bg);
 }
 
-.remote__head {
+.remote__head,
+.connection__head {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.remote__name {
+.remote__name,
+.connection__label {
   margin: 0;
   font-size: 16px;
 }
 
-.remote__url {
+.remote__url,
+.connection__prefix {
   margin: 4px 0 8px;
   color: var(--tx-dim);
   overflow-wrap: anywhere;
@@ -3144,18 +3149,21 @@ select {
   color: var(--tx-dim);
 }
 
-.remote__facts {
+.remote__facts,
+.connection__facts {
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 2px 12px;
   margin: 0 0 8px;
 }
 
-.remote__facts dt {
+.remote__facts dt,
+.connection__facts dt {
   color: var(--tx-dim);
 }
 
-.remote__facts dd {
+.remote__facts dd,
+.connection__facts dd {
   margin: 0;
   overflow-wrap: anywhere;
 }
@@ -3189,6 +3197,7 @@ select {
 }
 
 .remote__actions,
+.connection__actions,
 .origin,
 .session__head {
   display: flex;


### PR DESCRIPTION
Closes #498.

## What

Adds a receiving-side connection-credential surface to the Remotes page, beside the existing workspace-origin allowlist. An authorized operator can mint, display-once, copy, inventory, inspect, and revoke the credentials this instance issues for a peer to present at its server-side directory fetch — no CLI on the serving instance.

## Contract / migration decisions

- **No contract change.** The locked `/api/v1/instance/connections` operations, types, and Zod schemas already existed; this PR is WebUI only.
- **Regenerated artifacts:** none. Generated clients are untouched.
- `showInstanceConnection` is intentionally left unused — list rows carry the full `InstanceConnection`, so per-row detail needs no extra fetch (CLI-parity ops may be unused).

## Security invariants held

- Minted plaintext is display-once: the mint does **not** go through a TanStack mutation (which caches `data`); the value flows straight to the dialog and enters no query/mutation cache, is never placed in a URL/log/toast/DOM diagnostic/durable storage, and the list reads metadata only.
- Lifetime is a radio (default / custom / indefinite) so the contract's both-named 400 is unreachable from the UI; indefinite-when-disallowed surfaces as the server refusal.
- Revocation retires the credential + its principal only. Workspace sessions follow the origin allowlist, not this credential — the confirmation states exactly that plus the peer's next-fetch consequence. Double revoke surfaces the 409.
- Cross-origin handoff, unauthorized/nonexistent shaping, and credential eligibility are unchanged.

## Copy (AC#1)

Empty-state, remove-note, and `credential-rejected` state text now link to the peer's Connection credentials section instead of instructing "over there" via CLI. The management UI runs on the **serving** instance; where the peer's origin is known here, the copy deep-links to `<origin>/remotes#connection-credentials`.

## Validation

- `pnpm --dir web typecheck` — clean
- `pnpm --dir web test` — 531 passed (10 new in `Remotes.connections.test.tsx`)
- `pnpm --dir web build` — clean
- Playwright: new end-to-end journey in `workspace.spec.ts` (desktop) — mints in the UI on one instance, a peer connects at the protocol level with the minted value, revokes through the UI, proves the next presentation is refused. 1 passed (3.0m). Rides CI group 2 (no new spec file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)