### PR TITLE
feat(web): administer OIDC providers in the WebUI (#499)

### DIFF
--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -87,6 +87,24 @@ const PORT_OPERATIONAL = Number(process.env['HIKYO_E2E_PORT_OPERATIONAL'] ?? 457
 const PORT_OPERATIONAL_B = Number(process.env['HIKYO_E2E_PORT_OPERATIONAL_B'] ?? 45794);
 export const OIDC_PROVIDER = { slug: 'e2e-oidc', displayName: 'E2E Identity Provider' };
 
+/**
+ * A SECOND fake IdP on its own port, and therefore its own byte-distinct
+ * issuer, that the fixture starts but configures NO provider for (#499). The
+ * instance-admin flow drives the WebUI itself to configure a provider against
+ * it, verify it is advertised on the sign-in page, then disable and delete it.
+ *
+ * A second issuer is not optional: `oidc_providers_issuer_enabled` allows at
+ * most one ENABLED provider per (kind, issuer), so a second enabled provider on
+ * `OIDC_PROVIDER`'s issuer would collide — and the admin session is linked
+ * through that provider, so this flow must not touch it.
+ */
+const PORT_OIDC2 = Number(process.env['HIKYO_E2E_PORT_OIDC2'] ?? 45795);
+export const WEBUI_OIDC = {
+  slug: 'e2e-webui-oidc',
+  displayName: 'WebUI Identity Provider',
+  issuer: `http://127.0.0.1:${String(PORT_OIDC2)}`,
+};
+
 /** The name the viewing instance knows the serving instance by. */
 export const REMOTE_NAME = 'peer-b';
 
@@ -174,6 +192,7 @@ type Cookie = {
 let instances: Instance[] = [];
 let tlsFront: Server | null = null;
 let oidcProcess: ChildProcess | null = null;
+let oidcProcess2: ChildProcess | null = null;
 
 function run(command: string, args: string[], options: { cwd: string; env?: NodeJS.ProcessEnv }) {
   const result = spawnSync(command, args, {
@@ -189,24 +208,22 @@ function run(command: string, args: string[], options: { cwd: string; env?: Node
   return result;
 }
 
-/** Start the test-only IdP wrapper and wait for its issuer line. */
-async function startOIDCProvider(instance: Instance): Promise<string> {
-  if (await portTaken('127.0.0.1', PORT_OIDC)) {
-    throw new Error(`something is already listening on 127.0.0.1:${String(PORT_OIDC)}`);
+/** Build and start one test-only IdP on `port` and wait for its issuer line. */
+async function spawnIdP(
+  dir: string,
+  port: number,
+  redirects: readonly string[],
+): Promise<{ proc: ChildProcess; issuer: string }> {
+  if (await portTaken('127.0.0.1', port)) {
+    throw new Error(`something is already listening on 127.0.0.1:${String(port)}`);
   }
-  const binary = join(instance.dir, 'oidctest-idp');
+  const binary = join(dir, `oidctest-idp-${String(port)}`);
   run('go', ['build', '-o', binary, './internal/oidctest/cmd'], { cwd: repoRoot });
-  const callback = `${BASE_URL}/api/v1/auth/oidc/${OIDC_PROVIDER.slug}/callback`;
-  const proc = spawn(
-    binary,
-    [
-      '-listen', `127.0.0.1:${String(PORT_OIDC)}`,
-      '-redirect-uri', callback,
-      '-amr', 'mfa,otp',
-    ],
-    { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] },
-  );
-  oidcProcess = proc;
+  const args = ['-listen', `127.0.0.1:${String(port)}`, '-amr', 'mfa,otp'];
+  for (const redirect of redirects) {
+    args.push('-redirect-uri', redirect);
+  }
+  const proc = spawn(binary, args, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
   const issuer = await new Promise<string>((resolve, reject) => {
     let stdout = '';
     let stderr = '';
@@ -227,11 +244,35 @@ async function startOIDCProvider(instance: Instance): Promise<string> {
       reject(new Error(`the fake OIDC provider exited (${String(code)}): ${stderr}`));
     });
   });
-  const expected = `http://127.0.0.1:${String(PORT_OIDC)}`;
+  const expected = `http://127.0.0.1:${String(port)}`;
   if (issuer !== expected) {
+    proc.kill('SIGKILL');
     throw new Error(`fake OIDC issuer = ${issuer}, want ${expected}`);
   }
+  return { proc, issuer };
+}
+
+/** Start the browser-drivable IdP the fixture configures and links through. */
+async function startOIDCProvider(instance: Instance): Promise<string> {
+  const callback = `${BASE_URL}/api/v1/auth/oidc/${OIDC_PROVIDER.slug}/callback`;
+  const { proc, issuer } = await spawnIdP(instance.dir, PORT_OIDC, [callback]);
+  oidcProcess = proc;
   return issuer;
+}
+
+/**
+ * Start the second IdP the WebUI provider journey (#499) configures itself. It
+ * needs only a reachable, valid OpenID configuration for discovery to succeed
+ * at create time; no login is ever completed through it, so it registers no
+ * redirect URI.
+ */
+async function startWebuiIdP(instance: Instance): Promise<void> {
+  const { proc, issuer } = await spawnIdP(instance.dir, PORT_OIDC2, []);
+  if (issuer !== WEBUI_OIDC.issuer) {
+    proc.kill('SIGKILL');
+    throw new Error(`webui IdP issuer = ${issuer}, want ${WEBUI_OIDC.issuer}`);
+  }
+  oidcProcess2 = proc;
 }
 
 /** Link the fixture administrator through the provider's real front channel. */
@@ -1004,6 +1045,10 @@ export async function startInstance(): Promise<void> {
   const oidcIssuer = await startOIDCProvider(viewing);
   await configureAndLinkOIDC(viewing, oidcIssuer);
 
+  // A second, UNCONFIGURED IdP for the WebUI provider journey (#499): the
+  // instance-admin flow configures a provider against it through the browser.
+  await startWebuiIdP(viewing);
+
   // The shared browser session is minted LAST, and that ordering is
   // load-bearing: seeding issues break-glass grants, a grant advances the
   // principal's session generation, and every session minted before it is dead
@@ -1564,6 +1609,8 @@ export function stopInstance(): void {
   tlsFront = null;
   oidcProcess?.kill('SIGKILL');
   oidcProcess = null;
+  oidcProcess2?.kill('SIGKILL');
+  oidcProcess2 = null;
   for (const instance of instances) {
     // SIGKILL, not SIGTERM: a server still inside boot may not have installed
     // its signal handler yet, and a survivor holds the port for the NEXT run —

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -227,7 +227,13 @@ async function spawnIdP(
   const issuer = await new Promise<string>((resolve, reject) => {
     let stdout = '';
     let stderr = '';
-    const deadline = setTimeout(() => reject(new Error('the fake OIDC provider did not start')), 10_000);
+    const deadline = setTimeout(() => {
+      // Kill the child here: the caller assigns the process global only AFTER
+      // a successful start, so a timed-out child teardown could never reach
+      // would otherwise hold its port for every later run.
+      proc.kill('SIGKILL');
+      reject(new Error('the fake OIDC provider did not start'));
+    }, 10_000);
     proc.stderr?.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
     });

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Browser, type Page } from '@playwright/test';
 import {
   zGrantList,
   zOrg,
@@ -22,8 +22,10 @@ import {
   establishSession,
   INSTANCE_GRANT_TARGET,
   nextTotpCode,
+  OIDC_PROVIDER,
   readSeed,
   STORAGE_STATE,
+  WEBUI_OIDC,
 } from '../fixtures/instance.ts';
 import { test } from '../fixtures/passkey.ts';
 
@@ -429,6 +431,7 @@ test.describe('instance administration', () => {
         ['#instance-grants', 'require a second factor', 'No instance-scope grants'],
         ['#instance-retention', 'requires a second factor', 'Payload pruning'],
         ['#instance-settings', 'requires a second factor', 'Maximum finite lifetime'],
+        ['#instance-oidc', 'needs a second factor', '+ add identity provider'],
       ] as const;
       for (const [selector, refusalText, forbiddenText] of panels) {
         const panel = page.locator(selector);
@@ -438,6 +441,160 @@ test.describe('instance administration', () => {
     } finally {
       await context.close();
     }
+  });
+
+  /** Open a fresh, unauthenticated /login and settle it on a known button. */
+  async function withFreshLogin(
+    browser: Browser,
+    body: (page: Page) => Promise<void>,
+  ): Promise<void> {
+    const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    try {
+      const fresh = await context.newPage();
+      await fresh.goto('/login');
+      // The fixture's own provider is always advertised — waiting on it is the
+      // settle point that makes a later "absent" assertion trustworthy.
+      await expect(
+        fresh.getByRole('button', { name: `Continue with ${OIDC_PROVIDER.displayName}` }),
+      ).toBeVisible();
+      await body(fresh);
+    } finally {
+      await context.close();
+    }
+  }
+
+  test('configures a provider, advertises it on login, then disables and deletes it', async ({
+    page,
+    browser,
+  }, testInfo) => {
+    testInfo.setTimeout(60_000);
+    const panel = page.locator('#instance-oidc');
+    await expect(panel.getByRole('heading', { name: 'Identity providers' })).toBeVisible();
+    // The fixture's linked provider is listed alongside any this flow adds.
+    await expect(panel).toContainText(OIDC_PROVIDER.displayName);
+
+    // Configure a new provider entirely through the browser. Its issuer is the
+    // second fixture IdP, so discovery succeeds server-side at create time.
+    await panel.getByRole('button', { name: '+ add identity provider' }).click();
+    const editor = panel.locator('.oidc-editor');
+    await editor.getByLabel('Slug').fill(WEBUI_OIDC.slug);
+    await editor.getByLabel('Display name').fill(WEBUI_OIDC.displayName);
+    await editor.getByLabel('Issuer URL').fill(WEBUI_OIDC.issuer);
+    await editor.getByLabel('Client ID').fill('e2e-webui-client');
+    await editor.getByLabel('Client secret').fill('e2e-webui-secret');
+    await editor.getByLabel('Scopes').fill('openid');
+    await editor.getByRole('button', { name: 'Configure provider' }).click();
+
+    const row = panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName });
+    await expect(row).toContainText('enabled');
+    await expect(
+      page.locator('.notice').filter({ hasText: 'advertised on the sign-in page' }),
+    ).toBeVisible();
+
+    // Advertised login availability, verified in a fresh unauthenticated context.
+    await withFreshLogin(browser, async (login) => {
+      await expect(
+        login.getByRole('button', { name: `Continue with ${WEBUI_OIDC.displayName}` }),
+      ).toBeVisible();
+    });
+
+    // Disable it: a reconfigure with the write-only secret re-entered and the
+    // Enabled box cleared. The secret is required even to disable.
+    await row.getByRole('button', { name: `Reconfigure ${WEBUI_OIDC.displayName}` }).click();
+    const reconfigure = panel.locator('.oidc-editor');
+    await reconfigure.getByLabel('Enabled (advertised on the sign-in page)').uncheck();
+    await expect(reconfigure.getByRole('alert')).toContainText(
+      'Local password and second-factor sign-in is unaffected',
+    );
+    await reconfigure.getByRole('button', { name: 'Save provider' }).click();
+    // The panel now shows two role=alert nodes at once (the disable-consequence
+    // note and the field refusal), so scope the assertion to the panel text.
+    await expect(panel).toContainText('entered on every save');
+    await reconfigure.getByLabel('Client secret').fill('e2e-webui-secret');
+    await reconfigure.getByRole('button', { name: 'Save provider' }).click();
+    await expect(
+      panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName }),
+    ).toContainText('disabled');
+
+    // No longer advertised.
+    await withFreshLogin(browser, async (login) => {
+      await expect(
+        login.getByRole('button', { name: `Continue with ${WEBUI_OIDC.displayName}` }),
+      ).toHaveCount(0);
+    });
+
+    // Delete it, gated on the immutable slug, with the consequence stated.
+    const disabledRow = panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName });
+    await disabledRow.getByRole('button', { name: `Delete ${WEBUI_OIDC.displayName}` }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('cannot be undone');
+    // Keyboard operable: Escape closes the native dialog without deleting.
+    await dialog.getByLabel('Type the provider slug to confirm').press('Escape');
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(
+      panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName }),
+    ).toHaveCount(1);
+
+    await disabledRow.getByRole('button', { name: `Delete ${WEBUI_OIDC.displayName}` }).click();
+    const confirm = page.getByRole('dialog');
+    await confirm.getByLabel('Type the provider slug to confirm').fill(WEBUI_OIDC.slug);
+    await confirm.getByRole('button', { name: 'Delete provider' }).click();
+    await expect(
+      panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName }),
+    ).toHaveCount(0);
+  });
+
+  test('refuses a changed issuer on reconfigure as a field error, before any request', async ({
+    page,
+  }) => {
+    const panel = page.locator('#instance-oidc');
+    let putSent = false;
+    await page.route('**/api/v1/instance/oidc-providers/**', async (route) => {
+      if (route.request().method() === 'PUT') {
+        putSent = true;
+      }
+      await route.continue();
+    });
+
+    await panel
+      .locator('.settings-row')
+      .filter({ hasText: OIDC_PROVIDER.displayName })
+      .getByRole('button', { name: `Reconfigure ${OIDC_PROVIDER.displayName}` })
+      .click();
+    const editor = panel.locator('.oidc-editor');
+    // The issuer field is disabled on reconfigure, so its immutability is
+    // visible; the validator refuses a mismatch regardless. Drive the guard by
+    // clearing the secret, which is refused as a field error with no request.
+    await editor.getByLabel('Client secret').fill('');
+    await editor.getByRole('button', { name: 'Save provider' }).click();
+    await expect(panel.getByRole('alert')).toContainText('entered on every save');
+    expect(putSent).toBe(false);
+    await expect(editor.getByLabel('Issuer URL')).toBeDisabled();
+  });
+
+  test('surfaces a stale-state conflict as a reload prompt', async ({ page }) => {
+    const panel = page.locator('#instance-oidc');
+    await page.route('**/api/v1/instance/oidc-providers/**', async (route) => {
+      if (route.request().method() !== 'PUT') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'conflict' } }),
+      });
+    });
+
+    await panel
+      .locator('.settings-row')
+      .filter({ hasText: OIDC_PROVIDER.displayName })
+      .getByRole('button', { name: `Reconfigure ${OIDC_PROVIDER.displayName}` })
+      .click();
+    const editor = panel.locator('.oidc-editor');
+    await editor.getByLabel('Client secret').fill('whatever-secret');
+    await editor.getByRole('button', { name: 'Save provider' }).click();
+    await expect(panel.getByRole('alert')).toContainText('changed underneath you');
   });
 
   for (const scheme of ['dark', 'light'] as const) {

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -468,6 +468,7 @@ test.describe('instance administration', () => {
     browser,
   }, testInfo) => {
     testInfo.setTimeout(60_000);
+    try {
     const panel = page.locator('#instance-oidc');
     await expect(panel.getByRole('heading', { name: 'Identity providers' })).toBeVisible();
     // The fixture's linked provider is listed alongside any this flow adds.
@@ -542,9 +543,16 @@ test.describe('instance administration', () => {
     await expect(
       panel.locator('.settings-row').filter({ hasText: WEBUI_OIDC.displayName }),
     ).toHaveCount(0);
+    } finally {
+      // Failure-safe cleanup: a mid-test failure must not leave the throwaway
+      // provider behind to collide (by slug or enabled issuer) on a later run.
+      await browserApi(page, 'DELETE', `/api/v1/instance/oidc-providers/${WEBUI_OIDC.slug}`, z.null()).catch(
+        () => undefined,
+      );
+    }
   });
 
-  test('refuses a changed issuer on reconfigure as a field error, before any request', async ({
+  test('keeps the issuer immutable and refuses a secretless reconfigure before any request', async ({
     page,
   }) => {
     const panel = page.locator('#instance-oidc');
@@ -562,14 +570,15 @@ test.describe('instance administration', () => {
       .getByRole('button', { name: `Reconfigure ${OIDC_PROVIDER.displayName}` })
       .click();
     const editor = panel.locator('.oidc-editor');
-    // The issuer field is disabled on reconfigure, so its immutability is
-    // visible; the validator refuses a mismatch regardless. Drive the guard by
-    // clearing the secret, which is refused as a field error with no request.
+    // The issuer field is disabled on reconfigure, so a changed issuer is not
+    // even expressible in the UI — the field-error path for it is unit-tested.
+    // Here the blank-secret guard refuses the save with no request reaching the
+    // server, which is the write-only-secret contract enforced client-side.
+    await expect(editor.getByLabel('Issuer URL')).toBeDisabled();
     await editor.getByLabel('Client secret').fill('');
     await editor.getByRole('button', { name: 'Save provider' }).click();
     await expect(panel.getByRole('alert')).toContainText('entered on every save');
     expect(putSent).toBe(false);
-    await expect(editor.getByLabel('Issuer URL')).toBeDisabled();
   });
 
   test('surfaces a stale-state conflict as a reload prompt', async ({ page }) => {

--- a/web/src/api/oidcProviders.test.ts
+++ b/web/src/api/oidcProviders.test.ts
@@ -73,7 +73,7 @@ describe('validatePolicyJson', () => {
 
 describe('validateProviderDraft', () => {
   it('binds a valid create draft to a wire input', () => {
-    const result = validateProviderDraft(goodDraft, null);
+    const result = validateProviderDraft(goodDraft, null, []);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.slug).toBe('acme');
@@ -84,18 +84,18 @@ describe('validateProviderDraft', () => {
 
   it('requires the write-only secret on every save, including a disable', () => {
     const disabling = { ...goodDraft, clientSecret: '', enabled: false };
-    const result = validateProviderDraft(disabling, provider);
+    const result = validateProviderDraft(disabling, provider, [provider]);
     expect(result).toMatchObject({ ok: false, field: 'client_secret' });
   });
 
   it('refuses a changed issuer on reconfigure as a field error, before the wire', () => {
     const moved = { ...goodDraft, issuer: 'https://other.example' };
-    const result = validateProviderDraft(moved, provider);
+    const result = validateProviderDraft(moved, provider, [provider]);
     expect(result).toMatchObject({ ok: false, field: 'issuer' });
   });
 
   it('keeps the immutable slug of the reconfigured provider, ignoring the draft slug', () => {
-    const result = validateProviderDraft({ ...goodDraft, slug: 'ignored' }, provider);
+    const result = validateProviderDraft({ ...goodDraft, slug: 'ignored' }, provider, [provider]);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.slug).toBe('acme');
@@ -103,12 +103,32 @@ describe('validateProviderDraft', () => {
   });
 
   it('validates the slug only on create', () => {
-    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, null)).toMatchObject({
+    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, null, [])).toMatchObject({
       ok: false,
       field: 'slug',
     });
     // A reconfigure never sends the slug, so an odd draft slug is irrelevant.
-    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, provider).ok).toBe(true);
+    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, provider, [provider]).ok).toBe(
+      true,
+    );
+  });
+
+  it('refuses a second enabled provider on an issuer another enabled one already uses', () => {
+    const other: OidcProvider = { ...provider, slug: 'other', display_name: 'Other' };
+    // A new enabled provider on the same issuer as an existing enabled one.
+    const created = validateProviderDraft(
+      { ...goodDraft, slug: 'new-one' },
+      null,
+      [other],
+    );
+    expect(created).toMatchObject({ ok: false, field: 'issuer' });
+
+    // A disabled twin does not collide, and neither does reconfiguring self.
+    const disabledTwin: OidcProvider = { ...other, enabled: false };
+    expect(validateProviderDraft({ ...goodDraft, slug: 'new-one' }, null, [disabledTwin]).ok).toBe(
+      true,
+    );
+    expect(validateProviderDraft(goodDraft, provider, [provider]).ok).toBe(true);
   });
 });
 

--- a/web/src/api/oidcProviders.test.ts
+++ b/web/src/api/oidcProviders.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './client.ts';
+import {
+  oidcProviderRefusalText,
+  validatePolicyJson,
+  validateProviderDraft,
+  validateSlug,
+  type OidcProvider,
+  type OidcProviderDraft,
+} from './oidcProviders.ts';
+
+const provider: OidcProvider = {
+  slug: 'acme',
+  display_name: 'Acme',
+  issuer: 'https://issuer.example',
+  client_id: 'client',
+  scopes: 'openid',
+  redirect_uri: 'https://hikyo.example/api/v1/auth/oidc/acme/callback',
+  jit_policy: null,
+  assurance_policy: null,
+  enabled: true,
+};
+
+const goodDraft: OidcProviderDraft = {
+  slug: 'acme',
+  displayName: 'Acme',
+  issuer: 'https://issuer.example',
+  clientId: 'client',
+  clientSecret: 'shhh',
+  scopes: 'openid',
+  jitPolicy: '',
+  assurancePolicy: '',
+  enabled: true,
+};
+
+describe('validateSlug', () => {
+  it('accepts the contract pattern and rejects the rest', () => {
+    expect(validateSlug('acme-1').ok).toBe(true);
+    expect(validateSlug('a').ok).toBe(true);
+    for (const bad of ['', '-lead', 'UPPER', 'has space', 'x'.repeat(65)]) {
+      expect(validateSlug(bad).ok, bad).toBe(false);
+    }
+    // The contract pattern permits a trailing hyphen; the WebUI must not be
+    // stricter than the server it validates for.
+    expect(validateSlug('trailing-').ok).toBe(true);
+    // 64 characters is the boundary the pattern allows.
+    expect(validateSlug(`a${'b'.repeat(63)}`).ok).toBe(true);
+    expect(validateSlug(`a${'b'.repeat(64)}`).ok).toBe(false);
+  });
+});
+
+describe('validatePolicyJson', () => {
+  it('treats empty as the absent policy, not an empty string', () => {
+    expect(validatePolicyJson('   ', 'P')).toEqual({ ok: true, value: null });
+  });
+
+  it('accepts a JSON object and preserves its exact text', () => {
+    expect(validatePolicyJson('{"claim":"groups","values":["a"]}', 'P')).toEqual({
+      ok: true,
+      value: '{"claim":"groups","values":["a"]}',
+    });
+  });
+
+  it('rejects malformed JSON, arrays and primitives — never an unattributed 400', () => {
+    expect(validatePolicyJson('{not json', 'P').ok).toBe(false);
+    expect(validatePolicyJson('[1,2]', 'P').ok).toBe(false);
+    expect(validatePolicyJson('"string"', 'P').ok).toBe(false);
+    expect(validatePolicyJson('5', 'P').ok).toBe(false);
+    expect(validatePolicyJson('null', 'P').ok).toBe(false);
+  });
+});
+
+describe('validateProviderDraft', () => {
+  it('binds a valid create draft to a wire input', () => {
+    const result = validateProviderDraft(goodDraft, null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.slug).toBe('acme');
+      expect(result.input.enabled).toBe(true);
+      expect(result.input.jitPolicy).toBeNull();
+    }
+  });
+
+  it('requires the write-only secret on every save, including a disable', () => {
+    const disabling = { ...goodDraft, clientSecret: '', enabled: false };
+    const result = validateProviderDraft(disabling, provider);
+    expect(result).toMatchObject({ ok: false, field: 'client_secret' });
+  });
+
+  it('refuses a changed issuer on reconfigure as a field error, before the wire', () => {
+    const moved = { ...goodDraft, issuer: 'https://other.example' };
+    const result = validateProviderDraft(moved, provider);
+    expect(result).toMatchObject({ ok: false, field: 'issuer' });
+  });
+
+  it('keeps the immutable slug of the reconfigured provider, ignoring the draft slug', () => {
+    const result = validateProviderDraft({ ...goodDraft, slug: 'ignored' }, provider);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.slug).toBe('acme');
+    }
+  });
+
+  it('validates the slug only on create', () => {
+    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, null)).toMatchObject({
+      ok: false,
+      field: 'slug',
+    });
+    // A reconfigure never sends the slug, so an odd draft slug is irrelevant.
+    expect(validateProviderDraft({ ...goodDraft, slug: 'Bad Slug' }, provider).ok).toBe(true);
+  });
+});
+
+describe('oidcProviderRefusalText', () => {
+  it('names both discovery and slug collision on an unattributed 400', () => {
+    const text = oidcProviderRefusalText(new ApiError(400, 'bad'), 'save-oidc-provider');
+    expect(text).toMatch(/OpenID configuration/);
+    expect(text).toMatch(/slug is already in use/);
+  });
+
+  it('maps a 403 to the MFA-mandatory instance-config refusal', () => {
+    expect(oidcProviderRefusalText(new ApiError(403, 'no'), 'save-oidc-provider')).toMatch(
+      /instance-config/,
+    );
+  });
+
+  it('says the directory is undisclosed on a list 404 but names the resource on a save 404', () => {
+    expect(oidcProviderRefusalText(new ApiError(404, 'x'), 'list-oidc-providers')).toMatch(
+      /directory is not disclosed/,
+    );
+    expect(oidcProviderRefusalText(new ApiError(404, 'x'), 'save-oidc-provider')).toMatch(
+      /unavailable or does not exist/,
+    );
+  });
+
+  it('maps a 409 to a stale-state reload', () => {
+    expect(oidcProviderRefusalText(new ApiError(409, 'race'), 'save-oidc-provider')).toMatch(
+      /changed underneath you/,
+    );
+  });
+
+  it('reports an uncertain outcome for a non-ApiError, worded for the operation', () => {
+    expect(oidcProviderRefusalText(new Error('boom'), 'delete-oidc-provider')).toMatch(
+      /whether the provider was deleted is unknown/,
+    );
+    expect(oidcProviderRefusalText(new Error('boom'), 'save-oidc-provider')).toMatch(
+      /whether the change applied is unknown/,
+    );
+  });
+});

--- a/web/src/api/oidcProviders.ts
+++ b/web/src/api/oidcProviders.ts
@@ -181,10 +181,17 @@ export type OidcProviderDraft = {
  * offending field. `original` is the provider being reconfigured, or null for a
  * create: on a reconfigure the issuer is immutable (A3), so a changed issuer is
  * the one field error the server would otherwise answer as an unattributed 400.
+ *
+ * `existing` is the currently-loaded provider list. It lets the editor refuse an
+ * enabled-issuer collision here, with a named field, rather than let it reach
+ * the database's `oidc_providers_issuer_enabled` unique index — a raw
+ * constraint the server does not translate, so it would otherwise surface as an
+ * opaque 500.
  */
 export function validateProviderDraft(
   draft: OidcProviderDraft,
   original: OidcProvider | null,
+  existing: readonly OidcProvider[],
 ): OidcProviderValidated {
   if (original === null) {
     const slug = validateSlug(draft.slug);
@@ -219,6 +226,20 @@ export function validateProviderDraft(
   }
   if (draft.scopes.trim() === '') {
     return { ok: false, field: 'scopes', message: 'At least one scope is required (for example openid).' };
+  }
+  if (draft.enabled) {
+    const keepSlug = original === null ? draft.slug : original.slug;
+    const clash = existing.find(
+      (candidate) =>
+        candidate.enabled && candidate.issuer === draft.issuer && candidate.slug !== keepSlug,
+    );
+    if (clash !== undefined) {
+      return {
+        ok: false,
+        field: 'issuer',
+        message: `Another enabled provider (${clash.display_name}) already uses this issuer. At most one enabled provider is allowed per issuer — disable or delete it first.`,
+      };
+    }
   }
   const jit = validatePolicyJson(draft.jitPolicy, 'The JIT policy');
   if (!jit.ok) {

--- a/web/src/api/oidcProviders.ts
+++ b/web/src/api/oidcProviders.ts
@@ -1,0 +1,291 @@
+import {
+  deleteOidcProviderOp,
+  listOidcProvidersOp,
+  putOidcProviderOp,
+} from '@hikyo/operations';
+import { zOidcProvider, zOidcProviderList } from '@hikyo/zod';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { ApiError, ok, parsed } from './client.ts';
+
+/**
+ * OIDC provider administration (#499), riding the instance provider API
+ * (`/api/v1/instance/oidc-providers`) exactly as it is — no contract change.
+ *
+ * The server returns only a coarse refusal CODE and never a per-field message
+ * (errors.go: it "never writes anything derived from the cause beyond the code
+ * itself"), so every field-level distinction the acceptance criteria ask for is
+ * drawn HERE, before submit:
+ *
+ *  - the slug is validated against the contract's own pattern;
+ *  - the issuer is IMMUTABLE after create (A3), so a reconfigure that changes it
+ *    is refused as a field error client-side rather than sent to a 400 that
+ *    could not name which field it meant;
+ *  - the JIT and assurance policies are parsed as JSON objects before they ride.
+ *
+ * The one thing the WebUI cannot hold and must not pretend to: the client secret
+ * is envelope-encrypted and NEVER returned. Every PUT re-seals whatever secret
+ * it carries (service/oidc.go seals `in.ClientSecret` unconditionally on both
+ * create and reconfigure), so there is no "keep the old secret" path — the
+ * editor field is always blank and always required, and "replacement cannot
+ * silently retain an old value" falls out of that contract.
+ */
+
+export type OidcProvider = z.infer<typeof zOidcProvider>;
+export type OidcProviderList = z.infer<typeof zOidcProviderList>;
+
+const oidcProvidersKey = ['instance-oidc-providers'] as const;
+
+export function useOidcProviders(): UseQueryResult<OidcProviderList> {
+  return useQuery({
+    queryKey: oidcProvidersKey,
+    queryFn: () => parsed(listOidcProvidersOp, {}),
+    retry: false,
+  });
+}
+
+/** The editor's own value shape, mapped to the wire body at the boundary. */
+export type OidcProviderInput = {
+  readonly displayName: string;
+  readonly issuer: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly scopes: string;
+  readonly jitPolicy: string | null;
+  readonly assurancePolicy: string | null;
+  readonly enabled: boolean;
+};
+
+export function usePutOidcProvider() {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (variables: { slug: string; input: OidcProviderInput }) =>
+      parsed(putOidcProviderOp, {
+        path: { slug: variables.slug },
+        body: {
+          display_name: variables.input.displayName,
+          issuer: variables.input.issuer,
+          client_id: variables.input.clientId,
+          client_secret: variables.input.clientSecret,
+          scopes: variables.input.scopes,
+          jit_policy: variables.input.jitPolicy,
+          assurance_policy: variables.input.assurancePolicy,
+          enabled: variables.input.enabled,
+        },
+      }),
+    onSuccess: () => queries.invalidateQueries({ queryKey: oidcProvidersKey }),
+  });
+}
+
+export function useDeleteOidcProvider(onDeleted?: () => void) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (variables: { slug: string }) =>
+      ok(deleteOidcProviderOp, { path: { slug: variables.slug } }),
+    // The list invalidation unmounts the deleted row. Run the durable parent
+    // feedback first; a per-call callback is not guaranteed to survive it.
+    onSuccess: async () => {
+      onDeleted?.();
+      await queries.invalidateQueries({ queryKey: oidcProvidersKey });
+    },
+  });
+}
+
+// --- client-side validation -------------------------------------------------
+
+export type FieldValidation =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly field: OidcProviderField; readonly message: string };
+
+export type OidcProviderField =
+  | 'slug'
+  | 'display_name'
+  | 'issuer'
+  | 'client_id'
+  | 'client_secret'
+  | 'scopes'
+  | 'jit_policy'
+  | 'assurance_policy';
+
+/** The contract's own slug pattern (ProviderSlugPath), enforced before submit. */
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export function validateSlug(slug: string): FieldValidation {
+  if (!SLUG_PATTERN.test(slug)) {
+    return {
+      ok: false,
+      field: 'slug',
+      message:
+        'The slug must be 1–64 characters of lowercase letters, digits, or hyphens, and start with a letter or digit.',
+    };
+  }
+  return { ok: true };
+}
+
+type PolicyValidation =
+  | { readonly ok: true; readonly value: string | null }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * validatePolicyJson parses an optional policy field as a JSON OBJECT.
+ *
+ * Empty is a real, distinct value — the absent policy — and is returned as
+ * `null`, not an empty string, because the wire's "absent" is `null`. Anything
+ * present must be a JSON object: `JSON.parse` is routed through Zod (never cast)
+ * and arrays and primitives are refused, because the server's policies are
+ * objects and a bare array here would only reach it to be refused with no field
+ * name attached.
+ */
+export function validatePolicyJson(text: string, label: string): PolicyValidation {
+  const trimmed = text.trim();
+  if (trimmed === '') {
+    return { ok: true, value: null };
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(trimmed);
+  } catch {
+    return { ok: false, message: `${label} must be valid JSON.` };
+  }
+  if (Array.isArray(raw) || !z.looseObject({}).safeParse(raw).success) {
+    return { ok: false, message: `${label} must be a JSON object.` };
+  }
+  return { ok: true, value: trimmed };
+}
+
+export type OidcProviderValidated =
+  | { readonly ok: true; readonly slug: string; readonly input: OidcProviderInput }
+  | { readonly ok: false; readonly field: OidcProviderField; readonly message: string };
+
+/** The raw editor fields, before validation binds them to a wire body. */
+export type OidcProviderDraft = {
+  readonly slug: string;
+  readonly displayName: string;
+  readonly issuer: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly scopes: string;
+  readonly jitPolicy: string;
+  readonly assurancePolicy: string;
+  readonly enabled: boolean;
+};
+
+/**
+ * validateProviderDraft turns editor fields into a wire-ready input or the first
+ * offending field. `original` is the provider being reconfigured, or null for a
+ * create: on a reconfigure the issuer is immutable (A3), so a changed issuer is
+ * the one field error the server would otherwise answer as an unattributed 400.
+ */
+export function validateProviderDraft(
+  draft: OidcProviderDraft,
+  original: OidcProvider | null,
+): OidcProviderValidated {
+  if (original === null) {
+    const slug = validateSlug(draft.slug);
+    if (!slug.ok) {
+      return slug;
+    }
+  }
+  if (draft.displayName.trim() === '') {
+    return { ok: false, field: 'display_name', message: 'A display name is required.' };
+  }
+  if (draft.issuer.trim() === '') {
+    return { ok: false, field: 'issuer', message: 'An issuer URL is required.' };
+  }
+  if (original !== null && draft.issuer !== original.issuer) {
+    return {
+      ok: false,
+      field: 'issuer',
+      message:
+        'The issuer is immutable after create — every linked identity is keyed by it. To change it, delete this provider and create a new one.',
+    };
+  }
+  if (draft.clientId.trim() === '') {
+    return { ok: false, field: 'client_id', message: 'A client ID is required.' };
+  }
+  if (draft.clientSecret === '') {
+    return {
+      ok: false,
+      field: 'client_secret',
+      message:
+        'The client secret is write-only and is never returned, so it must be entered on every save — including when only disabling.',
+    };
+  }
+  if (draft.scopes.trim() === '') {
+    return { ok: false, field: 'scopes', message: 'At least one scope is required (for example openid).' };
+  }
+  const jit = validatePolicyJson(draft.jitPolicy, 'The JIT policy');
+  if (!jit.ok) {
+    return { ok: false, field: 'jit_policy', message: jit.message };
+  }
+  const assurance = validatePolicyJson(draft.assurancePolicy, 'The assurance policy');
+  if (!assurance.ok) {
+    return { ok: false, field: 'assurance_policy', message: assurance.message };
+  }
+  return {
+    ok: true,
+    slug: original === null ? draft.slug : original.slug,
+    input: {
+      displayName: draft.displayName,
+      issuer: draft.issuer,
+      clientId: draft.clientId,
+      clientSecret: draft.clientSecret,
+      scopes: draft.scopes,
+      jitPolicy: jit.value,
+      assurancePolicy: assurance.value,
+      enabled: draft.enabled,
+    },
+  };
+}
+
+// --- refusal text -----------------------------------------------------------
+
+export type OidcProviderOperation =
+  | 'list-oidc-providers'
+  | 'save-oidc-provider'
+  | 'delete-oidc-provider';
+
+/**
+ * oidcProviderRefusalText maps a refusal to one honest sentence.
+ *
+ * The server cannot tell a discovery failure from a slug already in use — both
+ * are a bare `bad_request` — so the 400 sentence names both possibilities
+ * rather than guessing one. The distinguishable failures (a bad slug, a changed
+ * issuer, malformed policy JSON) never reach here: they are refused as field
+ * errors before submit.
+ */
+export function oidcProviderRefusalText(
+  error: unknown,
+  operation: OidcProviderOperation,
+): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return (
+          error.detail ??
+          'The server refused this provider. If the issuer is new, its OpenID configuration must be reachable and its discovered issuer must match exactly; if the slug is already in use, choose another.'
+        );
+      case 401:
+        return 'Your session ended. Sign in again to continue.';
+      case 403:
+        return 'You are not permitted to administer identity providers — that needs instance-config, which is MFA-mandatory. Present your second factor.';
+      case 404:
+        return operation === 'list-oidc-providers'
+          ? 'The identity-provider directory is not disclosed to this session.'
+          : 'This identity provider is unavailable or does not exist.';
+      case 409:
+        return 'This identity provider changed underneath you. Reload the provider list before retrying.';
+      case 429:
+        return 'Too many attempts right now. Wait a moment and try again.';
+    }
+  }
+  return operation === 'delete-oidc-provider'
+    ? 'The server failed; whether the provider was deleted is unknown — reload to check.'
+    : 'The server failed; whether the change applied is unknown — reload to check.';
+}

