### PR TITLE
perf(auth): reuse request session resolution #512

### DIFF
--- a/docs/handoff/512-session-clock-resolution.md
+++ b/docs/handoff/512-session-clock-resolution.md
@@ -1,0 +1,37 @@
+# Handoff: #512 reuse request authentication for session-clock sliding
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/512
+
+## Outcome
+
+`SlideSessionClocks` now consumes a narrow request-local activity hint recorded
+by the in-transaction authentication chokepoint. A recent authenticated GET no
+longer opens a second read transaction, and an unresolvable bearer on a public
+route performs no datastore work.
+
+The hint contains only the resolved last-seen time and whether the identity
+owns the generic session or service-account touch path. It contains no
+principal, proof, scope, raw bearer, or transaction token. A due write still
+re-authenticates the raw bearer inside its own transaction, so revocation and
+the database remain authoritative.
+
+## Preserved boundaries
+
+- The touch remains post-response.
+- `SlideGranularity` is checked first against request-time state, then again
+  against the fresh row inside the write transaction for multi-instance races.
+- SCIM provisioning credentials and instance-connection credentials retain
+  their dedicated touch paths; the generic path handles only sessions and
+  service-account credentials.
+- Public routes do not authenticate a presented bearer solely to slide it.
+
+## Verification
+
+- SQLite and PostgreSQL HTTP conformance cover one session resolution, zero
+  fabricated-bearer queries, due-clock sliding, cross-instance suppression,
+  and instance-connection path isolation.
+- `go vet ./...` passed.
+- `HIKYO_TEST_POSTGRES_DSN=... go test -p 1 -count=1 ./...` passed: 5,173 tests
+  across 69 packages.
+- Standards and issue-spec reviews returned `CLEAN` after valid findings were
+  fixed and rechecked.

