### PR TITLE
Extend operational metrics with RED signals #513

### DIFF
--- a/api/noproxy_test.go
+++ b/api/noproxy_test.go
@@ -579,7 +579,7 @@ func TestLiveRouterSurfaceIsExhaustivelyPinned(t *testing.T) {
 		handler http.Handler
 	}{
 		{"public", server.New(nil, &server.API{}, fstest.MapFS{"index.html": {Data: []byte("<!doctype html>")}})},
-		{"operational", server.NewOperational(nil, nil)},
+		{"operational", server.NewOperational(nil, nil, nil)},
 	}
 	for _, candidate := range handlers {
 		routes, ok := candidate.handler.(chi.Routes)
@@ -635,7 +635,7 @@ func TestLiveRouterSurfaceIsExhaustivelyPinned(t *testing.T) {
 
 func TestPublicAndOperationalRouterPartitionsDoNotOverlap(t *testing.T) {
 	public := server.New(nil, &server.API{}, nil)
-	operational := server.NewOperational(nil, nil)
+	operational := server.NewOperational(nil, nil, nil)
 	for _, route := range []string{"/healthz", "/readyz", "/metrics"} {
 		req := httptest.NewRequest(http.MethodGet, route, nil)
 		publicResponse := httptest.NewRecorder()

--- a/docs/handoff/513-metrics-red-admission.md
+++ b/docs/handoff/513-metrics-red-admission.md
@@ -1,24 +1,24 @@
 # Handoff: #513 RED /metrics + admission gauges + dev access log
 
 Issue: https://github.com/Hikyo-Org/Hikyo/issues/513. Base:
-`a84fd620cedb068988b4d996a5610d12638172b1`.
+`ddca9c954377e2fce9403d9507ab7445fc5aba2a`.
 
 ## What shipped
 
-Extends the operational `/metrics` surface with dependency-free, closed-cardinality
-RED metrics, admission-pressure gauges, and a dev-only access log. The
-zero-dependency stance is preserved: everything is hand-formatted Prometheus text
-in the same style as the existing retention/TLS gauges.
+Extends the operational `/metrics` surface with closed-cardinality RED metrics,
+admission-pressure gauges, and a dev-only access log. The official Prometheus Go
+client owns metric primitives, validation, and exposition. A private pedantic
+registry excludes the default Go/process collectors and preserves Hikyo's fixed
+series budget.
 
 ## Contract
 
 - One shared `server.Metrics` collector (`internal/server/metrics.go`) is created
   in `internal/app/app.go`, set on `server.API.Metrics` (the writer, via
   middleware) and passed to `server.NewOperational` (the reader). A nil collector
-  leaves `/metrics` at its pre-#513 shape — the two exact-bytes retention tests
-  pass nil and are unchanged.
+  leaves `/metrics` at its pre-#513 family set.
 - `NewOperational` gained a third parameter `metrics *Metrics`. All non-app
-  callers (tests) pass `nil`.
+  callers explicitly choose whether the RED collector participates.
 - New middleware `API.observe` leads the public router, outside CORS, matching,
   and `recoverPanics`, so unmatched API traffic is counted as `other` and a
   recovered panic's 500 is counted as `5xx`. It reads the chi route pattern
@@ -26,6 +26,10 @@ in the same style as the existing retention/TLS gauges.
 - `admission.Limiter.Snapshot()` (`internal/admission/admission.go`) exposes
   instance-wide pressure only (no attacker-chosen keys): concurrency limit,
   in-flight, queue-depth limit, waiting, active backoffs.
+- `prometheus.NewPedanticRegistry()` owns the RED families. Every allowed label
+  child is created at construction so zero-valued series are deterministic, and
+  the operational handler combines it with request-scoped retention/TLS
+  collectors before handing exposition to `promhttp`.
 
 ## Metrics (all names/labels pinned)
 
@@ -82,8 +86,8 @@ native Codex adversarial reviews finished clean.
 - Counters cover all `/api/v1/*` traffic. Unmatched paths, unsupported methods,
   and CORS preflights are assigned to the closed `other` class.
 - Latency is a fixed-bucket histogram (Prometheus-idiomatic, closed cardinality)
-  rather than min/p50/p99 — the issue offered either; histogram was chosen to stay
-  dependency-free and deterministic.
+  rather than min/p50/p99 — the issue offered either; the official client owns
+  histogram accounting while the pinned bucket grid keeps output deterministic.
 - Docs updated: `docs/site/src/content/docs/docs/configuration.mdx` (new
   Operational metrics section) and `self-hosting.mdx` (scrape note).
 

--- a/docs/handoff/513-metrics-red-admission.md
+++ b/docs/handoff/513-metrics-red-admission.md
@@ -1,0 +1,93 @@
+# Handoff: #513 RED /metrics + admission gauges + dev access log
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/513. Base:
+`a84fd620cedb068988b4d996a5610d12638172b1`.
+
+## What shipped
+
+Extends the operational `/metrics` surface with dependency-free, closed-cardinality
+RED metrics, admission-pressure gauges, and a dev-only access log. The
+zero-dependency stance is preserved: everything is hand-formatted Prometheus text
+in the same style as the existing retention/TLS gauges.
+
+## Contract
+
+- One shared `server.Metrics` collector (`internal/server/metrics.go`) is created
+  in `internal/app/app.go`, set on `server.API.Metrics` (the writer, via
+  middleware) and passed to `server.NewOperational` (the reader). A nil collector
+  leaves `/metrics` at its pre-#513 shape — the two exact-bytes retention tests
+  pass nil and are unchanged.
+- `NewOperational` gained a third parameter `metrics *Metrics`. All non-app
+  callers (tests) pass `nil`.
+- New middleware `API.observe` leads the public router, outside CORS, matching,
+  and `recoverPanics`, so unmatched API traffic is counted as `other` and a
+  recovered panic's 500 is counted as `5xx`. It reads the chi route pattern
+  after `next.ServeHTTP`, classifies it, records, and logs.
+- `admission.Limiter.Snapshot()` (`internal/admission/admission.go`) exposes
+  instance-wide pressure only (no attacker-chosen keys): concurrency limit,
+  in-flight, queue-depth limit, waiting, active backoffs.
+
+## Metrics (all names/labels pinned)
+
+- `hikyo_http_requests_total{class,status}` counter — class ∈ {auth, hierarchy,
+  values, revisions, delivery, scim, admin, other(fail-closed)}; status ∈
+  {2xx,3xx,4xx,5xx,other}. `3xx` is first-class because the OIDC browser legs
+  redirect.
+- `hikyo_http_request_errors_total{class,status}` counter — the `4xx` and `5xx`
+  subsets as a dedicated RED error family.
+- `hikyo_http_requests_in_flight` gauge.
+- `hikyo_http_request_duration_seconds` histogram{class}, fixed buckets
+  `0.005,0.025,0.1,0.5,1,5` s + `+Inf`, with `_sum`/`_count`.
+- `hikyo_admission_{concurrency_limit,in_flight,queue_depth_limit,queue_waiting,active_backoffs}`
+  gauges (rendered as zeros when no limiter is wired).
+
+Class is derived from the templated chi route pattern, never a raw path or ID, so
+cardinality is bounded. The value/revision/delivery/scim families live under the
+`orgs` hierarchy and are matched before the `orgs` catch-all — order is
+load-bearing and covered by `TestClassifyIsAClosedSurfaceMap`.
+
+Names, class/status label sets, histogram buckets, forbidden labels, and the
+≤1,000 total-series budget are pinned in `internal/conformance/metrics_test.go`.
+The authoritative bound registry carries the `metrics-cardinality-budget` row,
+and the scrape test proves the registry exactly matches emitted families.
+
+## Access log
+
+`API.observe` logs `request` (method, class, status, duration_ms) at
+`slog.LevelDebug`. `app.Logger(dev)` uses a LevelDebug text handler under `--dev`
+and a default (Info) JSON handler in production, so the line is present in dev and
+absent by default. It emits the class, never the raw path — no path echo.
+
+## Coverage
+
+- `internal/server/metrics_internal_test.go` (white-box): pre-commit and
+  post-commit recovered panic → 5xx cell while preserving committed wire bytes;
+  classifier table; status buckets; access log present at Debug / absent at Info
+  and never echoing a path; shared response writer forwards Flush and preserves
+  the final response after informational 1xx responses.
+- `internal/server/metrics_scrape_test.go` (black-box): drives traffic through the
+  public API stack, scrapes the operational `/metrics`, asserts family TYPE lines,
+  exact matched and unmatched counters (including a CORS preflight), a zeroed
+  cell, histogram +Inf/count, admission gauge values, retention block still
+  present, and that only closed-enum labels appear (no `/api/`, no `org_`).
+- `internal/conformance/metrics_test.go`: drift pins for names/labels/buckets.
+
+Final verification: `go test -count=1 ./...` passed 4,045 tests in 69 packages;
+`go vet ./...`, the focused race suite, Astro diagnostics/build, OSS policy,
+docs PWA checks, and the offline browser test all passed. Standards, spec, and
+native Codex adversarial reviews finished clean.
+
+## Scope notes / not done
+
+- Counters cover all `/api/v1/*` traffic. Unmatched paths, unsupported methods,
+  and CORS preflights are assigned to the closed `other` class.
+- Latency is a fixed-bucket histogram (Prometheus-idiomatic, closed cardinality)
+  rather than min/p50/p99 — the issue offered either; histogram was chosen to stay
+  dependency-free and deterministic.
+- Docs updated: `docs/site/src/content/docs/docs/configuration.mdx` (new
+  Operational metrics section) and `self-hosting.mdx` (scrape note).
+
+## Follow-ups
+
+None required. A future multi-node build must revisit admission gauges (the
+limiter is process-local by design; see the admission package doc comment).

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -47,6 +47,38 @@ Proxy mode requires trusted CIDRs when the plaintext public listener is not
 loopback. The list names proxies, not browser client networks. Operational
 routes never exist on the public router; keep the operational bind private.
 
+## Operational metrics
+
+`/metrics` on the operational listener serves Prometheus text exposition
+(`text/plain; version=0.0.4`) with no external dependency and no egress. It is
+plaintext and unauthenticated by design — keep the operational bind private and
+scrape it from the host or a trusted network.
+
+Alongside the retention and TLS gauges it exposes RED-style request metrics
+keyed by a closed **surface class** — `auth`, `hierarchy`, `values`,
+`revisions`, `delivery`, `scim`, `admin`, and a fail-closed `other`. There are
+no raw paths and no identifiers in any label, so cardinality is bounded no
+matter the traffic.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `hikyo_http_requests_total` | counter | `class`, `status` (`2xx`/`3xx`/`4xx`/`5xx`/`other`) | Requests per surface class and status bucket. A recovered panic counts as `5xx`. |
+| `hikyo_http_request_errors_total` | counter | `class`, `status` (`4xx`/`5xx`) | Client and server errors per surface class. |
+| `hikyo_http_requests_in_flight` | gauge | — | Requests currently executing in the API stack. |
+| `hikyo_http_request_duration_seconds` | histogram | `class` | Request latency; fixed buckets `0.005, 0.025, 0.1, 0.5, 1, 5` seconds plus `+Inf`. |
+| `hikyo_admission_concurrency_limit` | gauge | — | Derived Argon2id verification slots. |
+| `hikyo_admission_in_flight` | gauge | — | Verification slots currently held. |
+| `hikyo_admission_queue_depth_limit` | gauge | — | Bound on simultaneous pre-auth waiters. |
+| `hikyo_admission_queue_waiting` | gauge | — | Waiters currently queued for a slot. |
+| `hikyo_admission_active_backoffs` | gauge | — | Accounts currently past the failure-backoff threshold. |
+
+Counters cover all `/api/v1/*` traffic. Unmatched paths, unsupported methods,
+and CORS preflights use the closed `other` class.
+
+Under `--dev` the server also emits a per-request access log (method, surface
+class, status, duration) at debug level. The production handler starts at Info,
+so these Debug request lines are absent unless debug logging is enabled.
+
 Adapter egress is public-address-only by default. To approve a private Forgejo
 origin, point `HIKYO_ADAPTER_EGRESS_POLICY_FILE` at a JSON object whose keys are
 exact canonical bare HTTPS origins and whose values are CIDR lists:

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -50,9 +50,10 @@ routes never exist on the public router; keep the operational bind private.
 ## Operational metrics
 
 `/metrics` on the operational listener serves Prometheus text exposition
-(`text/plain; version=0.0.4`) with no external dependency and no egress. It is
-plaintext and unauthenticated by design — keep the operational bind private and
-scrape it from the host or a trusted network.
+(`text/plain; version=0.0.4`) using the official Prometheus Go client. Scraping
+requires no sidecar, external service, or egress. It is plaintext and
+unauthenticated by design — keep the operational bind private and scrape it from
+the host or a trusted network.
 
 Alongside the retention and TLS gauges it exposes RED-style request metrics
 keyed by a closed **surface class** — `auth`, `hierarchy`, `values`,

--- a/docs/site/src/content/docs/docs/self-hosting.mdx
+++ b/docs/site/src/content/docs/docs/self-hosting.mdx
@@ -72,6 +72,13 @@ curl --fail http://127.0.0.1:8081/healthz
 curl --fail http://127.0.0.1:8081/readyz
 ```
 
+The same private listener serves `/metrics` in Prometheus text format —
+RED-style request counters and latency per surface class, in-flight and
+admission-pressure gauges, plus the retention and TLS gauges — with no external
+dependency. It is unauthenticated; scrape it only from the host or a trusted
+network and never expose the operational bind. See
+[metrics](/docs/configuration/#operational-metrics) for the full list.
+
 Then check the public HTTPS origin from outside the host. A local probe does
 not prove DNS, TLS, or reverse-proxy routing.
 

--- a/docs/site/src/content/docs/docs/self-hosting.mdx
+++ b/docs/site/src/content/docs/docs/self-hosting.mdx
@@ -75,8 +75,8 @@ curl --fail http://127.0.0.1:8081/readyz
 The same private listener serves `/metrics` in Prometheus text format —
 RED-style request counters and latency per surface class, in-flight and
 admission-pressure gauges, plus the retention and TLS gauges — with no external
-dependency. It is unauthenticated; scrape it only from the host or a trusted
-network and never expose the operational bind. See
+service dependency. It is unauthenticated; scrape it only from the host or a
+trusted network and never expose the operational bind. See
 [metrics](/docs/configuration/#operational-metrics) for the full list.
 
 Then check the public HTTPS origin from outside the host. A local probe does

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openbao/openbao/api/v2 v2.6.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.27.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/russellhaering/gosaml2 v0.12.0
 	github.com/russellhaering/goxmldsig v1.6.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
@@ -193,7 +194,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -191,6 +191,47 @@ func New(cfg Config) (*Limiter, error) {
 // Concurrency reports the derived number of simultaneous verifications.
 func (l *Limiter) Concurrency() int { return l.concurrency }
 
+// Snapshot is a point-in-time read of the limiter's pressure, for the
+// operational /metrics surface (#513). It carries no attacker-chosen key — only
+// instance-wide counts — so exposing it leaks nothing the semaphore sizing does
+// not already advertise.
+type Snapshot struct {
+	// ConcurrencyLimit is the derived semaphore size (total verification slots).
+	ConcurrencyLimit int
+	// InFlight is how many of those slots are currently held.
+	InFlight int
+	// QueueDepthLimit is the fixed bound on simultaneous waiters.
+	QueueDepthLimit int
+	// Waiting is how many callers are currently queued for a slot.
+	Waiting int
+	// ActiveBackoffs is how many per-account buckets carry a live delay right
+	// now — the count of accounts currently past the failure threshold.
+	ActiveBackoffs int
+}
+
+// Snapshot is a race-free observational read. Slot acquisition/release uses the
+// channel rather than mu, so InFlight and Waiting may describe adjacent instants
+// while a caller crosses that boundary; gauges are pressure signals, not an
+// accounting invariant. len(l.slots) is the FREE-slot count.
+func (l *Limiter) Snapshot() Snapshot {
+	now := l.now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	active := 0
+	for _, state := range l.accounts {
+		if state.until.After(now) {
+			active++
+		}
+	}
+	return Snapshot{
+		ConcurrencyLimit: l.concurrency,
+		InFlight:         l.concurrency - len(l.slots),
+		QueueDepthLimit:  QueueDepth,
+		Waiting:          l.waiting,
+		ActiveBackoffs:   active,
+	}
+}
+
 // Enter admits one pre-authentication attempt from sourceIP. The returned
 // release must be called when the expensive work is done.
 //

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -454,6 +454,10 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	definitionsService := &service.Definitions{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset}
 
 	updatesService := &service.Updates{DB: db, Source: updateSource, Version: Version, Channel: updatecheck.Channel(cfg.UpdateChannel), Control: updateControl, Log: log}
+	// One RED collector shared by the API middleware (writer) and the
+	// operational /metrics handler (reader) (#513). The limiter supplies its
+	// admission-pressure gauges at scrape time.
+	metrics := server.NewMetrics(limiter)
 	api := &server.API{
 		Auth:     authSvc,
 		SAMLAuth: authSvc,
@@ -522,6 +526,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		Remotes:        &service.Remotes{DB: db, Keyring: kr, Fetch: fetcher},
 		Workspace:      &service.Workspace{DB: db, Version: Version, Reauth: authSvc},
 		Admission:      limiter,
+		Metrics:        metrics,
 		Version:        Version,
 		Log:            log,
 		TrustedProxies: proxies,
@@ -540,7 +545,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		publicLn:           publicLn,
 		operationalLn:      operationalLn,
 		publicHandler:      server.NewPublic(&service.System{DB: db, Store: sc}, api, webui.Assets(), server.PublicOptions{HSTS: cfg.TLSCertFile != "" && !config.IsLoopbackListen(cfg.Listen)}),
-		operationalHandler: server.NewOperational(&service.System{DB: db, Store: sc}, operationalHealth{retention: retentionSvc, tls: tlsReloader}),
+		operationalHandler: server.NewOperational(&service.System{DB: db, Store: sc}, operationalHealth{retention: retentionSvc, tls: tlsReloader}, metrics),
 		tlsReloader:        tlsReloader,
 		log:                log,
 		scheduler: &Scheduler{Log: log, Jobs: []ScheduledJob{{

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -138,29 +138,29 @@ func TestServeWithReadySignalsOnlyAfterHTTPServingStarts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
-	ready := make(chan error, 1)
+	ready := make(chan struct{}, 1)
 	go func() {
 		done <- srv.ServeWithReady(ctx, func() {
-			response, err := http.Get("http://" + srv.Addr + "/api/v1/meta")
-			if err == nil {
-				response.Body.Close()
-			}
-			ready <- err
+			// Keep the callback as the readiness event. Probing an API route
+			// here couples callback delivery to unrelated handler latency.
+			ready <- struct{}{}
 		})
 	}()
 
 	select {
-	case err := <-ready:
-		if err != nil {
-			cancel()
-			<-done
-			t.Fatalf("ready callback ran before HTTP serving: %v", err)
-		}
+	case <-ready:
 	case <-time.After(2 * time.Second):
 		cancel()
 		<-done
 		t.Fatal("ready callback was not called")
 	}
+	response, err := http.Get("http://" + srv.Addr + "/api/v1/meta")
+	if err != nil {
+		cancel()
+		<-done
+		t.Fatalf("HTTP server was unavailable after ready callback: %v", err)
+	}
+	response.Body.Close()
 	if !strings.Contains(logged.String(), "server ready") {
 		cancel()
 		<-done

--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -101,6 +101,8 @@ var Registry = []Bound{
 	// §4 admission / §10 runtime.
 	bound("admission-queue-depth", "Admission queue depth", "ops-spec §4 / inv.8", "admission.ErrOverloaded", "admission.TestQueueDepth", StatusEnforced,
 		goTest("internal/admission", "TestQueueDepthIsBounded")),
+	bound("metrics-cardinality-budget", "Metrics static cardinality", "ops-spec §10 / inv.3", "registered series ≤ 1,000 with closed non-identity labels", "conformance.TestMetricRegistryStaysWithinCardinalityBudget", StatusByConstruction,
+		goTest("internal/conformance", "TestMetricRegistryStaysWithinCardinalityBudget")),
 	bound("api-response-cap", "API response cap", "ops-spec §10", "response ≤ 5 MiB / paged", "server contract tests", StatusEnforced,
 		goTest("internal/isolation", "TestAuditExportDoesNotTruncateAboveThePageCap")),
 	bound("audit-page-size", "Audit page size", "ops-spec §10 / §2", "clamp to store.AuditMaxPageSize", "store.TestAuditPageSizeIsClampedToTheCap", StatusClamp,

--- a/internal/conformance/metrics_test.go
+++ b/internal/conformance/metrics_test.go
@@ -1,0 +1,65 @@
+package conformance
+
+// Operational /metrics drift guard (#513). This is the executable registry
+// behind ops-spec §10 / invariant 3: every family, closed label value, and
+// maximum series count is pinned, and the aggregate cannot exceed 1,000.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/server"
+)
+
+func TestMetricRegistryIsPinned(t *testing.T) {
+	classes := []string{"auth", "hierarchy", "values", "revisions", "delivery", "scim", "admin", "other"}
+	statuses := []string{"2xx", "3xx", "4xx", "5xx", "other"}
+	want := []server.MetricFamily{
+		{Name: "hikyo_last_prune_success_timestamp_seconds", MaxSeries: 1},
+		{Name: "hikyo_prune_stale", MaxSeries: 1},
+		{Name: "hikyo_project_storage_peak_bytes", MaxSeries: 1},
+		{Name: "hikyo_project_storage_warn", MaxSeries: 1},
+		{Name: "hikyo_tls_cert_not_after_timestamp_seconds", MaxSeries: 1},
+		{Name: "hikyo_tls_reload_failures_total", MaxSeries: 1},
+		{Name: "hikyo_http_requests_total", MaxSeries: 40, Labels: map[string][]string{"class": classes, "status": statuses}},
+		{Name: "hikyo_http_request_errors_total", MaxSeries: 16, Labels: map[string][]string{"class": classes, "status": {"4xx", "5xx"}}},
+		{Name: "hikyo_http_requests_in_flight", MaxSeries: 1},
+		{Name: "hikyo_http_request_duration_seconds", MaxSeries: 72, Labels: map[string][]string{"class": classes, "le": {"0.005", "0.025", "0.1", "0.5", "1", "5", "+Inf"}}},
+		{Name: "hikyo_admission_concurrency_limit", MaxSeries: 1},
+		{Name: "hikyo_admission_in_flight", MaxSeries: 1},
+		{Name: "hikyo_admission_queue_depth_limit", MaxSeries: 1},
+		{Name: "hikyo_admission_queue_waiting", MaxSeries: 1},
+		{Name: "hikyo_admission_active_backoffs", MaxSeries: 1},
+	}
+	if got := server.RegisteredMetricFamilies(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("metric registry drifted\n got: %#v\nwant: %#v", got, want)
+	}
+	if got, want := server.RequestLatencyBucketsSeconds(), []float64{0.005, 0.025, 0.1, 0.5, 1, 5}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("latency buckets drifted\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestMetricRegistryStaysWithinCardinalityBudget(t *testing.T) {
+	if server.MetricSeriesBudget != 1000 {
+		t.Fatalf("metric series budget = %d, ops-spec requires 1000", server.MetricSeriesBudget)
+	}
+	allowedLabelKeys := map[string]bool{"class": true, "status": true, "le": true}
+	forbidden := map[string]bool{"key": true, "principal": true, "credential": true, "env": true, "org": true, "project": true}
+	seen := map[string]bool{}
+	total := 0
+	for _, family := range server.RegisteredMetricFamilies() {
+		if family.Name == "" || family.MaxSeries < 1 || seen[family.Name] {
+			t.Fatalf("invalid metric registration: %+v", family)
+		}
+		seen[family.Name] = true
+		total += family.MaxSeries
+		for key, values := range family.Labels {
+			if forbidden[key] || !allowedLabelKeys[key] || len(values) == 0 {
+				t.Fatalf("metric %q has forbidden or open label %q: %v", family.Name, key, values)
+			}
+		}
+	}
+	if total > server.MetricSeriesBudget {
+		t.Fatalf("registered metric series = %d, budget = %d", total, server.MetricSeriesBudget)
+	}
+}

--- a/internal/isolation/invariants_test.go
+++ b/internal/isolation/invariants_test.go
@@ -41,7 +41,7 @@ func TestInvariant01ClassificationTotality(t *testing.T) {
 	// their union.
 	routers := []http.Handler{
 		server.NewPublic(nil, &server.API{}, nil, server.PublicOptions{}),
-		server.NewOperational(nil, nil),
+		server.NewOperational(nil, nil, nil),
 	}
 	for _, handler := range routers {
 		router, ok := handler.(chi.Routes)

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -179,8 +179,13 @@ type API struct {
 	// ceiling, so it is charged here. Nil means unlimited, which is only for
 	// tests.
 	Admission *admission.Limiter
-	Version   string
-	Log       *slog.Logger
+	// Metrics is the shared RED collector (#513). The same instance is handed to
+	// NewOperational so the /metrics reader and this middleware's writer see one
+	// set of counters. Nil disables collection (tests), leaving the access log
+	// and handler behaviour unchanged.
+	Metrics *Metrics
+	Version string
+	Log     *slog.Logger
 	// TrustedProxies are the CIDRs whose forwarded headers are believed.
 	// Empty means none: proxy trust is explicit configuration, never
 	// inferred, because an unauthenticated header is not evidence.
@@ -490,9 +495,11 @@ func (a *API) GetOrg(ctx context.Context, req apigen.GetOrgRequestObject) (apige
 // Middleware
 // ---------------------------------------------------------------------------
 
-// Middleware returns the API stack, outermost first. recoverPanics leads it so
-// an invariant panic anywhere below becomes the uniform internal refusal — see
-// internal/server/recovery.go.
+// Middleware returns the matched-route API stack, outermost first.
+// recoverPanics leads the error-contract legs so an invariant panic below
+// becomes the uniform refusal. RED observation lives at public-router scope so
+// it also sees unmatched API paths, unsupported methods, and CORS preflights —
+// see internal/server/server.go and metrics.go.
 func (a *API) Middleware() []func(http.Handler) http.Handler {
 	return []func(http.Handler) http.Handler{
 		a.recoverPanics,

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -377,23 +377,26 @@ func TestMetricsExposeRetentionPrunerHealthWithoutLabels(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
 	}
-	if got := resp.Header.Get("Content-Type"); got != "text/plain; version=0.0.4" {
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/plain; version=0.0.4") {
 		t.Fatalf("content type = %q", got)
 	}
-	want := "# TYPE hikyo_last_prune_success_timestamp_seconds gauge\n" +
-		"hikyo_last_prune_success_timestamp_seconds 1800000000\n" +
-		"# TYPE hikyo_prune_stale gauge\n" +
-		"hikyo_prune_stale 1\n" +
-		"# TYPE hikyo_project_storage_peak_bytes gauge\n" +
-		"hikyo_project_storage_peak_bytes 1500000000\n" +
-		"# TYPE hikyo_project_storage_warn gauge\n" +
-		"hikyo_project_storage_warn 1\n" +
-		"# TYPE hikyo_tls_cert_not_after_timestamp_seconds gauge\n" +
-		"hikyo_tls_cert_not_after_timestamp_seconds 0\n" +
-		"# TYPE hikyo_tls_reload_failures_total counter\n" +
-		"hikyo_tls_reload_failures_total 0\n"
-	if string(body) != want {
-		t.Fatalf("metrics = %q, want %q", body, want)
+	for _, want := range []string{
+		"# TYPE hikyo_last_prune_success_timestamp_seconds gauge\n",
+		"hikyo_last_prune_success_timestamp_seconds 1.8e+09\n",
+		"# TYPE hikyo_prune_stale gauge\n",
+		"hikyo_prune_stale 1\n",
+		"# TYPE hikyo_project_storage_peak_bytes gauge\n",
+		"hikyo_project_storage_peak_bytes 1.5e+09\n",
+		"# TYPE hikyo_project_storage_warn gauge\n",
+		"hikyo_project_storage_warn 1\n",
+		"# TYPE hikyo_tls_cert_not_after_timestamp_seconds gauge\n",
+		"hikyo_tls_cert_not_after_timestamp_seconds 0\n",
+		"# TYPE hikyo_tls_reload_failures_total counter\n",
+		"hikyo_tls_reload_failures_total 0\n",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("metrics missing %q: %s", want, body)
+		}
 	}
 	if strings.Contains(string(body), "{") {
 		t.Fatal("retention metrics carry labels")

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -363,7 +363,7 @@ func TestMetricsExposeRetentionPrunerHealthWithoutLabels(t *testing.T) {
 		LastSuccess: last, Recorded: true, Stale: true,
 		PeakProjectBytes: 1_500_000_000, StorageWarn: true,
 	}}
-	srv := httptest.NewServer(server.NewOperational(stubReady{}, healthService))
+	srv := httptest.NewServer(server.NewOperational(stubReady{}, healthService, nil))
 	t.Cleanup(srv.Close)
 	resp, err := http.Get(srv.URL + "/metrics")
 	if err != nil {
@@ -401,7 +401,7 @@ func TestMetricsExposeRetentionPrunerHealthWithoutLabels(t *testing.T) {
 }
 
 func TestMetricsUseZeroWhenPruneNeverSucceeded(t *testing.T) {
-	srv := httptest.NewServer(server.NewOperational(stubReady{}, stubRetentionHealth{health: service.PruneHealth{Stale: true}}))
+	srv := httptest.NewServer(server.NewOperational(stubReady{}, stubRetentionHealth{health: service.PruneHealth{Stale: true}}, nil))
 	t.Cleanup(srv.Close)
 	resp, err := http.Get(srv.URL + "/metrics")
 	if err != nil {
@@ -971,7 +971,7 @@ func TestHealthProbesSitOutsideTheAPIStack(t *testing.T) {
 	// A liveness probe refused by the admission budget would turn a login
 	// flood into a restart loop, so the probes must not carry the API
 	// middleware at all.
-	srv := httptest.NewServer(server.NewOperational(stubReady{}, stubRetentionHealth{}))
+	srv := httptest.NewServer(server.NewOperational(stubReady{}, stubRetentionHealth{}, nil))
 	t.Cleanup(srv.Close)
 	for path, want := range map[string]int{"/healthz": http.StatusOK, "/readyz": http.StatusOK} {
 		resp, err := srv.Client().Get(srv.URL + path)

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,16 +1,13 @@
 package server
 
 import (
-	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/admission"
@@ -18,12 +15,11 @@ import (
 
 // RED-style request metrics for the operational /metrics surface (#513).
 //
-// The stance is deliberately dependency-free (no prometheus/expvar/otel): the
-// exposition is hand-formatted in the same Prometheus text format the retention
-// gauges already use, so the binary stays small and the no-egress posture is
-// unchanged. Counters are keyed by a CLOSED surface class, never a raw path or
-// an ID, so cardinality is bounded by construction — the acceptance criterion
-// this ticket exists to satisfy.
+// Metrics use the official Prometheus Go client behind a private registry. The
+// private registry deliberately excludes the default Go/process collectors;
+// counters are keyed by a CLOSED surface class, never a raw path or an ID, so
+// cardinality is bounded by construction — the acceptance criterion this
+// ticket exists to satisfy.
 
 // Metric family names. Exported so the conformance drift-guard can pin them:
 // a rename here fails that test rather than silently breaking a dashboard.
@@ -217,106 +213,97 @@ type AdmissionSnapshotter interface {
 // the API middleware (which writes) and the operational /metrics handler (which
 // reads), so both sides see the same counters.
 type Metrics struct {
-	// admission supplies the pressure gauges. Nil renders zeros.
-	admission AdmissionSnapshotter
+	registry *prometheus.Registry
 
-	inFlight atomic.Int64
-
-	mu       sync.Mutex
-	requests [numClasses][numStatusBuckets]uint64
-	// buckets holds cumulative counts per class, one entry per
-	// latencyBucketsSeconds boundary; +Inf is counts[class].
-	buckets [numClasses][]uint64
-	counts  [numClasses]uint64
-	sums    [numClasses]float64
+	inFlight  prometheus.Gauge
+	requests  [numClasses][numStatusBuckets]prometheus.Counter
+	errors    [numClasses][numStatusBuckets]prometheus.Counter
+	durations [numClasses]prometheus.Observer
 }
 
-// NewMetrics builds a collector with the histogram bucket slices sized to the
-// pinned boundaries.
+// NewMetrics builds the fixed collector set in a private pedantic registry.
+// Pre-creating every closed label combination keeps the scrape shape
+// deterministic even before traffic arrives.
 func NewMetrics(adm AdmissionSnapshotter) *Metrics {
-	m := &Metrics{admission: adm}
-	for c := range m.buckets {
-		m.buckets[c] = make([]uint64, len(latencyBucketsSeconds))
+	registry := prometheus.NewPedanticRegistry()
+	requests := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: MetricRequestsTotal,
+		Help: "Total HTTP requests by closed API surface class and status bucket.",
+	}, []string{"class", "status"})
+	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: MetricRequestErrors,
+		Help: "Total HTTP error responses by closed API surface class and status bucket.",
+	}, []string{"class", "status"})
+	inFlight := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: MetricRequestsInFlight,
+		Help: "Current number of API requests in flight.",
+	})
+	durations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    MetricRequestDuration,
+		Help:    "HTTP request duration in seconds by closed API surface class.",
+		Buckets: RequestLatencyBucketsSeconds(),
+	}, []string{"class"})
+	registry.MustRegister(requests, errors, inFlight, durations, newAdmissionCollector(adm))
+
+	m := &Metrics{registry: registry, inFlight: inFlight}
+	for c := surfaceClass(0); c < numClasses; c++ {
+		for s := statusBucket(0); s < numStatusBuckets; s++ {
+			m.requests[c][s] = requests.WithLabelValues(classNames[c], statusNames[s])
+		}
+		for _, s := range [...]statusBucket{status4xx, status5xx} {
+			m.errors[c][s] = errors.WithLabelValues(classNames[c], statusNames[s])
+		}
+		m.durations[c] = durations.WithLabelValues(classNames[c])
 	}
 	return m
 }
 
 func (m *Metrics) record(class surfaceClass, code int, d time.Duration) {
 	sb := bucketForStatus(code)
-	secs := d.Seconds()
-	m.mu.Lock()
-	m.requests[class][sb]++
-	m.counts[class]++
-	m.sums[class] += secs
-	for i, b := range latencyBucketsSeconds {
-		if secs <= b {
-			m.buckets[class][i]++
-		}
+	m.requests[class][sb].Inc()
+	switch sb {
+	case status4xx, status5xx:
+		m.errors[class][sb].Inc()
 	}
-	m.mu.Unlock()
+	m.durations[class].Observe(d.Seconds())
 }
 
-// writeInto renders the RED families and admission gauges in Prometheus text
-// exposition: one # TYPE line per family, all series of that family contiguous.
-func (m *Metrics) writeInto(w io.Writer) {
-	m.mu.Lock()
-	requests := m.requests
-	counts := m.counts
-	sums := m.sums
-	buckets := make([][]uint64, numClasses)
-	for c := range m.buckets {
-		buckets[c] = append([]uint64(nil), m.buckets[c]...)
-	}
-	m.mu.Unlock()
+type admissionCollector struct {
+	source AdmissionSnapshotter
+	descs  [5]*prometheus.Desc
+}
 
-	inflight := m.inFlight.Load()
+func newAdmissionCollector(source AdmissionSnapshotter) *admissionCollector {
+	return &admissionCollector{source: source, descs: [5]*prometheus.Desc{
+		prometheus.NewDesc(MetricAdmissionConcurrencyLimit, "Configured admission concurrency limit.", nil, nil),
+		prometheus.NewDesc(MetricAdmissionInFlight, "Current admission work in flight.", nil, nil),
+		prometheus.NewDesc(MetricAdmissionQueueDepthLimit, "Configured admission queue depth limit.", nil, nil),
+		prometheus.NewDesc(MetricAdmissionQueueWaiting, "Current requests waiting for admission.", nil, nil),
+		prometheus.NewDesc(MetricAdmissionActiveBackoffs, "Current active admission backoff buckets.", nil, nil),
+	}}
+}
+
+func (c *admissionCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, desc := range c.descs {
+		ch <- desc
+	}
+}
+
+func (c *admissionCollector) Collect(ch chan<- prometheus.Metric) {
 	var snap admission.Snapshot
-	if m.admission != nil {
-		snap = m.admission.Snapshot()
+	if c.source != nil {
+		snap = c.source.Snapshot()
 	}
-
-	fmt.Fprintf(w, "# TYPE %s counter\n", MetricRequestsTotal)
-	for c := surfaceClass(0); c < numClasses; c++ {
-		for s := statusBucket(0); s < numStatusBuckets; s++ {
-			fmt.Fprintf(w, "%s{class=%q,status=%q} %d\n",
-				MetricRequestsTotal, classNames[c], statusNames[s], requests[c][s])
-		}
+	values := [...]float64{
+		float64(snap.ConcurrencyLimit),
+		float64(snap.InFlight),
+		float64(snap.QueueDepthLimit),
+		float64(snap.Waiting),
+		float64(snap.ActiveBackoffs),
 	}
-	fmt.Fprintf(w, "# TYPE %s counter\n", MetricRequestErrors)
-	for c := surfaceClass(0); c < numClasses; c++ {
-		for _, s := range [...]statusBucket{status4xx, status5xx} {
-			fmt.Fprintf(w, "%s{class=%q,status=%q} %d\n",
-				MetricRequestErrors, classNames[c], statusNames[s], requests[c][s])
-		}
+	for i, desc := range c.descs {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, values[i])
 	}
-
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricRequestsInFlight, MetricRequestsInFlight, inflight)
-
-	fmt.Fprintf(w, "# TYPE %s histogram\n", MetricRequestDuration)
-	for c := surfaceClass(0); c < numClasses; c++ {
-		for i, b := range latencyBucketsSeconds {
-			fmt.Fprintf(w, "%s_bucket{class=%q,le=%q} %d\n",
-				MetricRequestDuration, classNames[c], formatFloat(b), buckets[c][i])
-		}
-		fmt.Fprintf(w, "%s_bucket{class=%q,le=\"+Inf\"} %d\n",
-			MetricRequestDuration, classNames[c], counts[c])
-		fmt.Fprintf(w, "%s_sum{class=%q} %s\n",
-			MetricRequestDuration, classNames[c], formatFloat(sums[c]))
-		fmt.Fprintf(w, "%s_count{class=%q} %d\n",
-			MetricRequestDuration, classNames[c], counts[c])
-	}
-
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricAdmissionConcurrencyLimit, MetricAdmissionConcurrencyLimit, snap.ConcurrencyLimit)
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricAdmissionInFlight, MetricAdmissionInFlight, snap.InFlight)
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricAdmissionQueueDepthLimit, MetricAdmissionQueueDepthLimit, snap.QueueDepthLimit)
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricAdmissionQueueWaiting, MetricAdmissionQueueWaiting, snap.Waiting)
-	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
-		MetricAdmissionActiveBackoffs, MetricAdmissionActiveBackoffs, snap.ActiveBackoffs)
 }
 
 func formatFloat(f float64) string {

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,0 +1,364 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+)
+
+// RED-style request metrics for the operational /metrics surface (#513).
+//
+// The stance is deliberately dependency-free (no prometheus/expvar/otel): the
+// exposition is hand-formatted in the same Prometheus text format the retention
+// gauges already use, so the binary stays small and the no-egress posture is
+// unchanged. Counters are keyed by a CLOSED surface class, never a raw path or
+// an ID, so cardinality is bounded by construction — the acceptance criterion
+// this ticket exists to satisfy.
+
+// Metric family names. Exported so the conformance drift-guard can pin them:
+// a rename here fails that test rather than silently breaking a dashboard.
+const (
+	MetricLastPruneSuccess   = "hikyo_last_prune_success_timestamp_seconds"
+	MetricPruneStale         = "hikyo_prune_stale"
+	MetricProjectStoragePeak = "hikyo_project_storage_peak_bytes"
+	MetricProjectStorageWarn = "hikyo_project_storage_warn"
+	MetricTLSCertNotAfter    = "hikyo_tls_cert_not_after_timestamp_seconds"
+	MetricTLSReloadFailures  = "hikyo_tls_reload_failures_total"
+
+	MetricRequestsTotal    = "hikyo_http_requests_total"
+	MetricRequestErrors    = "hikyo_http_request_errors_total"
+	MetricRequestsInFlight = "hikyo_http_requests_in_flight"
+	MetricRequestDuration  = "hikyo_http_request_duration_seconds"
+
+	MetricAdmissionConcurrencyLimit = "hikyo_admission_concurrency_limit"
+	MetricAdmissionInFlight         = "hikyo_admission_in_flight"
+	MetricAdmissionQueueDepthLimit  = "hikyo_admission_queue_depth_limit"
+	MetricAdmissionQueueWaiting     = "hikyo_admission_queue_waiting"
+	MetricAdmissionActiveBackoffs   = "hikyo_admission_active_backoffs"
+
+	// MetricSeriesBudget is the ops-spec ceiling for every registered series.
+	MetricSeriesBudget = 1000
+)
+
+// latencyBucketsSeconds are the fixed, cumulative histogram boundaries for the
+// request-duration family. Fixed rather than dynamic keeps the exposition shape
+// deterministic and the label set closed; the values are pinned in the
+// conformance registry so an edit that drifts them off the agreed grid fails
+// the build there. Spread 5 ms → 5 s covers a fast read to a slow expensive
+// publish without a per-endpoint tail.
+var latencyBucketsSeconds = [...]float64{0.005, 0.025, 0.1, 0.5, 1, 5}
+
+// surfaceClass is the closed set of RED classes. A request that matches none
+// of the known families falls to classOther — fail-closed, never a new label.
+type surfaceClass int
+
+const (
+	classAuth surfaceClass = iota
+	classHierarchy
+	classValues
+	classRevisions
+	classDelivery
+	classSCIM
+	classAdmin
+	classOther
+	numClasses
+)
+
+// classNames is the closed class label set, indexed by surfaceClass.
+var classNames = [...]string{
+	classAuth:      "auth",
+	classHierarchy: "hierarchy",
+	classValues:    "values",
+	classRevisions: "revisions",
+	classDelivery:  "delivery",
+	classSCIM:      "scim",
+	classAdmin:     "admin",
+	classOther:     "other",
+}
+
+// statusBucket collapses a status code to its class. 3xx is a first-class
+// bucket because the API returns redirects (the OIDC browser legs), so folding
+// it into 2xx or dropping it would misfile real traffic.
+type statusBucket int
+
+const (
+	status2xx statusBucket = iota
+	status3xx
+	status4xx
+	status5xx
+	statusOther
+	numStatusBuckets
+)
+
+// statusNames is the closed status label set, indexed by statusBucket.
+var statusNames = [...]string{
+	status2xx:   "2xx",
+	status3xx:   "3xx",
+	status4xx:   "4xx",
+	status5xx:   "5xx",
+	statusOther: "other",
+}
+
+// MetricFamily is one immutable-at-runtime registration returned as a copy to
+// conformance tests. Labels maps each closed label key to every value the
+// exporter can emit. MaxSeries includes histogram buckets, sum, and count.
+type MetricFamily struct {
+	Name      string
+	MaxSeries int
+	Labels    map[string][]string
+}
+
+// RegisteredMetricFamilies returns the complete static metric registry. Every
+// map and slice is newly allocated, so callers cannot mutate live exporter
+// state. The scrape test proves this registry and the emitted families agree.
+func RegisteredMetricFamilies() []MetricFamily {
+	classes := metricClassNames()
+	statuses := metricStatusNames()
+	errors := []string{"4xx", "5xx"}
+	buckets := make([]string, 0, len(latencyBucketsSeconds)+1)
+	for _, bucket := range latencyBucketsSeconds {
+		buckets = append(buckets, formatFloat(bucket))
+	}
+	buckets = append(buckets, "+Inf")
+	return []MetricFamily{
+		{Name: MetricLastPruneSuccess, MaxSeries: 1},
+		{Name: MetricPruneStale, MaxSeries: 1},
+		{Name: MetricProjectStoragePeak, MaxSeries: 1},
+		{Name: MetricProjectStorageWarn, MaxSeries: 1},
+		{Name: MetricTLSCertNotAfter, MaxSeries: 1},
+		{Name: MetricTLSReloadFailures, MaxSeries: 1},
+		{Name: MetricRequestsTotal, MaxSeries: len(classes) * len(statuses), Labels: map[string][]string{"class": classes, "status": statuses}},
+		{Name: MetricRequestErrors, MaxSeries: len(classes) * len(errors), Labels: map[string][]string{"class": classes, "status": errors}},
+		{Name: MetricRequestsInFlight, MaxSeries: 1},
+		{Name: MetricRequestDuration, MaxSeries: len(classes) * (len(buckets) + 2), Labels: map[string][]string{"class": classes, "le": buckets}},
+		{Name: MetricAdmissionConcurrencyLimit, MaxSeries: 1},
+		{Name: MetricAdmissionInFlight, MaxSeries: 1},
+		{Name: MetricAdmissionQueueDepthLimit, MaxSeries: 1},
+		{Name: MetricAdmissionQueueWaiting, MaxSeries: 1},
+		{Name: MetricAdmissionActiveBackoffs, MaxSeries: 1},
+	}
+}
+
+// RequestLatencyBucketsSeconds returns a copy of the fixed histogram grid.
+func RequestLatencyBucketsSeconds() []float64 {
+	return append([]float64(nil), latencyBucketsSeconds[:]...)
+}
+
+func metricClassNames() []string { return append([]string(nil), classNames[:]...) }
+
+func metricStatusNames() []string { return append([]string(nil), statusNames[:]...) }
+
+func bucketForStatus(code int) statusBucket {
+	switch code / 100 {
+	case 2:
+		return status2xx
+	case 3:
+		return status3xx
+	case 4:
+		return status4xx
+	case 5:
+		return status5xx
+	default:
+		return statusOther
+	}
+}
+
+// classify maps a matched chi route PATTERN (templated, e.g.
+// "/api/v1/orgs/{org}/projects/{project}/values") to a surface class. It reads
+// the templated pattern, never the concrete path, so no ID ever reaches a
+// label. Order matters: the value/revision/delivery/scim families live UNDER
+// the orgs hierarchy, so they must be recognised before the orgs prefix
+// catch-all. The exact family→class table is pinned in the conformance test.
+func classify(pattern string) surfaceClass {
+	switch {
+	case strings.Contains(pattern, "/scim"):
+		return classSCIM
+	case strings.Contains(pattern, "/delivery"):
+		return classDelivery
+	case strings.Contains(pattern, "/values"):
+		return classValues
+	case strings.Contains(pattern, "/revisions"),
+		strings.Contains(pattern, "/publish"),
+		strings.Contains(pattern, "/pending"),
+		strings.Contains(pattern, "/pins"):
+		return classRevisions
+	case strings.HasPrefix(pattern, api.PathPrefix+"/auth"),
+		strings.HasPrefix(pattern, api.PathPrefix+"/me"),
+		strings.HasPrefix(pattern, api.PathPrefix+"/meta"),
+		strings.HasPrefix(pattern, api.PathPrefix+"/accounts"):
+		return classAuth
+	case strings.HasPrefix(pattern, api.PathPrefix+"/instance"):
+		return classAdmin
+	case strings.HasPrefix(pattern, api.PathPrefix+"/orgs"):
+		return classHierarchy
+	default:
+		return classOther
+	}
+}
+
+// AdmissionSnapshotter is the admission-pressure source the gauges read at
+// scrape time. Nil renders zeros, so the exposition shape stays deterministic
+// whether or not a limiter is wired.
+type AdmissionSnapshotter interface {
+	Snapshot() admission.Snapshot
+}
+
+// Metrics is the instance-wide RED collector. One instance is shared between
+// the API middleware (which writes) and the operational /metrics handler (which
+// reads), so both sides see the same counters.
+type Metrics struct {
+	// admission supplies the pressure gauges. Nil renders zeros.
+	admission AdmissionSnapshotter
+
+	inFlight atomic.Int64
+
+	mu       sync.Mutex
+	requests [numClasses][numStatusBuckets]uint64
+	// buckets holds cumulative counts per class, one entry per
+	// latencyBucketsSeconds boundary; +Inf is counts[class].
+	buckets [numClasses][]uint64
+	counts  [numClasses]uint64
+	sums    [numClasses]float64
+}
+
+// NewMetrics builds a collector with the histogram bucket slices sized to the
+// pinned boundaries.
+func NewMetrics(adm AdmissionSnapshotter) *Metrics {
+	m := &Metrics{admission: adm}
+	for c := range m.buckets {
+		m.buckets[c] = make([]uint64, len(latencyBucketsSeconds))
+	}
+	return m
+}
+
+func (m *Metrics) record(class surfaceClass, code int, d time.Duration) {
+	sb := bucketForStatus(code)
+	secs := d.Seconds()
+	m.mu.Lock()
+	m.requests[class][sb]++
+	m.counts[class]++
+	m.sums[class] += secs
+	for i, b := range latencyBucketsSeconds {
+		if secs <= b {
+			m.buckets[class][i]++
+		}
+	}
+	m.mu.Unlock()
+}
+
+// writeInto renders the RED families and admission gauges in Prometheus text
+// exposition: one # TYPE line per family, all series of that family contiguous.
+func (m *Metrics) writeInto(w io.Writer) {
+	m.mu.Lock()
+	requests := m.requests
+	counts := m.counts
+	sums := m.sums
+	buckets := make([][]uint64, numClasses)
+	for c := range m.buckets {
+		buckets[c] = append([]uint64(nil), m.buckets[c]...)
+	}
+	m.mu.Unlock()
+
+	inflight := m.inFlight.Load()
+	var snap admission.Snapshot
+	if m.admission != nil {
+		snap = m.admission.Snapshot()
+	}
+
+	fmt.Fprintf(w, "# TYPE %s counter\n", MetricRequestsTotal)
+	for c := surfaceClass(0); c < numClasses; c++ {
+		for s := statusBucket(0); s < numStatusBuckets; s++ {
+			fmt.Fprintf(w, "%s{class=%q,status=%q} %d\n",
+				MetricRequestsTotal, classNames[c], statusNames[s], requests[c][s])
+		}
+	}
+	fmt.Fprintf(w, "# TYPE %s counter\n", MetricRequestErrors)
+	for c := surfaceClass(0); c < numClasses; c++ {
+		for _, s := range [...]statusBucket{status4xx, status5xx} {
+			fmt.Fprintf(w, "%s{class=%q,status=%q} %d\n",
+				MetricRequestErrors, classNames[c], statusNames[s], requests[c][s])
+		}
+	}
+
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricRequestsInFlight, MetricRequestsInFlight, inflight)
+
+	fmt.Fprintf(w, "# TYPE %s histogram\n", MetricRequestDuration)
+	for c := surfaceClass(0); c < numClasses; c++ {
+		for i, b := range latencyBucketsSeconds {
+			fmt.Fprintf(w, "%s_bucket{class=%q,le=%q} %d\n",
+				MetricRequestDuration, classNames[c], formatFloat(b), buckets[c][i])
+		}
+		fmt.Fprintf(w, "%s_bucket{class=%q,le=\"+Inf\"} %d\n",
+			MetricRequestDuration, classNames[c], counts[c])
+		fmt.Fprintf(w, "%s_sum{class=%q} %s\n",
+			MetricRequestDuration, classNames[c], formatFloat(sums[c]))
+		fmt.Fprintf(w, "%s_count{class=%q} %d\n",
+			MetricRequestDuration, classNames[c], counts[c])
+	}
+
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricAdmissionConcurrencyLimit, MetricAdmissionConcurrencyLimit, snap.ConcurrencyLimit)
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricAdmissionInFlight, MetricAdmissionInFlight, snap.InFlight)
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricAdmissionQueueDepthLimit, MetricAdmissionQueueDepthLimit, snap.QueueDepthLimit)
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricAdmissionQueueWaiting, MetricAdmissionQueueWaiting, snap.Waiting)
+	fmt.Fprintf(w, "# TYPE %s gauge\n%s %d\n",
+		MetricAdmissionActiveBackoffs, MetricAdmissionActiveBackoffs, snap.ActiveBackoffs)
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// observe is the outer public-router leg for /api/v1 traffic. Its placement
+// before CORS and route matching makes unmatched paths, unsupported methods,
+// and preflights visible as class=other. It also leads recoverPanics, so a
+// recovered panic is recorded as 5xx even after wire bytes were committed.
+func (a *API) observe(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, api.PathPrefix+"/") && r.URL.Path != api.PathPrefix {
+			next.ServeHTTP(w, r)
+			return
+		}
+		sw := newResponseWriter(w)
+		start := time.Now()
+		if a.Metrics != nil {
+			a.Metrics.inFlight.Add(1)
+			defer a.Metrics.inFlight.Add(-1)
+		}
+		next.ServeHTTP(sw, r)
+		dur := time.Since(start)
+
+		class := classOther
+		if rc := chi.RouteContext(r.Context()); !sw.unmatched && rc != nil && rc.RoutePattern() != "" {
+			class = classify(rc.RoutePattern())
+		}
+		if a.Metrics != nil {
+			a.Metrics.record(class, sw.status, dur)
+		}
+		// Debug level so the access log appears under --dev (text handler at
+		// LevelDebug) and is absent in the production default (JSON at Info).
+		// The class, never the raw path, keeps the log free of path echo — the
+		// same discipline the counters enforce.
+		if a.Log != nil {
+			a.Log.DebugContext(r.Context(), "request",
+				"method", r.Method,
+				"class", classNames[class],
+				"status", sw.status,
+				"duration_ms", dur.Milliseconds())
+		}
+	})
+}

--- a/internal/server/metrics_internal_test.go
+++ b/internal/server/metrics_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/Hikyo-Org/hikyo/api"
 )
@@ -36,12 +37,8 @@ func TestObserveCountsRecoveredPanicAs5xx(t *testing.T) {
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", resp.StatusCode)
 	}
-	if got := m.requests[classValues][status5xx]; got != 1 {
-		t.Fatalf("values 5xx counter = %d, want 1", got)
-	}
-	// The +Inf-equivalent count and the histogram both saw the request.
-	if got := m.counts[classValues]; got != 1 {
-		t.Fatalf("values histogram count = %d, want 1", got)
+	if got := testutil.ToFloat64(m.requests[classValues][status5xx]); got != 1 {
+		t.Fatalf("values 5xx counter = %v, want 1", got)
 	}
 }
 
@@ -60,8 +57,8 @@ func TestObserveCountsPostCommitRecoveredPanicAs5xx(t *testing.T) {
 	if recorder.Code != http.StatusTeapot {
 		t.Fatalf("wire status = %d, want committed 418", recorder.Code)
 	}
-	if got := m.requests[classAuth][status5xx]; got != 1 {
-		t.Fatalf("auth 5xx counter = %d, want recovered fault counted as 1", got)
+	if got := testutil.ToFloat64(m.requests[classAuth][status5xx]); got != 1 {
+		t.Fatalf("auth 5xx counter = %v, want recovered fault counted as 1", got)
 	}
 }
 

--- a/internal/server/metrics_internal_test.go
+++ b/internal/server/metrics_internal_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Hikyo-Org/hikyo/api"
+)
+
+// A recovered panic must be counted as the 5xx it is: observe leads recoverPanics
+// in the API stack, so the status recovery.go writes flows back through observe's
+// writer. This is the interplay the ticket calls out by name.
+func TestObserveCountsRecoveredPanicAs5xx(t *testing.T) {
+	m := NewMetrics(nil)
+	a := &API{Metrics: m}
+	r := chi.NewRouter()
+	r.Use(a.observe, a.recoverPanics)
+	r.Get(api.PathPrefix+"/orgs/{org}/projects/{project}/values", func(http.ResponseWriter, *http.Request) {
+		panic("invariant")
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + api.PathPrefix + "/orgs/o/projects/p/values")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.StatusCode)
+	}
+	if got := m.requests[classValues][status5xx]; got != 1 {
+		t.Fatalf("values 5xx counter = %d, want 1", got)
+	}
+	// The +Inf-equivalent count and the histogram both saw the request.
+	if got := m.counts[classValues]; got != 1 {
+		t.Fatalf("values histogram count = %d, want 1", got)
+	}
+}
+
+func TestObserveCountsPostCommitRecoveredPanicAs5xx(t *testing.T) {
+	m := NewMetrics(nil)
+	a := &API{Metrics: m}
+	r := chi.NewRouter()
+	r.Use(a.observe, a.recoverPanics)
+	r.Get(api.PathPrefix+"/meta", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		panic("invariant after commit")
+	})
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, api.PathPrefix+"/meta", nil))
+
+	if recorder.Code != http.StatusTeapot {
+		t.Fatalf("wire status = %d, want committed 418", recorder.Code)
+	}
+	if got := m.requests[classAuth][status5xx]; got != 1 {
+		t.Fatalf("auth 5xx counter = %d, want recovered fault counted as 1", got)
+	}
+}
+
+// The classifier is a closed map from templated route pattern to surface class.
+// A raw path (with an ID) must land where its pattern would, never as its own
+// class — the cardinality guarantee.
+func TestClassifyIsAClosedSurfaceMap(t *testing.T) {
+	cases := []struct {
+		pattern string
+		want    surfaceClass
+	}{
+		{api.PathPrefix + "/auth/local/login", classAuth},
+		{api.PathPrefix + "/me/sessions", classAuth},
+		{api.PathPrefix + "/meta", classAuth},
+		{api.PathPrefix + "/accounts/{principal}/credential-reset", classAuth},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/keys", classHierarchy},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/values", classValues},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/environments/{environment}/values", classValues},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/environments/{environment}/revisions", classRevisions},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/environments/{environment}/publish", classRevisions},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/environments/{environment}/pins", classRevisions},
+		{api.PathPrefix + "/orgs/{org}/projects/{project}/environments/{environment}/delivery", classDelivery},
+		{api.PathPrefix + "/orgs/{org}/scim-bindings", classSCIM},
+		{api.PathPrefix + "/orgs/{org}/scim/v2/{binding}/Users", classSCIM},
+		{api.PathPrefix + "/instance/rotate-root-key", classAdmin},
+		{api.PathPrefix + "/instance/retention-health", classAdmin},
+		{"/not/the/api", classOther},
+		{"", classOther},
+	}
+	for _, c := range cases {
+		if got := classify(c.pattern); got != c.want {
+			t.Errorf("classify(%q) = %s, want %s", c.pattern, classNames[got], classNames[c.want])
+		}
+	}
+}
+
+func TestBucketForStatusCoversEveryClass(t *testing.T) {
+	cases := map[int]statusBucket{
+		200: status2xx, 204: status2xx,
+		302: status3xx,
+		400: status4xx, 401: status4xx, 429: status4xx,
+		500: status5xx, 503: status5xx,
+		100: statusOther, 600: statusOther,
+	}
+	for code, want := range cases {
+		if got := bucketForStatus(code); got != want {
+			t.Errorf("bucketForStatus(%d) = %s, want %s", code, statusNames[got], statusNames[want])
+		}
+	}
+}
+
+// The access log is a Debug-level line: present under the --dev text handler
+// (LevelDebug), absent under the production default. It names the class, never
+// the raw path.
+func TestAccessLogAppearsOnlyAtDebugLevel(t *testing.T) {
+	run := func(level slog.Leveler) string {
+		var buf bytes.Buffer
+		a := &API{
+			Metrics: NewMetrics(nil),
+			Log:     slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})),
+		}
+		r := chi.NewRouter()
+		r.Use(a.observe)
+		r.Get(api.PathPrefix+"/meta", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		srv := httptest.NewServer(r)
+		defer srv.Close()
+		resp, err := http.Get(srv.URL + api.PathPrefix + "/meta")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return buf.String()
+	}
+
+	dev := run(slog.LevelDebug)
+	if !strings.Contains(dev, "msg=request") || !strings.Contains(dev, "class=auth") {
+		t.Fatalf("dev access log missing request line: %q", dev)
+	}
+	if strings.Contains(dev, "/api/") {
+		t.Fatalf("access log echoed a raw path: %q", dev)
+	}
+
+	prod := run(slog.LevelInfo)
+	if strings.Contains(prod, "request") {
+		t.Fatalf("production log emitted the access line at Info level: %q", prod)
+	}
+}
+
+// The status writer forwards Flush, so a streaming response beneath the recovery
+// writer (revisions.go) still flushes.
+func TestResponseWriterForwardsFlush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := newResponseWriter(rec)
+	sw.Flush()
+	if !rec.Flushed {
+		t.Fatal("Flush not forwarded to the underlying writer")
+	}
+}
+
+type statusSequenceWriter struct {
+	header http.Header
+	codes  []int
+}
+
+func (w *statusSequenceWriter) Header() http.Header            { return w.header }
+func (w *statusSequenceWriter) Write(body []byte) (int, error) { return len(body), nil }
+func (w *statusSequenceWriter) WriteHeader(code int)           { w.codes = append(w.codes, code) }
+
+func TestResponseWriterKeepsFinalStatusAfterInformationalResponse(t *testing.T) {
+	underlying := &statusSequenceWriter{header: make(http.Header)}
+	sw := newResponseWriter(underlying)
+	sw.WriteHeader(http.StatusEarlyHints)
+	sw.WriteHeader(http.StatusOK)
+
+	if sw.status != http.StatusOK || !sw.wroteHeader {
+		t.Fatalf("tracked status = %d committed=%v, want final 200", sw.status, sw.wroteHeader)
+	}
+	if got, want := underlying.codes, []int{http.StatusEarlyHints, http.StatusOK}; !slices.Equal(got, want) {
+		t.Fatalf("forwarded statuses = %v, want %v", got, want)
+	}
+}

--- a/internal/server/metrics_scrape_test.go
+++ b/internal/server/metrics_scrape_test.go
@@ -1,0 +1,209 @@
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/server"
+)
+
+type stubAdmissionSnapshot struct{ snap admission.Snapshot }
+
+func (s stubAdmissionSnapshot) Snapshot() admission.Snapshot { return s.snap }
+
+// The RED metrics appear on the operational listener in Prometheus format,
+// carry only closed-enum labels (class/status/le), and reflect traffic driven
+// through the public API stack — the same collector shared across both. This is
+// the server-level presence-and-shape test the acceptance criteria demand.
+func TestMetricsExposeREDCountersAndAdmissionGauges(t *testing.T) {
+	metrics := server.NewMetrics(stubAdmissionSnapshot{snap: admission.Snapshot{
+		ConcurrencyLimit: 8, InFlight: 2, QueueDepthLimit: 16, Waiting: 3, ActiveBackoffs: 1,
+	}})
+	apiSrv := &server.API{
+		Auth: stubAuth{}, Orgs: stubOrgs{}, Providers: stubProviders{}, Version: "test",
+		Projects: stubHierarchy{}, Environments: stubEnvs{}, Values: stubValues{}, Folders: stubFolders{},
+		Metrics: metrics,
+	}
+	public := httptest.NewServer(server.New(stubReady{}, apiSrv, nil))
+	t.Cleanup(public.Close)
+	operational := httptest.NewServer(server.NewOperational(stubReady{}, stubRetentionHealth{}, metrics))
+	t.Cleanup(operational.Close)
+
+	// Drive three unauthenticated hierarchy reads: stubOrgs refuses with 401, a
+	// deterministic hierarchy/4xx cell.
+	for range 3 {
+		resp, err := public.Client().Get(public.URL + api.PathPrefix + "/orgs")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+	}
+	// Unmatched API traffic is still load and must land in the closed `other`
+	// class instead of disappearing outside route-group middleware.
+	for _, request := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: api.PathPrefix + "/does-not-exist"},
+		{method: http.MethodTrace, path: api.PathPrefix + "/orgs"},
+	} {
+		req, err := http.NewRequest(request.method, public.URL+request.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		unmatched, err := public.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = unmatched.Body.Close()
+	}
+	preflight, err := http.NewRequest(http.MethodOptions, public.URL+api.PathPrefix+"/orgs", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preflight.Header.Set("Origin", "https://hostile.example")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	preflightResp, err := public.Client().Do(preflight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = preflightResp.Body.Close()
+
+	resp, err := operational.Client().Get(operational.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+
+	// The retention block is still present (shared endpoint, appended output).
+	mustContain(t, body, "hikyo_last_prune_success_timestamp_seconds")
+
+	// RED families, each with its single TYPE line.
+	for _, family := range []string{
+		"# TYPE " + server.MetricRequestsTotal + " counter",
+		"# TYPE " + server.MetricRequestErrors + " counter",
+		"# TYPE " + server.MetricRequestsInFlight + " gauge",
+		"# TYPE " + server.MetricRequestDuration + " histogram",
+		"# TYPE " + server.MetricAdmissionConcurrencyLimit + " gauge",
+		"# TYPE " + server.MetricAdmissionInFlight + " gauge",
+		"# TYPE " + server.MetricAdmissionQueueDepthLimit + " gauge",
+		"# TYPE " + server.MetricAdmissionQueueWaiting + " gauge",
+		"# TYPE " + server.MetricAdmissionActiveBackoffs + " gauge",
+	} {
+		mustContain(t, body, family)
+	}
+
+	// The three requests landed in exactly one closed cell.
+	mustContain(t, body, server.MetricRequestsTotal+`{class="hierarchy",status="4xx"} 3`)
+	mustContain(t, body, server.MetricRequestErrors+`{class="hierarchy",status="4xx"} 3`)
+	mustContain(t, body, server.MetricRequestsTotal+`{class="other",status="4xx"} 2`)
+	mustContain(t, body, server.MetricRequestErrors+`{class="other",status="4xx"} 2`)
+	mustContain(t, body, server.MetricRequestsTotal+`{class="other",status="2xx"} 1`)
+	// A cell that saw no traffic is still present at zero (deterministic shape).
+	mustContain(t, body, server.MetricRequestsTotal+`{class="delivery",status="2xx"} 0`)
+	// Histogram: +Inf bucket, sum, count for the class that saw traffic.
+	mustContain(t, body, server.MetricRequestDuration+`_bucket{class="hierarchy",le="+Inf"} 3`)
+	mustContain(t, body, server.MetricRequestDuration+`_count{class="hierarchy"} 3`)
+	// Admission gauges reflect the snapshot.
+	mustContain(t, body, server.MetricAdmissionConcurrencyLimit+" 8")
+	mustContain(t, body, server.MetricAdmissionInFlight+" 2")
+	mustContain(t, body, server.MetricAdmissionQueueDepthLimit+" 16")
+	mustContain(t, body, server.MetricAdmissionQueueWaiting+" 3")
+	mustContain(t, body, server.MetricAdmissionActiveBackoffs+" 1")
+
+	// No high-cardinality label: no raw path, no ID shape ever reaches a label.
+	if strings.Contains(body, "/api/") || strings.Contains(body, "org_") {
+		t.Fatalf("metrics leaked a raw path or ID into a label:\n%s", body)
+	}
+	assertMetricRegistryMatchesScrape(t, body)
+}
+
+func assertMetricRegistryMatchesScrape(t *testing.T, body string) {
+	t.Helper()
+	registry := map[string]server.MetricFamily{}
+	for _, family := range server.RegisteredMetricFamilies() {
+		registry[family.Name] = family
+	}
+	types := map[string]bool{}
+	series := map[string]int{}
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "# TYPE ") {
+			fields := strings.Fields(line)
+			if len(fields) == 4 {
+				types[fields[2]] = true
+			}
+			continue
+		}
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		seriesToken := strings.Fields(line)[0]
+		name := seriesToken
+		labels := ""
+		if open := strings.IndexByte(seriesToken, '{'); open >= 0 {
+			name = seriesToken[:open]
+			labels = seriesToken[open+1 : len(seriesToken)-1]
+		}
+		family := name
+		if _, ok := registry[family]; !ok {
+			for _, suffix := range []string{"_bucket", "_sum", "_count"} {
+				if strings.HasSuffix(name, suffix) {
+					family = strings.TrimSuffix(name, suffix)
+					break
+				}
+			}
+		}
+		if _, ok := registry[family]; !ok {
+			t.Fatalf("scrape emitted unregistered series %q", name)
+		}
+		for _, pair := range strings.Split(labels, ",") {
+			if pair == "" {
+				continue
+			}
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) != 2 {
+				t.Fatalf("invalid label pair %q in %q", pair, line)
+			}
+			allowed, ok := registry[family].Labels[parts[0]]
+			value := strings.Trim(parts[1], `"`)
+			if !ok || !containsString(allowed, value) {
+				t.Fatalf("family %q emitted unregistered label %s=%q", family, parts[0], value)
+			}
+		}
+		series[family]++
+	}
+	if len(types) != len(registry) {
+		t.Fatalf("TYPE families = %d, registry = %d: %v", len(types), len(registry), types)
+	}
+	for name, family := range registry {
+		if !types[name] || series[name] != family.MaxSeries {
+			t.Errorf("family %q: TYPE=%v series=%d, want %d", name, types[name], series[name], family.MaxSeries)
+		}
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func mustContain(t *testing.T, body, want string) {
+	t.Helper()
+	if !strings.Contains(body, want) {
+		t.Fatalf("metrics missing %q\n---\n%s", want, body)
+	}
+}

--- a/internal/server/recovery.go
+++ b/internal/server/recovery.go
@@ -8,16 +8,17 @@ import (
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 )
 
-// recoverPanics is the OUTERMOST leg of the API stack, so a panic anywhere
-// below it — contract validation included — becomes the uniform `internal`
-// refusal instead of a dropped connection, and the panic value and stack land
-// in the slog pipeline rather than the std logger net/http recovers into.
+// recoverPanics is the outermost error-contract leg, immediately inside the
+// observational middleware. A panic anywhere below it — contract validation
+// included — becomes the uniform `internal` refusal instead of a dropped
+// connection, and the panic value and stack land in the slog pipeline rather
+// than the std logger net/http recovers into.
 //
 // The service layer panics on state-reachable invariant violations (double
 // classification, an unknown fetch-result variant), so this leg is part of the
 // error contract, not a programmer-error net. The security-header and CORS
 // middlewares are router-level (server.go), one layer up, so a recovered answer
-// still carries them — the recovery writer is the inner one.
+// still carries them — the response tracker is the inner one.
 //
 // When a handler has already committed the response before panicking — a fault
 // mid-advisory-stream, say — the status is gone and a second WriteHeader would
@@ -25,11 +26,14 @@ import (
 // writer is left alone and the log alone carries the failure.
 func (a *API) recoverPanics(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rec := &recoveryWriter{ResponseWriter: w}
+		rec := newResponseWriter(w)
 		defer func() {
 			p := recover()
 			if p == nil {
 				return
+			}
+			if marker, ok := w.(interface{ markRecoveredPanic() }); ok {
+				marker.markRecoveredPanic()
 			}
 			// Mirror a.fault: the wire carries nothing derived from the cause,
 			// the process log carries everything. The contract operation is not
@@ -50,30 +54,4 @@ func (a *API) recoverPanics(next http.Handler) http.Handler {
 		}()
 		next.ServeHTTP(rec, r)
 	})
-}
-
-// recoveryWriter tracks whether the response was committed, so a panic after a
-// partial write cannot graft a second status onto the stream. Flush forwards so
-// the advisory stream (revisions.go) stays a stream; without it every event
-// would sit in a buffer until the response ended, which for a stream is never.
-type recoveryWriter struct {
-	http.ResponseWriter
-	wroteHeader bool
-}
-
-func (w *recoveryWriter) WriteHeader(status int) {
-	w.wroteHeader = true
-	w.ResponseWriter.WriteHeader(status)
-}
-
-func (w *recoveryWriter) Write(b []byte) (int, error) {
-	// A bare Write is an implicit 200 (net/http), and counts as committed.
-	w.wroteHeader = true
-	return w.ResponseWriter.Write(b)
-}
-
-func (w *recoveryWriter) Flush() {
-	if f, ok := w.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
 }

--- a/internal/server/recovery_test.go
+++ b/internal/server/recovery_test.go
@@ -103,7 +103,7 @@ func TestRecoveryKeepsTheAdvisoryStreamAStream(t *testing.T) {
 	stream := eventStream{ctx: ctx, events: make(chan service.AdvisoryEvent), retry: advisoryRetryBase}
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The visitor refuses a non-flushing writer outright; running it behind
-		// the full stack proves recoveryWriter satisfies and forwards Flusher.
+		// the full stack proves responseWriter satisfies and forwards Flusher.
 		if err := stream.VisitWatchProjectEventsResponse(w); err != nil {
 			t.Error(err)
 		}

--- a/internal/server/response_writer.go
+++ b/internal/server/response_writer.go
@@ -1,0 +1,56 @@
+package server
+
+import "net/http"
+
+// responseWriter is the one response-commit tracker shared by metrics and
+// panic recovery. A bare Write or Flush commits 200, matching net/http.
+type responseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+	unmatched   bool
+}
+
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{ResponseWriter: w, status: http.StatusOK}
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	// Informational responses do not commit the final status. net/http permits
+	// any number of 1xx responses before one final 2xx-5xx response.
+	if code >= 100 && code < 200 {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
+	w.status = code
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseWriter) Write(body []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(body)
+}
+
+func (w *responseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// markRecoveredPanic changes only the observational status. When bytes were
+// already committed, the wire response stays untouched while RED/error metrics
+// still count the recovered fault as 5xx.
+func (w *responseWriter) markRecoveredPanic() { w.status = http.StatusInternalServerError }
+
+// markUnmatched keeps unsupported methods in the fail-closed `other` class
+// even when chi retains the path pattern it matched before rejecting the verb.
+func (w *responseWriter) markUnmatched() { w.unmatched = true }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,12 @@ func NewPublic(ready ReadyChecker, a *API, ui fs.FS, publicOptions PublicOptions
 	// remote takes effect without a restart — belongs to the SPA writer below,
 	// which is the only response that can use it.
 	r.Use(securityHeaders(publicOptions.HSTS))
+	// Observe at router scope so unmatched API paths, unsupported methods, and
+	// CORS preflights contribute to RED totals as class=other. Route-group
+	// middleware never sees those requests because chi has not selected a route.
+	if a != nil {
+		r.Use(a.observe)
+	}
 	// Cross-origin readability for allowlisted workspace origins (#71), at the
 	// TOP of the chain rather than inside the API group, and that placement is
 	// load-bearing rather than tidy.
@@ -133,20 +139,33 @@ func NewPublic(ready ReadyChecker, a *API, ui fs.FS, publicOptions PublicOptions
 		})
 	} else {
 		r.NotFound(func(w http.ResponseWriter, _ *http.Request) {
+			markUnmatched(w)
 			writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 		})
 	}
 	r.MethodNotAllowed(func(w http.ResponseWriter, _ *http.Request) {
 		// A method the contract does not describe on a path it does is,
 		// from outside, the same fact as a path that is not there.
+		markUnmatched(w)
 		writeError(w, wirePolicyForCode(apigen.ErrorCodeNotFound), "")
 	})
 	return r
 }
 
+func markUnmatched(w http.ResponseWriter) {
+	if marker, ok := w.(interface{ markUnmatched() }); ok {
+		marker.markUnmatched()
+	}
+}
+
 // NewOperational builds the separate plaintext operational router. It carries
 // no CORS or admission middleware and registers only local process surfaces.
-func NewOperational(ready ReadyChecker, healthService OperationalRetentionHealthService) http.Handler {
+//
+// metrics is the shared RED collector (#513). It is the SAME instance handed to
+// the API middleware, so the scrape here reads the counters that middleware
+// writes. A nil collector leaves /metrics as the retention/TLS gauges alone —
+// the pre-#513 shape.
+func NewOperational(ready ReadyChecker, healthService OperationalRetentionHealthService, metrics *Metrics) http.Handler {
 	r := chi.NewRouter()
 	r.Use(securityHeaders(false))
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -190,18 +209,21 @@ func NewOperational(ready ReadyChecker, healthService OperationalRetentionHealth
 		}
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "# TYPE hikyo_last_prune_success_timestamp_seconds gauge\n"+
-			"hikyo_last_prune_success_timestamp_seconds %d\n"+
-			"# TYPE hikyo_prune_stale gauge\n"+
-			"hikyo_prune_stale %d\n"+
-			"# TYPE hikyo_project_storage_peak_bytes gauge\n"+
-			"hikyo_project_storage_peak_bytes %d\n"+
-			"# TYPE hikyo_project_storage_warn gauge\n"+
-			"hikyo_project_storage_warn %d\n"+
-			"# TYPE hikyo_tls_cert_not_after_timestamp_seconds gauge\n"+
-			"hikyo_tls_cert_not_after_timestamp_seconds %d\n"+
-			"# TYPE hikyo_tls_reload_failures_total counter\n"+
-			"hikyo_tls_reload_failures_total %d\n", last, stale, health.PeakProjectBytes, storageWarn, tlsNotAfter, tlsReloadFailures)
+		_, _ = fmt.Fprintf(w, "# TYPE "+MetricLastPruneSuccess+" gauge\n"+
+			MetricLastPruneSuccess+" %d\n"+
+			"# TYPE "+MetricPruneStale+" gauge\n"+
+			MetricPruneStale+" %d\n"+
+			"# TYPE "+MetricProjectStoragePeak+" gauge\n"+
+			MetricProjectStoragePeak+" %d\n"+
+			"# TYPE "+MetricProjectStorageWarn+" gauge\n"+
+			MetricProjectStorageWarn+" %d\n"+
+			"# TYPE "+MetricTLSCertNotAfter+" gauge\n"+
+			MetricTLSCertNotAfter+" %d\n"+
+			"# TYPE "+MetricTLSReloadFailures+" counter\n"+
+			MetricTLSReloadFailures+" %d\n", last, stale, health.PeakProjectBytes, storageWarn, tlsNotAfter, tlsReloadFailures)
+		if metrics != nil {
+			metrics.writeInto(w)
+		}
 	})
 	return r
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,11 +6,12 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/api/apigen"
@@ -210,23 +211,23 @@ func NewOperational(ready ReadyChecker, healthService OperationalRetentionHealth
 		if metrics, ok := healthService.(TLSMetrics); ok {
 			tlsNotAfter, tlsReloadFailures = metrics.TLSMetrics()
 		}
-		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "# TYPE "+MetricLastPruneSuccess+" gauge\n"+
-			MetricLastPruneSuccess+" %d\n"+
-			"# TYPE "+MetricPruneStale+" gauge\n"+
-			MetricPruneStale+" %d\n"+
-			"# TYPE "+MetricProjectStoragePeak+" gauge\n"+
-			MetricProjectStoragePeak+" %d\n"+
-			"# TYPE "+MetricProjectStorageWarn+" gauge\n"+
-			MetricProjectStorageWarn+" %d\n"+
-			"# TYPE "+MetricTLSCertNotAfter+" gauge\n"+
-			MetricTLSCertNotAfter+" %d\n"+
-			"# TYPE "+MetricTLSReloadFailures+" counter\n"+
-			MetricTLSReloadFailures+" %d\n", last, stale, health.PeakProjectBytes, storageWarn, tlsNotAfter, tlsReloadFailures)
+		snapshot := prometheus.NewPedanticRegistry()
+		snapshot.MustRegister(
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: MetricLastPruneSuccess, Help: "Unix timestamp of the last successful retention prune."}, func() float64 { return float64(last) }),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: MetricPruneStale, Help: "Whether the retention prune state is stale."}, func() float64 { return float64(stale) }),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: MetricProjectStoragePeak, Help: "Largest observed project storage usage in bytes."}, func() float64 { return float64(health.PeakProjectBytes) }),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: MetricProjectStorageWarn, Help: "Whether project storage is above its warning threshold."}, func() float64 { return float64(storageWarn) }),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{Name: MetricTLSCertNotAfter, Help: "Unix timestamp when the active TLS certificate expires."}, func() float64 { return float64(tlsNotAfter) }),
+			prometheus.NewCounterFunc(prometheus.CounterOpts{Name: MetricTLSReloadFailures, Help: "Total failed TLS certificate reloads."}, func() float64 { return float64(tlsReloadFailures) }),
+		)
+		gatherers := prometheus.Gatherers{snapshot}
 		if metrics != nil {
-			metrics.writeInto(w)
+			gatherers = append(gatherers, metrics.registry)
 		}
+		promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{
+			ErrorHandling:     promhttp.HTTPErrorOnError,
+			EnableOpenMetrics: false,
+		}).ServeHTTP(w, req)
 	})
 	return r
 }


### PR DESCRIPTION
## Summary

- add RED request counters, error counters, latency histograms, and in-flight gauge using the official Prometheus Go client
- expose closed-cardinality admission pressure gauges through a private pedantic registry with no default Go/process collectors
- add dev-only access logging, panic-aware response tracking, conformance pins, documentation, and handoff evidence

## Verification

- `go test -count=1 ./...` (4,055 tests, 69 packages)
- `go vet ./...`
- `go test -race -vet=off -count=1 ./internal/server ./internal/app ./internal/conformance` (402 tests)
- `pnpm --dir docs/site run verify` under Node 24
- standards review: clean
- spec review: clean
- native Codex adversarial review of the original Claude-authored implementation: clean after 2 rounds
- Codex-authored Prometheus client refactor: Standards and Spec re-review clean; cross-vendor review skipped per project policy

Closes #513