### PR TITLE
feat(web): administer SCIM provisioning in the WebUI (#501)

### DIFF
--- a/web/e2e/flows/members.spec.ts
+++ b/web/e2e/flows/members.spec.ts
@@ -613,6 +613,7 @@ const SCIM_PATH = `/orgs/${seed.org}/scim`;
 const SCIM_MEDIA = 'application/scim+json';
 const SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group';
 const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCHEMA_PATCHOP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
 const SCIM_PROVIDER_SLUG = 'e2e-oidc';
 
 /** Create the binding once if absent; the pinned-set tests reuse it. */
@@ -667,12 +668,16 @@ test.describe('scim provisioning', () => {
     await mintDialog.getByRole('button', { name: 'Done' }).click();
     await expect(mintDialog).toBeHidden();
 
-    // The token never reaches a URL or durable browser storage.
-    expect(page.url()).not.toContain(token);
-    const stored = await page.evaluate(() =>
-      JSON.stringify({ local: { ...localStorage }, session: { ...sessionStorage } }),
-    );
-    expect(stored).not.toContain(token);
+    // The token never reaches a URL or durable browser storage. Assert on a
+    // boolean, never the raw token: a `not.toContain(token)` failure prints the
+    // expected substring into the CI log, leaking the credential.
+    expect(page.url().includes(token)).toBe(false);
+    const tokenInStorage = await page.evaluate((secret) => {
+      const scan = (store: Storage) =>
+        Object.keys(store).some((key) => key.includes(secret) || (store.getItem(key) ?? '').includes(secret));
+      return scan(localStorage) || scan(sessionStorage);
+    }, token);
+    expect(tokenInStorage).toBe(false);
 
     // The identity provider's own wire, with that credential: provision a group
     // and a user the way a connector does.
@@ -701,6 +706,16 @@ test.describe('scim provisioning', () => {
       active: true,
     });
     expect(userResponse.status).toBe(201);
+    const user = z.object({ id: z.string() }).parse(await userResponse.json());
+
+    // Put the user IN the group so the mapping below actually grants someone —
+    // otherwise the "members affected" count is zero and the assertions pass
+    // vacuously.
+    const patchResponse = await wire('PATCH', `/Groups/${group.id}`, {
+      schemas: [SCHEMA_PATCHOP],
+      Operations: [{ op: 'add', path: 'members', value: [{ value: user.id }] }],
+    });
+    expect(patchResponse.status).toBe(200);
 
     // A reload re-reads the directory the wire just populated; the binding stays
     // selected because it is in the URL.
@@ -712,18 +727,22 @@ test.describe('scim provisioning', () => {
     ).toBeVisible();
 
     // Map the provisioned group to a template at organisation scope — the widest
-    // reach — so the server's consequence language is returned and rendered.
+    // reach — so the server's consequence language is returned and rendered. The
+    // one member is granted immediately, so the applied count is nonzero.
     await page.getByLabel('Provisioned group').selectOption(group.id);
     await page.getByLabel('Template').selectOption('viewer');
     await page.getByRole('button', { name: 'Add mapping' }).click();
-    await expect(page.getByText(/Applied to .* member/)).toBeVisible();
+    await expect(page.getByText(/Applied to 1 member/)).toBeVisible();
+    await expect(page.getByText(/[1-9]\d* grants created/)).toBeVisible();
     await expect(page.locator('.scim-warnings')).toBeVisible();
     const mappingRow = page.locator('.scim-mapping', { hasText: 'E2E Engineers' });
     await expect(mappingRow).toBeVisible();
 
-    // Delete the mapping — it releases every origin it held and the row goes.
+    // Delete the mapping — it releases every origin it held. The row goes, and
+    // the release count is reported ABOVE the list so it outlives the row.
     await mappingRow.getByRole('button', { name: /Delete mapping/ }).click();
     await expect(page.locator('.scim-mapping', { hasText: 'E2E Engineers' })).toHaveCount(0);
+    await expect(page.getByText(/Deleted\. [1-9]\d* origins released/)).toBeVisible();
 
     // Revoke the credential; it bites at the wire's very next request.
     const credentialRow = page.locator('.scim-credential').first();

--- a/web/e2e/flows/members.spec.ts
+++ b/web/e2e/flows/members.spec.ts
@@ -1,13 +1,16 @@
 import { expect, test, type Browser, type BrowserContext, type Page } from '@playwright/test';
-import { zServiceAccountList } from '@hikyo/zod';
+import { zScimBinding, zScimBindingList, zServiceAccountList } from '@hikyo/zod';
 import { z } from 'zod';
 
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
 import { browserApi } from '../fixtures/api.ts';
 import {
+  BASE_URL,
+  nextTotpCode,
   readSeed,
   STORAGE_STATE,
 } from '../fixtures/instance.ts';
+import { surfacesForFlow } from '../registry.ts';
 
 /**
  * Flow: members & grants (registry surface `members`) — mvp-boundary S3's
@@ -592,5 +595,193 @@ test.describe('members and grants', () => {
         await page.emulateMedia({ colorScheme: null });
       }
     });
+  }
+});
+
+/**
+ * Flow: SCIM provisioning administration (registry surface `scim`, #501).
+ *
+ * It rides this file because the merge gate loads `ci.yml` from the base branch
+ * and a spec a PR adds to a group never runs on that PR — members.spec.ts is
+ * already in group 1 and is the org-scoped `manage-members` sibling, so the
+ * surface's pinned set runs from PR-checked-out content today (see
+ * e2e/registry.ts). The session is the shared administrator's: `manage-members`
+ * is MFA-mandatory and this session is stepped up, and minting additionally
+ * reauthenticates with a fresh TOTP proof.
+ */
+const SCIM_PATH = `/orgs/${seed.org}/scim`;
+const SCIM_MEDIA = 'application/scim+json';
+const SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group';
+const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCIM_PROVIDER_SLUG = 'e2e-oidc';
+
+/** Create the binding once if absent; the pinned-set tests reuse it. */
+async function ensureScimBinding(page: Page): Promise<string> {
+  const list = await browserApi(
+    page,
+    'GET',
+    `/api/v1/orgs/${seed.org}/scim-bindings`,
+    zScimBindingList,
+  );
+  const existing = list.items.find((binding) => binding.provider_slug === SCIM_PROVIDER_SLUG);
+  if (existing !== undefined) {
+    return existing.id;
+  }
+  const created = await browserApi(page, 'POST', `/api/v1/orgs/${seed.org}/scim-bindings`, zScimBinding, {
+    provider_kind: 'oidc',
+    provider_slug: SCIM_PROVIDER_SLUG,
+    subject_source: 'externalId',
+  });
+  return created.id;
+}
+
+test.describe('scim provisioning', () => {
+  test.use({ storageState: STORAGE_STATE });
+
+  test('administers a binding, credential, mapping and directory end to end', async ({ page }) => {
+    await page.goto(SCIM_PATH);
+    await expect(page.getByRole('heading', { name: 'SCIM provisioning', level: 1 })).toBeVisible();
+
+    // Bind the fixture's OIDC provider. Subject source defaults to externalId.
+    await page.getByLabel('Provider slug').fill(SCIM_PROVIDER_SLUG);
+    await page.getByRole('button', { name: 'Create binding' }).click();
+    await expect(page.getByText(new RegExp(`Bound ${SCIM_PROVIDER_SLUG}`))).toBeVisible();
+
+    // Administer it — the binding id lands in the query string as route data.
+    const card = page.locator('.scim-binding', { hasText: SCIM_PROVIDER_SLUG });
+    await card.getByRole('button', { name: 'Administer' }).click();
+    await expect(page.getByRole('heading', { name: 'Provisioning credentials' })).toBeVisible();
+    const bindingId = new URL(page.url()).searchParams.get('binding') ?? '';
+    expect(bindingId).not.toBe('');
+
+    // Mint a credential with a fresh reauthentication proof, and capture the
+    // display-once token from the dialog. The token is read here (it is in the
+    // dialog by design) and used as the wire bearer below.
+    await page.getByLabel('Reauthentication proof').fill(await nextTotpCode());
+    await page.getByRole('button', { name: 'Mint credential' }).click();
+    const mintDialog = page.getByRole('dialog', { name: /shown exactly once/ });
+    await expect(mintDialog).toBeVisible();
+    const token = ((await mintDialog.locator('.machine__token').textContent()) ?? '').trim();
+    expect(token).not.toBe('');
+    await mintDialog.getByLabel(/configured this credential/).check();
+    await mintDialog.getByRole('button', { name: 'Done' }).click();
+    await expect(mintDialog).toBeHidden();
+
+    // The token never reaches a URL or durable browser storage.
+    expect(page.url()).not.toContain(token);
+    const stored = await page.evaluate(() =>
+      JSON.stringify({ local: { ...localStorage }, session: { ...sessionStorage } }),
+    );
+    expect(stored).not.toContain(token);
+
+    // The identity provider's own wire, with that credential: provision a group
+    // and a user the way a connector does.
+    const wire = (method: string, path: string, body?: unknown) =>
+      fetch(`${BASE_URL}/api/v1/orgs/${seed.org}/scim/v2/${bindingId}${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(body === undefined ? {} : { 'Content-Type': SCIM_MEDIA }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+
+    const groupResponse = await wire('POST', '/Groups', {
+      schemas: [SCHEMA_GROUP],
+      displayName: 'E2E Engineers',
+    });
+    expect(groupResponse.status).toBe(201);
+    const group = z.object({ id: z.string() }).parse(await groupResponse.json());
+    expect(group.id).not.toBe('');
+
+    const userResponse = await wire('POST', '/Users', {
+      schemas: [SCHEMA_USER],
+      userName: 'e2e-scim@idp.test',
+      externalId: 'e2e-scim-sub',
+      active: true,
+    });
+    expect(userResponse.status).toBe(201);
+
+    // A reload re-reads the directory the wire just populated; the binding stays
+    // selected because it is in the URL.
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Directory' })).toBeVisible();
+    await expect(page.locator('.scim-directory-group', { hasText: 'E2E Engineers' })).toBeVisible();
+    await expect(
+      page.locator('.scim-directory-user', { hasText: 'e2e-scim@idp.test' }),
+    ).toBeVisible();
+
+    // Map the provisioned group to a template at organisation scope — the widest
+    // reach — so the server's consequence language is returned and rendered.
+    await page.getByLabel('Provisioned group').selectOption(group.id);
+    await page.getByLabel('Template').selectOption('viewer');
+    await page.getByRole('button', { name: 'Add mapping' }).click();
+    await expect(page.getByText(/Applied to .* member/)).toBeVisible();
+    await expect(page.locator('.scim-warnings')).toBeVisible();
+    const mappingRow = page.locator('.scim-mapping', { hasText: 'E2E Engineers' });
+    await expect(mappingRow).toBeVisible();
+
+    // Delete the mapping — it releases every origin it held and the row goes.
+    await mappingRow.getByRole('button', { name: /Delete mapping/ }).click();
+    await expect(page.locator('.scim-mapping', { hasText: 'E2E Engineers' })).toHaveCount(0);
+
+    // Revoke the credential; it bites at the wire's very next request.
+    const credentialRow = page.locator('.scim-credential').first();
+    await credentialRow.getByRole('button', { name: /Revoke credential/ }).click();
+    await expect(credentialRow.locator('.badge', { hasText: 'revoked' })).toBeVisible();
+    const afterRevoke = await wire('GET', '/ServiceProviderConfig');
+    expect(afterRevoke.status).toBe(401);
+
+    // Delete the binding through its typed-name gate; the teardown runs and the
+    // card is gone.
+    await card.getByLabel('Confirm by typing the provider slug').fill(SCIM_PROVIDER_SLUG);
+    await card.getByRole('button', { name: 'Delete binding' }).click();
+    await expect(page.locator('.scim-binding', { hasText: SCIM_PROVIDER_SLUG })).toHaveCount(0);
+  });
+
+  for (const scheme of ['dark', 'light'] as const) {
+    for (const surface of surfacesForFlow('scim')) {
+      test(`meets the pinned assertion set on ${surface.label} (${scheme})`, async ({
+        page,
+      }, testInfo) => {
+        await page.emulateMedia({ colorScheme: scheme });
+        try {
+          const bindingId = await ensureScimBinding(page);
+          await page.goto(`${SCIM_PATH}?binding=${bindingId}`);
+
+          const heading = page.getByRole('heading', { name: 'SCIM provisioning', level: 1 });
+          const panel = page.locator('.panel').first();
+          const slug = page.locator('.scim-binding__slug .mono').first();
+          const badge = page.locator('.scim-binding .badge').first();
+          const administer = page.getByRole('button', { name: 'Administering' }).first();
+          const rowDensity = testInfo.project.name === 'mobile' ? '--touch' : '--row';
+
+          await expectPinnedAssertionSet(page, {
+            flow: 'scim',
+            surface: surface.id,
+            theme: scheme,
+            text: [heading, slug],
+            radii: [
+              [panel, 'container'],
+              [administer, 'control'],
+              [badge, 'badge'],
+            ],
+            fonts: [
+              [heading, 'ui'],
+              [slug, 'mono'],
+            ],
+            colours: [
+              [heading, 'color', '--tx'],
+              [panel, 'backgroundColor', '--bg-panel'],
+              [panel, 'borderTopColor', '--panel-line'],
+            ],
+            hairlines: [panel],
+            density: [[administer, rowDensity]],
+          });
+        } finally {
+          await page.emulateMedia({ colorScheme: null });
+        }
+      });
+    }
   }
 });

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -41,6 +41,14 @@ export const FLOWS: readonly Flow[] = [
   // navigation, and a surface with six panels of its own earns its own flow.
   { id: 'shell', spec: 'flows/shell.spec.ts', surfaces: ['overview', 'projects'] },
   { id: 'members', spec: 'flows/members.spec.ts', surfaces: ['members'] },
+  // SCIM provisioning administration (#501) is a new SURFACE, so the S3 closure
+  // demands a flow, but it cannot get its own spec FILE for the key-detail
+  // reason below: the merge gate loads `ci.yml` from the base branch, so a spec
+  // a PR adds to a group never runs on that PR and its pinned claims would
+  // never execute. It rides `members.spec.ts` — already in group 1 on main, and
+  // the org-scoped `manage-members` sibling surface — so the pinned set runs
+  // from PR-checked-out spec content today.
+  { id: 'scim', spec: 'flows/members.spec.ts', surfaces: ['scim'] },
   {
     id: 'chrome-settings',
     spec: 'flows/settings.spec.ts',

--- a/web/src/api/scim.test.ts
+++ b/web/src/api/scim.test.ts
@@ -43,8 +43,15 @@ describe('scimMintFailureText', () => {
     );
   });
 
-  it('routes 403 to the second-factor answer and 500 to no-credential-issued', () => {
+  it('routes 403 to the second-factor answer', () => {
     expect(scimMintFailureText(err(403))).toMatch(/second factor/i);
-    expect(scimMintFailureText(err(500))).toMatch(/no credential was issued/i);
+  });
+
+  it('calls a 5xx or lost-response outcome unknown, not "no credential issued"', () => {
+    // A 5xx may have committed before the response was lost, so claiming
+    // nothing issued would strand a live credential.
+    expect(scimMintFailureText(err(500))).toMatch(/unknown/i);
+    expect(scimMintFailureText(err(500))).not.toMatch(/no credential was issued/i);
+    expect(scimMintFailureText(new Error('network'))).toMatch(/unknown/i);
   });
 });

--- a/web/src/api/scim.test.ts
+++ b/web/src/api/scim.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './client.ts';
+import { scimMintFailureText, scimMutationFailureText, scimReadFailureText } from './scim.ts';
+
+const err = (status: number, detail?: string) => new ApiError(status, `status ${status}`, detail);
+
+describe('scimReadFailureText', () => {
+  it('names the second-factor refusal on 403 and the uniform absence on 404', () => {
+    expect(scimReadFailureText(err(403))).toMatch(/second factor/i);
+    expect(scimReadFailureText(err(404))).toMatch(/the same answer/i);
+  });
+
+  it('reports an unknown server failure with its status, and a non-ApiError as unreachable', () => {
+    expect(scimReadFailureText(err(500))).toMatch(/500/);
+    expect(scimReadFailureText(new Error('boom'))).toMatch(/could not be reached/i);
+  });
+});
+
+describe('scimMutationFailureText', () => {
+  it('prefers a caller-safe detail on 400 and 409, falling back when absent', () => {
+    expect(scimMutationFailureText(err(400, 'template not admitted at this scope'))).toBe(
+      'template not admitted at this scope',
+    );
+    expect(scimMutationFailureText(err(409))).toMatch(/conflicts/i);
+  });
+
+  it('shares the second-factor and uniform-absence answers with reads', () => {
+    expect(scimMutationFailureText(err(403))).toMatch(/second factor/i);
+    expect(scimMutationFailureText(err(404))).toMatch(/the same answer/i);
+  });
+
+  it('is honest that an unknown server failure leaves the outcome unknown', () => {
+    expect(scimMutationFailureText(err(500))).toMatch(/unknown/i);
+  });
+});
+
+describe('scimMintFailureText', () => {
+  it('says no credential was issued on a 400 proof/opt-in refusal', () => {
+    expect(scimMintFailureText(err(400))).toMatch(/no credential was issued/i);
+    expect(scimMintFailureText(err(400, 'that code was not accepted'))).toBe(
+      'that code was not accepted',
+    );
+  });
+
+  it('routes 403 to the second-factor answer and 500 to no-credential-issued', () => {
+    expect(scimMintFailureText(err(403))).toMatch(/second factor/i);
+    expect(scimMintFailureText(err(500))).toMatch(/no credential was issued/i);
+  });
+});

--- a/web/src/api/scim.ts
+++ b/web/src/api/scim.ts
@@ -1,0 +1,412 @@
+import {
+  createScimBindingOp,
+  createScimMappingOp,
+  deleteScimBindingOp,
+  deleteScimMappingOp,
+  getScimBindingOp,
+  listScimBindingsOp,
+  listScimCredentialsOp,
+  listScimDirectoryGroupsOp,
+  listScimDirectoryUsersOp,
+  listScimMappingsOp,
+  mintScimCredentialOp,
+  revokeScimCredentialOp,
+  updateScimMappingOp,
+} from '@hikyo/operations';
+import {
+  zScimAttention,
+  zScimBinding,
+  zScimBindingList,
+  zScimBlastWarning,
+  zScimCredential,
+  zScimCredentialList,
+  zScimDirectoryGroup,
+  zScimDirectoryGroupList,
+  zScimDirectoryUser,
+  zScimDirectoryUserList,
+  zScimMapping,
+  zScimMappingList,
+  zScimMappingResult,
+  zScimMintResult,
+} from '@hikyo/zod';
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { useState } from 'react';
+import type { z } from 'zod';
+
+import { ApiError, ok, parsed, parsedPick } from './client.ts';
+
+export type ScimBinding = z.infer<typeof zScimBinding>;
+export type ScimBindingList = z.infer<typeof zScimBindingList>;
+export type ScimAttention = z.infer<typeof zScimAttention>;
+export type ScimMapping = z.infer<typeof zScimMapping>;
+export type ScimMappingList = z.infer<typeof zScimMappingList>;
+export type ScimMappingResult = z.infer<typeof zScimMappingResult>;
+export type ScimBlastWarning = z.infer<typeof zScimBlastWarning>;
+export type ScimCredential = z.infer<typeof zScimCredential>;
+export type ScimCredentialList = z.infer<typeof zScimCredentialList>;
+export type ScimMintResult = z.infer<typeof zScimMintResult>;
+export type ScimDirectoryUser = z.infer<typeof zScimDirectoryUser>;
+export type ScimDirectoryUserList = z.infer<typeof zScimDirectoryUserList>;
+export type ScimDirectoryGroup = z.infer<typeof zScimDirectoryGroup>;
+export type ScimDirectoryGroupList = z.infer<typeof zScimDirectoryGroupList>;
+
+/**
+ * The minted credential exactly as the display-once dialog holds it: the token
+ * and the two facts framing it, and nothing that could pull the plaintext back
+ * out of the list read. `parsedPick` narrows the mint response to these three
+ * so unrelated metadata drift cannot hide the one irretrievable member.
+ */
+export type MintedScimCredential = Pick<ScimMintResult, 'credential' | 'token' | 'rotated'>;
+
+// Query keys are addressed by (org, binding) so switching binding never reads
+// another binding's cached mappings, credentials or directory. The bindings
+// list keys on the org alone.
+export const scimBindingsKey = (org: string) => ['scim-bindings', org] as const;
+export const scimBindingKey = (org: string, binding: string) =>
+  ['scim-binding', org, binding] as const;
+export const scimMappingsKey = (org: string, binding: string) =>
+  ['scim-mappings', org, binding] as const;
+export const scimCredentialsKey = (org: string, binding: string) =>
+  ['scim-credentials', org, binding] as const;
+export const scimDirectoryUsersKey = (org: string, binding: string) =>
+  ['scim-directory-users', org, binding] as const;
+export const scimDirectoryGroupsKey = (org: string, binding: string) =>
+  ['scim-directory-groups', org, binding] as const;
+
+export function useScimBindings(org: string): UseQueryResult<ScimBindingList> {
+  return useQuery({
+    queryKey: scimBindingsKey(org),
+    queryFn: () => parsed(listScimBindingsOp, { path: { org } }),
+    retry: false,
+  });
+}
+
+/**
+ * useScimBinding reads ONE binding with its live attention states. Enabled only
+ * when a binding is selected — the surface renders the list until one is.
+ */
+export function useScimBinding(org: string, binding: string): UseQueryResult<ScimBinding> {
+  return useQuery({
+    queryKey: scimBindingKey(org, binding),
+    queryFn: () => parsed(getScimBindingOp, { path: { org, binding } }),
+    enabled: binding !== '',
+    retry: false,
+  });
+}
+
+export type CreateScimBindingInput = {
+  readonly providerKind: 'oidc' | 'saml';
+  readonly providerSlug: string;
+  readonly subjectSource: string;
+};
+
+/**
+ * useCreateScimBinding creates the org's binding for one provider. The subject
+ * source and provider are immutable after creation, so the form is the only
+ * place they are chosen. A concurrent create resolves to one row; the loser is
+ * a 409, surfaced rather than swallowed.
+ */
+export function useCreateScimBinding(org: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateScimBindingInput) =>
+      parsed(createScimBindingOp, {
+        path: { org },
+        body: {
+          provider_kind: input.providerKind,
+          provider_slug: input.providerSlug,
+          subject_source: input.subjectSource,
+        },
+      }),
+    onSuccess: () => queries.invalidateQueries({ queryKey: scimBindingsKey(org) }),
+  });
+}
+
+/**
+ * useDeleteScimBinding runs the atomic teardown. It refreshes on SETTLE, not
+ * just success: a teardown whose response never arrived may still have
+ * committed, so the list must re-read to show the truth either way.
+ */
+export function useDeleteScimBinding(org: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (binding: string) => ok(deleteScimBindingOp, { path: { org, binding } }),
+    onSettled: () => queries.invalidateQueries({ queryKey: scimBindingsKey(org) }),
+  });
+}
+
+export function useScimMappings(org: string, binding: string): UseQueryResult<ScimMappingList> {
+  return useQuery({
+    queryKey: scimMappingsKey(org, binding),
+    queryFn: () => parsed(listScimMappingsOp, { path: { org, binding } }),
+    enabled: binding !== '',
+    retry: false,
+  });
+}
+
+export type ScimMappingInput = {
+  readonly groupId: string;
+  readonly template: string;
+  readonly projectId?: string;
+  readonly environmentId?: string;
+};
+
+function mappingBody(input: ScimMappingInput) {
+  return {
+    group_id: input.groupId,
+    template: input.template,
+    ...(input.projectId === undefined ? {} : { project_id: input.projectId }),
+    ...(input.environmentId === undefined ? {} : { environment_id: input.environmentId }),
+  };
+}
+
+// A mapping mutation may change grants for members of the named group, so it
+// refreshes the mapping table AND the directory the flags live on.
+function invalidateMappingScope(
+  queries: ReturnType<typeof useQueryClient>,
+  org: string,
+  binding: string,
+) {
+  void queries.invalidateQueries({ queryKey: scimMappingsKey(org, binding) });
+  void queries.invalidateQueries({ queryKey: scimDirectoryUsersKey(org, binding) });
+}
+
+/**
+ * useCreateScimMapping adds a row and grants the group's current members in the
+ * same transaction. The server-authored consequence language rides the RESULT
+ * (`warnings`), never a client guess, so the caller renders `warnings` verbatim
+ * after the commit returns.
+ */
+export function useCreateScimMapping(org: string, binding: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: ScimMappingInput): Promise<ScimMappingResult> =>
+      parsed(createScimMappingOp, { path: { org, binding }, body: mappingBody(input) }),
+    onSettled: () => invalidateMappingScope(queries, org, binding),
+  });
+}
+
+/**
+ * useUpdateScimMapping retargets an existing row's template. The row keeps its
+ * id, so widening creates the newly covered origins and narrowing releases the
+ * rest in one transaction — the result reports both.
+ */
+export function useUpdateScimMapping(org: string, binding: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: ScimMappingInput): Promise<ScimMappingResult> =>
+      parsed(updateScimMappingOp, { path: { org, binding }, body: mappingBody(input) }),
+    onSettled: () => invalidateMappingScope(queries, org, binding),
+  });
+}
+
+export type DeleteScimMappingInput = {
+  readonly group: string;
+  readonly project?: string;
+  readonly environment?: string;
+};
+
+/**
+ * useDeleteScimMapping releases every origin the addressed row held. The row is
+ * addressed by its (group, scope) triple as query parameters, and the 200 body
+ * reports the origin count released, so this is a body operation, not a bodyless
+ * one.
+ */
+export function useDeleteScimMapping(org: string, binding: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: DeleteScimMappingInput): Promise<ScimMappingResult> =>
+      parsed(deleteScimMappingOp, {
+        path: { org, binding },
+        query: {
+          group: input.group,
+          ...(input.project === undefined ? {} : { project: input.project }),
+          ...(input.environment === undefined ? {} : { environment: input.environment }),
+        },
+      }),
+    onSettled: () => invalidateMappingScope(queries, org, binding),
+  });
+}
+
+export function useScimCredentials(
+  org: string,
+  binding: string,
+): UseQueryResult<ScimCredentialList> {
+  return useQuery({
+    queryKey: scimCredentialsKey(org, binding),
+    queryFn: () => parsed(listScimCredentialsOp, { path: { org, binding } }),
+    enabled: binding !== '',
+    retry: false,
+  });
+}
+
+export type MintScimCredentialInput = {
+  /** A fresh reauthentication proof: a TOTP code, or the password if unfactored. */
+  readonly proof: string;
+  readonly indefinite?: boolean;
+};
+
+/**
+ * useMintScimCredential returns the display-once token WITHOUT a TanStack
+ * mutation on purpose: a mutation caches its `data`, and this token exists in
+ * the mint response and nowhere else, ever. So it flows straight back to the
+ * caller and touches no query or mutation cache — the same discipline the
+ * connection-credential mint follows (#498).
+ */
+export function useMintScimCredential(org: string, binding: string) {
+  const queries = useQueryClient();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const mint = async (input: MintScimCredentialInput): Promise<MintedScimCredential> => {
+    setPending(true);
+    setError(null);
+    try {
+      const minted = await parsedPick(
+        mintScimCredentialOp,
+        {
+          path: { org, binding },
+          body: {
+            proof: input.proof,
+            ...(input.indefinite === undefined ? {} : { indefinite: input.indefinite }),
+          },
+        },
+        { credential: true, token: true, rotated: true },
+      );
+      // Disclose FIRST, refresh the inventory second and un-awaited: the token
+      // is irretrievable, so it must reach the guarded dialog the instant the
+      // POST returns, never after a list refetch the operator could interrupt.
+      void queries.invalidateQueries({ queryKey: scimCredentialsKey(org, binding) });
+      return minted;
+    } catch (caught) {
+      // A mint whose response never arrived may still have committed, so the
+      // inventory is refreshed on the failure path too: a lost-but-live
+      // credential must at least become visible enough to revoke.
+      void queries.invalidateQueries({ queryKey: scimCredentialsKey(org, binding) });
+      setError(caught);
+      throw caught;
+    } finally {
+      setPending(false);
+    }
+  };
+  return { mint, pending, error };
+}
+
+/**
+ * useRevokeScimCredential marks the credential dead; it bites at the next wire
+ * request. A double revoke is a 409 — refreshing on SETTLE flips the row to
+ * revoked in exactly that case rather than leaving one that reads live and
+ * cannot be revoked again.
+ */
+export function useRevokeScimCredential(org: string, binding: string) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => ok(revokeScimCredentialOp, { path: { org, binding, id } }),
+    onSettled: () => queries.invalidateQueries({ queryKey: scimCredentialsKey(org, binding) }),
+  });
+}
+
+export function useScimDirectoryUsers(
+  org: string,
+  binding: string,
+): UseQueryResult<ScimDirectoryUserList> {
+  return useQuery({
+    queryKey: scimDirectoryUsersKey(org, binding),
+    queryFn: () => parsed(listScimDirectoryUsersOp, { path: { org, binding } }),
+    enabled: binding !== '',
+    retry: false,
+  });
+}
+
+export function useScimDirectoryGroups(
+  org: string,
+  binding: string,
+): UseQueryResult<ScimDirectoryGroupList> {
+  return useQuery({
+    queryKey: scimDirectoryGroupsKey(org, binding),
+    queryFn: () => parsed(listScimDirectoryGroupsOp, { path: { org, binding } }),
+    enabled: binding !== '',
+    retry: false,
+  });
+}
+
+// --- refusals ---------------------------------------------------------------
+//
+// Every SCIM administration route is `manage-members@org` and MFA-mandatory, so
+// on this surface a 403 IS the second-factor refusal (the same pin members and
+// grants rely on) and a 404 is the uniform "not available OR does not exist"
+// answer, never an oracle for which the two it is.
+
+function commonScimFailureText(error: ApiError): string | null {
+  switch (error.status) {
+    case 401:
+      return 'Your session ended. Sign in again to continue.';
+    case 403:
+      return 'Administering SCIM needs a second factor. Sign in again and present your passkey or a code, then retry.';
+    case 404:
+      return 'This is not available to you, or it does not exist. The two are deliberately the same answer.';
+    case 429:
+      return 'Too many attempts right now. Wait a moment and try again.';
+    default:
+      return null;
+  }
+}
+
+/** scimReadFailureText names a failed read without inventing a cause. */
+export function scimReadFailureText(error: unknown): string {
+  if (error instanceof ApiError) {
+    const common = commonScimFailureText(error);
+    if (common !== null) {
+      return common;
+    }
+    return `The server failed while reading (${error.status}). Reload to try again.`;
+  }
+  return 'The SCIM surface could not be reached, or it answered something this client does not understand. Reload to try again.';
+}
+
+/** scimMutationFailureText names a failed create/update/delete. */
+export function scimMutationFailureText(error: unknown): string {
+  if (error instanceof ApiError) {
+    const common = commonScimFailureText(error);
+    if (common !== null) {
+      return common;
+    }
+    switch (error.status) {
+      case 400:
+        return error.detail ?? 'That request was refused: it did not meet the contract for this operation.';
+      case 409:
+        return (
+          error.detail ??
+          'Refused: this conflicts with the current state — reload to see what changed, then retry.'
+        );
+      default:
+        return `The server failed (${error.status}); whether the change applied is unknown — reload to check.`;
+    }
+  }
+  return 'The SCIM surface could not be reached, or it answered something this client does not understand. Whether the change applied is unknown — reload to check.';
+}
+
+/**
+ * scimMintFailureText names a failed mint. A 400 here is the proof or the
+ * indefinite opt-in refused by name: the token was never issued, so the message
+ * says exactly that rather than the mutation family's "unknown whether applied".
+ */
+export function scimMintFailureText(error: unknown): string {
+  if (error instanceof ApiError) {
+    const common = commonScimFailureText(error);
+    if (common !== null) {
+      return common;
+    }
+    switch (error.status) {
+      case 400:
+        return (
+          error.detail ??
+          'The mint was refused: the reauthentication proof was not accepted, or an indefinite credential is not allowed on this instance. No credential was issued.'
+        );
+      case 409:
+        return error.detail ?? 'Refused: reload to see the binding’s current credentials, then retry.';
+      default:
+        return `The mint failed (${error.status}). No credential was issued; try again shortly.`;
+    }
+  }
+  return 'The mint could not be completed: the server could not be reached, or it answered something this client does not understand. No credential was issued.';
+}

--- a/web/src/api/scim.ts
+++ b/web/src/api/scim.ts
@@ -118,7 +118,10 @@ export function useCreateScimBinding(org: string) {
           subject_source: input.subjectSource,
         },
       }),
-    onSuccess: () => queries.invalidateQueries({ queryKey: scimBindingsKey(org) }),
+    // Refresh on SETTLE: a create whose response was lost may still have
+    // committed, and a concurrent-create 409 means a row now exists this list
+    // does not show — both leave the inventory stale on the failure path too.
+    onSettled: () => queries.invalidateQueries({ queryKey: scimBindingsKey(org) }),
   });
 }
 
@@ -405,8 +408,13 @@ export function scimMintFailureText(error: unknown): string {
       case 409:
         return error.detail ?? 'Refused: reload to see the binding’s current credentials, then retry.';
       default:
-        return `The mint failed (${error.status}). No credential was issued; try again shortly.`;
+        // A 5xx may have committed the mint before the response was lost, so
+        // this must NOT claim nothing was issued — that would strand a live,
+        // unrevoked credential. Say the outcome is unknown and point at the
+        // list, where a stray credential shows up revocable.
+        return `The mint failed (${error.status}); whether a credential was issued is unknown. Reload the list — if a new credential appears, revoke it.`;
     }
   }
-  return 'The mint could not be completed: the server could not be reached, or it answered something this client does not understand. No credential was issued.';
+  // Same honesty for a lost/garbled response: the request may have committed.
+  return 'The mint could not be completed: the server could not be reached, or it answered something this client does not understand. Whether a credential was issued is unknown — reload the list, and revoke any credential you did not intend.';
 }

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -14,6 +14,7 @@ import { NotFound, Overview } from '../routes/Placeholder.tsx';
 import { ProjectSettings } from '../routes/ProjectSettings.tsx';
 import { Projects } from '../routes/Projects.tsx';
 import { Remotes } from '../routes/Remotes.tsx';
+import { ScimProvisioning } from '../routes/ScimProvisioning.tsx';
 import { Shell } from '../routes/Shell.tsx';
 import { Values } from '../routes/Values.tsx';
 import { WorkspaceApprove } from '../routes/WorkspaceApprove.tsx';
@@ -45,6 +46,7 @@ const ELEMENTS: Record<SurfaceId, ReactElement> = {
   remotes: <Remotes />,
   members: <Members />,
   'org-settings': <OrgSettings />,
+  scim: <ScimProvisioning />,
   'project-settings': <ProjectSettings />,
   'instance-admin': <InstanceAdmin />,
   settings: <AccountSecurity />,

--- a/web/src/app/navigation.test.ts
+++ b/web/src/app/navigation.test.ts
@@ -11,6 +11,7 @@ describe('the route policy registry', () => {
       'remotes:authenticated:shell',
       'members:authenticated:shell',
       'org-settings:authenticated:shell',
+      'scim:authenticated:shell',
       'project-settings:authenticated:shell',
       'instance-admin:authenticated:shell',
       'settings:authenticated:shell',

--- a/web/src/app/navigation.ts
+++ b/web/src/app/navigation.ts
@@ -168,6 +168,20 @@ export const SURFACES = defineSurfaceRegistry([
     mode: 'authenticated',
     chrome: 'shell',
   },
+  // SCIM provisioning administration (#501, #73). Org-scoped for the same
+  // reason members is: `manage-members@org` addresses ONE organisation, so the
+  // org is route data and the rail's active circle fills it. The binding under
+  // administration is a `?binding=` query parameter — an id, never a secret —
+  // so a reload and a shared link resolve the same binding, exactly as the
+  // matrix's per-key filter does.
+  {
+    id: 'scim',
+    path: '/orgs/:org/scim',
+    label: 'SCIM provisioning',
+    section: 'Organisation',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
   // Project settings addresses ONE project, exactly like the matrix, so no
   // static sidebar entry could know which one to mean. It is reached from the
   // project list and by deep link.

--- a/web/src/routes/ScimProvisioning.tsx
+++ b/web/src/routes/ScimProvisioning.tsx
@@ -1,0 +1,1132 @@
+import { useMemo, useRef, useState, type FormEvent } from 'react';
+import { useParams, useSearchParams } from 'react-router';
+
+import {
+  optionByValue,
+  scopeOptions,
+  templatesAt,
+  type Level,
+  type ScopeOption,
+  type ScopeRef,
+} from '../api/access.ts';
+import { isoDay } from '../api/identities.ts';
+import {
+  scimMintFailureText,
+  scimMutationFailureText,
+  scimReadFailureText,
+  useCreateScimBinding,
+  useCreateScimMapping,
+  useDeleteScimBinding,
+  useDeleteScimMapping,
+  useMintScimCredential,
+  useRevokeScimCredential,
+  useScimBindings,
+  useScimCredentials,
+  useScimDirectoryGroups,
+  useScimDirectoryUsers,
+  useScimMappings,
+  useUpdateScimMapping,
+  type MintedScimCredential,
+  type ScimAttention,
+  type ScimBinding,
+  type ScimBlastWarning,
+  type ScimCredential,
+  type ScimDirectoryUser,
+  type ScimMapping,
+  type ScimMappingResult,
+} from '../api/scim.ts';
+import { useOrg, useOrgTopology } from '../api/settings.ts';
+import { writeClipboard } from '../app/clipboard.ts';
+import { Alert, Done, Explain, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
+import { useFeedback, useModalDialog } from './useModalDialog.ts';
+import { useNavigationGuard } from './MachineAccess.tsx';
+
+/**
+ * SCIM provisioning administration (registry surface `scim`, #501; #73,
+ * scim-provisioning ADR §8).
+ *
+ * The org admin's whole browser answer to "manage SCIM": binding CRUD, the
+ * group→template mapping table, the provisioning-credential lifecycle, and the
+ * provisioned directory. Every operation here is `manage-members` held at ORG
+ * SCOPE EXACTLY and is MFA-mandatory, so the surface renders the server's
+ * refusals rather than second-guessing the caller's authority — a 403 IS the
+ * second-factor refusal, a 404 is the uniform "not available or absent".
+ *
+ * The consequence language a human is TOLD is server-authored on purpose: a
+ * mapping mutation returns `warnings`, and this surface renders them verbatim
+ * rather than composing a second, unreviewed policy. What the surface states on
+ * its own — the binding teardown, the revocation bite — is factual and drawn
+ * from the contract, never a guess about scope reach.
+ */
+export function ScimProvisioning() {
+  const params = useParams();
+  const org = params['org'] ?? '';
+  const [search, setSearch] = useSearchParams();
+  // The selected binding is ROUTE DATA in the query string — an id, never a
+  // secret — so a reload and a shared link land on the same binding.
+  const selected = search.get('binding') ?? '';
+
+  const bindings = useScimBindings(org);
+  const items = bindings.data?.items ?? [];
+  const active = items.find((binding) => binding.id === selected) ?? null;
+
+  const sections = [
+    { id: 'scim-bindings', label: 'Bindings' },
+    ...(active === null
+      ? []
+      : [
+          { id: 'scim-mappings', label: 'Mappings' },
+          { id: 'scim-credentials', label: 'Provisioning credentials' },
+          { id: 'scim-directory', label: 'Directory' },
+        ]),
+  ];
+
+  const select = (binding: string) => {
+    const next = new URLSearchParams(search);
+    if (binding === '') {
+      next.delete('binding');
+    } else {
+      next.set('binding', binding);
+    }
+    setSearch(next, { replace: true });
+  };
+
+  return (
+    <div className="page page--chrome">
+      <h1>SCIM provisioning</h1>
+      <p className="page__lede">
+        Bind an identity provider, map its groups to capability templates, mint the credentials it
+        presents, and watch what it has provisioned. Every action here needs organisation member
+        management and a second factor.
+      </p>
+
+      <JumpIndex sections={sections} />
+
+      <Panel id="scim-bindings" title="Bindings">
+        <BindingsSection
+          org={org}
+          bindings={items}
+          isError={bindings.isError}
+          error={bindings.error}
+          isSuccess={bindings.isSuccess}
+          selected={selected}
+          onSelect={select}
+        />
+      </Panel>
+
+      {active === null ? null : (
+        <>
+          <MappingsSection org={org} binding={active} />
+          <CredentialsSection org={org} binding={active} />
+          <DirectorySection org={org} binding={active} />
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- bindings ---------------------------------------------------------------
+
+function BindingsSection({
+  org,
+  bindings,
+  isError,
+  error,
+  isSuccess,
+  selected,
+  onSelect,
+}: {
+  org: string;
+  bindings: readonly ScimBinding[];
+  isError: boolean;
+  error: unknown;
+  isSuccess: boolean;
+  selected: string;
+  onSelect: (binding: string) => void;
+}) {
+  return (
+    <>
+      <p>
+        At most one binding per identity provider. Creating one also mints its provisioning
+        connection and that connection&apos;s structural grant, in one transaction.
+      </p>
+
+      {isError ? <Alert>{scimReadFailureText(error)}</Alert> : null}
+
+      {isSuccess && bindings.length === 0 ? (
+        <p role="status">
+          No bindings yet. Create one below to begin provisioning from an identity provider.
+        </p>
+      ) : null}
+
+      <ul className="scim-bindings">
+        {bindings.map((binding) => (
+          <BindingCard
+            key={binding.id}
+            org={org}
+            binding={binding}
+            selected={binding.id === selected}
+            onSelect={() => onSelect(binding.id)}
+          />
+        ))}
+      </ul>
+
+      <CreateBindingForm org={org} />
+    </>
+  );
+}
+
+function BindingCard({
+  org,
+  binding,
+  selected,
+  onSelect,
+}: {
+  org: string;
+  binding: ScimBinding;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <li className={`card scim-binding${selected ? ' scim-binding--selected' : ''}`}>
+      <div className="scim-binding__head">
+        <h3 className="scim-binding__slug">
+          <span className="mono">{binding.provider_slug}</span>
+          <span className="badge" data-state={binding.provider_kind}>
+            {binding.provider_kind}
+          </span>
+        </h3>
+        <button
+          type="button"
+          className={selected ? 'btn btn--primary' : 'btn'}
+          aria-pressed={selected}
+          onClick={onSelect}
+        >
+          {selected ? 'Administering' : 'Administer'}
+        </button>
+      </div>
+      <dl className="scim-binding__facts">
+        <dt>Issuer</dt>
+        <dd className="mono">{binding.provider_issuer}</dd>
+        <dt>Subject source</dt>
+        <dd className="mono">{binding.subject_source}</dd>
+        <dt>Created</dt>
+        <dd>{isoDay(binding.created_at)}</dd>
+        <dt>Last contact</dt>
+        <dd>
+          {binding.last_contact_at === undefined ? 'never contacted' : isoDay(binding.last_contact_at)}
+        </dd>
+      </dl>
+      <AttentionList attention={binding.attention} subjectPrefix="" />
+      {selected ? <DeleteBinding org={org} binding={binding} /> : null}
+    </li>
+  );
+}
+
+/** The six attention states each name their cause AND a server-authored fix. */
+function AttentionList({
+  attention,
+  subjectPrefix,
+}: {
+  attention: readonly ScimAttention[];
+  subjectPrefix: string;
+}) {
+  if (attention.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="scim-attention" aria-label={`${subjectPrefix}attention states`}>
+      {attention.map((state, index) => (
+        <li key={`${state.state}-${state.subject_ref}-${index}`} className="scim-attention__row">
+          <span className="badge" data-state={state.state}>
+            {state.state.replace(/_/g, ' ')}
+          </span>
+          <span className="scim-attention__fix">{state.remediation}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DeleteBinding({ org, binding }: { org: string; binding: ScimBinding }) {
+  const remove = useDeleteScimBinding(org);
+  const feedback = useFeedback(scimMutationFailureText);
+  return (
+    <div className="scim-binding__danger">
+      <h4>Delete this binding</h4>
+      <p>
+        One transaction, in order: every credential is revoked so no new sync can begin; every SCIM
+        origin is released (lockout conversion included); the provisioning connection and its grant
+        are retired; the directory, mapping table and binding row go. Identity links and accounts{' '}
+        <strong>survive</strong> — they are account property.
+      </p>
+      {feedback.failure === null ? null : <Alert>{feedback.failure}</Alert>}
+      <TypedNameConfirm
+        label="Confirm by typing the provider slug"
+        expect={binding.provider_slug}
+        action="Delete binding"
+        busy={remove.isPending}
+        hint={
+          <>
+            This runs the teardown above and cannot be undone. Type{' '}
+            <span className="mono">{binding.provider_slug}</span> to enable it.
+          </>
+        }
+        onConfirm={() => {
+          feedback.clear();
+          remove.mutate(binding.id, {
+            onError: (caught) => feedback.report(caught),
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+function CreateBindingForm({ org }: { org: string }) {
+  const create = useCreateScimBinding(org);
+  const feedback = useFeedback(scimMutationFailureText);
+  const [providerKind, setProviderKind] = useState<'oidc' | 'saml'>('oidc');
+  const [providerSlug, setProviderSlug] = useState('');
+  const [subjectSource, setSubjectSource] = useState('externalId');
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const slug = providerSlug.trim();
+    const source = subjectSource.trim();
+    if (slug === '' || source === '' || create.isPending) {
+      return;
+    }
+    feedback.clear();
+    create.mutate(
+      { providerKind, providerSlug: slug, subjectSource: source },
+      {
+        onSuccess: (binding) => {
+          feedback.ok(`Bound ${binding.provider_slug}. Select it above to map groups and mint credentials.`);
+          setProviderSlug('');
+          setSubjectSource('externalId');
+        },
+        onError: (caught) => feedback.report(caught),
+      },
+    );
+  };
+
+  return (
+    <form className="form" onSubmit={onSubmit} noValidate>
+      <h3>Create a binding</h3>
+      {feedback.failure === null ? null : <Alert>{feedback.failure}</Alert>}
+      {feedback.done === null ? null : <Done>{feedback.done}</Done>}
+      <fieldset className="field">
+        <legend>Provider kind</legend>
+        <div className="chk">
+          <input
+            id="scim-kind-oidc"
+            type="radio"
+            name="scim-kind"
+            checked={providerKind === 'oidc'}
+            onChange={() => setProviderKind('oidc')}
+          />
+          <label htmlFor="scim-kind-oidc">OIDC</label>
+        </div>
+        <div className="chk">
+          <input
+            id="scim-kind-saml"
+            type="radio"
+            name="scim-kind"
+            checked={providerKind === 'saml'}
+            onChange={() => setProviderKind('saml')}
+          />
+          <label htmlFor="scim-kind-saml">SAML</label>
+        </div>
+      </fieldset>
+      <div className="field">
+        <label htmlFor="scim-provider-slug">Provider slug</label>
+        <input
+          id="scim-provider-slug"
+          className="mono"
+          value={providerSlug}
+          onChange={(event) => setProviderSlug(event.target.value)}
+          maxLength={256}
+          autoComplete="off"
+          spellCheck={false}
+          required
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="scim-subject-source">
+          Subject source{' '}
+          <Explain
+            label="subject source"
+            text="The SCIM attribute path carrying identity material. externalId or a declared extension path — userName is refused by name. Immutable after creation."
+          />
+        </label>
+        <input
+          id="scim-subject-source"
+          className="mono"
+          value={subjectSource}
+          onChange={(event) => setSubjectSource(event.target.value)}
+          maxLength={256}
+          autoComplete="off"
+          spellCheck={false}
+          required
+        />
+      </div>
+      <button
+        className="btn btn--primary"
+        type="submit"
+        disabled={create.isPending || providerSlug.trim() === '' || subjectSource.trim() === ''}
+      >
+        {create.isPending ? 'Creating…' : 'Create binding'}
+      </button>
+    </form>
+  );
+}
+
+// --- mappings ---------------------------------------------------------------
+
+function MappingsSection({ org, binding }: { org: string; binding: ScimBinding }) {
+  const mappings = useScimMappings(org, binding.id);
+  const groups = useScimDirectoryGroups(org, binding.id);
+  const rows = mappings.data?.items ?? [];
+  const groupNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const group of groups.data?.items ?? []) {
+      map.set(group.id, group.display_name);
+    }
+    return map;
+  }, [groups.data]);
+
+  return (
+    <Panel id="scim-mappings" title="Mappings">
+      <p>
+        Each row grants a provider group&apos;s members the capabilities a template expands into, at
+        one scope. Adding a row grants the group&apos;s current members immediately — the consequence
+        language is returned by the server and shown after the change.
+      </p>
+
+      {mappings.isError ? <Alert>{scimReadFailureText(mappings.error)}</Alert> : null}
+
+      {mappings.isSuccess && rows.length === 0 ? (
+        <p role="status">No mappings yet. Map a provisioned group to a template below.</p>
+      ) : null}
+
+      <ul className="scim-mappings">
+        {rows.map((row) => (
+          <MappingRow
+            key={row.id}
+            org={org}
+            binding={binding.id}
+            row={row}
+            groupName={groupNames.get(row.group_id) ?? row.group_id}
+          />
+        ))}
+      </ul>
+
+      <CreateMappingForm org={org} binding={binding.id} />
+    </Panel>
+  );
+}
+
+function scopeOfMapping(row: ScimMapping): { project?: string; environment?: string } {
+  return {
+    ...(row.project_id === undefined || row.project_id === '' ? {} : { project: row.project_id }),
+    ...(row.environment_id === undefined || row.environment_id === ''
+      ? {}
+      : { environment: row.environment_id }),
+  };
+}
+
+function scopeLabel(row: ScimMapping): string {
+  if (row.environment_id !== undefined && row.environment_id !== '') {
+    return `environment ${row.environment_id}`;
+  }
+  if (row.project_id !== undefined && row.project_id !== '') {
+    return `project ${row.project_id}`;
+  }
+  return 'organisation (widest)';
+}
+
+function scopeLevel(row: ScimMapping): Level {
+  if (row.environment_id !== undefined && row.environment_id !== '') {
+    return 'environment';
+  }
+  if (row.project_id !== undefined && row.project_id !== '') {
+    return 'project';
+  }
+  return 'org';
+}
+
+function MappingRow({
+  org,
+  binding,
+  row,
+  groupName,
+}: {
+  org: string;
+  binding: string;
+  row: ScimMapping;
+  groupName: string;
+}) {
+  const update = useUpdateScimMapping(org, binding);
+  const remove = useDeleteScimMapping(org, binding);
+  const feedback = useFeedback(scimMutationFailureText);
+  const [result, setResult] = useState<ScimMappingResult | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [template, setTemplate] = useState(row.template);
+
+  const templates = templatesAt(scopeLevel(row));
+
+  const onRetarget = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (update.isPending) {
+      return;
+    }
+    feedback.clear();
+    setResult(null);
+    update.mutate(
+      { groupId: row.group_id, template, ...scopeOfMapping(row) },
+      {
+        onSuccess: (next) => {
+          setResult(next);
+          setEditing(false);
+          feedback.ok(mappingChangeSummary(next));
+        },
+        onError: (caught) => feedback.report(caught),
+      },
+    );
+  };
+
+  const onDelete = () => {
+    feedback.clear();
+    setResult(null);
+    remove.mutate(
+      { group: row.group_id, ...scopeOfMapping(row) },
+      {
+        onSuccess: (next) => {
+          setResult(next);
+          feedback.ok(`Deleted. ${String(next.origins_released)} origins released.`);
+        },
+        onError: (caught) => feedback.report(caught),
+      },
+    );
+  };
+
+  return (
+    <li className="card scim-mapping">
+      <div className="scim-mapping__head">
+        <h3 className="scim-mapping__group">
+          {groupName}
+          {row.inert ? (
+            <span className="badge" data-state="inert">
+              inert
+            </span>
+          ) : null}
+        </h3>
+        <span className="mono scim-mapping__template">{row.template}</span>
+      </div>
+      <p className="scim-mapping__scope">{scopeLabel(row)}</p>
+      {row.inert ? (
+        <p className="notice" role="status">
+          The provider group behind this row no longer exists. It grants nothing until it is edited
+          or deleted; it is never removed automatically.
+        </p>
+      ) : null}
+      <ul className="scim-mapping__caps">
+        {row.capabilities.map((capability) => (
+          <li key={capability} className="mono chip">
+            {capability}
+          </li>
+        ))}
+      </ul>
+
+      {feedback.failure === null ? null : <Alert>{feedback.failure}</Alert>}
+      {feedback.done === null ? null : <Done>{feedback.done}</Done>}
+      {result === null ? null : <MappingWarnings warnings={result.warnings} />}
+
+      {editing ? (
+        <form className="form scim-mapping__edit" onSubmit={onRetarget} noValidate>
+          <div className="field">
+            <label htmlFor={`retarget-${row.id}`}>Retarget template</label>
+            <select
+              id={`retarget-${row.id}`}
+              value={template}
+              onChange={(event) => setTemplate(event.target.value)}
+            >
+              {templates.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.id}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="scim-mapping__actions">
+            <button className="btn btn--primary" type="submit" disabled={update.isPending}>
+              {update.isPending ? 'Retargeting…' : 'Save template'}
+            </button>
+            <button
+              className="btn"
+              type="button"
+              onClick={() => {
+                setEditing(false);
+                setTemplate(row.template);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="scim-mapping__actions">
+          <button
+            className="btn"
+            type="button"
+            onClick={() => setEditing(true)}
+            aria-label={`Retarget ${groupName}`}
+          >
+            Retarget
+          </button>
+          <button
+            className="btn btn--danger"
+            type="button"
+            disabled={remove.isPending}
+            aria-label={`Delete mapping for ${groupName}`}
+            onClick={onDelete}
+          >
+            {remove.isPending ? 'Deleting…' : 'Delete'}
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function mappingChangeSummary(result: ScimMappingResult): string {
+  const created = result.grants_created;
+  const released = result.origins_released;
+  return (
+    `Applied to ${String(result.members_affected)} member(s): ` +
+    `${String(created)} grants created, ${String(released)} origins released.`
+  );
+}
+
+/** Server-authored consequence language, rendered VERBATIM (never composed here). */
+function MappingWarnings({ warnings }: { warnings: readonly ScimBlastWarning[] }) {
+  if (warnings.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="scim-warnings" aria-label="Consequences">
+      {warnings.map((warning, index) => (
+        <li
+          key={`${warning.code}-${index}`}
+          className={warning.severity === 'critical' ? 'alert' : 'notice'}
+          role={warning.severity === 'critical' ? 'alert' : 'status'}
+        >
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{warning.message}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CreateMappingForm({ org, binding }: { org: string; binding: string }) {
+  const create = useCreateScimMapping(org, binding);
+  const groups = useScimDirectoryGroups(org, binding);
+  const orgQuery = useOrg(org);
+  const topology = useOrgTopology(org);
+  const feedback = useFeedback(scimMutationFailureText);
+  const [result, setResult] = useState<ScimMappingResult | null>(null);
+  const [groupId, setGroupId] = useState('');
+  const [scope, setScope] = useState('');
+
+  const options = useMemo<ScopeOption[]>(
+    () => scopeOptions(org, orgQuery.data?.name ?? org, topology.projects),
+    [org, orgQuery.data, topology.projects],
+  );
+  const chosen = scope === '' ? null : (optionByValue(options, scope) ?? null);
+  const level: Level = chosen?.level ?? 'org';
+  const templates = templatesAt(level);
+  const [template, setTemplate] = useState('');
+  const templateValid = templates.some((option) => option.id === template);
+
+  const groupItems = groups.data?.items ?? [];
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (groupId === '' || !templateValid || create.isPending) {
+      return;
+    }
+    feedback.clear();
+    setResult(null);
+    const target = scopeToTarget(chosen?.scope);
+    create.mutate(
+      { groupId, template, ...target },
+      {
+        onSuccess: (next) => {
+          setResult(next);
+          feedback.ok(mappingChangeSummary(next));
+          setGroupId('');
+          setTemplate('');
+        },
+        onError: (caught) => feedback.report(caught),
+      },
+    );
+  };
+
+  return (
+    <form className="form" onSubmit={onSubmit} noValidate>
+      <h3>Map a group to a template</h3>
+      <p>
+        Absent scope means organisation — the widest a binding reaches. Nothing preselects a scope
+        for you.
+      </p>
+      {feedback.failure === null ? null : <Alert>{feedback.failure}</Alert>}
+      {feedback.done === null ? null : <Done>{feedback.done}</Done>}
+      {result === null ? null : <MappingWarnings warnings={result.warnings} />}
+
+      {groups.isSuccess && groupItems.length === 0 ? (
+        <p role="status">
+          No provisioned groups to map yet. A group appears here after the identity provider pushes
+          it over SCIM.
+        </p>
+      ) : null}
+
+      <div className="field">
+        <label htmlFor="mapping-group">Provisioned group</label>
+        <select
+          id="mapping-group"
+          value={groupId}
+          onChange={(event) => setGroupId(event.target.value)}
+          required
+        >
+          <option value="">Choose a group…</option>
+          {groupItems.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.display_name} ({group.member_count})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="field">
+        <label htmlFor="mapping-scope">Scope</label>
+        <select
+          id="mapping-scope"
+          value={scope}
+          onChange={(event) => {
+            setScope(event.target.value);
+            setTemplate('');
+          }}
+        >
+          <option value="">Organisation (every project and environment)</option>
+          {options
+            .filter((option) => option.level !== 'org')
+            .map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+        </select>
+      </div>
+
+      <div className="field">
+        <label htmlFor="mapping-template">Template</label>
+        <select
+          id="mapping-template"
+          value={template}
+          onChange={(event) => setTemplate(event.target.value)}
+          required
+        >
+          <option value="">Choose a template…</option>
+          {templates.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.id}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        className="btn btn--primary"
+        type="submit"
+        disabled={create.isPending || groupId === '' || !templateValid}
+      >
+        {create.isPending ? 'Mapping…' : 'Add mapping'}
+      </button>
+    </form>
+  );
+}
+
+function scopeToTarget(scope: ScopeRef | undefined): { projectId?: string; environmentId?: string } {
+  if (scope === undefined || scope.kind === 'org' || scope.kind === 'instance') {
+    return {};
+  }
+  if (scope.kind === 'project') {
+    return { projectId: scope.project };
+  }
+  return { projectId: scope.project, environmentId: scope.environment };
+}
+
+// --- credentials ------------------------------------------------------------
+
+function CredentialsSection({ org, binding }: { org: string; binding: ScimBinding }) {
+  const credentials = useScimCredentials(org, binding.id);
+  const mint = useMintScimCredential(org, binding.id);
+  const [disclosed, setDisclosed] = useState<MintedScimCredential | null>(null);
+  const items = credentials.data?.items ?? [];
+
+  return (
+    <Panel id="scim-credentials" title="Provisioning credentials">
+      <p>
+        The bearer tokens the identity provider presents at this binding&apos;s SCIM endpoint. The
+        list holds metadata only — the token exists in the mint response and nowhere else, ever.
+        Several may be live at once, which is how overlap rotation works.
+      </p>
+
+      {credentials.isError ? <Alert>{scimReadFailureText(credentials.error)}</Alert> : null}
+
+      {credentials.isSuccess && items.length === 0 ? (
+        <p role="status">None minted. Mint one below and configure it at the identity provider.</p>
+      ) : null}
+
+      <ul className="scim-credentials">
+        {items.map((credential) => (
+          <CredentialRow key={credential.id} org={org} binding={binding.id} credential={credential} />
+        ))}
+      </ul>
+
+      <MintCredentialForm mint={mint} onMinted={setDisclosed} />
+
+      {disclosed === null ? null : (
+        <MintDialog minted={disclosed} onClose={() => setDisclosed(null)} />
+      )}
+    </Panel>
+  );
+}
+
+function CredentialRow({
+  org,
+  binding,
+  credential,
+}: {
+  org: string;
+  binding: string;
+  credential: ScimCredential;
+}) {
+  const revoke = useRevokeScimCredential(org, binding);
+  const feedback = useFeedback(scimMutationFailureText);
+  const revoked = credential.revoked_at !== undefined;
+  const state = revoked ? 'revoked' : credential.live ? 'live' : 'expired';
+  return (
+    <li className="scim-credential">
+      <div className="scim-credential__head">
+        <span className="mono scim-credential__id">{credential.id}</span>
+        <span className="badge" data-state={state}>
+          {state}
+        </span>
+      </div>
+      <dl className="scim-credential__facts">
+        <dt>Created</dt>
+        <dd>{isoDay(credential.created_at)}</dd>
+        <dt>Expires</dt>
+        <dd>{credential.expires_at === undefined ? 'never' : isoDay(credential.expires_at)}</dd>
+        <dt>Last used</dt>
+        <dd>{credential.last_used_at === undefined ? 'never used' : isoDay(credential.last_used_at)}</dd>
+        {credential.revoked_at === undefined ? null : (
+          <>
+            <dt>Revoked</dt>
+            <dd>{isoDay(credential.revoked_at)}</dd>
+          </>
+        )}
+      </dl>
+      {feedback.failure === null ? null : <Alert>{feedback.failure}</Alert>}
+      {revoked ? null : (
+        <div className="scim-credential__actions">
+          <button
+            className="btn btn--danger"
+            type="button"
+            disabled={revoke.isPending}
+            aria-label={`Revoke credential ${credential.id}`}
+            onClick={() => {
+              feedback.clear();
+              revoke.mutate(credential.id, { onError: (caught) => feedback.report(caught) });
+            }}
+          >
+            {revoke.isPending ? 'Revoking…' : 'Revoke'}
+          </button>
+          <p className="scim-credential__note">Revoking bites at the provider&apos;s next request.</p>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function MintCredentialForm({
+  mint,
+  onMinted,
+}: {
+  mint: ReturnType<typeof useMintScimCredential>;
+  onMinted: (minted: MintedScimCredential) => void;
+}) {
+  const [proof, setProof] = useState('');
+  const [indefinite, setIndefinite] = useState(false);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (proof.trim() === '' || mint.pending) {
+      return;
+    }
+    void mint
+      .mint({ proof: proof.trim(), ...(indefinite ? { indefinite: true } : {}) })
+      .then(
+        (minted) => {
+          onMinted(minted);
+          setProof('');
+          setIndefinite(false);
+        },
+        () => {
+          // Surfaced from mint.error below; the proof stays so it can be retried.
+        },
+      );
+  };
+
+  return (
+    <form className="form" onSubmit={onSubmit} noValidate>
+      <h3>Mint a credential</h3>
+      <p>
+        Minting reauthenticates: present a current authenticator code, or your account password if
+        you have no factor enrolled. It is never stored and never appears again.
+      </p>
+      {mint.error !== null ? <Alert>{scimMintFailureText(mint.error)}</Alert> : null}
+      <div className="field">
+        <label htmlFor="scim-proof">Reauthentication proof</label>
+        <input
+          id="scim-proof"
+          type="password"
+          value={proof}
+          onChange={(event) => setProof(event.target.value)}
+          maxLength={512}
+          autoComplete="one-time-code"
+          required
+        />
+      </div>
+      <div className="field chk">
+        <input
+          id="scim-indefinite"
+          type="checkbox"
+          checked={indefinite}
+          onChange={(event) => setIndefinite(event.target.checked)}
+        />
+        <label htmlFor="scim-indefinite">
+          Never expires (refused unless this instance allows indefinite credentials)
+        </label>
+      </div>
+      <button
+        className="btn btn--primary"
+        type="submit"
+        disabled={mint.pending || proof.trim() === ''}
+      >
+        {mint.pending ? 'Minting…' : 'Mint credential'}
+      </button>
+    </form>
+  );
+}
+
+/**
+ * The display-once ceremony. The token lives only in this dialog's props while
+ * it is open: copy is best-effort, a stored-confirmation gates dismissal, and a
+ * Back press or reload is routed through the same guard so the one disclosure is
+ * not lost.
+ */
+function MintDialog({
+  minted,
+  onClose,
+}: {
+  minted: MintedScimCredential;
+  onClose: () => void;
+}) {
+  const confirmation = useRef<HTMLInputElement>(null);
+  const dialog = useModalDialog(confirmation);
+  const [stored, setStored] = useState(false);
+  const [heldBack, setHeldBack] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const dismiss = () => {
+    if (!stored) {
+      setHeldBack(true);
+      return;
+    }
+    onClose();
+  };
+
+  useNavigationGuard(!stored, dismiss);
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="scim-mint-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        dismiss();
+      }}
+    >
+      <h2 className="ceremony__title" id="scim-mint-title">
+        Provisioning credential minted — shown exactly once
+      </h2>
+      {minted.rotated ? (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>
+            This joined an already-live credential — that is overlap rotation. Update the identity
+            provider to this value, then revoke the old one.
+          </span>
+        </p>
+      ) : null}
+      <p className="mono machine__token">{minted.token}</p>
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          This value is never retrievable again. The list shows metadata only. Configure it at the
+          identity provider now; if it is lost, revoke this credential and mint a fresh one.
+        </span>
+      </p>
+      <button
+        className="btn"
+        type="button"
+        onClick={async () => {
+          const result = await writeClipboard(minted.token);
+          setCopyStatus(
+            result === 'ok'
+              ? 'Copied. The clipboard is now the only copy outside the identity provider.'
+              : 'This browser refused clipboard access, so nothing was copied.',
+          );
+        }}
+      >
+        Copy to clipboard
+      </button>
+      {copyStatus === null ? null : (
+        <p className="notice" role="status">
+          <span className="alert__glyph" aria-hidden="true">
+            ⧉
+          </span>
+          <span>{copyStatus}</span>
+        </p>
+      )}
+      <div className="field chk">
+        <input
+          id="scim-stored"
+          type="checkbox"
+          ref={confirmation}
+          checked={stored}
+          onChange={(event) => {
+            setStored(event.target.checked);
+            if (event.target.checked) {
+              setHeldBack(false);
+            }
+          }}
+        />
+        <label htmlFor="scim-stored">I have configured this credential at the identity provider.</label>
+      </div>
+      {heldBack ? (
+        <Alert>Store the credential first — it cannot be shown again once this closes.</Alert>
+      ) : null}
+      <button className="btn btn--primary" type="button" disabled={!stored} onClick={dismiss}>
+        Done
+      </button>
+    </dialog>
+  );
+}
+
+// --- directory --------------------------------------------------------------
+
+function DirectorySection({ org, binding }: { org: string; binding: ScimBinding }) {
+  const users = useScimDirectoryUsers(org, binding.id);
+  const groups = useScimDirectoryGroups(org, binding.id);
+  const [filter, setFilter] = useState('');
+
+  const userItems = users.data?.items ?? [];
+  const groupItems = groups.data?.items ?? [];
+  const needle = filter.trim().toLowerCase();
+  // The server bounds the list; the filter narrows what came back, in the
+  // browser. The directory takes no search parameter, so this invents none.
+  const shownUsers =
+    needle === ''
+      ? userItems
+      : userItems.filter((user) => user.user_name.toLowerCase().includes(needle));
+
+  return (
+    <Panel id="scim-directory" title="Directory">
+      <p>
+        What the identity provider has provisioned into this organisation. A deprovisioned user is
+        flagged loudly — the provider declared them gone, but grants made by hand here remain and are
+        still usable until a human decides about them.
+      </p>
+
+      {users.isError ? <Alert>{scimReadFailureText(users.error)}</Alert> : null}
+      {groups.isError ? <Alert>{scimReadFailureText(groups.error)}</Alert> : null}
+
+      <div className="field">
+        <label htmlFor="scim-directory-filter">Filter users by name</label>
+        <input
+          id="scim-directory-filter"
+          type="search"
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          autoComplete="off"
+        />
+      </div>
+
+      <h3>Users ({userItems.length})</h3>
+      {users.isSuccess && userItems.length === 0 ? (
+        <p role="status">No users provisioned yet.</p>
+      ) : null}
+      {users.isSuccess && userItems.length > 0 && shownUsers.length === 0 ? (
+        <p role="status">No provisioned user matches that filter.</p>
+      ) : null}
+      <ul className="scim-directory-users">
+        {shownUsers.map((user) => (
+          <DirectoryUserRow key={user.id} user={user} />
+        ))}
+      </ul>
+
+      <h3>Groups ({groupItems.length})</h3>
+      {groups.isSuccess && groupItems.length === 0 ? (
+        <p role="status">No groups provisioned yet.</p>
+      ) : null}
+      <ul className="scim-directory-groups">
+        {groupItems.map((group) => (
+          <li key={group.id} className="scim-directory-group">
+            <span className="scim-directory-group__name">{group.display_name}</span>
+            <span className="scim-directory-group__count">{group.member_count} members</span>
+            <span className="mono scim-directory-group__id">{group.id}</span>
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
+
+function DirectoryUserRow({ user }: { user: ScimDirectoryUser }) {
+  return (
+    <li className="scim-directory-user">
+      <div className="scim-directory-user__head">
+        <span className="scim-directory-user__name">{user.user_name}</span>
+        <span className="badge" data-state={user.active ? 'active' : 'inactive'}>
+          {user.active ? 'active' : 'inactive'}
+        </span>
+      </div>
+      <p className="scim-directory-user__groups">
+        {user.groups.length === 0 ? 'in no groups' : `${String(user.groups.length)} group(s)`}
+      </p>
+      <AttentionList attention={user.attention} subjectPrefix={`${user.user_name} `} />
+    </li>
+  );
+}

--- a/web/src/routes/ScimProvisioning.tsx
+++ b/web/src/routes/ScimProvisioning.tsx
@@ -115,11 +115,17 @@ export function ScimProvisioning() {
       </Panel>
 
       {active === null ? null : (
-        <>
+        // Keyed by binding id so switching the administered binding REMOUNTS
+        // these sections: an in-flight mint or an open display-once dialog can
+        // never carry one binding's token into another binding's panel. A mint
+        // still committing when the operator switches loses the dialog, but the
+        // credentials list was already invalidated, so the new credential shows
+        // as revocable metadata rather than a wrong-panel disclosure.
+        <div key={active.id}>
           <MappingsSection org={org} binding={active} />
           <CredentialsSection org={org} binding={active} />
           <DirectorySection org={org} binding={active} />
-        </>
+        </div>
       )}
     </div>
   );
@@ -388,6 +394,10 @@ function MappingsSection({ org, binding }: { org: string; binding: ScimBinding }
   const mappings = useScimMappings(org, binding.id);
   const groups = useScimDirectoryGroups(org, binding.id);
   const rows = mappings.data?.items ?? [];
+  // The delete outcome lives HERE, not in the row: deleting releases the row on
+  // the settled refetch, and feedback stored inside it would vanish with it, so
+  // the consequence a delete reports has to outlive the row it describes.
+  const [deleteOutcome, setDeleteOutcome] = useState<string | null>(null);
   const groupNames = useMemo(() => {
     const map = new Map<string, string>();
     for (const group of groups.data?.items ?? []) {
@@ -405,6 +415,7 @@ function MappingsSection({ org, binding }: { org: string; binding: ScimBinding }
       </p>
 
       {mappings.isError ? <Alert>{scimReadFailureText(mappings.error)}</Alert> : null}
+      {deleteOutcome === null ? null : <Done>{deleteOutcome}</Done>}
 
       {mappings.isSuccess && rows.length === 0 ? (
         <p role="status">No mappings yet. Map a provisioned group to a template below.</p>
@@ -418,6 +429,9 @@ function MappingsSection({ org, binding }: { org: string; binding: ScimBinding }
             binding={binding.id}
             row={row}
             groupName={groupNames.get(row.group_id) ?? row.group_id}
+            onDeleted={(released) =>
+              setDeleteOutcome(`Deleted. ${String(released)} origins released.`)
+            }
           />
         ))}
       </ul>
@@ -461,11 +475,13 @@ function MappingRow({
   binding,
   row,
   groupName,
+  onDeleted,
 }: {
   org: string;
   binding: string;
   row: ScimMapping;
   groupName: string;
+  onDeleted: (originsReleased: number) => void;
 }) {
   const update = useUpdateScimMapping(org, binding);
   const remove = useDeleteScimMapping(org, binding);
@@ -502,10 +518,9 @@ function MappingRow({
     remove.mutate(
       { group: row.group_id, ...scopeOfMapping(row) },
       {
-        onSuccess: (next) => {
-          setResult(next);
-          feedback.ok(`Deleted. ${String(next.origins_released)} origins released.`);
-        },
+        // Report UP: this row is about to be removed by the settled refetch, so
+        // its own feedback would disappear with it.
+        onSuccess: (next) => onDeleted(next.origins_released),
         onError: (caught) => feedback.report(caught),
       },
     );


### PR DESCRIPTION
Closes #501.

## What

New org-scoped surface `/orgs/:org/scim` — complete browser management of the SCIM binding, mapping, provisioning-credential and provisioned-directory domain, on the generated operations and shared mutation/refusal patterns. Protocol-shaped SCIM client endpoints stay parity-exempt.

- **Bindings** — create (provider kind + slug + immutable subject source), list with live attention states, typed-name delete gate stating the atomic teardown.
- **Mappings** — group→template table with `inert` flag and expanded capabilities; create/retarget/delete; server-authored blast `warnings` rendered **verbatim** post-commit (no client-composed policy).
- **Credentials** — display-once mint (fresh reauthentication proof in the body, no TanStack cache for the irretrievable token), metadata-only inventory, revoke that bites at the next wire request.
- **Directory** — provisioned users + groups, server-bounded and narrowed by a client-side name filter (the wire takes no search param), loud per-user deprovision flag.

## Acceptance criteria

- [x] Binding & mapping list/detail/create/update/delete, capability-gated (surface renders server 403/404).
- [x] Credentials minted, copied once, inventoried by metadata, revoked with no later plaintext recovery.
- [x] Directory inventory bounded, searchable, reports sync state/failures safely.
- [x] Mapping consequences, binding-deletion teardown, and revocation bite previewed (warnings verbatim; factual teardown/revocation copy).
- [x] Token never enters URLs, logs, toasts, or durable browser storage; binding selected via `?binding=` id.
- [x] End-to-end: creates binding/credential, wire-pushes a group+user with the minted token, observes the directory, maps at org scope (warning), deletes mapping, revokes, confirms wire then 401s, deletes binding.

## Contract / migration decisions

None. No generated client, authorization, refusal, or redaction contract changed. No migration.

## Regenerated artifacts

None — the SCIM operations and Zod schemas were already generated from `api/openapi.yaml`.

## Validation

- `pnpm --dir web typecheck` — clean
- `pnpm --dir web test` — 567 pass
- `pnpm --dir web build` — clean
- Targeted Playwright: `scim provisioning` flow (journey + dark/light pinned assertion set) passes on **desktop and mobile**

🤖 Generated with [Claude Code](https://claude.com/claude-code)