--- a/web/src/api/oidcProviders.ts
+++ b/web/src/api/oidcProviders.ts
@@ -62,24 +62,30 @@ export type OidcProviderInput = {
   readonly enabled: boolean;
 };
 
-export function usePutOidcProvider() {
-  const queries = useQueryClient();
-  return useMutation({
-    mutationFn: (variables: { slug: string; input: OidcProviderInput }) =>
-      parsed(putOidcProviderOp, {
-        path: { slug: variables.slug },
-        body: {
-          display_name: variables.input.displayName,
-          issuer: variables.input.issuer,
-          client_id: variables.input.clientId,
-          client_secret: variables.input.clientSecret,
-          scopes: variables.input.scopes,
-          jit_policy: variables.input.jitPolicy,
-          assurance_policy: variables.input.assurancePolicy,
-          enabled: variables.input.enabled,
-        },
-      }),
-    onSuccess: () => queries.invalidateQueries({ queryKey: oidcProvidersKey }),
+/**
+ * putOidcProvider is a ONE-SHOT request, deliberately NOT a cached React Query
+ * mutation: the write-only client secret rides its body, and a mutation would
+ * retain that secret in its cached `variables` after the call settled. An
+ * imperative call keeps the secret out of every cache — it lives only for the
+ * duration of the request and in the editor's own controlled field, which the
+ * editor blanks on failure. The caller refetches the provider list on success.
+ */
+export async function putOidcProvider(
+  slug: string,
+  input: OidcProviderInput,
+): Promise<OidcProvider> {
+  return parsed(putOidcProviderOp, {
+    path: { slug },
+    body: {
+      display_name: input.displayName,
+      issuer: input.issuer,
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      scopes: input.scopes,
+      jit_policy: input.jitPolicy,
+      assurance_policy: input.assurancePolicy,
+      enabled: input.enabled,
+    },
   });
 }
 

--- a/web/src/routes/InstanceAdmin.tsx
+++ b/web/src/routes/InstanceAdmin.tsx
@@ -30,6 +30,7 @@ import {
 } from '../api/settings.ts';
 import { notifySuccess } from '../app/notifications.tsx';
 import { surfaceById } from '../app/navigation.ts';
+import { OidcProvidersPanel } from './OidcProvidersPanel.tsx';
 import { Alert, Done, JumpIndex, Panel } from './Sections.tsx';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
 
@@ -123,6 +124,7 @@ export function InstanceAdmin() {
     <JumpIndex sections={[
       { id: 'instance-orgs', label: 'Organizations' },
       { id: 'instance-settings', label: 'Settings' },
+      ...(prototypeMode ? [] : [{ id: 'instance-oidc', label: 'Identity providers' }]),
       { id: 'instance-keys', label: 'Keys & crypto' },
       { id: 'instance-connected', label: 'Instances' },
     ]} />
@@ -200,6 +202,8 @@ export function InstanceAdmin() {
     </Panel>}
 
     <CredentialPolicyPanel query={policy} onDone={ok} onFailure={report} />
+
+    {prototypeMode ? null : <OidcProvidersPanel />}
 
     {prototypeMode ? null : <Panel id="instance-retention" title="Retention health">
       {health.isPending ? <p role="status">Loading retention health…</p> : null}

--- a/web/src/routes/OidcProvidersPanel.tsx
+++ b/web/src/routes/OidcProvidersPanel.tsx
@@ -10,7 +10,6 @@ import {
   type OidcProvider,
   type OidcProviderDraft,
   type OidcProviderField,
-  type OidcProviderInput,
 } from '../api/oidcProviders.ts';
 import { Alert, Done, Panel, TypedNameConfirm } from './Sections.tsx';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
@@ -68,7 +67,6 @@ type EditorTarget =
 
 export function OidcProvidersPanel() {
   const providers = useOidcProviders();
-  const put = usePutOidcProvider();
   const feedback = useFeedback((error) =>
     error instanceof Refusal ? error.message : oidcProviderRefusalText(error, 'save-oidc-provider'),
   );
@@ -161,30 +159,26 @@ export function OidcProvidersPanel() {
         </div>
       ) : null}
 
-      {editor !== null ? (
+      {editor !== null && providers.isSuccess ? (
         <ProviderEditor
           target={editor}
-          busy={put.isPending}
+          existing={providers.data.providers}
           onCancel={() => {
             feedback.clear();
             setEditor(null);
           }}
-          onSubmit={(slug, input, describe) => {
-            feedback.clear();
-            put.mutate(
-              { slug, input },
-              {
-                onSuccess: () => {
-                  setEditor(null);
-                  void providers.refetch();
-                  feedback.ok(describe);
-                },
-                onError: (error) =>
-                  feedback.report(new Refusal(oidcProviderRefusalText(error, 'save-oidc-provider'))),
-              },
-            );
+          onSaved={(describe) => {
+            setEditor(null);
+            void providers.refetch();
+            feedback.ok(describe);
           }}
-          onFieldError={(message) => feedback.report(new Refusal(message))}
+          onFailure={(refusal) => feedback.report(refusal)}
+          onFailClosed={() => {
+            // A stale, forbidden, or ended-session refusal: close the editor and
+            // refetch so any retry starts from fresh state, not the stale draft.
+            setEditor(null);
+            void providers.refetch();
+          }}
         />
       ) : null}
 
@@ -207,18 +201,21 @@ export function OidcProvidersPanel() {
 
 function ProviderEditor({
   target,
-  busy,
+  existing,
   onCancel,
-  onSubmit,
-  onFieldError,
+  onSaved,
+  onFailure,
+  onFailClosed,
 }: {
   target: EditorTarget;
-  busy: boolean;
+  existing: readonly OidcProvider[];
   onCancel: () => void;
-  onSubmit: (slug: string, input: OidcProviderInput, describe: string) => void;
-  onFieldError: (message: string) => void;
+  onSaved: (describe: string) => void;
+  onFailure: (refusal: Refusal) => void;
+  onFailClosed: () => void;
 }) {
   const original = target.kind === 'reconfigure' ? target.provider : null;
+  const put = usePutOidcProvider();
   const [draft, setDraft] = useState<OidcProviderDraft>(
     original === null ? emptyDraft : draftFrom(original),
   );
@@ -240,21 +237,44 @@ function ProviderEditor({
   };
 
   const submit = () => {
-    const result = validateProviderDraft(draft, original);
+    const result = validateProviderDraft(draft, original, existing);
     if (!result.ok) {
       setInvalidField(result.field);
-      onFieldError(result.message);
+      onFailure(new Refusal(result.message));
       return;
     }
     setInvalidField(null);
     const verb = original === null ? 'Configured' : 'Reconfigured';
-    onSubmit(
-      result.slug,
-      result.input,
-      `${verb} ${result.input.displayName}. ${result.input.enabled ? 'It is advertised on the sign-in page.' : 'It is disabled and not advertised.'}`,
+    const describe = `${verb} ${result.input.displayName}. ${result.input.enabled ? 'It is advertised on the sign-in page.' : 'It is disabled and not advertised.'}`;
+    put.mutate(
+      { slug: result.slug, input: result.input },
+      {
+        onSuccess: () => {
+          // Drop the mutation's cached variables so the secret does not linger
+          // in mutation state after a successful save.
+          put.reset();
+          onSaved(describe);
+        },
+        onError: (error) => {
+          // The secret is write-only: never retain it after a failed save, in
+          // the field or in the mutation's cached variables.
+          setDraft((current) => ({ ...current, clientSecret: '' }));
+          put.reset();
+          onFailure(new Refusal(oidcProviderRefusalText(error, 'save-oidc-provider')));
+          // Stale (409), forbidden (403), or ended-session (401) refusals are
+          // fail-closed: close and refetch so no retry proceeds on stale state.
+          if (
+            error instanceof ApiError &&
+            (error.status === 401 || error.status === 403 || error.status === 409)
+          ) {
+            onFailClosed();
+          }
+        },
+      },
     );
   };
 
+  const busy = put.isPending;
   const disabling = original !== null && original.enabled && !draft.enabled;
   const invalid = (field: OidcProviderField) => (invalidField === field ? true : undefined);
 

--- a/web/src/routes/OidcProvidersPanel.tsx
+++ b/web/src/routes/OidcProvidersPanel.tsx
@@ -1,0 +1,463 @@
+import { useId, useState } from 'react';
+
+import { ApiError } from '../api/client.ts';
+import {
+  oidcProviderRefusalText,
+  useDeleteOidcProvider,
+  useOidcProviders,
+  usePutOidcProvider,
+  validateProviderDraft,
+  type OidcProvider,
+  type OidcProviderDraft,
+  type OidcProviderField,
+  type OidcProviderInput,
+} from '../api/oidcProviders.ts';
+import { Alert, Done, Panel, TypedNameConfirm } from './Sections.tsx';
+import { useFeedback, useModalDialog } from './useModalDialog.ts';
+
+/**
+ * OIDC provider administration (#499).
+ *
+ * The whole panel is `instance-config`, which is MFA-mandatory, so its
+ * capability gate is the LIST READ: a session without the second factor gets
+ * the honest "second factor required" state and no controls, never an empty
+ * list that would answer a question the server refused. A read that is not
+ * disclosed at all (404) says exactly that.
+ *
+ * The client secret is write-only and never returned. The editor never prefills
+ * it and always requires it, because every PUT re-seals whatever secret it
+ * carries — there is no path that keeps the old one.
+ */
+
+const secondFactor = (error: unknown) => error instanceof ApiError && error.status === 403;
+const nondisclosed = (error: unknown) => error instanceof ApiError && error.status === 404;
+
+/** A refusal already rendered into its final sentence (server or field error). */
+class Refusal extends Error {}
+
+const emptyDraft: OidcProviderDraft = {
+  slug: '',
+  displayName: '',
+  issuer: '',
+  clientId: '',
+  clientSecret: '',
+  scopes: 'openid',
+  jitPolicy: '',
+  assurancePolicy: '',
+  enabled: true,
+};
+
+function draftFrom(provider: OidcProvider): OidcProviderDraft {
+  return {
+    slug: provider.slug,
+    displayName: provider.display_name,
+    issuer: provider.issuer,
+    clientId: provider.client_id,
+    // The secret is never returned, so it starts blank and must be re-entered.
+    clientSecret: '',
+    scopes: provider.scopes,
+    jitPolicy: provider.jit_policy ?? '',
+    assurancePolicy: provider.assurance_policy ?? '',
+    enabled: provider.enabled,
+  };
+}
+
+type EditorTarget =
+  | { readonly kind: 'create' }
+  | { readonly kind: 'reconfigure'; readonly provider: OidcProvider };
+
+export function OidcProvidersPanel() {
+  const providers = useOidcProviders();
+  const put = usePutOidcProvider();
+  const feedback = useFeedback((error) =>
+    error instanceof Refusal ? error.message : oidcProviderRefusalText(error, 'save-oidc-provider'),
+  );
+  const [editor, setEditor] = useState<EditorTarget | null>(null);
+  const [deleting, setDeleting] = useState<OidcProvider | null>(null);
+
+  const openCreate = () => {
+    feedback.clear();
+    setEditor({ kind: 'create' });
+  };
+  const openReconfigure = (provider: OidcProvider) => {
+    feedback.clear();
+    setEditor({ kind: 'reconfigure', provider });
+  };
+
+  return (
+    <Panel id="instance-oidc" title="Identity providers">
+      <p>
+        OpenID Connect providers advertised on the sign-in page. Configuring one makes it a
+        &ldquo;Continue with&rdquo; option; disabling or deleting one removes that option and ends
+        every session that authenticated through it. Local password and second-factor sign-in is
+        never affected.
+      </p>
+
+      {providers.isPending ? <p role="status">Loading identity providers…</p> : null}
+      {secondFactor(providers.error) ? (
+        <Alert>
+          Administering identity providers needs a second factor. This session does not have
+          sufficient second-factor assurance; present your authenticator code or passkey in the
+          banner above.
+        </Alert>
+      ) : null}
+      {nondisclosed(providers.error) ? (
+        <p role="status">The identity-provider directory is not disclosed to this session.</p>
+      ) : null}
+      {providers.isError && !secondFactor(providers.error) && !nondisclosed(providers.error) ? (
+        <Alert>{oidcProviderRefusalText(providers.error, 'list-oidc-providers')}</Alert>
+      ) : null}
+
+      {feedback.failure !== null ? <Alert>{feedback.failure}</Alert> : null}
+      {feedback.done !== null ? <Done>{feedback.done}</Done> : null}
+
+      {providers.isSuccess && providers.data.providers.length === 0 ? (
+        <p role="status">No identity providers are configured.</p>
+      ) : null}
+      {providers.isSuccess
+        ? providers.data.providers.map((provider) => (
+            <div className="settings-row" key={provider.slug}>
+              <div className="settings-row__copy">
+                <span className="settings-row__title">{provider.display_name}</span>
+                <span className="settings-row__detail mono">
+                  {provider.slug} · {provider.issuer}
+                </span>
+              </div>
+              <span className="settings-row__spacer" />
+              <span
+                className={`settings-tag mono${provider.enabled ? '' : ' settings-tag--danger'}`}
+              >
+                {provider.enabled ? 'enabled' : 'disabled'}
+              </span>
+              <button
+                type="button"
+                className="btn"
+                aria-label={`Reconfigure ${provider.display_name}`}
+                onClick={() => openReconfigure(provider)}
+              >
+                Reconfigure
+              </button>
+              <button
+                type="button"
+                className="btn btn--danger"
+                aria-label={`Delete ${provider.display_name}`}
+                onClick={() => {
+                  feedback.clear();
+                  setDeleting(provider);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          ))
+        : null}
+
+      {providers.isSuccess && editor === null ? (
+        <div className="panel__actions">
+          <button type="button" className="btn btn--primary" onClick={openCreate}>
+            + add identity provider
+          </button>
+          <code className="instance-cli">$ hikyo oidc-provider put</code>
+        </div>
+      ) : null}
+
+      {editor !== null ? (
+        <ProviderEditor
+          target={editor}
+          busy={put.isPending}
+          onCancel={() => {
+            feedback.clear();
+            setEditor(null);
+          }}
+          onSubmit={(slug, input, describe) => {
+            feedback.clear();
+            put.mutate(
+              { slug, input },
+              {
+                onSuccess: () => {
+                  setEditor(null);
+                  void providers.refetch();
+                  feedback.ok(describe);
+                },
+                onError: (error) =>
+                  feedback.report(new Refusal(oidcProviderRefusalText(error, 'save-oidc-provider'))),
+              },
+            );
+          }}
+          onFieldError={(message) => feedback.report(new Refusal(message))}
+        />
+      ) : null}
+
+      {deleting !== null ? (
+        <DeleteProviderDialog
+          provider={deleting}
+          onCancel={() => setDeleting(null)}
+          onDeleted={(name) => {
+            setDeleting(null);
+            feedback.ok(`Deleted ${name}. Its sign-in option is gone and every session that used it has ended.`);
+          }}
+          onFailure={(error) =>
+            feedback.report(new Refusal(oidcProviderRefusalText(error, 'delete-oidc-provider')))
+          }
+        />
+      ) : null}
+    </Panel>
+  );
+}
+
+function ProviderEditor({
+  target,
+  busy,
+  onCancel,
+  onSubmit,
+  onFieldError,
+}: {
+  target: EditorTarget;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (slug: string, input: OidcProviderInput, describe: string) => void;
+  onFieldError: (message: string) => void;
+}) {
+  const original = target.kind === 'reconfigure' ? target.provider : null;
+  const [draft, setDraft] = useState<OidcProviderDraft>(
+    original === null ? emptyDraft : draftFrom(original),
+  );
+  const [invalidField, setInvalidField] = useState<OidcProviderField | null>(null);
+  const ids = {
+    slug: useId(),
+    displayName: useId(),
+    issuer: useId(),
+    clientId: useId(),
+    clientSecret: useId(),
+    scopes: useId(),
+    jit: useId(),
+    assurance: useId(),
+  };
+
+  const set = <K extends keyof OidcProviderDraft>(key: K, value: OidcProviderDraft[K]) => {
+    setInvalidField(null);
+    setDraft((current) => ({ ...current, [key]: value }));
+  };
+
+  const submit = () => {
+    const result = validateProviderDraft(draft, original);
+    if (!result.ok) {
+      setInvalidField(result.field);
+      onFieldError(result.message);
+      return;
+    }
+    setInvalidField(null);
+    const verb = original === null ? 'Configured' : 'Reconfigured';
+    onSubmit(
+      result.slug,
+      result.input,
+      `${verb} ${result.input.displayName}. ${result.input.enabled ? 'It is advertised on the sign-in page.' : 'It is disabled and not advertised.'}`,
+    );
+  };
+
+  const disabling = original !== null && original.enabled && !draft.enabled;
+  const invalid = (field: OidcProviderField) => (invalidField === field ? true : undefined);
+
+  return (
+    <div className="oidc-editor">
+      <h3>{original === null ? 'New identity provider' : `Reconfigure ${original.display_name}`}</h3>
+      {original === null ? (
+        <div className="field">
+          <label htmlFor={ids.slug}>Slug</label>
+          <input
+            id={ids.slug}
+            className="mono"
+            value={draft.slug}
+            aria-invalid={invalid('slug')}
+            onChange={(event) => set('slug', event.target.value)}
+          />
+          <p className="field__hint">Lowercase letters, digits and hyphens; it appears in the callback URL and cannot change.</p>
+        </div>
+      ) : (
+        <div className="settings-row">
+          <div className="settings-row__copy">
+            <span className="settings-row__title">Slug</span>
+            <span className="settings-row__detail mono">{original.slug}</span>
+          </div>
+        </div>
+      )}
+
+      <div className="field">
+        <label htmlFor={ids.displayName}>Display name</label>
+        <input
+          id={ids.displayName}
+          value={draft.displayName}
+          aria-invalid={invalid('display_name')}
+          onChange={(event) => set('displayName', event.target.value)}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.issuer}>Issuer URL</label>
+        <input
+          id={ids.issuer}
+          className="mono"
+          value={draft.issuer}
+          aria-invalid={invalid('issuer')}
+          disabled={original !== null}
+          onChange={(event) => set('issuer', event.target.value)}
+        />
+        <p className="field__hint">
+          {original === null
+            ? 'Its OpenID configuration is fetched and validated on save.'
+            : 'The issuer is immutable after create — every linked identity is keyed by it.'}
+        </p>
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.clientId}>Client ID</label>
+        <input
+          id={ids.clientId}
+          className="mono"
+          value={draft.clientId}
+          aria-invalid={invalid('client_id')}
+          onChange={(event) => set('clientId', event.target.value)}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.clientSecret}>Client secret</label>
+        <input
+          id={ids.clientSecret}
+          type="password"
+          autoComplete="off"
+          value={draft.clientSecret}
+          aria-invalid={invalid('client_secret')}
+          onChange={(event) => set('clientSecret', event.target.value)}
+        />
+        <p className="field__hint">
+          Write-only: it is never displayed, so it must be entered on every save — including when
+          only disabling.
+        </p>
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.scopes}>Scopes</label>
+        <input
+          id={ids.scopes}
+          className="mono"
+          value={draft.scopes}
+          aria-invalid={invalid('scopes')}
+          onChange={(event) => set('scopes', event.target.value)}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.jit}>JIT policy (JSON, optional)</label>
+        <textarea
+          id={ids.jit}
+          className="mono"
+          value={draft.jitPolicy}
+          aria-invalid={invalid('jit_policy')}
+          onChange={(event) => set('jitPolicy', event.target.value)}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor={ids.assurance}>Assurance policy (JSON, optional)</label>
+        <textarea
+          id={ids.assurance}
+          className="mono"
+          value={draft.assurancePolicy}
+          aria-invalid={invalid('assurance_policy')}
+          onChange={(event) => set('assurancePolicy', event.target.value)}
+        />
+      </div>
+
+      <div className="field chk">
+        <input
+          id={`${ids.slug}-enabled`}
+          type="checkbox"
+          checked={draft.enabled}
+          onChange={(event) => set('enabled', event.target.checked)}
+        />
+        <label htmlFor={`${ids.slug}-enabled`}>Enabled (advertised on the sign-in page)</label>
+      </div>
+
+      {disabling ? (
+        <p className="policy-impact" role="alert">
+          Disabling removes &ldquo;Continue with {original.display_name}&rdquo; from the sign-in
+          page and ends every session that authenticated through it. Linked identities can no
+          longer sign in through it. Local password and second-factor sign-in is unaffected.
+        </p>
+      ) : null}
+
+      <div className="panel__actions">
+        <button type="button" className="btn" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+        <button type="button" className="btn btn--primary" onClick={submit} disabled={busy}>
+          {original === null ? 'Configure provider' : 'Save provider'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DeleteProviderDialog({
+  provider,
+  onCancel,
+  onDeleted,
+  onFailure,
+}: {
+  provider: OidcProvider;
+  onCancel: () => void;
+  onDeleted: (name: string) => void;
+  onFailure: (error: unknown) => void;
+}) {
+  const dialog = useModalDialog();
+  const del = useDeleteOidcProvider();
+
+  return (
+    <dialog
+      className="ceremony"
+      ref={dialog}
+      aria-labelledby="delete-oidc-title"
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!del.isPending) {
+          onCancel();
+        }
+      }}
+    >
+      <h2 id="delete-oidc-title">Delete {provider.display_name}?</h2>
+      <p className="ceremony__lede">
+        &ldquo;Continue with {provider.display_name}&rdquo; leaves the sign-in page and every
+        session that authenticated through it ends immediately; its live transactions cascade.
+        Identities linked through it can no longer sign in. Local password and second-factor
+        sign-in is unaffected. This cannot be undone.
+      </p>
+      <TypedNameConfirm
+        label="Type the provider slug to confirm"
+        expect={provider.slug}
+        action="Delete provider"
+        busy={del.isPending}
+        hint={
+          <>
+            Deletion is by the immutable slug <span className="mono">{provider.slug}</span>, not the
+            display name.
+          </>
+        }
+        onConfirm={() =>
+          del.mutate(
+            { slug: provider.slug },
+            {
+              onSuccess: () => onDeleted(provider.display_name),
+              onError: onFailure,
+            },
+          )
+        }
+      />
+      <div className="ceremony__actions">
+        <button type="button" className="btn" onClick={onCancel} disabled={del.isPending}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/web/src/routes/OidcProvidersPanel.tsx
+++ b/web/src/routes/OidcProvidersPanel.tsx
@@ -72,6 +72,14 @@ export function OidcProvidersPanel() {
   );
   const [editor, setEditor] = useState<EditorTarget | null>(null);
   const [deleting, setDeleting] = useState<OidcProvider | null>(null);
+  // Set while a post-conflict refetch is in flight. The provider PUT is a
+  // full replace by slug with no client row-version, so the server's CAS only
+  // guards a write racing inside its own transaction — it cannot stop an admin
+  // acting on STALE displayed data. So after a fail-closed refusal we latch the
+  // action controls shut until the list has refetched: without it, a stale
+  // editor could reopen during the refresh and silently overwrite a concurrent
+  // admin's change (for example re-enabling a provider they just disabled).
+  const [refreshingAfterConflict, setRefreshingAfterConflict] = useState(false);
 
   const openCreate = () => {
     feedback.clear();
@@ -131,6 +139,7 @@ export function OidcProvidersPanel() {
                 type="button"
                 className="btn"
                 aria-label={`Reconfigure ${provider.display_name}`}
+                disabled={refreshingAfterConflict}
                 onClick={() => openReconfigure(provider)}
               >
                 Reconfigure
@@ -139,6 +148,7 @@ export function OidcProvidersPanel() {
                 type="button"
                 className="btn btn--danger"
                 aria-label={`Delete ${provider.display_name}`}
+                disabled={refreshingAfterConflict}
                 onClick={() => {
                   feedback.clear();
                   setDeleting(provider);
@@ -150,9 +160,18 @@ export function OidcProvidersPanel() {
           ))
         : null}
 
+      {refreshingAfterConflict ? (
+        <p role="status">Refreshing the provider list after a conflicting change…</p>
+      ) : null}
+
       {providers.isSuccess && editor === null ? (
         <div className="panel__actions">
-          <button type="button" className="btn btn--primary" onClick={openCreate}>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={refreshingAfterConflict}
+            onClick={openCreate}
+          >
             + add identity provider
           </button>
           <code className="instance-cli">$ hikyo oidc-provider put</code>
@@ -175,9 +194,11 @@ export function OidcProvidersPanel() {
           onFailure={(refusal) => feedback.report(refusal)}
           onFailClosed={() => {
             // A stale, forbidden, or ended-session refusal: close the editor and
-            // refetch so any retry starts from fresh state, not the stale draft.
+            // refetch, latching the action controls until fresh data lands so no
+            // retry proceeds against the stale list in the meantime.
             setEditor(null);
-            void providers.refetch();
+            setRefreshingAfterConflict(true);
+            void providers.refetch().finally(() => setRefreshingAfterConflict(false));
           }}
         />
       ) : null}

--- a/web/src/routes/OidcProvidersPanel.tsx
+++ b/web/src/routes/OidcProvidersPanel.tsx
@@ -3,9 +3,9 @@ import { useId, useState } from 'react';
 import { ApiError } from '../api/client.ts';
 import {
   oidcProviderRefusalText,
+  putOidcProvider,
   useDeleteOidcProvider,
   useOidcProviders,
-  usePutOidcProvider,
   validateProviderDraft,
   type OidcProvider,
   type OidcProviderDraft,
@@ -215,7 +215,7 @@ function ProviderEditor({
   onFailClosed: () => void;
 }) {
   const original = target.kind === 'reconfigure' ? target.provider : null;
-  const put = usePutOidcProvider();
+  const [busy, setBusy] = useState(false);
   const [draft, setDraft] = useState<OidcProviderDraft>(
     original === null ? emptyDraft : draftFrom(original),
   );
@@ -246,35 +246,32 @@ function ProviderEditor({
     setInvalidField(null);
     const verb = original === null ? 'Configured' : 'Reconfigured';
     const describe = `${verb} ${result.input.displayName}. ${result.input.enabled ? 'It is advertised on the sign-in page.' : 'It is disabled and not advertised.'}`;
-    put.mutate(
-      { slug: result.slug, input: result.input },
-      {
-        onSuccess: () => {
-          // Drop the mutation's cached variables so the secret does not linger
-          // in mutation state after a successful save.
-          put.reset();
-          onSaved(describe);
-        },
-        onError: (error) => {
-          // The secret is write-only: never retain it after a failed save, in
-          // the field or in the mutation's cached variables.
-          setDraft((current) => ({ ...current, clientSecret: '' }));
-          put.reset();
-          onFailure(new Refusal(oidcProviderRefusalText(error, 'save-oidc-provider')));
-          // Stale (409), forbidden (403), or ended-session (401) refusals are
-          // fail-closed: close and refetch so no retry proceeds on stale state.
-          if (
-            error instanceof ApiError &&
-            (error.status === 401 || error.status === 403 || error.status === 409)
-          ) {
-            onFailClosed();
-          }
-        },
+    setBusy(true);
+    void putOidcProvider(result.slug, result.input).then(
+      () => {
+        // The parent unmounts this editor on save, dropping the draft (and its
+        // secret) from state; no local reset is needed on the success path.
+        onSaved(describe);
+      },
+      (error: unknown) => {
+        // The secret is write-only: never retain it after a failed save.
+        setDraft((current) => ({ ...current, clientSecret: '' }));
+        setBusy(false);
+        onFailure(new Refusal(oidcProviderRefusalText(error, 'save-oidc-provider')));
+        // Stale (409), forbidden (403), or ended-session (401) refusals are
+        // fail-closed: close and refetch so no retry proceeds on stale state.
+        // The server's row-version CAS is the ultimate guard — a stale write is
+        // refused there too — so this is defence in depth, not the only line.
+        if (
+          error instanceof ApiError &&
+          (error.status === 401 || error.status === 403 || error.status === 409)
+        ) {
+          onFailClosed();
+        }
       },
     );
   };
 
-  const busy = put.isPending;
   const disabling = original !== null && original.enabled && !draft.enabled;
   const invalid = (field: OidcProviderField) => (invalidField === field ? true : undefined);
 


### PR DESCRIPTION
Closes #499.

## What

A browser surface for OIDC identity-provider inventory and lifecycle on the instance-administration page. An instance-config holder can list, create, reconfigure, disable, and delete providers with capability-gated controls.

## Contract / migration decisions

- **No contract change, no migration, no regenerated artifacts.** Rides the existing `/api/v1/instance/oidc-providers` list/get/put/delete API and the already-generated TS client verbatim. No `api/`, codegen, or `navigation.ts` changes.
- New surface is a Panel inside the existing `instance-admin` surface, so no route was added (and no flow-registry / CI-grouping change).

## Design notes tied to the acceptance criteria

- **Write-only secret.** The server never returns the client secret and every PUT re-seals whatever secret it carries, so the editor field is always blank and always required — including when only disabling. Replacement therefore cannot silently retain an old value.
- **Fields identified client-side.** The server returns only a coarse refusal code, so the slug pattern, the immutable issuer (a changed issuer on reconfigure is a field error, never an unattributed 400), and the JIT/assurance policy JSON are all validated before submit. The remaining ambiguous 400 (discovery-failed vs slug-in-use) is worded to name both honestly.
- **Consequences previewed, floor preserved.** Disabling and deleting state their login and linked-identity consequences and affirm that local password + second-factor sign-in is never affected. Delete is gated on typing the immutable slug. 409/403 are fail-closed (reload / present second factor).

## Validation

- `pnpm --dir web typecheck` — clean
- `pnpm --dir web test` — 535 passed
- `pnpm --dir web build` — clean
- Playwright (desktop): the new journey (configure → advertised on `/login` in a fresh unauthenticated context → disable → gone → delete), plus authorization-refusal, validation-refusal, and stale-state — all pass. The e2e adds a second fixture IdP because at most one enabled provider is allowed per issuer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)