### PR TITLE
feat(web): create and delete service accounts in Machine Access (#464)

### DIFF
--- a/docs/handoff/67-machine-access.md
+++ b/docs/handoff/67-machine-access.md
@@ -235,6 +235,74 @@ check. Neither was touched — `e2e/global-teardown.ts` is #56's locked harness.
 | Environment grant | `createEnvGrant` |
 | Grant warning's newly-reachable key set | `listValues` for the chosen environment (presence only — the surface never asks for plaintext) |
 
+## #464 — Create and delete service accounts (browser parity)
+
+Full server-capability parity was approved (2026-08-24), so the locked surface
+grew the two acts that let a browser-only operator seed and deprovision its own
+inventory — a fresh project no longer presents an inert list that only a
+CLI/API seed can fill.
+
+- **Create** — a primary `Create service account` action, above the table and
+  the one thing the empty state points at. The dialog collects **name and kind**
+  and posts the locked `createServiceAccount` body verbatim.
+- **Delete** — a per-account `btn--danger` in the row's action column, behind
+  the shared `TypedNameConfirm` gate (the same danger-zone control the project
+  and key deletes use): the destructive button stays dead until the exact
+  account name is typed.
+
+### Two contract decisions worth stating
+
+1. **Create collects name + kind, not name + description.** The ticket text said
+   "name and description", but the locked `CreateServiceAccountRequest` is
+   exactly `{ name, kind }` — there is no description field anywhere in the
+   contract, the store, or the audit payload. Adding one would be a
+   server + OpenAPI + migration change the handoff explicitly forbids
+   ("preserve the locked API… using generated operations"), so the form asks for
+   the field the contract actually has. `kind` (workload | automation) is
+   **immutable at creation**, so it is a select, never an edit.
+2. **Delete is an atomic cascade, not a dependency refusal.** The ticket asked
+   the dialog to "explain server refusal while credentials or bindings still
+   depend on the account", but `DeleteServiceAccount` (service layer, #15's
+   atomic revocation) **revokes every credential and releases every grant in one
+   transaction, then removes the principal** — and the delete contract declares
+   no 409. There is no dependency refusal to honour. So the dialog states that
+   **truth**: it names how many live credentials go and that the grants go with
+   them, immediate and non-recoverable, rather than warning of a refusal the
+   server never raises. A 404 (concurrent deletion) still maps to *"that service
+   account is no longer here."*
+
+### The gates, and why they differ from the mint's
+
+- **No passkey on delete.** Deprovisioning runs under the plain capability with
+  no disclosure gate and no reauthentication — the service comment is explicit
+  that requiring `reveal` to kill a compromised workload would be a
+  self-inflicted incident-response delay. The mint's ceremony loop is **not**
+  copied here; the typed name is the only gate.
+- **Create/delete gate on `canAdminister`, not `inputsReady`.** Both are
+  narrowings that carry no reach-quantifying warning, so neither needs the grant,
+  environment or credential reads `inputsReady` waits on. Coupling them to that
+  predicate would let a `manage-identities` admin who lacks `manage-members`
+  (an unreadable scope column) be unable to seed a fresh project — the exact
+  inert inventory #464 removes. They need only a live session and a known
+  listing.
+- **Commit-aware, like every other write here.** A create or delete that was
+  issued and then failed refreshes the inventory (and, for delete, the grant
+  column) and reports the act *may still have landed*. The delete's success and
+  failure paths **remove** the dead account's credential query rather than
+  invalidate it — an invalidate would race the account refetch into a 404 and
+  flip the whole surface to error.
+
+### Refusal vocabulary
+
+`createServiceAccountRefusalText` is a **separate** mapper from
+`identityRefusalText`: the shared 409 ("the live-credential ceiling, or an
+identical binding") is the *mint's* conflict. A create 409 is a **duplicate live
+name or a structural limit**, and a create 400 is the name constraint (1–64
+chars) — a wrong sentence here would send an operator to look at credentials for
+a name collision. The name is also refused client-side
+(`serviceAccountNameRefusal`: empty-after-trim or over 64) so a duplicate/blank
+name is a form refusal, not a bare 400, and editing the field clears it.
+
 ## The e2e fixture
 
 `seedTenant` now also creates, **inside the stepped-up TOTP session** (because

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -488,6 +488,95 @@ test.describe('machine access', () => {
     });
   }
 
+  test('a browser operator creates an account, mints, revokes, and deletes it — no CLI', async () => {
+    // The whole point of #464: a fresh project must no longer present an inert
+    // inventory that only a CLI/API seed can fill. The name is unique per run so
+    // a retry (or the second viewport project) never collides with a live
+    // sibling and reads a 409 as a broken create.
+    const name = `e2e-sa-${test.info().project.name}-${Date.now().toString(36)}`;
+
+    // CREATE. The empty-tab primary action is always present; here the tab is
+    // seeded, so the same action sits above the table.
+    await page.getByRole('button', { name: 'Create service account', exact: true }).first().click();
+    const createDialog = page.getByRole('dialog');
+    await expect(createDialog.getByRole('heading', { level: 2 })).toHaveText(
+      'Create service account',
+    );
+    await createDialog.getByLabel('Name').fill(name);
+    // Kind defaults to workload — a fresh workload's empty reach is what makes
+    // the mint below take the no-ceremony branch.
+    await createDialog.getByRole('button', { name: 'Create service account' }).click();
+    await expect(createDialog).toBeHidden();
+    await expect(
+      page.getByRole('status').filter({ hasText: `Created ${name} (workload)` }),
+    ).toBeVisible();
+
+    // It is immediately in the inventory and usable — no reload, no CLI.
+    const row = accountRow(page, name);
+    await expect(row).toBeVisible();
+    await row.click();
+    const expansion = page.locator('.machine__sub');
+
+    // MINT. A fresh account reaches no plaintext, so the mint is the
+    // no-passkey branch: the button reads "Mint credential", not "Use a passkey
+    // and mint".
+    await expansion.getByRole('button', { name: `Mint credential for ${name}` }).click();
+    const mintDialog = page.getByRole('dialog');
+    await expect(mintDialog).toContainText('reaches no plaintext');
+    await mintDialog.getByRole('button', { name: 'Mint credential' }).click();
+    await expect(mintDialog.locator('.machine__token')).toHaveText(/^hik_1_wl_/);
+    await mintDialog.getByRole('checkbox').check();
+    await mintDialog.getByRole('button', { name: 'Done' }).click();
+    await expect(mintDialog).toBeHidden();
+    await expect(expansion.locator('.cred')).toHaveCount(1);
+
+    // REVOKE. It bites at the next request, and the account survives it.
+    await expansion.getByRole('button', { name: /^Revoke hik_1_wl_/ }).click();
+    await expect(expansion.locator('.cred')).toHaveCount(0);
+    await expect(
+      page.getByRole('status').filter({ hasText: 'stops authenticating at the next request' }),
+    ).toBeVisible();
+
+    // DELETE, behind a typed-name confirmation. The dialog states the cascade —
+    // the credentials revoked and the grants released — never a refusal, because
+    // the server delete is atomic and does not refuse on dependency.
+    await expansion.getByRole('button', { name: `Delete ${name}` }).click();
+    const deleteDialog = page.getByRole('dialog');
+    await expect(deleteDialog.getByRole('heading', { level: 2 })).toHaveText(
+      `Delete service account · ${name}`,
+    );
+    await expect(deleteDialog).toContainText('cannot be undone');
+
+    // The destructive button is dead until the exact name is typed.
+    const confirm = deleteDialog.getByRole('button', { name: 'Delete service account' });
+    await expect(confirm).toBeDisabled();
+    await deleteDialog.getByLabel('Confirm the account name to delete it').fill(name);
+    await expect(confirm).toBeEnabled();
+    await confirm.click();
+    await expect(deleteDialog).toBeHidden();
+    await expect(page.getByRole('status').filter({ hasText: `Deleted ${name}` })).toBeVisible();
+
+    // And it is gone from the inventory — the surface returns to what it was.
+    await expect(accountRow(page, name)).toHaveCount(0);
+  });
+
+  test('a duplicate name is refused actionably, without a stale account', async () => {
+    // The create 409 is a name already in use among live siblings — a distinct
+    // sentence from the mint's ceiling 409, and it must leave the operator able
+    // to pick another name rather than staring at a dead form.
+    await page.getByRole('button', { name: 'Create service account', exact: true }).first().click();
+    const dialog = page.getByRole('dialog');
+    // A seeded account name is guaranteed to already be live.
+    await dialog.getByLabel('Name').fill(seed.machine.workload);
+    await dialog.getByRole('button', { name: 'Create service account' }).click();
+    await expect(dialog.getByRole('alert')).toContainText('already used');
+    // The dialog stays open and editable: editing clears the refusal.
+    await dialog.getByLabel('Name').fill(`${seed.machine.workload}-x`);
+    await expect(dialog.getByRole('alert')).toHaveCount(0);
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
   test('meets the pinned assertion set with the display-once value on screen', async () => {
     // The mint dialog is the component this ticket exists for, and it is the
     // only place in the SPA a credential value is ever rendered. Asserting only

--- a/web/src/api/identities.test.ts
+++ b/web/src/api/identities.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import { ApiError } from './client.ts';
 import {
+  createServiceAccountFailureText,
+  createServiceAccountRefusalText,
+  deleteServiceAccountFailureText,
+  deleteServiceAccountRefusalText,
   expiryLabel,
   grantWideningReach,
   lastUsedLabel,
@@ -8,6 +13,7 @@ import {
   postStateReach,
   pullRequestRefusal,
   scopeOf,
+  serviceAccountNameRefusal,
   setupJourney,
   type Grant,
   type MachineCredential,
@@ -252,5 +258,93 @@ describe('pullRequestRefusal', () => {
     // The rule is about the pinned event being one of exactly two values, not
     // about the string looking pull-request-ish.
     expect(pullRequestRefusal('pull_request_review')).toBeNull();
+  });
+});
+
+describe('serviceAccountNameRefusal', () => {
+  it('refuses an empty name, and only an empty one', () => {
+    // The server checks `name == "" || len(name) > 64` — byte-for-byte, no trim.
+    // A whitespace-only name is server-legal, so the client does not invent a
+    // stricter rule that would refuse what the server accepts.
+    expect(serviceAccountNameRefusal('')).not.toBeNull();
+    expect(serviceAccountNameRefusal('   ')).toBeNull();
+  });
+
+  it('refuses a name past the 64-BYTE ceiling, counting bytes not code units', () => {
+    expect(serviceAccountNameRefusal('a'.repeat(65))).not.toBeNull();
+    expect(serviceAccountNameRefusal('a'.repeat(64))).toBeNull();
+    // 22 three-byte characters is 66 bytes but only 22 UTF-16 units: a
+    // code-unit check would wave it through and the server would 400.
+    expect(serviceAccountNameRefusal('€'.repeat(22))).not.toBeNull();
+    expect(serviceAccountNameRefusal('€'.repeat(21))).toBeNull();
+  });
+
+  it('accepts an ordinary name', () => {
+    expect(serviceAccountNameRefusal('ci-deploy')).toBeNull();
+  });
+});
+
+describe('createServiceAccountRefusalText', () => {
+  it('names the duplicate-name / limit conflict on 409, not the credential ceiling', () => {
+    const text = createServiceAccountRefusalText(new ApiError(409, 'conflict'));
+    // The account-create 409 is a duplicate live name or a structural limit —
+    // never the "live-credential ceiling or identical binding" the mint's 409
+    // is. A wrong sentence here sends an operator to look at credentials.
+    expect(text).toContain('name');
+    expect(text).not.toContain('binding');
+  });
+
+  it('names the name constraint on 400', () => {
+    expect(createServiceAccountRefusalText(new ApiError(400, 'bad'))).toContain('64');
+  });
+
+  it('never demands disclosure or reauth on 403 — create needs neither', () => {
+    const text = createServiceAccountRefusalText(new ApiError(403, 'no'));
+    expect(text).toContain('manage-identities');
+    expect(text).not.toContain('reauth');
+    expect(text).not.toContain('disclosure');
+  });
+
+  it('names the PROJECT, not a service account, on 404', () => {
+    // A create 404 is the project (or the authorization mask), never a
+    // service account that "is no longer here".
+    const text = createServiceAccountRefusalText(new ApiError(404, 'gone'));
+    expect(text).toContain('project');
+  });
+});
+
+describe('deleteServiceAccountRefusalText', () => {
+  it('reads 404 as an already-gone account (the concurrent-deletion case)', () => {
+    expect(deleteServiceAccountRefusalText(new ApiError(404, 'gone'))).toContain('no longer here');
+  });
+
+  it('never demands disclosure or reauth — delete is plain-capability', () => {
+    const text = deleteServiceAccountRefusalText(new ApiError(403, 'no'));
+    expect(text).not.toContain('reauth');
+    expect(text).not.toContain('disclosure');
+  });
+});
+
+describe('createServiceAccountFailureText', () => {
+  it('stays plain on a pre-commit refusal', () => {
+    // 409 is decided before any commit: nothing was created, so no "may still
+    // have been created" caveat.
+    expect(createServiceAccountFailureText(new ApiError(409, 'dup'))).not.toContain('may still');
+  });
+
+  it('warns of a possible commit on an ambiguous failure', () => {
+    // A 500 or a lost/unparseable response may have committed a create.
+    expect(createServiceAccountFailureText(new ApiError(500, 'boom'))).toContain('may still');
+    expect(createServiceAccountFailureText(new Error('network'))).toContain('may still');
+  });
+});
+
+describe('deleteServiceAccountFailureText', () => {
+  it('stays plain when the account was already gone', () => {
+    expect(deleteServiceAccountFailureText(new ApiError(404, 'gone'))).not.toContain('may still');
+  });
+
+  it('warns of a possible commit on an ambiguous failure', () => {
+    expect(deleteServiceAccountFailureText(new ApiError(500, 'boom'))).toContain('may still');
   });
 });

--- a/web/src/api/identities.ts
+++ b/web/src/api/identities.ts
@@ -1,6 +1,8 @@
 import {
   createEnvGrantOp,
   createFederatedBindingOp,
+  createServiceAccountOp,
+  deleteServiceAccountOp,
   listKeysOp,
   listMachineCredentialsOp,
   listProjectGrantsOp,
@@ -195,6 +197,22 @@ export function useRefreshAccount(p: ProjectRef): (serviceAccount: string) => vo
 }
 
 /**
+ * useRefreshServiceAccounts re-reads the account listing.
+ *
+ * It exists for the create and delete failure paths: an issued mutation whose
+ * response never arrived may still have COMMITTED, and a committed create or
+ * delete must show in the inventory even when the dialog reports a failure. It
+ * deliberately does not touch any credential listing — invalidating a deleted
+ * account's rows would race the account refetch into a 404.
+ */
+export function useRefreshServiceAccounts(p: ProjectRef): () => void {
+  const queries = useQueryClient();
+  return () => {
+    void queries.invalidateQueries({ queryKey: accountsKey(p) });
+  };
+}
+
+/**
  * useRefreshGrants re-reads the scope surface, for the same reason
  * useRefreshAccount exists: a grant whose response never arrived may still
  * have COMMITTED, and a committed widening must show in the scope column even
@@ -230,6 +248,75 @@ export function useRevokeCredential(p: ProjectRef) {
       void queries.invalidateQueries({ queryKey: accountsKey(p) });
     },
   });
+}
+
+/**
+ * useCreateServiceAccount seeds a project's machine inventory from the browser.
+ *
+ * The body is exactly `{ name, kind }` — the locked create contract has no
+ * description, and `kind` (workload | automation) is immutable at creation, so
+ * it is a form field, never an edit. It invalidates the account listing on
+ * success; failure is handled at the call site, where a create that was issued
+ * but whose response was lost may still have committed.
+ */
+export function useCreateServiceAccount(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { name: string; kind: ServiceAccount['kind'] }) =>
+      parsed(createServiceAccountOp, {
+          path: { org: p.org, project: p.project },
+          body: { name: input.name, kind: input.kind },
+        }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: accountsKey(p) });
+    },
+  });
+}
+
+/**
+ * useDeleteServiceAccount deprovisions a machine principal. The server deletes
+ * atomically — every credential revoked and every grant released in ONE
+ * transaction (#15) — so this is a cascade, never a dependency refusal.
+ *
+ * The deleted account's credential listing is REMOVED, not invalidated: a
+ * refetch of a now-absent account 404s, which would flip the surface's
+ * credential state to error and hold back every other act behind an alert. The
+ * account listing is invalidated (its rows and live counts moved) and the grant
+ * listing too (the released grants are gone from the scope column).
+ */
+export function useDeleteServiceAccount(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (serviceAccount: string) =>
+      ok(deleteServiceAccountOp, {
+          path: { org: p.org, project: p.project, serviceAccount },
+        }),
+    onSuccess: (_void, serviceAccount) => {
+      // ORDER IS LOAD-BEARING. Drop the account from the cached inventory FIRST,
+      // so the credentials `useQueries` stops observing it in the same render;
+      // only then remove its now-unobserved credential query. Removing the query
+      // before the account leaves the list would let the still-present account
+      // re-create and refetch it, and the delete's own 404 would flip the whole
+      // surface into credential-error state.
+      queries.setQueryData(accountsKey(p), dropServiceAccount(serviceAccount));
+      queries.removeQueries({ queryKey: credentialsKey(p, serviceAccount) });
+      void queries.invalidateQueries({ queryKey: accountsKey(p) });
+      void queries.invalidateQueries({ queryKey: projectGrantsKey(p) });
+    },
+  });
+}
+
+/** dropServiceAccount removes one account from a cached listing, count and all. */
+function dropServiceAccount(id: string) {
+  return (
+    current: z.infer<typeof zServiceAccountList> | undefined,
+  ): z.infer<typeof zServiceAccountList> | undefined => {
+    if (current === undefined) {
+      return current;
+    }
+    const items = current.items.filter((sa) => sa.id !== id);
+    return { ...current, items, count: items.length };
+  };
 }
 
 /** useCreateBinding mints a federated `(issuer, subject)` binding. */
