### PR TITLE
perf(server): skip redundant CORS allowlist reads #515

### DIFF
--- a/docs/handoff/515-cors-allowlist-fast-path.md
+++ b/docs/handoff/515-cors-allowlist-fast-path.md
@@ -1,0 +1,46 @@
+# Issue #515: CORS allowlist fast path
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/515. Base:
+`a84fd620cedb068988b4d996a5610d12638172b1`.
+
+## Contract
+
+- `PublicOptions.ExternalOrigin` carries the config-validated
+  `HIKYO_EXTERNAL_ORIGIN` into the public router. Same-origin comparison never
+  trusts the request `Host` header.
+- `crossOriginAllowed` canonicalizes the request `Origin`. An origin matching
+  the instance origin bypasses `Workspace.OriginAllowed`, emits no CORS grant,
+  and retains `Vary: Origin`.
+- `Workspace.PrimeOriginAllowlist` loads a negative-only snapshot before the
+  public listener serves. An empty allowlist refuses every foreign origin
+  without a request-path transaction.
+- A non-empty snapshot still performs the live membership read. Runtime read
+  errors therefore remain fail closed, and existing cross-origin grant/header
+  behavior remains unchanged.
+- `AddOrigin` and `RemoveOrigin` update the snapshot under the same lock as the
+  write transaction, so the empty/non-empty fast path changes atomically with
+  successful local writes.
+
+## Tests
+
+- `TestCORSSameOriginMutationSkipsAllowlistConsult` drives the real public
+  router and proves a canonical same-origin POST never reaches the workspace
+  allowlist service.
+- `TestCORSRequestsIssueNoAllowlistQueriesAfterSnapshot` uses a counting SQLite
+  driver through the isolation harness. Same-origin mutation and hostile
+  cross-origin traffic against an empty allowlist both execute zero datastore
+  queries.
+- The existing remote lifecycle primes the snapshot before adding and removing
+  origins, covering cache coherence on SQLite and PostgreSQL conformance legs.
+
+## Verification
+
+- `go build ./...`: clean.
+- `go vet ./...`: clean.
+- `go test -count=1 ./...`: 4,039 passed across 69 packages.
+- `go test ./internal/server ./internal/app -count=1`: 314 passed.
+- `go test ./internal/conformance -count=1`: 78 passed (SQLite; PostgreSQL runs
+  in CI with `HIKYO_TEST_POSTGRES_DSN`).
+- `go test ./internal/isolation -run 'TestCORSRequestsIssueNoAllowlistQueriesAfterSnapshot|TestRemoteLifecycleSQLite' -count=1`:
+  4 passed.
+- Two-axis review: Standards CLEAN; Spec CLEAN after three rounds.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -370,6 +370,10 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	if err := authSvc.ConfigureWebAuthnRP(); err != nil {
 		return nil, fmt.Errorf("boot: refusing to serve: webauthn relying party: %w", err)
 	}
