### PR TITLE
perf(api): warm OpenAPI validation at boot #514

### DIFF
--- a/api/artifact_admission_test.go
+++ b/api/artifact_admission_test.go
@@ -25,8 +25,9 @@ func TestOperationForDerivesArtifactEligibilityFromEmbeddedContract(t *testing.T
 	if op.ID != "listValues" {
 		t.Fatalf("operation id = %q, want listValues", op.ID)
 	}
-	if len(op.Artifacts) != 1 || op.Artifacts[0] != "human-session" {
-		t.Fatalf("artifact eligibility = %v, want [human-session]", op.Artifacts)
+	artifacts := op.Artifacts()
+	if len(artifacts) != 1 || artifacts[0] != "human-session" {
+		t.Fatalf("artifact eligibility = %v, want [human-session]", artifacts)
 	}
 }
 

--- a/api/match_test.go
+++ b/api/match_test.go
@@ -89,9 +89,10 @@ func TestMatchRequestResolvesTheContractRouteExactlyOnce(t *testing.T) {
 	}
 }
 
-// TestMatchedOperationIsACopyOfTheImmutableRow pins that a caller holding a
-// match cannot edit the artifact allowlist the next request is admitted by.
-func TestMatchedOperationIsACopyOfTheImmutableRow(t *testing.T) {
+// TestMatchedOperationCarriesTheResolvedRow pins that matching and validation
+// carry one operation row through the request rather than re-reading the
+// registry. Operation is shared and read-only by contract (#514).
+func TestMatchedOperationCarriesTheResolvedRow(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, PathPrefix+"/orgs",
 		strings.NewReader(`{"name":"acme"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -100,29 +101,32 @@ func TestMatchedOperationIsACopyOfTheImmutableRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createOrg did not resolve through the embedded contract: %v", err)
 	}
-	mutated := match.Operation()
-	mutated.Artifacts[0] = "forged"
-
-	fresh := match.Operation()
-	if fresh.Artifacts[0] == "forged" {
-		t.Fatal("editing a matched operation changed the row a later consumer reads")
+	matched := match.Operation()
+	returnedArtifacts := matched.Artifacts()
+	returnedArtifacts[0] = "forged"
+	if matched.AdmitsArtifact("forged") {
+		t.Fatal("editing the artifact accessor result changed the shared registry row")
+	}
+	returnedFormula := matched.Formula()
+	returnedFormula[0] = "forged@instance"
+	if match.Operation().Formula()[0] == "forged@instance" {
+		t.Fatal("editing the formula accessor result changed the shared registry row")
 	}
 	validated, err := match.Validate()
 	if err != nil {
 		t.Fatalf("a contract-conforming request was refused: %v", err)
 	}
-	validatedCopy := validated.Operation()
-	validatedCopy.Artifacts[0] = "forged"
 	ctx := validated.Request().Context()
-	originalRegistryRow := operations[fresh.ID]
-	changedRegistryRow := cloneOperation(originalRegistryRow)
-	changedRegistryRow.Artifacts[0] = "registry-forged"
-	operations[fresh.ID] = changedRegistryRow
-	t.Cleanup(func() { operations[fresh.ID] = originalRegistryRow })
+	originalRegistryRow := operations[matched.ID]
+	changedRegistryRow := originalRegistryRow
+	changedRegistryRow.artifacts = append([]string(nil), originalRegistryRow.artifacts...)
+	changedRegistryRow.artifacts[0] = "registry-forged"
+	operations[matched.ID] = changedRegistryRow
+	t.Cleanup(func() { operations[matched.ID] = originalRegistryRow })
 	if attached, ok := OperationFromContext(ctx); !ok ||
-		attached.Artifacts[0] == "forged" {
-		t.Fatal("editing a returned operation changed the validated row attached to context")
-	} else if attached.Artifacts[0] == "registry-forged" {
+		attached.ID != matched.ID {
+		t.Fatal("validated request lost the matched operation")
+	} else if attached.artifacts[0] == "registry-forged" {
 		t.Fatal("context re-read the registry instead of carrying the validated row")
 	}
 }

--- a/api/saml_contract_test.go
+++ b/api/saml_contract_test.go
@@ -64,8 +64,9 @@ func TestSAMLContractSurfaceIsLocked(t *testing.T) {
 	}
 	for _, id := range []string{"samlStart", "samlACS"} {
 		op := ops[id]
-		if !slices.Contains(op.Artifacts, "none") || !slices.Contains(op.Artifacts, "human-session") {
-			t.Errorf("%s artifact eligibility = %v, want anonymous login plus session-bound link/reauth", id, op.Artifacts)
+		artifacts := op.Artifacts()
+		if !slices.Contains(artifacts, "none") || !slices.Contains(artifacts, "human-session") {
+			t.Errorf("%s artifact eligibility = %v, want anonymous login plus session-bound link/reauth", id, artifacts)
 		}
 	}
 	doc, err := api.Doc()

--- a/api/spec.go
+++ b/api/spec.go
@@ -151,23 +151,34 @@ func load() {
 	}
 }
 
+// Warm parses and validates the embedded contract. Server boot calls it before
+// opening a listener so no request pays the one-time document load cost.
+func Warm() error {
+	loadOnce.Do(load)
+	return loadErr
+}
+
 // Doc returns the parsed contract. It fails loudly rather than serving
 // unvalidated traffic: an unparseable embedded document is a build defect.
 func Doc() (*openapi3.T, error) {
-	loadOnce.Do(load)
-	return doc, loadErr
+	if err := Warm(); err != nil {
+		return nil, err
+	}
+	return doc, nil
 }
 
-// Operation is one row of the contract registry, derived from the document
-// rather than restated in Go — one source, no drift.
+// Operation is one immutable row of the contract registry, derived from the
+// document rather than restated in Go — one source, no drift. Request
+// accessors share rows without cloning (#514); slice fields stay private so a
+// consumer cannot mutate authorization policy process-wide.
 type Operation struct {
 	ID          string
 	Method      string
 	Path        string
 	Class       string
 	AuthzOp     string
-	Formula     []string
-	Artifacts   []string
+	formula     []string
+	artifacts   []string
 	MinRevision int
 	// Secured reports whether the operation inherits the document's session
 	// security requirement. An operation that clears it with `security: []`
@@ -187,7 +198,7 @@ const (
 // AdmitsArtifact reports whether the operation's OpenAPI declaration admits
 // the authenticated artifact class. The declaration is a closed allowlist.
 func (o Operation) AdmitsArtifact(class string) bool {
-	for _, declared := range o.Artifacts {
+	for _, declared := range o.artifacts {
 		if declared == class {
 			return true
 		}
@@ -195,10 +206,14 @@ func (o Operation) AdmitsArtifact(class string) bool {
 	return false
 }
 
-func cloneOperation(op Operation) Operation {
-	op.Formula = append([]string(nil), op.Formula...)
-	op.Artifacts = append([]string(nil), op.Artifacts...)
-	return op
+// Formula returns a copy of the authorization formula declared for this row.
+func (o Operation) Formula() []string {
+	return append([]string(nil), o.formula...)
+}
+
+// Artifacts returns a copy of the authenticated artifact allowlist.
+func (o Operation) Artifacts() []string {
+	return append([]string(nil), o.artifacts...)
 }
 
 // AuthorizationOperationAdmitsArtifact reports whether any contract operation
@@ -231,14 +246,14 @@ func OperationFromContext(ctx context.Context) (Operation, bool) {
 	if !ok || op.ID == "" {
 		return Operation{}, false
 	}
-	return cloneOperation(op), true
+	return op, true
 }
 
 func withOperation(ctx context.Context, op Operation) context.Context {
 	if op.ID == "" {
 		return ctx
 	}
-	return context.WithValue(ctx, operationContextKey{}, cloneOperation(op))
+	return context.WithValue(ctx, operationContextKey{}, op)
 }
 
 // Operations returns every operation in the contract, keyed by operationId.
@@ -249,7 +264,7 @@ func Operations() (map[string]Operation, error) {
 	}
 	out := make(map[string]Operation, len(operations))
 	for id, op := range operations {
-		out[id] = cloneOperation(op)
+		out[id] = op
 	}
 	return out, nil
 }
@@ -275,13 +290,13 @@ func collectOperations(d *openapi3.T) (map[string]Operation, error) {
 			if row.AuthzOp, err = optionalString(op.Extensions, extOperation); err != nil {
 				return nil, fmt.Errorf("api: %s %s: %w", method, path, err)
 			}
-			if row.Formula, err = optionalStrings(op.Extensions, extFormula); err != nil {
+			if row.formula, err = optionalStrings(op.Extensions, extFormula); err != nil {
 				return nil, fmt.Errorf("api: %s %s: %w", method, path, err)
 			}
-			if row.Artifacts, err = extStrings(op.Extensions, extArtifacts); err != nil {
+			if row.artifacts, err = extStrings(op.Extensions, extArtifacts); err != nil {
 				return nil, fmt.Errorf("api: %s %s: %w", method, path, err)
 			}
-			if len(row.Artifacts) == 0 {
+			if len(row.artifacts) == 0 {
 				return nil, fmt.Errorf("api: %s %s: extension %s must declare at least one artifact class", method, path, extArtifacts)
 			}
 			if row.MinRevision, err = extInt(op.Extensions, extMinRevision); err != nil {
@@ -339,11 +354,11 @@ func resolveRequest(r *http.Request) (*resolvedRequest, error) {
 	if !ok {
 		return nil, fmt.Errorf("api: matched operation %q is absent from the contract registry", route.Operation.OperationID)
 	}
-	return &resolvedRequest{request: r, route: route, params: params, op: cloneOperation(op)}, nil
+	return &resolvedRequest{request: r, route: route, params: params, op: op}, nil
 }
 
 // MatchedRequest is one request's single resolution through the contract:
-// the route the OpenAPI router matched, its path parameters, and a cloned
+// the route the OpenAPI router matched, its path parameters, and the shared
 // immutable operation row. The mutable kin-openapi values stay attempt-local
 // and never enter a request context.
 type MatchedRequest struct {
@@ -353,7 +368,7 @@ type MatchedRequest struct {
 	op      Operation
 }
 
-// ValidatedRequest carries the original request and the cloned operation row
+// ValidatedRequest carries the original request and its shared operation row
 // proven by its validation. Its fields are private, so another package cannot
 // construct an alternate row or attach one to a different request.
 type ValidatedRequest struct {
@@ -377,9 +392,9 @@ func MatchRequest(r *http.Request) (*MatchedRequest, error) {
 	}, nil
 }
 
-// Operation returns a copy of the immutable contract row this request matched.
-// Consumers may hold and read it; editing the copy changes nothing.
-func (m *MatchedRequest) Operation() Operation { return cloneOperation(m.op) }
+// Operation returns the shared immutable contract row this request matched.
+// Consumers may hold and read it but must not mutate its slice fields.
+func (m *MatchedRequest) Operation() Operation { return m.op }
 
 // Validate checks the matched request against the contract and reports the
 // offending member on failure. The request is validated AS MATCHED: a caller
@@ -420,15 +435,15 @@ func (m *MatchedRequest) Validate() (*ValidatedRequest, error) {
 	if err := openapi3filter.ValidateRequest(m.request.Context(), input); err != nil {
 		return nil, &ValidationError{Member: offendingMember(err), Err: err}
 	}
-	return &ValidatedRequest{request: m.request, op: cloneOperation(m.op)}, nil
+	return &ValidatedRequest{request: m.request, op: m.op}, nil
 }
 
-// Operation returns a copy of the operation row proven by validation.
+// Operation returns the immutable operation row proven by validation.
 func (v *ValidatedRequest) Operation() Operation {
 	if v == nil {
 		return Operation{}
 	}
-	return cloneOperation(v.op)
+	return v.op
 }
 
 // Request returns the request that passed validation with its immutable
@@ -501,7 +516,7 @@ func OperationFor(r *http.Request) (Operation, bool) {
 	if err != nil {
 		return Operation{}, false
 	}
-	return cloneOperation(resolved.op), true
+	return resolved.op, true
 }
 
 // jsonPointerInReason recovers the offending member from a schema error.

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -302,6 +302,8 @@ func TestEveryOperationCarriesItsContractExtensions(t *testing.T) {
 		"scim-credential": true,
 	}
 	for id, op := range ops {
+		artifacts := op.Artifacts()
+		formula := op.Formula()
 		if !validClasses[op.Class] {
 			t.Errorf("%s: unknown probe class %q", id, op.Class)
 		}
@@ -309,10 +311,10 @@ func TestEveryOperationCarriesItsContractExtensions(t *testing.T) {
 			t.Errorf("%s: x-hikyo-min-revision %d is outside [1,%d] — an operation cannot require a revision this server does not serve",
 				id, op.MinRevision, api.Revision)
 		}
-		if len(op.Artifacts) == 0 {
+		if len(artifacts) == 0 {
 			t.Errorf("%s: empty artifact eligibility set", id)
 		}
-		for _, a := range op.Artifacts {
+		for _, a := range artifacts {
 			if !validArtifacts[a] {
 				t.Errorf("%s: unknown artifact class %q", id, a)
 			}
@@ -323,13 +325,13 @@ func TestEveryOperationCarriesItsContractExtensions(t *testing.T) {
 		// An operation that names an authz operation must state its formula,
 		// and one that names none must not: the pair is the behavioural half
 		// of the freeze promise, recorded per operation.
-		if (op.AuthzOp == "") != (len(op.Formula) == 0) {
+		if (op.AuthzOp == "") != (len(formula) == 0) {
 			t.Errorf("%s: x-hikyo-operation and x-hikyo-formula must be present together (op=%q formula=%v)",
-				id, op.AuthzOp, op.Formula)
+				id, op.AuthzOp, formula)
 		}
 		// A pre-authentication path takes no artifact, and an artifact-taking
 		// path must actually be secured — otherwise the matrix is decorative.
-		if op.Secured && len(op.Artifacts) == 1 && op.Artifacts[0] == "none" {
+		if op.Secured && len(artifacts) == 1 && artifacts[0] == "none" {
 			t.Errorf("%s: secured but declares artifact eligibility `none`", id)
 		}
 		if !op.Secured && op.AuthzOp != "" {
@@ -351,7 +353,7 @@ func TestBearerAdmittingOperationsDeclareArtifactRefusal(t *testing.T) {
 		for method, operation := range item.Operations() {
 			row := ops[operation.OperationID]
 			admitsBearer := false
-			for _, artifact := range row.Artifacts {
+			for _, artifact := range row.Artifacts() {
 				if artifact != api.ArtifactNone {
 					admitsBearer = true
 					break

--- a/docs/handoff/issue-514-openapi-warmup.md
+++ b/docs/handoff/issue-514-openapi-warmup.md
@@ -1,0 +1,28 @@
+# Handoff: #514 OpenAPI warmup and request allocations
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/514. Base:
+`a84fd620cedb068988b4d996a5610d12638172b1`.
+
+## Contract
+
+- Server boot parses and validates the embedded OpenAPI document before either
+  listener opens; a load failure refuses startup.
+- Runtime OpenAPI request validation remains enabled for every API request.
+- Matched request accessors share the immutable operation-registry row. Code
+  consuming `Operation.Formula` or `Operation.Artifacts` must treat both slices
+  as read-only.
+- Operation slice fields are private and inspection accessors return copies, so
+  the validated request can attach the immutable row to context with no clone.
+
+## Coverage
+
+- Boot test injects the warmup dependency and refuses any listener acquisition
+  before warmup completes.
+- HTTP benchmark covers authenticated `GET /api/v1/orgs` and
+  `POST /api/v1/orgs` through the public middleware stack with OpenAPI request
+  validation enabled.
+- Apple M2 Pro baseline to optimized allocation counts: GET 89 to 81 allocs/op
+  and 11,613 to 11,485 B/op; POST 1056 to 1048 allocs/op and 88,609 to
+  88,411 B/op. Five-run post-change counts were stable, excluding GET's first
+  warmup-affected sample.
+- Generated outputs: none.

--- a/docs/handoff/issue-514-openapi-warmup.md
+++ b/docs/handoff/issue-514-openapi-warmup.md
@@ -1,16 +1,15 @@
 # Handoff: #514 OpenAPI warmup and request allocations
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/514. Base:
-`a84fd620cedb068988b4d996a5610d12638172b1`.
+`09f26413714c4001ce120c3c7800217b8c25cf43`.
 
 ## Contract
 
 - Server boot parses and validates the embedded OpenAPI document before either
   listener opens; a load failure refuses startup.
 - Runtime OpenAPI request validation remains enabled for every API request.
-- Matched request accessors share the immutable operation-registry row. Code
-  consuming `Operation.Formula` or `Operation.Artifacts` must treat both slices
-  as read-only.
+- Matched request accessors share the immutable operation-registry row.
+  `Operation.Formula()` and `Operation.Artifacts()` return inspection copies.
 - Operation slice fields are private and inspection accessors return copies, so
   the validated request can attach the immutable row to context with no clone.
 
@@ -24,5 +23,10 @@ Issue: https://github.com/Hikyo-Org/Hikyo/issues/514. Base:
 - Apple M2 Pro baseline to optimized allocation counts: GET 89 to 81 allocs/op
   and 11,613 to 11,485 B/op; POST 1056 to 1048 allocs/op and 88,609 to
   88,411 B/op. Five-run post-change counts were stable, excluding GET's first
-  warmup-affected sample.
+  warmup-affected sample. Comparison was captured on original base
+  `a84fd620cedb068988b4d996a5610d12638172b1` before the final base refresh.
+- CI exposed a pre-existing importer test race: its dead Kubernetes origin
+  could refuse TCP before the hung exec-plugin deadline won. The fixture now
+  uses a reachable TLS server and fails if the API is reached, leaving the
+  plugin deadline as the sole expected outcome.
 - Generated outputs: none.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/adapter"
 	"github.com/Hikyo-Org/hikyo/internal/admission"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
@@ -209,14 +210,15 @@ type bootGuard struct {
 	log     *slog.Logger
 }
 
-// bootResources is the narrow seam for resources whose acquisition can leave
-// boot or a local-admin command with something to release. Service construction
-// and wiring stay local to their caller; tests replace only these constructors
-// and cleanup functions so they can inject failures at ownership boundaries and
-// count releases.
+// bootResources is the narrow seam for boot dependencies and resources whose
+// acquisition can leave boot or a local-admin command with something to
+// release. Service construction and wiring stay local to their caller; tests
+// replace only these functions to pin ordering, inject failures at ownership
+// boundaries, and count releases.
 type bootResources struct {
 	openDatabase       func(context.Context, store.Config) (*store.DB, error)
 	closeDatabase      func(*store.DB) error
+	warmOpenAPI        func() error
 	listen             func(string, string) (net.Listener, error)
 	closeListener      func(net.Listener) error
 	newDirectoryClient func(remotefetch.Config) (*remotefetch.Client, error)
@@ -228,7 +230,8 @@ func defaultBootResources() bootResources {
 		closeDatabase: func(db *store.DB) error {
 			return db.Close()
 		},
-		listen: net.Listen,
+		warmOpenAPI: api.Warm,
+		listen:      net.Listen,
 		closeListener: func(ln net.Listener) error {
 			return ln.Close()
 		},
@@ -378,6 +381,9 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	proxies, err := parseCIDRs(cfg.TrustedProxyCIDRs)
 	if err != nil {
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
+	}
+	if err := resources.warmOpenAPI(); err != nil {
+		return nil, fmt.Errorf("boot: refusing to serve: OpenAPI contract: %w", err)
 	}
 
 	ln, err := resources.listen("tcp", cfg.Listen)

--- a/internal/app/boot_cleanup_test.go
+++ b/internal/app/boot_cleanup_test.go
@@ -127,6 +127,27 @@ func TestBootResourceOwnershipOnFailure(t *testing.T) {
 	})
 }
 
+func TestBootWarmsOpenAPIBeforeListening(t *testing.T) {
+	resources := defaultBootResources()
+	warmed := false
+	resources.warmOpenAPI = func() error {
+		warmed = true
+		return nil
+	}
+	injected := errors.New("stop after OpenAPI warmup")
+	resources.listen = func(string, string) (net.Listener, error) {
+		if !warmed {
+			t.Fatal("listener opened before the OpenAPI document was warm")
+		}
+		return nil, injected
+	}
+
+	_, err := boot(t.Context(), devConfig(t), testLogger(), resources)
+	if !errors.Is(err, injected) {
+		t.Fatalf("boot error = %v, want injected listener error", err)
+	}
+}
+
 func TestBootSuccessTransfersResourceOwnershipToServer(t *testing.T) {
 	record := &bootResourceRecord{}
 	srv, err := boot(t.Context(), devConfig(t), testLogger(), recordingBootResources(record))

--- a/internal/importer/live_test.go
+++ b/internal/importer/live_test.go
@@ -557,12 +557,17 @@ users:
 }
 
 func TestK8sLiveExecPluginCannotOutrunConnectorDeadline(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("Kubernetes API reached before the hung exec plugin timed out")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
 	kubeconfig := filepath.Join(t.TempDir(), "config")
-	config := `apiVersion: v1
+	config := fmt.Sprintf(`apiVersion: v1
 kind: Config
 clusters:
 - name: fixture-cluster
-  cluster: {server: "https://127.0.0.1:1", insecure-skip-tls-verify: true}
+  cluster: {server: %q, insecure-skip-tls-verify: true}
 contexts:
 - name: fixture-context
   context: {cluster: fixture-cluster, user: exec-user}
@@ -575,7 +580,7 @@ users:
       interactiveMode: Never
       command: /bin/sh
       args: [-c, "sleep 1"]
-`
+`, server.URL)
 	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/isolation/contract_test.go
+++ b/internal/isolation/contract_test.go
@@ -115,7 +115,7 @@ func TestContractFormulasMatchTheOperationRegistry(t *testing.T) {
 		for _, atom := range formula {
 			want = append(want, string(atom.Cap)+"@"+levelNames[atom.At])
 		}
-		got := append([]string(nil), op.Formula...)
+		got := op.Formula()
 		sort.Strings(got)
 		sort.Strings(want)
 		if strings.Join(got, ",") != strings.Join(want, ",") {
@@ -151,7 +151,8 @@ func TestContractSecuredOperationsTakeAnArtifact(t *testing.T) {
 		// eligibility under, say, `manage-identities` fails here rather than
 		// advertising an authority no machine can ever hold. That is the property
 		// the old blanket refusal was standing in for.
-		for _, artifact := range op.Artifacts {
+		artifacts := op.Artifacts()
+		for _, artifact := range artifacts {
 			if artifact != "machine-credential" {
 				continue
 			}
@@ -161,10 +162,10 @@ func TestContractSecuredOperationsTakeAnArtifact(t *testing.T) {
 			}
 			if !machineSatisfiable(authz.Operation(op.AuthzOp)) {
 				t.Errorf("%s declares machine-credential eligibility, but no machine class may hold its formula %v",
-					id, op.Formula)
+					id, op.Formula())
 			}
 		}
-		if op.Secured && len(op.Artifacts) == 1 && op.Artifacts[0] == "none" {
+		if op.Secured && len(artifacts) == 1 && artifacts[0] == "none" {
 			t.Errorf("%s: secured but eligible for no artifact", id)
 		}
 	}
@@ -262,10 +263,10 @@ func TestTenantRoutesDeclareForbiddenOnlyForMFA(t *testing.T) {
 		switch {
 		case wanted && !declared:
 			t.Errorf("%s is tenant-class with an MFA-mandatory post-grant refusal (formula %v) but declares no 403 — the refusal it can return is undeclared",
-				id, op.Formula)
+				id, op.Formula())
 		case !wanted && declared:
 			t.Errorf("%s (formula %v) is tenant-class with no post-grant refusal but declares a 403 — grant refusal there is the uniform 404, so the status is unreachable or a leak",
-				id, op.Formula)
+				id, op.Formula())
 		}
 	}
 }

--- a/internal/isolation/eligibility_test.go
+++ b/internal/isolation/eligibility_test.go
@@ -31,7 +31,7 @@ func TestInstanceConnectionCredentialReachesOnlyDirectoryServe(t *testing.T) {
 	}
 	var eligible []string
 	for id, op := range ops {
-		if slices.Contains(op.Artifacts, api.ArtifactInstanceCredential) {
+		if slices.Contains(op.Artifacts(), api.ArtifactInstanceCredential) {
 			eligible = append(eligible, id)
 		}
 	}
@@ -80,7 +80,7 @@ func TestSharingTheDirectoryFormulaDoesNotWidenTheCredential(t *testing.T) {
 			if authz.Operation(contractOp.AuthzOp) != op {
 				continue
 			}
-			if slices.Contains(contractOp.Artifacts, api.ArtifactInstanceCredential) {
+			if slices.Contains(contractOp.Artifacts(), api.ArtifactInstanceCredential) {
 				t.Errorf("%s shares the instance-directory formula and became reachable by the "+
 					"instance-connection credential — eligibility must be per-artifact-per-operation, "+
 					"never derived from the formula", id)

--- a/internal/server/admission_benchmark_test.go
+++ b/internal/server/admission_benchmark_test.go
@@ -1,0 +1,65 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/internal/server"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+// BenchmarkAuthenticatedAPIRequests measures representative reads and writes
+// through the same public router and middleware stack used by the server. It
+// keeps OpenAPI request validation in the measured path because that runtime
+// enforcement is the performance boundary this benchmark protects.
+func BenchmarkAuthenticatedAPIRequests(b *testing.B) {
+	org := service.Org{
+		ID: testOrgID, Name: "acme", Active: true,
+		Metadata: []byte(`{}`), CreatedAt: liveIdentity.CreatedAt,
+	}
+	handler := server.New(stubReady{}, &server.API{
+		Auth: stubAuth{identity: liveIdentityFn},
+		Orgs: stubOrgs{
+			list: func(context.Context, service.Actor) ([]service.Org, error) {
+				return []service.Org{org}, nil
+			},
+			create: func(context.Context, service.Actor, string, bool, json.RawMessage) (service.Org, error) {
+				return org, nil
+			},
+		},
+		Providers: stubProviders{}, Version: "benchmark",
+		Projects: stubHierarchy{}, Environments: stubEnvs{}, Values: stubValues{}, Folders: stubFolders{},
+	}, nil)
+
+	for _, benchmark := range []struct {
+		name       string
+		method     string
+		path       string
+		body       []byte
+		statusCode int
+	}{
+		{name: "GET", method: http.MethodGet, path: api.PathPrefix + "/orgs", statusCode: http.StatusOK},
+		{name: "POST", method: http.MethodPost, path: api.PathPrefix + "/orgs", body: []byte(`{"name":"acme"}`), statusCode: http.StatusCreated},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				req := httptest.NewRequest(benchmark.method, benchmark.path, bytes.NewReader(benchmark.body))
+				req.Header.Set("Authorization", "Bearer hik_1_cli_benchmark")
+				if len(benchmark.body) > 0 {
+					req.Header.Set("Content-Type", "application/json")
+				}
+				response := httptest.NewRecorder()
+				handler.ServeHTTP(response, req)
+				if response.Code != benchmark.statusCode {
+					b.Fatalf("status = %d, want %d: %s", response.Code, benchmark.statusCode, response.Body)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/admission_internal_test.go
+++ b/internal/server/admission_internal_test.go
@@ -48,7 +48,7 @@ func TestAdmissionAttachesTheMatchedOperation(t *testing.T) {
 	if operation.ID != "createOrg" {
 		t.Fatalf("operation id = %q, want createOrg", operation.ID)
 	}
-	if len(operation.Artifacts) == 0 {
+	if len(operation.Artifacts()) == 0 {
 		t.Fatal("the attached operation carries no artifact allowlist")
 	}
 }


### PR DESCRIPTION
## Summary

- warm and validate the embedded OpenAPI document before listeners open
- share immutable operation rows through request validation with private policy slices
- add authenticated GET and POST middleware benchmarks plus startup ordering coverage
- remove a pre-existing importer deadline-test race exposed by CI: reachable TLS fixture replaces competing dead-port refusal

## Benchmark

Apple M2 Pro, `go test ./internal/server -run ^$ -bench ^BenchmarkAuthenticatedAPIRequests$ -benchmem -count=5`; stable steady-state samples captured on original base `a84fd620`:

| Request | Before | After | Delta |
| --- | ---: | ---: | ---: |
| GET /api/v1/orgs | 89 allocs/op, 11,613 B/op | 81 allocs/op, 11,485 B/op | -8 allocs/op, -128 B/op |
| POST /api/v1/orgs | 1,056 allocs/op, 88,609 B/op | 1,048 allocs/op, 88,411 B/op | -8 allocs/op, -198 B/op |

Post-rebase benchmark on base `09f26413` retained stable 81 GET and 1,048 POST allocs/op. Runtime OpenAPI validation remains enabled in the measured path.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- importer deadline loop: macOS 50/50; Linux Go 1.27 container 20/20
- code review: CLEAN after immutable-slice finding fix and CI repair
- DCO: both commits signed

Closes #514