@@ -624,6 +711,116 @@ export function pullRequestRefusal(eventName: string): string | null {
     `third-party code, so binding it hands every pull-request author this service ` +
     `account's fetch authority.`
   );
+}
+
+/**
+ * serviceAccountNameRefusal is the create form's client-side name gate, refused
+ * HERE rather than as a 400 so an operator meets it as a form.
+ *
+ * It mirrors the server's `name == "" || len(name) > 64` (ErrServiceAccountName)
+ * BYTE-FOR-BYTE: the name is sent untrimmed, so what is validated is what the
+ * server stores, and the limit is 64 BYTES — Go's `len` on a UTF-8 string, not
+ * 64 UTF-16 code units, so 22 three-byte characters already exceed it. Trimming
+ * would silently change the contract: " prod " sent as "prod" could collide
+ * with a different, byte-distinct account the server would have accepted.
+ */
+export function serviceAccountNameRefusal(name: string): string | null {
+  if (name === '') {
+    return 'A service account needs a name. Nothing was created.';
+  }
+  if (new TextEncoder().encode(name).length > 64) {
+    return 'The name is too long: 64 bytes at most. Nothing was created.';
+  }
+  return null;
+}
+
+/**
+ * createServiceAccountRefusalText names a create refusal in the create verb's
+ * OWN vocabulary — every status, never delegating to `identityRefusalText`.
+ *
+ * The shared mapper is wrong here in three places: its 409 is the MINT's
+ * conflict ("the live-credential ceiling, or an identical binding") rather than
+ * a duplicate name; its 403 demands a disclosure capability and reauthentication
+ * that a create never needs (create is `manage-identities`, no disclosure); and
+ * its 404 says "that service account is no longer here" when a create 404 is the
+ * PROJECT (or the authorization mask). Each wrong sentence sends the operator to
+ * the wrong place.
+ */
+export function createServiceAccountRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return 'The server refused that name: it must be 1–64 bytes. Nothing was created.';
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before creating a service account.';
+      case 403:
+        return 'Creating a service account needs manage-identities on this project. Nothing was created.';
+      case 404:
+        return 'This project is no longer here, or you may not administer its identities. Nothing was created.';
+      case 409:
+        return 'That name is already used by a live service account here, or this project has reached a service-account limit. Choose another name. Nothing was created.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The service account could not be created (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The service account could not be created.';
+}
+
+/**
+ * deleteServiceAccountRefusalText names a delete refusal in the delete verb's
+ * own vocabulary. It deliberately says nothing about disclosure capabilities or
+ * reauthentication — deprovisioning runs under the plain capability with no
+ * disclosure gate — so the shared 403 sentence would directly contradict the
+ * contract. A 404 is the concurrent-deletion case: already gone.
+ */
+export function deleteServiceAccountRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before deleting a service account.';
+      case 403:
+        return 'Deleting a service account needs manage-identities on this project.';
+      case 404:
+        return 'That service account is no longer here — someone may have deleted it already.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The service account could not be deleted (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The service account could not be deleted.';
+}
+
+/**
+ * createServiceAccountFailureText adds the issued-but-unconfirmed honesty: a
+ * create whose response was lost, or returned a 500 or an unparseable body, may
+ * still have COMMITTED — and a blind retry then reads the duplicate-name 409 as
+ * a fresh failure. The refusals DECIDED before any commit (a malformed name,
+ * authorization, a duplicate/limit, the budget) carry no such ambiguity, so
+ * they stay the plain sentence.
+ */
+export function createServiceAccountFailureText(error: unknown): string {
+  const base = createServiceAccountRefusalText(error);
+  if (error instanceof ApiError && [400, 401, 403, 404, 409, 429].includes(error.status)) {
+    return base;
+  }
+  return `${base} A service account may still have been created — check the inventory before retrying, since a retry can be refused as a duplicate name.`;
+}
+
+/**
+ * deleteServiceAccountFailureText is the same honesty for a delete: a lost
+ * response may still have removed the account and released its grants. The
+ * pre-commit refusals (401/403/429, and 404 which means it was already gone)
+ * stay plain.
+ */
+export function deleteServiceAccountFailureText(error: unknown): string {
+  const base = deleteServiceAccountRefusalText(error);
+  if (error instanceof ApiError && [401, 403, 404, 429].includes(error.status)) {
+    return base;
+  }
+  return `${base} The account may still have been deleted — check the inventory before retrying.`;
 }
 
 /**

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -16,6 +16,8 @@ import {
   BINDING_LIFETIMES,
   bindingFailureText,
   CI_EVENTS,
+  createServiceAccountFailureText,
+  deleteServiceAccountFailureText,
   expiryLabel,
   FEDERATION_PRESETS,
   grantFailureText,
@@ -31,14 +33,18 @@ import {
   presetFieldId,
   pullRequestRefusal,
   scopeOf,
+  serviceAccountNameRefusal,
   setupJourney,
   useCreateBinding,
+  useCreateServiceAccount,
   useCredentials,
+  useDeleteServiceAccount,
   useGrantEnvironment,
   useKeyCatalogue,
   useProjectGrants,
   useRefreshAccount,
   useRefreshGrants,
+  useRefreshServiceAccounts,
   useRevokeCredential,
   useServiceAccounts,
   type ClaimPin,
@@ -48,6 +54,7 @@ import {
   type ProjectRef,
   type ServiceAccount,
 } from '../api/identities.ts';
+import { TypedNameConfirm } from './Sections.tsx';
 import { useMachineReveal, useSetMachineReveal } from '../api/machineReveal.ts';
 import { useAuth } from '../app/AuthProvider.tsx';
 import { writeClipboard } from '../app/clipboard.ts';
@@ -92,7 +99,9 @@ type Tab = 'accounts' | 'federation' | 'kubernetes';
 
 type Dialog =
   | { kind: 'binding'; account: ServiceAccount }
-  | { kind: 'grant'; account: ServiceAccount };
+  | { kind: 'grant'; account: ServiceAccount }
+  | { kind: 'create' }
+  | { kind: 'delete'; account: ServiceAccount };
 
 type MintTransitionResult = {
   readonly state: MintLifecycle;
@@ -189,6 +198,16 @@ export function MachineAccess() {
     [],
   );
 
+  // A create, delete, binding or grant dialog carries a decision scoped to ONE
+  // project and session. A boundary crossing — a route change, or a session
+  // replacement — must close any open one, or a submit after the boundary would
+  // target the new project (its form still mounted, now reading the new prop) or
+  // act under a replaced session. The mint has its own lifecycle clear above;
+  // this covers the setDialog-based dialogs.
+  useEffect(() => {
+    setDialog(null);
+  }, [project.org, project.project, liveSessionId]);
+
   const revoke = useRevokeCredential(project);
   const now = useMemo(() => new Date(), []);
 
@@ -249,6 +268,20 @@ export function MachineAccess() {
     environmentsQuery.isSuccess &&
     !credentials.isPending &&
     !credentials.isError;
+
+  /**
+   * canAdminister gates create and delete, and it is deliberately lighter than
+   * inputsReady.
+   *
+   * Create and delete are NARROWINGS — neither carries a warning that quantifies
+   * reach, so neither needs the grant, environment or credential reads that
+   * inputsReady waits on. Coupling them to that predicate would let an
+   * unreadable membership surface (a `manage-identities` admin without
+   * `manage-members`) block seeding a fresh project — exactly the inert
+   * inventory this surface exists to remove. They need only a live session and a
+   * known account listing.
+   */
+  const canAdminister = liveSessionId !== null && accountsQuery.isSuccess;
 
   const tabCount: Record<Tab, string> = {
     accounts: accountsQuery.isSuccess ? String(accounts.length) : '—',
@@ -378,6 +411,16 @@ export function MachineAccess() {
         {tab === 'accounts' ? (
           <>
             <PolicyStrip project={project} />
+            <p className="machine__actions">
+              <button
+                className="btn btn--primary"
+                type="button"
+                disabled={!canAdminister}
+                onClick={() => setDialog({ kind: 'create' })}
+              >
+                Create service account
+              </button>
+            </p>
             <table className="values__table machine__table">
               <caption className="visually-hidden">
                 The project&apos;s service accounts. Credential values are never listed: a value is
@@ -426,10 +469,12 @@ export function MachineAccess() {
                         bindings={bindings(rows)}
                         now={now}
                         ready={inputsReady}
+                        canDelete={canAdminister}
                         onMint={(rotating) => reviewMint(sa, rotating)}
                         onBind={() => setDialog({ kind: 'binding', account: sa })}
                         onGrant={() => setDialog({ kind: 'grant', account: sa })}
                         onRevoke={(credential) => doRevoke(sa, credential)}
+                        onDelete={() => setDialog({ kind: 'delete', account: sa })}
                       />
                     </ExpandableRow>
                   );
@@ -437,7 +482,10 @@ export function MachineAccess() {
               </tbody>
             </table>
             {accounts.length === 0 && !accountsQuery.isPending && !accountsQuery.isError ? (
-              <p role="status">No service accounts on this project yet.</p>
+              <p role="status">
+                No service accounts on this project yet. Create one above — a browser operator seeds
+                this inventory, no CLI required.
+              </p>
             ) : null}
             <p className="machine__footnote">
               The credential list is metadata only — prefix, kind, scope, expiry, last used. Values
@@ -552,6 +600,38 @@ export function MachineAccess() {
             setDialog(null);
             setNotice(
               `Grant result for ${environment}: ${grantOutcomeSummary([result])}`,
+            );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'create' ? (
+        <CreateAccountDialog
+          project={project}
+          onClose={() => setDialog(null)}
+          onCreated={(name, kind) => {
+            setDialog(null);
+            setNotice(
+              `Created ${name} (${kind}). It is ready to mint credentials and take federated bindings — its kind is immutable from here.`,
+            );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'delete' ? (
+        <DeleteAccountDialog
+          project={project}
+          account={dialog.account}
+          onClose={() => setDialog(null)}
+          onDeleted={(name) => {
+            setDialog(null);
+            // The expanded row is gone; collapse before its listing is removed
+            // so nothing tries to render a deleted account's expansion.
+            if (expanded === dialog.account.id) {
+              setExpanded(null);
+            }
+            setNotice(
+              `Deleted ${name}. Every credential it held is revoked and every grant released — atomically, and this cannot be undone.`,
             );
           }}
         />
@@ -823,10 +903,12 @@ function ExpansionBody({
   bindings,
   now,
   ready,
+  canDelete,
   onMint,
   onBind,
   onGrant,
   onRevoke,
+  onDelete,
 }: {
   account: ServiceAccount;
   scope: readonly MachineEnvScope[];
@@ -836,10 +918,18 @@ function ExpansionBody({
   now: Date;
   /** Every query this surface's warnings are computed from has succeeded. */
   ready: boolean;
+  /**
+   * Delete's lighter gate: a session and a known listing. It is separate from
+   * `ready` because deprovisioning is a narrowing that needs no scope read —
+   * requiring one would keep an operator from deleting a compromised account
+   * when the membership surface is unreadable.
+   */
+  canDelete: boolean;
   onMint: (rotating: boolean) => void;
   onBind: () => void;
   onGrant: () => void;
   onRevoke: (credential: MachineCredential) => void;
+  onDelete: () => void;
 }) {
   const journey = setupJourney(account.kind, scope, machineReveal);
   return (
@@ -917,6 +1007,14 @@ function ExpansionBody({
             </button>
             <button className="btn" type="button" disabled={!ready} onClick={onGrant}>
               {`Add environment grant to ${account.name}`}
+            </button>
+            <button
+              className="btn btn--danger"
+              type="button"
+              disabled={!canDelete}
+              onClick={onDelete}
+            >
+              {`Delete ${account.name}`}
             </button>
           </div>
         </div>
@@ -1925,6 +2023,256 @@ function GrantBody({
         </button>
       </div>
     </>
+  );
+}
+
+/**
+ * CreateAccountDialog seeds a project's machine inventory from the browser.
+ *
+ * The body is exactly the locked create contract — `{ name, kind }`. There is
+ * no description field because the contract has none, and `kind` is a form field
+ * rather than an edit because it is immutable at creation. The name is refused
+ * HERE (empty or over 64) rather than as a 400, and the trimmed name is what is
+ * sent so the length checked is the length the server sees.
+ */
+function CreateAccountDialog({
+  project,
+  onClose,
+  onCreated,
+}: {
+  project: ProjectRef;
+  onClose: () => void;
+  onCreated: (name: string, kind: ServiceAccount['kind']) => void;
+}) {
+  const dialog = useModalDialog();
+  const create = useCreateServiceAccount(project);
+  const refresh = useRefreshServiceAccounts(project);
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<ServiceAccount['kind']>('workload');
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    // Validated and sent byte-for-byte, untrimmed: what is checked is what the
+    // server stores, so the client never changes the name contract behind the
+    // operator's back.
+    const nameRefusal = serviceAccountNameRefusal(name);
+    if (nameRefusal !== null) {
+      setFailure(nameRefusal);
+      return;
+    }
+    setBusy(true);
+    setFailure(null);
+    try {
+      await create.mutateAsync({ name, kind });
+      onCreated(name, kind);
+    } catch (error) {
+      // A create that returned a lost or unparseable response may still have
+      // committed, and the inventory is the only place it would show. Refresh
+      // regardless — harmless on a clean refusal — and let the failure text draw
+      // the may-have-committed distinction.
+      refresh();
+      setFailure(createServiceAccountFailureText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // An in-flight create is not dismissible: Escape, Back or unload here would
+  // hide a mutation that may commit.
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="create-account-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="create-account-title">
+        Create service account
+      </h2>
+      <p className="ceremony__lede">
+        A machine principal this project owns. Its kind is fixed at creation: a workload delivers to
+        a running process, an automation runs off-box on a schedule or in CI. A fresh account holds
+        no grants and reaches nothing until one is added.
+      </p>
+
+      <fieldset className="machine__lock" disabled={busy}>
+        <div className="field">
+          <label htmlFor="create-account-name">Name</label>
+          <input
+            id="create-account-name"
+            className="mono"
+            value={name}
+            autoComplete="off"
+            spellCheck={false}
+            maxLength={64}
+            onChange={(event) => {
+              setName(event.target.value);
+              setFailure(null);
+            }}
+          />
+        </div>
+
+        <div className="field">
+          <label htmlFor="create-account-kind">Kind (immutable)</label>
+          <select
+            id="create-account-kind"
+            value={kind}
+            onChange={(event) => {
+              setKind(event.target.value === 'automation' ? 'automation' : 'workload');
+              setFailure(null);
+            }}
+          >
+            <option value="workload">workload — delivers to a running process</option>
+            <option value="automation">automation — runs off-box, on a schedule or in CI</option>
+          </select>
+        </div>
+      </fieldset>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => void submit()}
+        >
+          {busy ? 'Creating…' : 'Create service account'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * DeleteAccountDialog deprovisions a machine principal behind a typed-name
+ * confirmation.
+ *
+ * The server delete is a CASCADE, not a dependency refusal: every credential is
+ * revoked and every grant released in one transaction, then the principal is
+ * removed. So the dialog states that truth — how many live credentials go, and
+ * that the grants go with them — rather than warning of a refusal the contract
+ * does not raise. There is deliberately NO passkey here: deprovisioning runs
+ * under the plain capability with no disclosure gate, because requiring a
+ * ceremony to kill a compromised workload would be a self-inflicted delay.
+ */
+function DeleteAccountDialog({
+  project,
+  account,
+  onClose,
+  onDeleted,
+}: {
+  project: ProjectRef;
+  account: ServiceAccount;
+  onClose: () => void;
+  onDeleted: (name: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const remove = useDeleteServiceAccount(project);
+  const refreshAccounts = useRefreshServiceAccounts(project);
+  const refreshGrants = useRefreshGrants(project);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    setBusy(true);
+    setFailure(null);
+    try {
+      await remove.mutateAsync(account.id);
+      onDeleted(account.name);
+    } catch (error) {
+      // A delete that committed removed the account and released its grants, so
+      // both surfaces are re-read on the failure path — never the credential
+      // listing, which would race the account refetch into a 404 and flip the
+      // whole surface to error. The failure text says whether the delete may
+      // still have landed.
+      refreshAccounts();
+      refreshGrants();
+      setFailure(deleteServiceAccountFailureText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // An in-flight delete is not dismissible by Escape, Back or unload.
+  useNavigationGuard(busy, () => {});
+
+  const live = account.live_credentials;
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="delete-account-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="delete-account-title">
+        {`Delete service account · ${account.name}`}
+      </h2>
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          {`This deletes ${account.name} and everything attached to it in one act: ${String(live)} live credential${live === 1 ? '' : 's'} revoked — each stops authenticating at once — and every environment grant released. It does not cascade to anything else, and it cannot be undone.`}
+        </span>
+      </p>
+      <p className="ceremony__lede">
+        Any bearer token or federated binding this account issued authenticates nothing the moment
+        the delete lands. Distribute the replacement first if a workload still depends on it.
+      </p>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <TypedNameConfirm
+        label="Confirm the account name to delete it"
+        expect={account.name}
+        action="Delete service account"
+        hint={
+          <>
+            Type <span className="mono">{account.name}</span> to enable deletion.
+          </>
+        }
+        busy={busy}
+        onConfirm={() => void submit()}
+      />
+
+      <div className="ceremony__actions">
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
   );
 }
 


### PR DESCRIPTION
Closes #464.

Lets a browser-only operator seed and deprovision project-owned service accounts, so a fresh project no longer presents an inert Machine Access inventory that only a CLI/API seed can fill.

## What shipped
- **Create** — a primary `Create service account` action (the empty state points at it, and it also sits above a seeded table). The dialog collects **name and kind**; kind (workload | automation) is immutable at creation, so it is a `select`, not an edit.
- **Delete** — a per-account `btn--danger` behind the shared `TypedNameConfirm` gate (the same danger-zone control the project and key deletes use). The dialog states the server's **atomic cascade** — how many live credentials are revoked and that every grant is released — immediate and non-recoverable.
- New `useCreateServiceAccount` / `useDeleteServiceAccount` hooks, create/delete-specific refusal + ambiguous-outcome mappers, and client-side name validation.

## Contract decisions (no server / OpenAPI / migration change)
1. **Create collects name + kind, not name + description.** The ticket said "name and description", but the locked `CreateServiceAccountRequest` is exactly `{ name, kind }` — no description field exists in the contract, store or audit payload. Adding one would be server + OpenAPI + migration scope the handoff forbids, so the form asks for the field the contract has.
2. **Delete is an atomic cascade, not a dependency refusal.** `DeleteServiceAccount` revokes every credential and releases every grant in one transaction (#15), then removes the principal; the delete contract declares no 409. There is no dependency refusal to honour, so the dialog states that truth. There is deliberately **no passkey/reauth** on delete — it runs under the plain capability, because requiring a ceremony to kill a compromised workload would be a self-inflicted incident-response delay.

Both are recorded in `docs/handoff/67-machine-access.md`.

## Regenerated artifacts
None. The `createServiceAccount` / `deleteServiceAccount` operations were already generated in `@hikyo/operations`; no client was hand-edited or regenerated.

## Cross-model review
Codex (gpt-5.6-sol, high) adversarial review, 2 rounds. R1 raised 5 findings (1 delete cache resurrection race, issued-but-unconfirmed failure text, trim/UTF-16 length divergence, refusal vocabulary, dialogs not cleared on project/session boundary); all fixed. **R2 verdict: CLEAN**, all 5 RESOLVED, no residuals.

## Validation
- `pnpm --dir web typecheck` — clean
- `pnpm --dir web test` — 534 passed (incl. new pure-seam tests: name validation, refusal + ambiguous-outcome mappers)
- `pnpm --dir web build` — OK
- Playwright `machine-access.spec.ts` — full spec **26 passed** across desktop + mobile (pre-fix); new create→mint→revoke→delete + duplicate-name tests **re-verified green** post-fix on desktop. Full both-viewport run is left to CI.

No secret material touches URLs, logs, toasts, DOM diagnostics or durable storage; authorization is unchanged; refusal precedence is preserved.