+	workspaceSvc := &service.Workspace{DB: db, Version: Version, Reauth: authSvc}
+	if err := workspaceSvc.PrimeOriginAllowlist(ctx); err != nil {
+		return nil, fmt.Errorf("boot: refusing to serve: workspace origin allowlist: %w", err)
+	}
 
 	proxies, err := parseCIDRs(cfg.TrustedProxyCIDRs)
 	if err != nil {
@@ -520,7 +524,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		// foreign instance: with zero configured remotes it originates zero
 		// connections, which is what leaves the air-gap posture unchanged.
 		Remotes:        &service.Remotes{DB: db, Keyring: kr, Fetch: fetcher},
-		Workspace:      &service.Workspace{DB: db, Version: Version, Reauth: authSvc},
+		Workspace:      workspaceSvc,
 		Admission:      limiter,
 		Version:        Version,
 		Log:            log,
@@ -533,13 +537,16 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	// Construct the complete owner before disarming: future fallible work added
 	// to construction stays inside the guard's protection.
 	srv := &Server{
-		Addr:               ln.Addr().String(),
-		OperationalAddr:    operationalLn.Addr().String(),
-		db:                 db,
-		keyring:            kr,
-		publicLn:           publicLn,
-		operationalLn:      operationalLn,
-		publicHandler:      server.NewPublic(&service.System{DB: db, Store: sc}, api, webui.Assets(), server.PublicOptions{HSTS: cfg.TLSCertFile != "" && !config.IsLoopbackListen(cfg.Listen)}),
+		Addr:            ln.Addr().String(),
+		OperationalAddr: operationalLn.Addr().String(),
+		db:              db,
+		keyring:         kr,
+		publicLn:        publicLn,
+		operationalLn:   operationalLn,
+		publicHandler: server.NewPublic(&service.System{DB: db, Store: sc}, api, webui.Assets(), server.PublicOptions{
+			HSTS:           cfg.TLSCertFile != "" && !config.IsLoopbackListen(cfg.Listen),
+			ExternalOrigin: cfg.ExternalOrigin,
+		}),
 		operationalHandler: server.NewOperational(&service.System{DB: db, Store: sc}, operationalHealth{retention: retentionSvc, tls: tlsReloader}),
 		tlsReloader:        tlsReloader,
 		log:                log,

--- a/internal/isolation/cors_query_count_test.go
+++ b/internal/isolation/cors_query_count_test.go
@@ -1,0 +1,102 @@
+package isolation
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"modernc.org/sqlite"
+
+	"github.com/Hikyo-Org/hikyo/internal/server"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
+)
+
+const corsQueryDriverName = "hikyo-cors-query-counter"
+
+var corsQueryDriver = &queryCountingDriver{delegate: &sqlite.Driver{}}
+
+func init() {
+	sql.Register(corsQueryDriverName, corsQueryDriver)
+}
+
+type queryCountingDriver struct {
+	delegate driver.Driver
+	queries  atomic.Int64
+}
+
+func (d *queryCountingDriver) Open(name string) (driver.Conn, error) {
+	conn, err := d.delegate.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &queryCountingConn{Conn: conn, queries: &d.queries}, nil
+}
+
+type queryCountingConn struct {
+	driver.Conn
+	queries *atomic.Int64
+}
+
+func (c *queryCountingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return c.Conn.(driver.ConnBeginTx).BeginTx(ctx, opts)
+}
+
+func (c *queryCountingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.queries.Add(1)
+	return c.Conn.(driver.ExecerContext).ExecContext(ctx, query, args)
+}
+
+func (c *queryCountingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.queries.Add(1)
+	return c.Conn.(driver.QueryerContext).QueryContext(ctx, query, args)
+}
+
+func TestCORSRequestsIssueNoAllowlistQueriesAfterSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cors-query-count.db")
+	migrationConfig := store.Config{Engine: store.EngineSQLite, Path: path}
+	if err := migrate.Run(t.Context(), migrationConfig); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(t.Context(), store.Config{
+		Engine: store.EngineSQLite, Path: path, SQLiteDriver: corsQueryDriverName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	workspace := &service.Workspace{DB: db}
+	if err := workspace.PrimeOriginAllowlist(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	handler := server.NewPublic(nil, &server.API{Workspace: workspace}, nil, server.PublicOptions{
+		ExternalOrigin: "https://hikyo.example",
+	})
+
+	corsQueryDriver.queries.Store(0)
+	for _, tc := range []struct {
+		name   string
+		origin string
+	}{
+		{name: "same origin mutation", origin: "https://hikyo.example"},
+		{name: "foreign origin with empty allowlist", origin: "https://hostile.example"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := corsQueryDriver.queries.Load()
+			req := httptest.NewRequest(http.MethodPost, "/mutation", nil)
+			req.Header.Set("Origin", tc.origin)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if got := corsQueryDriver.queries.Load() - before; got != 0 {
+				t.Fatalf("request issued %d datastore queries, want 0", got)
+			}
+		})
+	}
+}

--- a/internal/isolation/remote_e2e_test.go
+++ b/internal/isolation/remote_e2e_test.go
@@ -111,6 +111,9 @@ func runRemoteLifecycle(t *testing.T, db *store.DB) {
 	ctx := t.Context()
 	remotes, workspace := remoteSvcs(t, db)
 	admin := service.LocalPrincipal(root)
+	if err := workspace.PrimeOriginAllowlist(ctx); err != nil {
+		t.Fatalf("prime workspace origin allowlist: %v", err)
+	}
 
 	// `root` holds instance-config from the shared fixtures; instance-directory
 	// is this ticket's own atom and has to be granted like any other.

--- a/internal/server/cors.go
+++ b/internal/server/cors.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"net/http"
+
+	"github.com/Hikyo-Org/hikyo/internal/service"
 )
 
 // Cross-origin access for the workspace tier (#71, multi-instance ADR §
@@ -105,12 +107,24 @@ func workspaceCORS(allowed func(context.Context, string) bool) func(http.Handler
 // workspaceOriginCheck adapts the workspace service to the middleware. Nil when
 // no workspace surface is wired, which leaves the server exactly as
 // same-origin-only as it was.
-func workspaceOriginCheck(a *API) func(context.Context, string) bool {
+func workspaceOriginCheck(a *API, externalOrigin string) func(context.Context, string) bool {
 	if a == nil || a.Workspace == nil {
 		return nil
 	}
-	return func(ctx context.Context, origin string) bool {
+	return crossOriginAllowed(externalOrigin, func(ctx context.Context, origin string) bool {
 		ok, err := a.Workspace.OriginAllowed(ctx, origin)
 		return err == nil && ok
+	})
+}
+
+func crossOriginAllowed(externalOrigin string, allowed func(context.Context, string) bool) func(context.Context, string) bool {
+	return func(ctx context.Context, origin string) bool {
+		canonicalOrigin, err := service.CanonicalOrigin(origin)
+		if err == nil && canonicalOrigin == externalOrigin {
+			// Same-origin traffic needs no CORS grant. Answering false preserves
+			// the header behavior while avoiding the allowlist read transaction.
+			return false
+		}
+		return allowed(ctx, origin)
 	}
 }

--- a/internal/server/cors_test.go
+++ b/internal/server/cors_test.go
@@ -11,6 +11,16 @@ import (
 // The two rules that make the allowlist mean something at the transport, and
 // the one that makes the CSP a closed list rather than an escape hatch.
 
+type countingWorkspaceOriginCheck struct {
+	WorkspaceService
+	consults int
+}
+
+func (c *countingWorkspaceOriginCheck) OriginAllowed(context.Context, string) (bool, error) {
+	c.consults++
+	return false, nil
+}
+
 func corsHandler(allowed ...string) http.Handler {
 	set := map[string]bool{}
 	for _, o := range allowed {
@@ -21,6 +31,30 @@ func corsHandler(allowed ...string) http.Handler {
 	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+}
+
+func TestCORSSameOriginMutationSkipsAllowlistConsult(t *testing.T) {
+	const externalOrigin = "https://hikyo.example"
+	workspace := &countingWorkspaceOriginCheck{}
+	h := NewPublic(nil, &API{Workspace: workspace}, nil, PublicOptions{ExternalOrigin: externalOrigin})
+
+	req := httptest.NewRequest(http.MethodPost, "/same-origin-mutation", nil)
+	req.Header.Set("Origin", "https://HIKYO.example/")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if workspace.consults != 0 {
+		t.Fatalf("same-origin mutation performed %d allowlist consults, want 0", workspace.consults)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want downstream status %d", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Allow-Origin = %q for a same-origin request, want no CORS grant", got)
+	}
+	if !strings.Contains(rec.Header().Get("Vary"), "Origin") {
+		t.Fatal("Vary: Origin is missing on the same-origin branch")
+	}
 }
 
 func TestCORSEchoesExactlyOneAllowlistedOriginAndNeverCredentials(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,9 @@ type ReadyChecker interface {
 // PublicOptions carries transport facts that affect public response policy.
 type PublicOptions struct {
 	HSTS bool
+	// ExternalOrigin is the config-validated canonical public origin. CORS uses
+	// it to identify same-origin requests without trusting the Host header.
+	ExternalOrigin string
 }
 
 // TLSMetrics reports the label-free native TLS gauges served operationally.
@@ -102,7 +105,7 @@ func NewPublic(ready ReadyChecker, a *API, ui fs.FS, publicOptions PublicOptions
 	// preflight carries no credential by definition, so it must be answered
 	// before anything tries to resolve one. Requests without an `Origin` header
 	// pass through untouched, so nothing else on the router changes.
-	r.Use(workspaceCORS(workspaceOriginCheck(a)))
+	r.Use(workspaceCORS(workspaceOriginCheck(a, publicOptions.ExternalOrigin)))
 
 	if a != nil {
 		r.Group(func(g chi.Router) {

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/audit"
@@ -52,6 +53,14 @@ var (
 // Workspace is the serving side's service.
 type Workspace struct {
 	DB *store.DB
+	// originAllowlist is a negative-only snapshot, primed before the public
+	// listener serves and updated under the same lock as allowlist writes. An
+	// empty map proves no origin can be allowed, avoiding all request-path reads.
+	// A non-empty map still uses the live datastore check so read errors keep
+	// failing closed. Nil preserves the direct datastore path for callers that
+	// construct Workspace outside app boot.
+	originAllowlistMu sync.RWMutex
+	originAllowlist   map[string]struct{}
 	// Version is this build's version string, served in the directory listing.
 	// It is injected rather than read from internal/app because app imports
 	// service; a display string is not worth an import cycle. Empty is
@@ -483,6 +492,32 @@ func (s *Workspace) ListOrigins(ctx context.Context, actor Actor) ([]OriginView,
 	return out, err
 }
 
+// PrimeOriginAllowlist loads the request-path snapshot before the public
+// listener serves. A load error is a boot refusal: silently starting with an
+// empty snapshot would turn configured cross-origin consent into a denial.
+func (s *Workspace) PrimeOriginAllowlist(ctx context.Context) error {
+	s.originAllowlistMu.Lock()
+	defer s.originAllowlistMu.Unlock()
+	if s.originAllowlist != nil {
+		return nil
+	}
+
+	var rows []authz.WorkspaceOrigin
+	if err := tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+		var err error
+		rows, err = az.WorkspaceOrigins(ctx)
+		return err
+	}); err != nil {
+		return err
+	}
+	allowlist := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		allowlist[row.Origin] = struct{}{}
+	}
+	s.originAllowlist = allowlist
+	return nil
+}
+
 // AddOrigin consents to one EXACT origin, and RETURNS the entry it wrote.
 //
 // Returning it is not a convenience: the transport's 201 body needs the
@@ -496,6 +531,8 @@ func (s *Workspace) AddOrigin(ctx context.Context, actor Actor, origin string) (
 	}
 	now := s.now()
 	var out OriginView
+	s.originAllowlistMu.Lock()
+	defer s.originAllowlistMu.Unlock()
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
@@ -523,6 +560,9 @@ func (s *Workspace) AddOrigin(ctx context.Context, actor Actor, origin string) (
 	if err != nil {
 		return OriginView{}, err
 	}
+	if s.originAllowlist != nil {
+		s.originAllowlist[canonical] = struct{}{}
+	}
 	return out, nil
 }
 
@@ -538,6 +578,8 @@ func (s *Workspace) RemoveOrigin(ctx context.Context, actor Actor, origin string
 	}
 	now := s.now()
 	var killed int64
+	s.originAllowlistMu.Lock()
+	defer s.originAllowlistMu.Unlock()
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		caller, err := actor.resolve(ctx, az, now)
 		if err != nil {
@@ -580,6 +622,9 @@ func (s *Workspace) RemoveOrigin(ctx context.Context, actor Actor, origin string
 		}
 		return r.Audit().InsertInstance(ctx, p, rev)
 	})
+	if err == nil && s.originAllowlist != nil {
+		delete(s.originAllowlist, canonical)
+	}
 	return killed, err
 }
 
@@ -592,6 +637,12 @@ func (s *Workspace) OriginAllowed(ctx context.Context, origin string) (bool, err
 	if err != nil {
 		return false, nil
 	}
+	s.originAllowlistMu.RLock()
+	if s.originAllowlist != nil && len(s.originAllowlist) == 0 {
+		s.originAllowlistMu.RUnlock()
+		return false, nil
+	}
+	s.originAllowlistMu.RUnlock()
 	var ok bool
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
 		var e error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,9 +34,10 @@ const (
 // Config selects and locates the datastore. Exactly one of Path (sqlite) or
 // DSN (postgres) is used, per Engine.
 type Config struct {
-	Engine Engine
-	Path   string
-	DSN    string
+	Engine       Engine
+	Path         string
+	DSN          string
+	SQLiteDriver string // optional database/sql driver name for test instrumentation
 }
 
 // Org is the tenancy boundary. Creation, listing and counting are
@@ -935,7 +936,7 @@ func sqliteReadDSN(path string) string {
 func Open(ctx context.Context, cfg Config) (*DB, error) {
 	switch cfg.Engine {
 	case EngineSQLite:
-		return openSQLite(ctx, cfg.Path)
+		return openSQLite(ctx, cfg.Path, cfg.SQLiteDriver)
 	case EnginePostgres:
 		return openPostgres(ctx, cfg.DSN)
 	default:
@@ -943,16 +944,19 @@ func Open(ctx context.Context, cfg Config) (*DB, error) {
 	}
 }
 
-func openSQLite(ctx context.Context, path string) (*DB, error) {
+func openSQLite(ctx context.Context, path, driverName string) (*DB, error) {
 	if path == "" {
 		return nil, errors.New("store: sqlite path is empty")
 	}
-	write, err := sql.Open("sqlite", SQLiteDSN(path))
+	if driverName == "" {
+		driverName = "sqlite"
+	}
+	write, err := sql.Open(driverName, SQLiteDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("store: open sqlite write pool: %w", err)
 	}
 	write.SetMaxOpenConns(1)
-	read, err := sql.Open("sqlite", sqliteReadDSN(path))
+	read, err := sql.Open(driverName, sqliteReadDSN(path))
 	if err != nil {
 		write.Close()
 		return nil, fmt.Errorf("store: open sqlite read pool: %w", err)


### PR DESCRIPTION
Closes #515

## Summary
- bypass workspace allowlist reads for canonical same-origin requests
- prime a negative-only allowlist snapshot so empty instances deny foreign origins without request-path queries
- preserve live DB checks and fail-closed behavior whenever the allowlist is non-empty
- add real SQLite query-count coverage through the public router

## Verification
- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...` (4,039 tests / 69 packages)
- `./scripts/ci/verify-docs.sh`
- Standards review: CLEAN
- Spec review: CLEAN