--- a/internal/authz/activity.go
+++ b/internal/authz/activity.go
@@ -1,0 +1,69 @@
+package authz
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+)
+
+// CallerActivity is the narrow, non-authorizing result the transport may
+// retain until its handler returns. It contains no principal, proof, scope or
+// transaction token: it can decide only whether the post-response idle-clock
+// write is worth attempting. The write still re-authenticates inside its own
+// transaction, so revocation remains authoritative.
+type CallerActivity struct {
+	lastSeenAt time.Time
+	slideable  bool
+}
+
+// LastSeenAt is the timestamp the request's own authentication read resolved.
+func (a CallerActivity) LastSeenAt() time.Time { return a.lastSeenAt }
+
+// Slideable reports whether the resolved identity owns a session idle clock
+// or service-account credential last-used stamp. Provisioning and instance
+// connections own separate touch paths and preserve the old generic no-op.
+func (a CallerActivity) Slideable() bool { return a.slideable }
+
+type callerActivityKey struct{}
+
+type callerActivityState struct {
+	mu       sync.Mutex
+	activity CallerActivity
+	resolved bool
+}
+
+// TrackCallerActivity installs request-local storage for the authentication
+// result. Authentication remains inside the operation transaction; only the
+// non-authorizing slide hint survives until the response has been written.
+func TrackCallerActivity(ctx context.Context) context.Context {
+	return context.WithValue(ctx, callerActivityKey{}, &callerActivityState{})
+}
+
+// ResolvedCallerActivity returns the most recent successful caller resolution
+// observed in this request. Fabricated and otherwise refused bearers leave it
+// empty, so post-response work can stop before opening any transaction.
+func ResolvedCallerActivity(ctx context.Context) (CallerActivity, bool) {
+	state, _ := ctx.Value(callerActivityKey{}).(*callerActivityState)
+	if state == nil {
+		return CallerActivity{}, false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.activity, state.resolved
+}
+
+func recordCallerActivity(ctx context.Context, identity Identity) {
+	state, _ := ctx.Value(callerActivityKey{}).(*callerActivityState)
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.activity = CallerActivity{
+		lastSeenAt: identity.LastSeenAt,
+		slideable:  identity.SessionID != "" || domain.IsServiceAccountKind(identity.Class),
+	}
+	state.resolved = true
+}

--- a/internal/authz/session.go
+++ b/internal/authz/session.go
@@ -245,31 +245,37 @@ func (a *TxAuthorizer) AuthenticateCaller(ctx context.Context, presented string,
 	if presented == "" {
 		return Identity{}, domain.ErrUnauthenticated
 	}
+	var (
+		identity Identity
+		err      error
+	)
 	if crypto.ParseArtifact(presented, crypto.ArtifactWorkload) == nil ||
 		crypto.ParseArtifact(presented, crypto.ArtifactAutomation) == nil {
-		return a.authenticateMachine(ctx, presented, now)
+		identity, err = a.authenticateMachine(ctx, presented, now)
+	} else if _, wire := api.OperationFromContext(ctx); wire && crypto.ParseArtifact(presented, crypto.ArtifactSCIM) == nil {
+		identity, _, err = a.AuthenticateSCIMCaller(ctx, presented, now)
+	} else if crypto.ParseArtifact(presented, crypto.ArtifactInstanceConn) == nil {
+		// The instance-connection credential (#71). It is a machine artifact with
+		// its own table and its own resolution leg, and it is admitted HERE rather
+		// than in Authenticate for the same reason the service-account credentials
+		// are: it has no session row to mutate, so every account-security verb
+		// refuses it by construction.
+		//
+		// Admission is not authorization. What this credential may actually reach
+		// is decided at the chokepoint from the embedded OpenAPI declaration, which
+		// confines it to the directory-serve operation and nothing else.
+		identity, err = a.authenticateInstanceConnection(ctx, presented, now)
+	} else {
+		// The session leg, admitting the WORKSPACE artifact (#71) alongside the two
+		// same-origin ones. This is the ONLY entry point that admits it: see
+		// authenticateSession for why Authenticate must not.
+		identity, err = a.authenticateSession(ctx, presented, now,
+			crypto.ArtifactCLISession, crypto.ArtifactBrowserSession, crypto.ArtifactWorkspaceSession)
 	}
-	if _, wire := api.OperationFromContext(ctx); wire && crypto.ParseArtifact(presented, crypto.ArtifactSCIM) == nil {
-		identity, _, err := a.AuthenticateSCIMCaller(ctx, presented, now)
-		return identity, err
+	if err == nil {
+		recordCallerActivity(ctx, identity)
 	}
-	// The instance-connection credential (#71). It is a machine artifact with
-	// its own table and its own resolution leg, and it is admitted HERE rather
-	// than in Authenticate for the same reason the service-account credentials
-	// are: it has no session row to mutate, so every account-security verb
-	// refuses it by construction.
-	//
-	// Admission is not authorization. What this credential may actually reach
-	// is decided at the chokepoint from the embedded OpenAPI declaration, which
-	// confines it to the directory-serve operation and nothing else.
-	if crypto.ParseArtifact(presented, crypto.ArtifactInstanceConn) == nil {
-		return a.authenticateInstanceConnection(ctx, presented, now)
-	}
-	// The session leg, admitting the WORKSPACE artifact (#71) alongside the two
-	// same-origin ones. This is the ONLY entry point that admits it: see
-	// authenticateSession for why Authenticate must not.
-	return a.authenticateSession(ctx, presented, now,
-		crypto.ArtifactCLISession, crypto.ArtifactBrowserSession, crypto.ArtifactWorkspaceSession)
+	return identity, err
 }
 
 // AuthenticateSCIMCaller resolves a live provisioning credential without

--- a/internal/isolation/access_wire_test.go
+++ b/internal/isolation/access_wire_test.go
@@ -13,12 +13,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/server"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -44,12 +47,13 @@ import (
 
 // accessWireEnv is the assembled real stack for these tests.
 type accessWireEnv struct {
-	srv   *httptest.Server
-	token string
-	db    *store.DB
-	auth  *service.Auth
-	admin domain.PrincipalID
-	org   string
+	srv       *httptest.Server
+	token     string
+	db        *store.DB
+	auth      *service.Auth
+	workspace *service.Workspace
+	admin     domain.PrincipalID
+	org       string
 	// project and env genuinely EXIST under org. They are what makes the
 	// "unauthorized" leg unauthorized-and-existing rather than a second kind
 	// of missing: probing a child of a real org that the caller may not reach
@@ -105,6 +109,7 @@ func newAccessWireEnv(t *testing.T, db *store.DB) accessWireEnv {
 			`VALUES ('%s', '%s', '%s', 'wire-env', '', %s, 0)`,
 		wireEnv, org.ID, wireProject, ts))
 
+	workspace := &service.Workspace{DB: db, Version: "wire"}
 	srv := httptest.NewServer(server.New(&service.System{DB: db}, &server.API{
 		Auth:         auth,
 		Orgs:         orgs,
@@ -115,11 +120,12 @@ func newAccessWireEnv(t *testing.T, db *store.DB) accessWireEnv {
 		Settings:     &service.ProjectSettings{DB: db, Auth: auth},
 		Delivery:     &service.Delivery{DB: db, Keyring: auth.Keyring},
 		SCIMWire:     &service.SCIM{DB: db},
+		Workspace:    workspace,
 		Version:      "wire",
 	}, nil))
 	t.Cleanup(srv.Close)
 	return accessWireEnv{
-		srv: srv, token: token, db: db, auth: auth, admin: administrator.boot.PrincipalID,
+		srv: srv, token: token, db: db, auth: auth, workspace: workspace, admin: administrator.boot.PrincipalID,
 		org: org.ID, project: wireProject, env: wireEnv,
 	}
 }
@@ -164,6 +170,165 @@ func TestAccessWireUniformitySQLite(t *testing.T) {
 }
 func TestAccessWireUniformityPostgres(t *testing.T) {
 	runAccessWireUniformity(t, seededDB(t, openPostgres))
+}
+
+func TestSessionClockResolutionReuseSQLite(t *testing.T) {
+	runSessionClockResolutionReuse(t, seededDB(t, openSQLite))
+}
+
+func TestSessionClockResolutionReusePostgres(t *testing.T) {
+	runSessionClockResolutionReuse(t, seededDB(t, openPostgres))
+}
+
+// runSessionClockResolutionReuse pins the HTTP seam #512 changes: the
+// post-response idle-clock touch consumes authentication already resolved by
+// the handler instead of opening a second read transaction to resolve it
+// again. GetSessionByVerifier is the first fixed-cost query on every session
+// resolution, so exactly one occurrence means exactly one resolution pass.
+//
+// A fabricated but grammatically valid bearer on a public route is the
+// complementary control. The route itself touches no storage; zero observed
+// queries therefore proves the post-response path did not start the full
+// authentication read it used to run for every Authorization header.
+func runSessionClockResolutionReuse(t *testing.T, db *store.DB) {
+	e := newAccessWireEnv(t, db)
+
+	t.Run("authenticated_get_resolves_once", func(t *testing.T) {
+		var sessionReads int
+		restore := authn.SetQueryObserver(func(query string) {
+			if strings.Contains(query, "-- name: GetSessionByVerifier ") {
+				sessionReads++
+			}
+		})
+		defer restore()
+
+		code, body := e.call(t, http.MethodGet, api.PathPrefix+"/auth/whoami", nil)
+		if code != http.StatusOK {
+			t.Fatalf("whoami = %d %s, want 200", code, body)
+		}
+		if sessionReads != 1 {
+			t.Fatalf("authenticated GET resolved the session %d times, want exactly 1 read transaction", sessionReads)
+		}
+	})
+
+	t.Run("fabricated_bearer_on_public_get_does_no_db_work", func(t *testing.T) {
+		fabricated, _, err := crypto.NewArtifact(crypto.ArtifactCLISession)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var queries int
+		restore := authn.SetQueryObserver(func(string) { queries++ })
+		defer restore()
+
+		code, body := e.callAs(t, fabricated, http.MethodGet, api.PathPrefix+"/meta", nil)
+		if code != http.StatusOK {
+			t.Fatalf("meta = %d %s, want 200", code, body)
+		}
+		if queries != 0 {
+			t.Fatalf("fabricated bearer caused %d DB queries on a public GET, want 0", queries)
+		}
+	})
+
+	t.Run("due_idle_clock_still_slides", func(t *testing.T) {
+		now := time.Now().UTC().Add(2 * service.SlideGranularity)
+		e.auth.Now = func() time.Time { return now }
+		defer func() { e.auth.Now = nil }()
+
+		var touches int
+		restore := authn.SetQueryObserver(func(query string) {
+			if strings.Contains(query, "-- name: TouchSession ") {
+				touches++
+			}
+		})
+		defer restore()
+
+		code, body := e.call(t, http.MethodGet, api.PathPrefix+"/auth/whoami", nil)
+		if code != http.StatusOK {
+			t.Fatalf("whoami = %d %s, want 200", code, body)
+		}
+		if touches != 1 {
+			t.Fatalf("due idle clock was touched %d times, want exactly 1", touches)
+		}
+	})
+
+	t.Run("fresh_cross_instance_slide_suppresses_duplicate_write", func(t *testing.T) {
+		// The preceding due-clock case advanced this same session by two
+		// granularities; move beyond that stamp so this request is due too.
+		now := time.Now().UTC().Add(4 * service.SlideGranularity)
+		var (
+			nowCalls      int
+			competitorErr error
+			competitorMu  sync.Mutex
+		)
+		e.auth.Now = func() time.Time {
+			nowCalls++
+			if nowCalls == 2 {
+				competitorMu.Lock()
+				competitorErr = tx.Write(t.Context(), db, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
+					id, err := az.AuthenticateCaller(ctx, e.token, now)
+					if err != nil {
+						return err
+					}
+					return az.SlideSession(ctx, id.SessionID, now, now.Add(time.Hour))
+				})
+				competitorMu.Unlock()
+			}
+			return now
+		}
+		defer func() { e.auth.Now = nil }()
+
+		var touches int
+		restore := authn.SetQueryObserver(func(query string) {
+			if strings.Contains(query, "-- name: TouchSession ") {
+				touches++
+			}
+		})
+		defer restore()
+
+		code, body := e.call(t, http.MethodGet, api.PathPrefix+"/auth/whoami", nil)
+		if code != http.StatusOK {
+			t.Fatalf("whoami = %d %s, want 200", code, body)
+		}
+		competitorMu.Lock()
+		err := competitorErr
+		competitorMu.Unlock()
+		if err != nil {
+			t.Fatalf("cross-instance slide: %v", err)
+		}
+		if touches != 1 {
+			t.Fatalf("fresh cross-instance slide was followed by %d total touches, want only its 1", touches)
+		}
+	})
+
+	t.Run("instance_connection_uses_only_its_own_touch_path", func(t *testing.T) {
+		value := mintInstanceConnection(t, db, "slide-path")
+		e.workspace.Now = func() time.Time {
+			return time.Now().UTC().Add(-2 * service.SlideGranularity)
+		}
+		defer func() { e.workspace.Now = nil }()
+
+		var instanceTouches, machineTouches int
+		restore := authn.SetQueryObserver(func(query string) {
+			switch {
+			case strings.Contains(query, "-- name: TouchInstanceConnection "):
+				instanceTouches++
+			case strings.Contains(query, "-- name: TouchMachineCredential "):
+				machineTouches++
+			}
+		})
+		defer restore()
+
+		code, body := e.callAs(t, value, http.MethodGet, api.PathPrefix+"/instance/directory", nil)
+		if code != http.StatusOK {
+			t.Fatalf("directory = %d %s, want 200", code, body)
+		}
+		if instanceTouches != 1 {
+			t.Fatalf("directory handler touched instance connection %d times, want 1", instanceTouches)
+		}
+		if machineTouches != 0 {
+			t.Fatalf("generic post-response path touched machine credentials %d times, want 0", machineTouches)
+		}
+	})
 }
 
 // runAccessWireUniformity drives the pair the acceptance criterion names, for

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -36,7 +36,7 @@ type AuthService interface {
 	Identity(ctx context.Context, presented string) (service.Identity, error)
 	Logout(ctx context.Context, presented string) error
 	VerifyBrowserCSRF(ctx context.Context, presented, csrfToken string) error
-	SlideIdleClock(ctx context.Context, presented string) error
+	SlideIdleClock(ctx context.Context, presented string, activity service.CallerActivity) error
 	EnrolTOTPStart(ctx context.Context, presented, password string) (string, error)
 	EnrolTOTPConfirm(ctx context.Context, presented, code string) (service.LoginResult, error)
 	StepUpTOTP(ctx context.Context, presented, code string) (service.LoginResult, error)
@@ -768,16 +768,21 @@ func (a *API) scimBodyIsOneValue(w http.ResponseWriter, r *http.Request) bool {
 // storm does not become a write storm.
 func (a *API) SlideSessionClocks(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(service.TrackCallerActivity(r.Context()))
 		next.ServeHTTP(w, r)
 		presented := bearer(r.Context())
 		if presented == "" {
+			return
+		}
+		activity, ok := service.ResolvedCallerActivity(r.Context())
+		if !ok {
 			return
 		}
 		// Detached from the request context: the client may already have
 		// disconnected, and the session's clock is still the server's to keep.
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
 		defer cancel()
-		if err := a.Auth.SlideIdleClock(ctx, presented); err != nil {
+		if err := a.Auth.SlideIdleClock(ctx, presented, activity); err != nil {
 			a.fault(ctx, "slide session idle clock", err)
 		}
 	})

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -114,7 +114,7 @@ func (s stubAuth) Logout(ctx context.Context, presented string) error {
 	return s.logout(ctx, presented)
 }
 
-func (s stubAuth) SlideIdleClock(context.Context, string) error { return nil }
+func (s stubAuth) SlideIdleClock(context.Context, string, service.CallerActivity) error { return nil }
 
 // Factor endpoints (#54): the transport contract for these is exercised in the
 // isolation suite end to end; the stubs here keep the interface satisfied and

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -975,43 +975,22 @@ func (s *Auth) Logout(ctx context.Context, presented string) error {
 // SlideGranularity. The transport calls it after a successful response, so
 // the write never sits between authorization and the answer.
 //
-// The decision is made in a READ transaction and a write is opened only when
-// one is actually needed. That ordering matters more than it looks: the
-// transport calls this for every request carrying any bearer at all,
-// including a fabricated one, so opening a write transaction first would let
-// anyone contend for sqlite's single write connection just by sending an
-// Authorization header full of noise.
+// The decision reuses the request's own authentication read, and a write is
+// opened only when one is actually needed. That ordering matters more than it
+// looks: a fabricated bearer has no resolved CallerActivity, so it cannot
+// contend for sqlite's single write connection by supplying header noise.
 //
 // It is a no-op — not an error — when the session has since died: the request
 // it belonged to already succeeded, and failing here would report a problem
 // that no longer has a subject.
-func (s *Auth) SlideIdleClock(ctx context.Context, presented string) error {
+func (s *Auth) SlideIdleClock(ctx context.Context, presented string, activity CallerActivity) error {
 	now := s.now()
-	var sessionID, credentialID string
-	err := tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
-		// Both classes: this path stamps a session's idle clock OR a machine
-		// credential's last-used, and it runs for every request.
-		id, err := az.AuthenticateCaller(ctx, presented, now)
-		if errors.Is(err, domain.ErrUnauthenticated) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		// The SCIM wire stamps provisioning credentials inside its binding-
-		// checked transaction. This generic post-response path owns sessions and
-		// service-account credentials only.
-		if id.Class == domain.ClassProvisioning {
-			return nil
-		}
-		if now.Sub(id.LastSeenAt) < SlideGranularity {
-			return nil
-		}
-		sessionID, credentialID = id.SessionID, id.CredentialID
+	// The request's own resolution already loaded both values. A fabricated
+	// bearer has no CallerActivity and never reaches this method. Provisioning
+	// and instance-connection credentials own separate touch paths and are not
+	// slideable here.
+	if !activity.resolved.Slideable() || now.Sub(activity.resolved.LastSeenAt()) < SlideGranularity {
 		return nil
-	})
-	if err != nil || (sessionID == "" && credentialID == "") {
-		return err
 	}
 	return tx.Write(ctx, s.DB, func(ctx context.Context, _ store.Repos, az *authz.TxAuthorizer) error {
 		// Re-authenticate inside the write transaction: the session may have
@@ -1024,6 +1003,13 @@ func (s *Auth) SlideIdleClock(ctx context.Context, presented string) error {
 		if err != nil {
 			return err
 		}
+		// Another instance may have touched the same row after this request's
+		// authentication read. The request-local hint avoids the common second
+		// read transaction; the fresh row in this authoritative write transaction
+		// still enforces the cross-instance granularity bound.
+		if now.Sub(id.LastSeenAt) < SlideGranularity {
+			return nil
+		}
 		// A MACHINE credential has no clock to slide — its lifetime is fixed
 		// at mint and no activity extends it (#61). What it has is a
 		// last-used stamp, which is observability and never an authorization
@@ -1035,9 +1021,12 @@ func (s *Auth) SlideIdleClock(ctx context.Context, presented string) error {
 		// It is checked FIRST because a machine identity's Artifact is a
 		// credential kind, not a session artifact: handing it to the
 		// per-artifact idle window below would ask a nonsense question.
-		if id.CredentialID != "" {
+		if domain.IsServiceAccountKind(id.Class) && id.CredentialID != "" {
 			return az.TouchMachineCredential(ctx, id.CredentialID, now)
 		}
-		return az.SlideSession(ctx, id.SessionID, now, now.Add(Artifact(id.Artifact).idle()))
+		if id.SessionID != "" {
+			return az.SlideSession(ctx, id.SessionID, now, now.Add(Artifact(id.Artifact).idle()))
+		}
+		return nil
 	})
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -96,6 +96,26 @@ type Actor struct {
 	scimBinding string
 }
 
+// CallerActivity is an opaque post-response slide hint. Its authz payload is
+// deliberately hidden from transport: server code may pass it back to Auth,
+// but cannot turn it into a principal or an authorization decision.
+type CallerActivity struct {
+	resolved authz.CallerActivity
+}
+
+// TrackCallerActivity prepares a request context to receive the narrow result
+// of successful in-transaction authentication.
+func TrackCallerActivity(ctx context.Context) context.Context {
+	return authz.TrackCallerActivity(ctx)
+}
+
+// ResolvedCallerActivity returns the request's authentication result as an
+// opaque slide hint. Fabricated bearers and public handlers return no value.
+func ResolvedCallerActivity(ctx context.Context) (CallerActivity, bool) {
+	resolved, ok := authz.ResolvedCallerActivity(ctx)
+	return CallerActivity{resolved: resolved}, ok
+}
+
 // Bearer is the network path: a presented session artifact, resolved at the
 // chokepoint inside whichever transaction the operation opens.
 func Bearer(artifact string) Actor { return Actor{bearer: artifact} }


### PR DESCRIPTION
Closes #512

## Summary
- reuse successful in-transaction bearer resolution for post-response clock decisions
- skip datastore work for fabricated bearers and preserve dedicated SCIM/instance-connection touch paths
- recheck fresh last-seen state in the write transaction for multi-instance throttling
- add SQLite/PostgreSQL HTTP conformance coverage and issue handoff

## Verification
- `go vet ./...`
- `HIKYO_TEST_POSTGRES_DSN=... go test -p 1 -count=1 ./...` (5,173 tests, 69 packages)
- standards review: CLEAN
- spec review after fixes: CLEAN