### PR TITLE
feat(web): administer SAML providers and SP keys in the WebUI (#500)

### DIFF
--- a/docs/handoff/500-saml-admin-webui.md
+++ b/docs/handoff/500-saml-admin-webui.md
@@ -1,0 +1,95 @@
+# #500 — Administer SAML providers and SP keys in the WebUI
+
+Parent: instance-administration parity (#25). **WebUI-only.** The backend
+(`internal/server/saml.go`, `internal/service/saml_providers.go`,
+`internal/service/saml_sp_keys.go`) and the generated TS operations already
+existed on `main`; this change adds no API, no codegen, no server code, and no
+new route.
+
+## Contract decisions (no server change)
+
+The locked contract is preserved verbatim. Two points the delivery notes ask to
+state explicitly:
+
+- **Endpoint-to-action mapping.** Each lifecycle act has exactly one surface,
+  following the contract's own intent so nothing is UI-special:
+  - **create** → `PUT /saml-providers/{slug}` (new slug).
+  - **replace metadata** → `POST /saml-providers/{slug}/refresh-metadata`
+    (file-backed supplies the replacement document; URL-backed re-fetches). PUT
+    is used for create only — refresh-metadata is the contract's own
+    reconfigure-metadata path, so there is no ambiguous second way to change
+    trust material.
+  - **policy / disable** → `PATCH /saml-providers/{slug}` (never demands
+    unreadable metadata, exactly why the endpoint exists).
+  - **delete** → `DELETE /saml-providers/{slug}`.
+- **The delete "impact preview" is ceremony copy, not a computed preview.** No
+  impact-preview API exists (matches OIDC delete). The removal ceremony states
+  the consequence in the product's words — every session through the provider is
+  swept, the provider stops advertising for sign-in, linked identities stop
+  resolving — and it names the invariant that local-floor, locally-authenticated
+  access is unaffected. Read this before flagging "preview" as unimplemented.
+
+## Write-only discipline
+
+`SamlProvider` never returns `metadata_document`, so metadata XML is only ever an
+input. The create form clears the textarea on a successful apply; no mutation
+echoes the document into feedback, a toast, or the URL. The e2e asserts the
+editor is gone (with its textarea) after a successful create.
+
+## Metadata diff-and-confirm ceremony
+
+Modelled on `CredentialPolicyPanel`'s preview machine. A first PUT/refresh with
+no `confirmed_*` returns `applied=false` + a `diff`; the panel holds the diff and
+the `required_fingerprints`/`required_endpoints`, and the confirm button reruns
+the same request with those copied into `confirmed_*`. One state machine serves
+both create (PUT) and refresh-metadata.
+
+## SP-key retirement: two distinct ceremonies
+
+- **Ordinary retire** is offered ONLY on a `retiring` key (the server 409s the
+  active key; `samlFailureText` surfaces that as "rotate first"). Typed-name
+  gate on the fingerprint; copy: the cert leaves SP metadata now.
+- **Compromise-retire** is offered ONLY on the `active` key. Typed-name gate;
+  copy: no overlap window, immediate erase + replacement.
+
+`retired` is not a listed state — retirement erases the key, so it leaves the
+inventory; the copy explains that rather than drawing a dead row.
+
+## Files
+
+- `web/src/api/samlProviders.ts` — query/mutation hooks, client-side validation
+  (slug pattern is the exact `ProviderSlugPath` one), and the per-action failure
+  mapper. `web/src/api/samlProviders.test.ts` covers validation + failure text.
+- `web/src/routes/SamlProvidersPanel.tsx`, `web/src/routes/SamlSpKeysPanel.tsx` —
+  the two panels, mounted (prototype-gated, like `instance-grants`) into
+  `web/src/routes/InstanceAdmin.tsx` with JumpIndex entries. No new registry
+  surface → no CI-grouping trap.
+- `web/src/routes/SamlAdmin.test.tsx` — component tests for the ceremony state
+  machine and the state-gated retirement buttons.
+- `web/e2e/flows/instance-admin.spec.ts` — the end-to-end journey (create via
+  ceremony → refresh metadata → login-availability probe → rotate → retire →
+  compromise-retire → delete → availability gone), plus the two new panels added
+  to the password-only second-factor refusal array.
+
+## Login availability
+
+SAML login stays a protocol-specific path (out of scope; `Login.tsx` renders
+OIDC buttons only). The e2e's availability check queries the public
+`/api/v1/auth/methods` from a fresh unauthenticated context — the same endpoint
+`AuthMethods` builds, which advertises enabled SAML providers by slug. Enabling
+makes the slug appear; deleting makes it vanish.
+
+## Validation
+
+- `pnpm --dir web typecheck` — clean.
+- `pnpm --dir web test` — 70 files, all green (adds `samlProviders.test.ts` +
+  `SamlAdmin.test.tsx`).
+- `pnpm --dir web build` — clean.
+- Targeted Playwright: the new instance-admin journey, desktop + mobile
+  (separate invocations — one shared backend, per the e2e serial-instance rule).
+
+## Fresh-worktree gotcha
+
+`clients/ts` needs its own `pnpm install --frozen-lockfile` before the web
+typecheck resolves `zod` from the generated sources; otherwise every `parsed()`
+return is `any` repo-wide (TS2307-adjacent). CI does this in a dedicated step.

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -1,9 +1,11 @@
 import { expect, type Browser, type Page } from '@playwright/test';
 import {
+  zAuthMethods,
   zGrantList,
   zOrg,
   zOrgList,
   zSamlProviderMutationResult,
+  zSamlSpKeyList,
   zScimBinding,
   zScimMappingResult,
   zScimMintResult,
@@ -411,6 +413,117 @@ test.describe('instance administration', () => {
       await expect(page.getByLabel('Name')).toHaveValue(name);
   });
 
+  test('configures a SAML provider, refreshes its metadata, rotates and retires SP keys, and gates login availability', async ({
+    page,
+    browser,
+  }, testInfo) => {
+    testInfo.setTimeout(90_000);
+    const slug = `saml-admin-${testInfo.project.name}`;
+    const entityId = `https://idp.example/${slug}`;
+    const providersPanel = page.locator('#instance-saml-providers');
+    const spPanel = page.locator('#instance-saml-sp-keys');
+
+    // A fresh, unauthenticated context asks the public auth-methods endpoint
+    // whether the provider is advertised for sign-in. Enabling a provider makes
+    // it appear; deleting it makes it vanish — that is the login-availability
+    // property this journey exists to hold.
+    const advertised = async (): Promise<boolean> => {
+      const anon = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+      try {
+        const response = await anon.request.get(`${BASE_URL}/api/v1/auth/methods`);
+        expect(response.ok(), await response.text()).toBe(true);
+        const methods = zAuthMethods.parse(await response.json());
+        return methods.providers.some((provider) => provider.slug === slug && provider.kind === 'saml');
+      } finally {
+        await anon.close();
+      }
+    };
+
+    // Defensive: a prior failed run can leave an overlap-retiring SP key that
+    // would 409 the rotate. Retire any before starting so the rotate is clean.
+    for (const key of (await browserApi(page, 'GET', '/api/v1/instance/saml-sp-keys', zSamlSpKeyList)).keys) {
+      if (key.state === 'retiring') {
+        await browserApi(page, 'DELETE', `/api/v1/instance/saml-sp-keys/${key.fingerprint}`, z.null());
+      }
+    }
+
+    try {
+      // Create through the diff-and-confirm ceremony.
+      await providersPanel.getByRole('button', { name: 'Configure a new SAML provider' }).click();
+      await providersPanel.getByLabel('Slug (immutable; addresses this provider)').fill(slug);
+      await providersPanel.getByLabel('Display name').fill(slug);
+      await providersPanel
+        .getByLabel('IdP entityID (byte-exact; immutable after create)')
+        .fill(entityId);
+      await providersPanel.getByLabel('Metadata XML').fill(samlMetadata(slug));
+      await providersPanel.getByRole('button', { name: 'Preview and configure' }).click();
+      await expect(providersPanel.getByText('changes trust state')).toBeVisible();
+      await providersPanel.getByRole('button', { name: 'Confirm trust and configure provider' }).click();
+      await expect(providersPanel.getByText(`Configured SAML provider ${slug}`)).toBeVisible();
+
+      const providerRow = providersPanel.locator(`[data-saml-provider="${slug}"]`);
+      await expect(providerRow).toContainText('enabled');
+      expect(await advertised()).toBe(true);
+
+      // Replace the pinned metadata through the same ceremony. A fresh
+      // self-signed certificate makes this a real trust change.
+      await providerRow.getByRole('button', { name: 'Refresh metadata' }).click();
+      await providerRow.getByLabel('Replacement metadata XML').fill(samlMetadata(slug));
+      await providerRow.getByRole('button', { name: 'Preview metadata change' }).click();
+      await expect(providerRow.getByText('changes trust state')).toBeVisible();
+      await providerRow
+        .getByRole('button', { name: 'Confirm and apply the trust change' })
+        .click();
+      await expect(providersPanel.getByText(`Refreshed the metadata for ${slug}`)).toBeVisible();
+
+      // Rotate the SP signing key: the old active key becomes retiring, a new
+      // one is published.
+      await spPanel.getByRole('button', { name: 'Rotate the active signing key' }).click();
+      await expect(spPanel.getByText('Rotated the SP signing key')).toBeVisible();
+
+      // Ordinary retirement erases the overlap-retiring key.
+      const retiringRow = spPanel.locator('[data-sp-key]').filter({ hasText: 'retiring' });
+      await expect(retiringRow).toHaveCount(1);
+      const retiringFingerprint = await retiringRow.getAttribute('data-sp-key');
+      expect(retiringFingerprint).not.toBeNull();
+      await retiringRow.getByRole('button', { name: 'Retire', exact: true }).click();
+      await retiringRow
+        .getByLabel('Type the fingerprint to erase this retiring key')
+        .fill(retiringFingerprint ?? '');
+      await retiringRow.getByRole('button', { name: 'Retire key' }).click();
+      await expect(spPanel.getByText('is erased and gone from SP metadata')).toBeVisible();
+      await expect(spPanel.locator('[data-sp-key]').filter({ hasText: 'retiring' })).toHaveCount(0);
+
+      // Compromise retirement erases and replaces the active key with no overlap.
+      const activeRow = spPanel.locator('[data-sp-key]').filter({ hasText: 'active' });
+      await expect(activeRow).toHaveCount(1);
+      const compromisedFingerprint = await activeRow.getAttribute('data-sp-key');
+      expect(compromisedFingerprint).not.toBeNull();
+      await activeRow.getByRole('button', { name: 'Compromise-retire' }).click();
+      await activeRow
+        .getByLabel('Type the fingerprint to erase and replace the compromised key')
+        .fill(compromisedFingerprint ?? '');
+      await activeRow.getByRole('button', { name: 'Compromise-retire key' }).click();
+      await expect(spPanel.getByText('minted a replacement')).toBeVisible();
+      // Exactly one active key remains and it is a new one.
+      const keysAfter = await browserApi(page, 'GET', '/api/v1/instance/saml-sp-keys', zSamlSpKeyList);
+      expect(keysAfter.keys.filter((key) => key.state === 'active')).toHaveLength(1);
+      expect(keysAfter.keys.some((key) => key.fingerprint === compromisedFingerprint)).toBe(false);
+
+      // Remove the provider through its typed-name danger gate.
+      await providerRow.getByRole('button', { name: 'Remove', exact: true }).click();
+      await providerRow.getByLabel(`Type ${slug} to remove this provider`).fill(slug);
+      await providerRow.getByRole('button', { name: 'Remove provider' }).click();
+      await expect(providersPanel.getByText(`Removed SAML provider ${slug}`)).toBeVisible();
+      expect(await advertised()).toBe(false);
+    } finally {
+      // The provider is gone on the happy path; sweep it if the run failed midway.
+      await browserApi(page, 'DELETE', `/api/v1/instance/saml-providers/${slug}`, z.null()).catch(
+        () => undefined,
+      );
+    }
+  });
+
   test('answers a password-only session with the second-factor state, not an empty list', async ({
     browser,
   }) => {
@@ -432,6 +545,8 @@ test.describe('instance administration', () => {
         ['#instance-retention', 'requires a second factor', 'Payload pruning'],
         ['#instance-settings', 'requires a second factor', 'Maximum finite lifetime'],
         ['#instance-oidc', 'needs a second factor', '+ add identity provider'],
+        ['#instance-saml-providers', 'needs a second factor', 'No SAML providers are configured'],
+        ['#instance-saml-sp-keys', 'needs a second factor', 'signs every AuthnRequest'],
       ] as const;
       for (const [selector, refusalText, forbiddenText] of panels) {
         const panel = page.locator(selector);

--- a/web/src/api/samlProviders.test.ts
+++ b/web/src/api/samlProviders.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './client.ts';
+import { samlFailureText, samlProviderInputErrors, SAML_SLUG_PATTERN } from './samlProviders.ts';
+
+describe('SAML_SLUG_PATTERN', () => {
+  it('accepts a lowercase slug and rejects uppercase, leading hyphen and overflow', () => {
+    expect(SAML_SLUG_PATTERN.test('acme-idp')).toBe(true);
+    expect(SAML_SLUG_PATTERN.test('a')).toBe(true);
+    expect(SAML_SLUG_PATTERN.test('Acme')).toBe(false);
+    expect(SAML_SLUG_PATTERN.test('-acme')).toBe(false);
+    expect(SAML_SLUG_PATTERN.test('a'.repeat(65))).toBe(false);
+  });
+});
+
+describe('samlProviderInputErrors', () => {
+  const base = {
+    creating: true,
+    slug: 'acme',
+    displayName: 'Acme',
+    entityId: 'https://idp.example/acme',
+    metadataSource: 'file' as const,
+    metadataDocument: '<md:EntityDescriptor/>',
+    metadataUrl: '',
+  };
+
+  it('passes a complete file-backed create', () => {
+    expect(samlProviderInputErrors(base)).toEqual([]);
+  });
+
+  it('rejects a bad slug only while creating', () => {
+    expect(samlProviderInputErrors({ ...base, slug: 'Bad Slug' })).toContain(
+      'Slug must be lowercase letters, digits or hyphens, and start with a letter or digit.',
+    );
+    // On reconfigure the slug is fixed route data, so it is not re-validated.
+    expect(samlProviderInputErrors({ ...base, creating: false, slug: 'Bad Slug' })).toEqual([]);
+  });
+
+  it('requires a display name and an entity id', () => {
+    expect(samlProviderInputErrors({ ...base, displayName: '   ' })).toContain(
+      'A display name is required.',
+    );
+    expect(samlProviderInputErrors({ ...base, entityId: '' })).toContain(
+      'An entity ID is required.',
+    );
+  });
+
+  it('requires exactly the metadata field its source names', () => {
+    expect(samlProviderInputErrors({ ...base, metadataSource: 'file', metadataDocument: '' })).toContain(
+      'Paste the IdP metadata XML for a file-backed provider.',
+    );
+    expect(
+      samlProviderInputErrors({ ...base, metadataSource: 'url', metadataDocument: '', metadataUrl: 'https://idp.example/meta' }),
+    ).toEqual([]);
+    expect(samlProviderInputErrors({ ...base, metadataSource: 'url', metadataDocument: '', metadataUrl: '' })).toContain(
+      'A metadata URL is required for a URL-backed provider.',
+    );
+    expect(
+      samlProviderInputErrors({ ...base, metadataSource: 'url', metadataDocument: '', metadataUrl: 'ftp://idp.example' }),
+    ).toContain('The metadata URL must be an https:// address.');
+  });
+});
+
+describe('samlFailureText', () => {
+  it('maps a 403 to a second-factor prompt', () => {
+    expect(samlFailureText(new ApiError(403, 'forbidden'), 'save-provider')).toContain(
+      'second factor',
+    );
+  });
+
+  it('prefers a 400 detail and falls back to a per-action sentence', () => {
+    expect(samlFailureText(new ApiError(400, 'bad', 'entityID selects no descriptor'), 'save-provider')).toBe(
+      'entityID selects no descriptor',
+    );
+    expect(samlFailureText(new ApiError(400, 'bad'), 'save-provider')).toContain('metadata');
+  });
+
+  it('explains the active-key conflict on retire', () => {
+    expect(samlFailureText(new ApiError(409, 'conflict'), 'retire-key')).toContain('active');
+  });
+
+  it('reports a not-disclosed 404 and a generic server fault', () => {
+    expect(samlFailureText(new ApiError(404, 'gone'), 'save-provider')).toContain('not');
+    expect(samlFailureText(new ApiError(500, 'boom'), 'save-provider')).toContain('server');
+  });
+});

--- a/web/src/api/samlProviders.ts
+++ b/web/src/api/samlProviders.ts
@@ -1,0 +1,290 @@
+import {
+  compromiseRetireSamlSpKeyOp,
+  deleteSamlProviderOp,
+  listSamlProvidersOp,
+  listSamlSpKeysOp,
+  patchSamlProviderOp,
+  putSamlProviderOp,
+  refreshSamlProviderMetadataOp,
+  retireSamlSpKeyOp,
+  rotateSamlSpKeyOp,
+} from '@hikyo/operations';
+import type { SamlMetadataSource, SamlProviderPatch } from '@hikyo/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { ApiError, ok, parsed } from './client.ts';
+
+/**
+ * The SAML administrative surface (#500): provider inventory and lifecycle plus
+ * SP signing-key rotation and retirement, riding the locked instance-config API
+ * exactly as it is. No route is added — these are panels on `instance-admin`,
+ * so there is no second place a provider is administered.
+ *
+ * The write-only rule the contract already enforces is preserved here: metadata
+ * XML is only ever an INPUT. `SamlProvider` never returns the document, so it is
+ * never rendered back, and no mutation here echoes it into feedback.
+ */
+
+/** Matches `ProviderSlugPath`: lowercase, digit or hyphen, no leading hyphen, ≤64. */
+export const SAML_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+const samlProvidersKey = ['instance-saml-providers'] as const;
+const samlSpKeysKey = ['instance-saml-sp-keys'] as const;
+
+export function useSamlProviders() {
+  return useQuery({
+    queryKey: samlProvidersKey,
+    queryFn: () => parsed(listSamlProvidersOp, {}),
+    retry: false,
+  });
+}
+
+export function useSamlSpKeys() {
+  return useQuery({
+    queryKey: samlSpKeysKey,
+    queryFn: () => parsed(listSamlSpKeysOp, {}),
+    retry: false,
+  });
+}
+
+/**
+ * The create/reconfigure body. `metadata_document` and `metadata_url` are
+ * mutually exclusive by source, enforced client-side before the request so a
+ * file-backed provider never carries an unused URL and vice versa. The
+ * `confirmed_*` arrays carry the metadata trust-diff acknowledgement on a rerun.
+ */
+export type SamlProviderInputDraft = {
+  readonly slug: string;
+  readonly displayName: string;
+  readonly entityId: string;
+  readonly metadataSource: SamlMetadataSource;
+  readonly metadataDocument: string;
+  readonly metadataUrl: string;
+  readonly assurancePolicy: readonly string[] | null;
+  readonly allowEmailNameid: boolean;
+  readonly forceSignRequests: boolean;
+  readonly enabled: boolean;
+  readonly confirmedFingerprints?: readonly string[];
+  readonly confirmedEndpoints?: readonly string[];
+};
+
+export function usePutSamlProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // The write-only metadata document rides through as mutation variables, so
+    // it must not linger in the cache after the ceremony: gcTime 0 drops the
+    // record the moment `reset()` makes it inactive.
+    gcTime: 0,
+    mutationFn: (draft: SamlProviderInputDraft) =>
+      parsed(putSamlProviderOp, {
+        path: { slug: draft.slug },
+        body: {
+          display_name: draft.displayName.trim(),
+          entity_id: draft.entityId.trim(),
+          metadata_source: draft.metadataSource,
+          metadata_document: draft.metadataSource === 'file' ? draft.metadataDocument : null,
+          metadata_url: draft.metadataSource === 'url' ? draft.metadataUrl.trim() : null,
+          assurance_policy: draft.assurancePolicy === null ? null : [...draft.assurancePolicy],
+          allow_email_nameid: draft.allowEmailNameid,
+          force_sign_requests: draft.forceSignRequests,
+          enabled: draft.enabled,
+          ...(draft.confirmedFingerprints ? { confirmed_fingerprints: [...draft.confirmedFingerprints] } : {}),
+          ...(draft.confirmedEndpoints ? { confirmed_endpoints: [...draft.confirmedEndpoints] } : {}),
+        },
+      }),
+    onSuccess: (result) => {
+      if (result.applied) void queryClient.invalidateQueries({ queryKey: samlProvidersKey });
+    },
+  });
+}
+
+export function usePatchSamlProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ slug, patch }: { slug: string; patch: SamlProviderPatch }) =>
+      parsed(patchSamlProviderOp, { path: { slug }, body: patch }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: samlProvidersKey }),
+  });
+}
+
+export type SamlMetadataRefreshDraft = {
+  readonly slug: string;
+  readonly metadataDocument: string | null;
+  readonly confirmedFingerprints?: readonly string[];
+  readonly confirmedEndpoints?: readonly string[];
+};
+
+export function useRefreshSamlMetadata() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // See usePutSamlProvider: keep the replacement document out of the cache.
+    gcTime: 0,
+    mutationFn: (draft: SamlMetadataRefreshDraft) =>
+      parsed(refreshSamlProviderMetadataOp, {
+        path: { slug: draft.slug },
+        body: {
+          ...(draft.metadataDocument === null ? {} : { metadata_document: draft.metadataDocument }),
+          ...(draft.confirmedFingerprints ? { confirmed_fingerprints: [...draft.confirmedFingerprints] } : {}),
+          ...(draft.confirmedEndpoints ? { confirmed_endpoints: [...draft.confirmedEndpoints] } : {}),
+        },
+      }),
+    onSuccess: (result) => {
+      if (result.applied) void queryClient.invalidateQueries({ queryKey: samlProvidersKey });
+    },
+  });
+}
+
+export function useDeleteSamlProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (slug: string) => ok(deleteSamlProviderOp, { path: { slug } }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: samlProvidersKey }),
+  });
+}
+
+export function useRotateSamlSpKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => parsed(rotateSamlSpKeyOp, {}),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: samlSpKeysKey }),
+  });
+}
+
+export function useRetireSamlSpKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fingerprint: string) => ok(retireSamlSpKeyOp, { path: { fingerprint } }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: samlSpKeysKey }),
+  });
+}
+
+export function useCompromiseRetireSamlSpKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fingerprint: string) =>
+      parsed(compromiseRetireSamlSpKeyOp, { path: { fingerprint } }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: samlSpKeysKey }),
+  });
+}
+
+/**
+ * Client-side validation, because the server returns only a coarse code for
+ * everything but a 400 detail: naming the wrong field to the operator has to
+ * happen here. Deliberately no stricter than the contract — the slug pattern is
+ * the exact `ProviderSlugPath` one, trailing hyphen and all.
+ */
+export function samlProviderInputErrors(draft: {
+  readonly creating: boolean;
+  readonly slug: string;
+  readonly displayName: string;
+  readonly entityId: string;
+  readonly metadataSource: SamlMetadataSource;
+  readonly metadataDocument: string;
+  readonly metadataUrl: string;
+}): string[] {
+  const errors: string[] = [];
+  // The slug is chosen at create and is fixed route data thereafter, so it is
+  // only validated while creating.
+  if (draft.creating && !SAML_SLUG_PATTERN.test(draft.slug)) {
+    errors.push('Slug must be lowercase letters, digits or hyphens, and start with a letter or digit.');
+  }
+  if (draft.displayName.trim() === '') errors.push('A display name is required.');
+  if (draft.entityId.trim() === '') errors.push('An entity ID is required.');
+  if (draft.metadataSource === 'file') {
+    if (draft.metadataDocument.trim() === '') {
+      errors.push('Paste the IdP metadata XML for a file-backed provider.');
+    }
+  } else if (draft.metadataUrl.trim() === '') {
+    errors.push('A metadata URL is required for a URL-backed provider.');
+  } else if (!/^https:\/\//i.test(draft.metadataUrl.trim())) {
+    errors.push('The metadata URL must be an https:// address.');
+  }
+  return errors;
+}
+
+export type SamlAction =
+  | 'list'
+  | 'save-provider'
+  | 'update-provider'
+  | 'refresh-metadata'
+  | 'delete-provider'
+  | 'rotate-key'
+  | 'retire-key'
+  | 'compromise-retire-key';
+
+/** Map each refusal to a sentence, keyed to the action that hit it. */
+export function samlFailureText(error: unknown, action: SamlAction): string {
+  if (!(error instanceof ApiError)) {
+    return 'The server failed; whether the change applied is unknown — reload to check.';
+  }
+  switch (error.status) {
+    case 400:
+      return error.detail ?? invalidText(action);
+    case 401:
+      return 'Your session ended. Sign in again to continue.';
+    case 403:
+      // A 403 on an instance-config operation is uniform: either the session's
+      // assurance is inadequate for this MFA-mandatory operation, or the
+      // principal does not hold the capability. The contract does not
+      // distinguish them, so the copy must not claim it is only step-up.
+      return `${samlAction(action)} needs a second factor and this authority. If you hold it, present your authenticator code or passkey in the banner above, then try again.`;
+    case 404:
+      return 'This is not disclosed to this session.';
+    case 409:
+      // Only a 400 carries a caller-safe detail; a 409 never does, so never
+      // render one.
+      return conflictText(action);
+    case 429:
+      return 'Too many attempts right now. Wait a moment and try again.';
+    default:
+      return 'The server failed; whether the change applied is unknown — reload to check.';
+  }
+}
+
+function samlAction(action: SamlAction): string {
+  switch (action) {
+    case 'list':
+      return 'Listing SAML providers';
+    case 'save-provider':
+      return 'Configuring a SAML provider';
+    case 'update-provider':
+      return 'Updating a SAML provider';
+    case 'refresh-metadata':
+      return 'Refreshing provider metadata';
+    case 'delete-provider':
+      return 'Removing a SAML provider';
+    case 'rotate-key':
+      return 'Rotating the SP signing key';
+    case 'retire-key':
+      return 'Retiring an SP signing key';
+    case 'compromise-retire-key':
+      return 'Compromise-retiring the active SP key';
+  }
+}
+
+function invalidText(action: SamlAction): string {
+  switch (action) {
+    case 'save-provider':
+    case 'update-provider':
+    case 'refresh-metadata':
+      return 'The provider metadata or policy was rejected. Check the entity ID, the metadata source, and that any trust changes were confirmed.';
+    default:
+      return 'The request was rejected.';
+  }
+}
+
+function conflictText(action: SamlAction): string {
+  switch (action) {
+    case 'save-provider':
+    case 'update-provider':
+    case 'refresh-metadata':
+      return 'The provider changed under you, or a trust change needs explicit confirmation. Reload and reapply.';
+    case 'retire-key':
+      return 'This key is the active signing key. Rotate first so request-signing continuity is explicit, then retire the key it leaves behind.';
+    case 'rotate-key':
+    case 'compromise-retire-key':
+      return 'The signing-key set changed under you. Reload the key inventory and try again.';
+    default:
+      return 'The current state refuses this change. Reload and try again.';
+  }
+}

--- a/web/src/routes/InstanceAdmin.tsx
+++ b/web/src/routes/InstanceAdmin.tsx
@@ -31,6 +31,8 @@ import {
 import { notifySuccess } from '../app/notifications.tsx';
 import { surfaceById } from '../app/navigation.ts';
 import { OidcProvidersPanel } from './OidcProvidersPanel.tsx';
+import { SamlProvidersPanel } from './SamlProvidersPanel.tsx';
+import { SamlSpKeysPanel } from './SamlSpKeysPanel.tsx';
 import { Alert, Done, JumpIndex, Panel } from './Sections.tsx';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
 
@@ -126,6 +128,10 @@ export function InstanceAdmin() {
       { id: 'instance-settings', label: 'Settings' },
       ...(prototypeMode ? [] : [{ id: 'instance-oidc', label: 'Identity providers' }]),
       { id: 'instance-keys', label: 'Keys & crypto' },
+      ...(prototypeMode ? [] : [
+        { id: 'instance-saml-providers', label: 'SAML providers' },
+        { id: 'instance-saml-sp-keys', label: 'SP signing keys' },
+      ]),
       { id: 'instance-connected', label: 'Instances' },
     ]} />
     {failure !== null ? <Alert>{failure}</Alert> : null}
@@ -228,6 +234,8 @@ export function InstanceAdmin() {
         <p className="field__hint">Root-key rotation, master-key rotation, re-encryption, <span className="mono">init</span>, <span className="mono">migrate</span>, restore reconciliation and break-glass are local host authority. They are deliberately absent from every network surface — CLI-at-the-box, not CLI-over-network.</p>
       </>}
     </Panel>
+    {prototypeMode ? null : <SamlProvidersPanel />}
+    {prototypeMode ? null : <SamlSpKeysPanel />}
     <Panel id="instance-connected" title="Connected instances · exploration" question>
       {prototypeMode ? <>
         <div className="settings-row"><div className="settings-row__copy"><span className="settings-row__title">this instance</span><span className="settings-row__detail">hikyo.example.com · v1.0</span></div><span className="settings-row__spacer" /><span className="settings-tag">main</span></div>

--- a/web/src/routes/SamlAdmin.test.tsx
+++ b/web/src/routes/SamlAdmin.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderForm, settleTask } from '../testkit/renderForm.tsx';
+import { SamlProvidersPanel } from './SamlProvidersPanel.tsx';
+import { SamlSpKeysPanel } from './SamlSpKeysPanel.tsx';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function pathOf(input: Parameters<typeof fetch>[0]): { method: string; path: string; request: Request } {
+  const request = input instanceof Request ? input : new Request(input);
+  return { method: request.method, path: new URL(request.url, 'http://localhost').pathname, request };
+}
+
+function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+  const proto = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+  if (setter === undefined) throw new Error('no value setter');
+  setter.call(element, value);
+  element.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const found = [...container.querySelectorAll('button')].find((b) => b.textContent === label);
+  if (found === undefined) throw new Error(`button "${label}" is missing`);
+  return found;
+}
+
+const provider = {
+  slug: 'acme',
+  display_name: 'Acme',
+  kind: 'saml',
+  entity_id: 'https://idp.example/acme',
+  acs_url: 'https://sp.example/acs',
+  sso_redirect_url: 'https://idp.example/acme/sso',
+  signing_certificate_fingerprints: ['sha256:AAA'],
+  assurance_policy: null,
+  allow_email_nameid: false,
+  force_sign_requests: false,
+  metadata_source: 'file',
+  metadata_url: null,
+  metadata_signed: false,
+  metadata_signing_fingerprint: null,
+  metadata_valid_until: null,
+  warnings: [],
+  enabled: true,
+  row_version: 1,
+  created_at: '2026-09-01T00:00:00Z',
+  updated_at: '2026-09-01T00:00:00Z',
+} as const;
+
+describe('SamlProvidersPanel metadata ceremony', () => {
+  it('previews the trust diff, then applies with the confirmed fingerprints and clears the document', async () => {
+    const bodies: string[] = [];
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const { method, path, request } = pathOf(args[0]);
+      if (method === 'GET' && path === '/api/v1/instance/saml-providers') {
+        return Promise.resolve(json({ providers: [] }));
+      }
+      if (method === 'PUT' && path === '/api/v1/instance/saml-providers/acme') {
+        return request.text().then((text) => {
+          bodies.push(text);
+          const parsed: unknown = JSON.parse(text);
+          const confirmed =
+            typeof parsed === 'object' && parsed !== null && 'confirmed_fingerprints' in parsed;
+          if (!confirmed) {
+            return json({
+              applied: false,
+              provider: null,
+              diff: { endpoints_added: ['https://idp.example/acme/sso'], endpoints_removed: [], certs_added_fps: ['sha256:AAA'], certs_removed_fps: [] },
+              required_fingerprints: ['sha256:AAA'],
+              required_endpoints: ['https://idp.example/acme/sso'],
+            });
+          }
+          return json({
+            applied: true,
+            provider,
+            diff: { endpoints_added: [], endpoints_removed: [], certs_added_fps: [], certs_removed_fps: [] },
+            required_fingerprints: [],
+            required_endpoints: [],
+          });
+        });
+      }
+      throw new Error(`unexpected ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    // The CSRF token the client echoes on mutations.
+    document.cookie = '__Host-hikyo-csrf=token';
+
+    const { container, client, unmount } = await renderForm(<SamlProvidersPanel />);
+    await settleTask();
+
+    await act(async () => button(container, '+ configure SAML provider').click());
+    const inputs = container.querySelectorAll<HTMLInputElement>('.saml-editor input');
+    const slug = inputs[0];
+    const name = inputs[1];
+    const entity = inputs[2];
+    const textarea = container.querySelector<HTMLTextAreaElement>('.saml-editor textarea');
+    if (slug === undefined || name === undefined || entity === undefined || textarea === null) {
+      throw new Error('provider create fields missing');
+    }
+    await act(async () => setNativeValue(slug, 'acme'));
+    await act(async () => setNativeValue(name, 'Acme'));
+    await act(async () => setNativeValue(entity, 'https://idp.example/acme'));
+    await act(async () => setNativeValue(textarea, '<md:EntityDescriptor/>'));
+
+    await act(async () => button(container, 'Preview and configure').click());
+    await settleTask();
+    // The diff is shown and nothing is applied yet.
+    expect(container.textContent).toContain('changes trust state');
+    expect(container.textContent).toContain('sha256:AAA');
+
+    await act(async () => button(container, 'Confirm trust and configure provider').click());
+    await settleTask();
+
+    // The second request carried the confirmed material copied from required_*.
+    const secondBody = bodies[1];
+    if (secondBody === undefined) throw new Error('confirm request was never sent');
+    const confirmBody: unknown = JSON.parse(secondBody);
+    expect(confirmBody).toMatchObject({
+      confirmed_fingerprints: ['sha256:AAA'],
+      confirmed_endpoints: ['https://idp.example/acme/sso'],
+    });
+    expect(container.textContent).toContain('Configured SAML provider acme');
+    // The write-only metadata never survives a successful apply in the DOM…
+    expect(container.querySelector('.saml-editor')).toBeNull();
+    // …nor in React Query's mutation cache: the ceremony resets the mutation so
+    // the document is not recoverable from the client afterwards.
+    const leaked = client
+      .getMutationCache()
+      .getAll()
+      .some((mutation) => JSON.stringify(mutation.state.variables ?? {}).includes('<md:EntityDescriptor/>'));
+    expect(leaked).toBe(false);
+    await unmount();
+  });
+
+  it('confirms the exact previewed document even if the form is edited while the preview is in flight', async () => {
+    const bodies: string[] = [];
+    let releasePreview: (() => void) | undefined;
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const { method, path, request } = pathOf(args[0]);
+      if (method === 'GET' && path === '/api/v1/instance/saml-providers') {
+        return Promise.resolve(json({ providers: [] }));
+      }
+      if (method === 'PUT' && path === '/api/v1/instance/saml-providers/acme') {
+        return request.text().then((text) => {
+          bodies.push(text);
+          const parsedBody: unknown = JSON.parse(text);
+          const confirmed =
+            typeof parsedBody === 'object' && parsedBody !== null && 'confirmed_fingerprints' in parsedBody;
+          if (confirmed) {
+            return json({ applied: true, provider, diff: { endpoints_added: [], endpoints_removed: [], certs_added_fps: [], certs_removed_fps: [] }, required_fingerprints: [], required_endpoints: [] });
+          }
+          // Hold the preview response so the form can be edited before it lands.
+          return new Promise<Response>((resolve) => {
+            releasePreview = () =>
+              resolve(
+                json({
+                  applied: false,
+                  provider: null,
+                  diff: { endpoints_added: [], endpoints_removed: [], certs_added_fps: ['sha256:AAA'], certs_removed_fps: [] },
+                  required_fingerprints: ['sha256:AAA'],
+                  required_endpoints: [],
+                }),
+              );
+          });
+        });
+      }
+      throw new Error(`unexpected ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    document.cookie = '__Host-hikyo-csrf=token';
+
+    const { container, unmount } = await renderForm(<SamlProvidersPanel />);
+    await settleTask();
+    await act(async () => button(container, '+ configure SAML provider').click());
+    const inputs = container.querySelectorAll<HTMLInputElement>('.saml-editor input');
+    const slug = inputs[0];
+    const name = inputs[1];
+    const entity = inputs[2];
+    const textarea = container.querySelector<HTMLTextAreaElement>('.saml-editor textarea');
+    if (slug === undefined || name === undefined || entity === undefined || textarea === null) {
+      throw new Error('provider create fields missing');
+    }
+    await act(async () => setNativeValue(slug, 'acme'));
+    await act(async () => setNativeValue(name, 'Acme'));
+    await act(async () => setNativeValue(entity, 'https://idp.example/acme'));
+    await act(async () => setNativeValue(textarea, 'DOCUMENT_A'));
+    await act(async () => button(container, 'Preview and configure').click());
+
+    // Cancel is disabled while the request is in flight, so a still-pending
+    // mutation can never be reset (and left to settle) with the document cached.
+    expect(button(container, 'Cancel').disabled).toBe(true);
+
+    // Edit to a different document while the preview response is still pending.
+    const liveTextarea = container.querySelector<HTMLTextAreaElement>('.saml-editor textarea');
+    if (liveTextarea === null) throw new Error('textarea vanished mid-preview');
+    await act(async () => setNativeValue(liveTextarea, 'DOCUMENT_B'));
+
+    // Now let the preview land; the pending diff is restored despite the edit.
+    await act(async () => {
+      releasePreview?.();
+      await Promise.resolve();
+    });
+    await settleTask();
+    await act(async () => button(container, 'Confirm trust and configure provider').click());
+    await settleTask();
+
+    // The confirm request must carry the previewed document A, never the edit B.
+    const confirmBody = bodies.find((body) => body.includes('confirmed_fingerprints'));
+    if (confirmBody === undefined) throw new Error('confirm request was never sent');
+    expect(confirmBody).toContain('DOCUMENT_A');
+    expect(confirmBody).not.toContain('DOCUMENT_B');
+    await unmount();
+  });
+});
+
+describe('SamlSpKeysPanel retirement gating', () => {
+  const activeKey = { fingerprint: 'sha256:ACTIVE', state: 'active', created_at: '2026-09-01T00:00:00Z' } as const;
+  const retiringKey = { fingerprint: 'sha256:RETIRING', state: 'retiring', created_at: '2026-08-01T00:00:00Z' } as const;
+
+  it('offers compromise-retire only for the active key and ordinary retire only for the retiring key', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const { method, path } = pathOf(args[0]);
+      if (method === 'GET' && path === '/api/v1/instance/saml-sp-keys') {
+        return Promise.resolve(json({ keys: [activeKey, retiringKey] }));
+      }
+      throw new Error(`unexpected ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container, unmount } = await renderForm(<SamlSpKeysPanel />);
+    await settleTask();
+
+    const activeRow = container.querySelector<HTMLElement>('[data-sp-key="sha256:ACTIVE"]');
+    const retiringRow = container.querySelector<HTMLElement>('[data-sp-key="sha256:RETIRING"]');
+    if (activeRow === null || retiringRow === null) throw new Error('key rows missing');
+
+    expect(button(activeRow, 'Compromise-retire')).toBeTruthy();
+    expect([...activeRow.querySelectorAll('button')].some((b) => b.textContent === 'Retire')).toBe(false);
+    expect(button(retiringRow, 'Retire')).toBeTruthy();
+    expect([...retiringRow.querySelectorAll('button')].some((b) => b.textContent === 'Compromise-retire')).toBe(false);
+
+    await unmount();
+  });
+
+  it('surfaces the active-key conflict when the server refuses an ordinary retire', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const { method, path } = pathOf(args[0]);
+      if (method === 'GET' && path === '/api/v1/instance/saml-sp-keys') {
+        return Promise.resolve(json({ keys: [retiringKey] }));
+      }
+      if (method === 'DELETE' && path === '/api/v1/instance/saml-sp-keys/sha256:RETIRING') {
+        return Promise.resolve(json({ code: 'conflict' }, 409));
+      }
+      throw new Error(`unexpected ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    document.cookie = '__Host-hikyo-csrf=token';
+
+    const { container, unmount } = await renderForm(<SamlSpKeysPanel />);
+    await settleTask();
+
+    await act(async () => button(container, 'Retire').click());
+    const confirmInput = container.querySelector<HTMLInputElement>('.danger-zone input');
+    if (confirmInput === null) throw new Error('retire confirm input missing');
+    await act(async () => setNativeValue(confirmInput, 'sha256:RETIRING'));
+    await act(async () => button(container, 'Retire key').click());
+    await settleTask();
+
+    expect(container.textContent).toContain('active signing key');
+    await unmount();
+  });
+});

--- a/web/src/routes/SamlProvidersPanel.tsx
+++ b/web/src/routes/SamlProvidersPanel.tsx
@@ -1,0 +1,649 @@
+import type { SamlMetadataDiff, SamlMetadataSource, SamlProvider } from '@hikyo/client';
+import { useId, useState } from 'react';
+
+import { ApiError } from '../api/client.ts';
+import {
+  samlFailureText,
+  samlProviderInputErrors,
+  useDeleteSamlProvider,
+  usePatchSamlProvider,
+  usePutSamlProvider,
+  useRefreshSamlMetadata,
+  useSamlProviders,
+  type SamlAction,
+  type SamlProviderInputDraft,
+} from '../api/samlProviders.ts';
+import { Alert, Done, Panel, TypedNameConfirm } from './Sections.tsx';
+
+const secondFactor = (error: unknown) => error instanceof ApiError && error.status === 403;
+const nondisclosed = (error: unknown) => error instanceof ApiError && error.status === 404;
+
+/** A refusal reporter keyed to the action, so one panel-wide status can name it. */
+type ReportFailure = (error: unknown, action: SamlAction) => void;
+
+function metadataSourceOf(value: string): SamlMetadataSource {
+  return value === 'url' ? 'url' : 'file';
+}
+
+/**
+ * The SAML provider inventory and lifecycle (#500), a panel on `instance-admin`.
+ *
+ * Endpoint-to-action mapping follows the locked contract's own intent so there
+ * is one obvious surface for each act: PUT creates, refresh-metadata replaces
+ * trust material through the diff-and-confirm ceremony, PATCH changes policy or
+ * disables without demanding unreadable metadata, and DELETE removes. The
+ * metadata document is only ever an input — the read model never returns it, so
+ * it can never be recovered from the browser.
+ */
+export function SamlProvidersPanel() {
+  const providers = useSamlProviders();
+  const [feedback, setFeedback] = useState<{ failure: string | null; done: string | null }>({
+    failure: null,
+    done: null,
+  });
+  const report: ReportFailure = (error, action) =>
+    setFeedback({ failure: samlFailureText(error, action), done: null });
+  const ok = (message: string) => setFeedback({ failure: null, done: message });
+  const clear = () => setFeedback({ failure: null, done: null });
+  const [creating, setCreating] = useState(false);
+
+  return (
+    <Panel id="instance-saml-providers" title="SAML providers">
+      <p>
+        Configure SAML identity providers from pinned metadata. Certificate,
+        endpoint and assurance changes ride a diff-and-confirm ceremony; nothing
+        that changes who can sign in is applied without an explicit
+        confirmation.
+      </p>
+      {providers.isPending ? <p role="status">Loading SAML providers…</p> : null}
+      {secondFactor(providers.error) ? (
+        <Alert>
+          Listing SAML providers needs a second factor and this authority. If
+          you hold it, this session lacks sufficient second-factor assurance;
+          present your authenticator code or passkey in the banner above.
+        </Alert>
+      ) : null}
+      {nondisclosed(providers.error) ? (
+        <p role="status">SAML providers are not disclosed to this session.</p>
+      ) : null}
+      {providers.isError && !secondFactor(providers.error) && !nondisclosed(providers.error) ? (
+        <Alert>{samlFailureText(providers.error, 'list')}</Alert>
+      ) : null}
+      {providers.isSuccess && providers.data.providers.length === 0 ? (
+        <p role="status">No SAML providers are configured.</p>
+      ) : null}
+
+      {feedback.failure !== null ? <Alert>{feedback.failure}</Alert> : null}
+      {feedback.done !== null ? <Done>{feedback.done}</Done> : null}
+
+      {providers.isSuccess
+        ? providers.data.providers.map((provider) => (
+            <ProviderRow
+              key={provider.slug}
+              provider={provider}
+              onDone={ok}
+              onFailure={report}
+              onBusy={clear}
+            />
+          ))
+        : null}
+
+      {creating ? (
+        <ProviderCreateForm
+          onCancel={() => setCreating(false)}
+          onCreated={(slug) => {
+            setCreating(false);
+            ok(`Configured SAML provider ${slug}. It is now listed above.`);
+          }}
+          onFailure={report}
+        />
+      ) : (
+        <div className="instance-create-row">
+          <button
+            type="button"
+            className="btn btn--primary"
+            aria-label="Configure a new SAML provider"
+            onClick={() => {
+              clear();
+              setCreating(true);
+            }}
+          >
+            + configure SAML provider
+          </button>
+          <code className="instance-cli">$ hikyo provider saml add</code>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function severityClass(severity: 'warning' | 'error'): string {
+  return severity === 'error' ? 'settings-tag settings-tag--danger' : 'settings-tag';
+}
+
+function ProviderRow({
+  provider,
+  onDone,
+  onFailure,
+  onBusy,
+}: {
+  provider: SamlProvider;
+  onDone: (message: string) => void;
+  onFailure: ReportFailure;
+  onBusy: () => void;
+}) {
+  const [mode, setMode] = useState<'idle' | 'policy' | 'refresh' | 'remove'>('idle');
+  const remove = useDeleteSamlProvider();
+  const validUntil = provider.metadata_valid_until;
+  const toggle = (next: 'policy' | 'refresh' | 'remove') => {
+    onBusy();
+    setMode((current) => (current === next ? 'idle' : next));
+  };
+
+  return (
+    <div className="settings-row settings-row--stacked" data-saml-provider={provider.slug}>
+      <div className="settings-row__copy">
+        <span className="settings-row__title">{provider.display_name}</span>
+        <span className="settings-row__detail mono">{provider.slug}</span>
+        <span className="settings-row__detail mono">entityID: {provider.entity_id}</span>
+        <span className="settings-row__detail mono">ACS: {provider.acs_url}</span>
+        <span className="settings-row__detail mono">
+          metadata: {provider.metadata_source}
+          {provider.metadata_url ? ` · ${provider.metadata_url}` : ''} ·{' '}
+          {provider.metadata_signed ? 'signed' : 'unsigned'}
+          {validUntil ? ` · valid until ${new Date(validUntil).toLocaleString()}` : ''}
+        </span>
+        <span className="settings-row__detail mono">
+          {provider.signing_certificate_fingerprints.length} signing certificate
+          {provider.signing_certificate_fingerprints.length === 1 ? '' : 's'} ·{' '}
+          {provider.assurance_policy && provider.assurance_policy.length > 0
+            ? `assurance: ${provider.assurance_policy.join(', ')}`
+            : 'single-factor'}{' '}
+          · {provider.allow_email_nameid ? 'email NameID allowed' : 'opaque NameID only'} ·{' '}
+          {provider.force_sign_requests ? 'signed AuthnRequests' : 'metadata-driven signing'}
+        </span>
+        {provider.warnings.map((warning) => (
+          <span
+            className="settings-row__detail"
+            role={warning.severity === 'error' ? 'alert' : 'status'}
+            key={`${warning.code}:${warning.fingerprint ?? ''}`}
+          >
+            <span className={severityClass(warning.severity)}>{warning.severity}</span> {warning.message}
+          </span>
+        ))}
+      </div>
+      <span className="settings-row__spacer" />
+      <span className={provider.enabled ? 'settings-tag' : 'settings-tag settings-tag--danger'}>
+        {provider.enabled ? 'enabled' : 'disabled'}
+      </span>
+      <div className="panel__actions">
+        <button type="button" className="btn" onClick={() => toggle('policy')}>Edit policy</button>
+        <button type="button" className="btn" onClick={() => toggle('refresh')}>Refresh metadata</button>
+        <button type="button" className="btn btn--danger" onClick={() => toggle('remove')}>Remove</button>
+      </div>
+
+      {mode === 'policy' ? (
+        <ProviderPolicyForm
+          provider={provider}
+          onCancel={() => setMode('idle')}
+          onSaved={(message) => {
+            setMode('idle');
+            onDone(message);
+          }}
+          onFailure={onFailure}
+        />
+      ) : null}
+
+      {mode === 'refresh' ? (
+        <RefreshMetadataForm
+          provider={provider}
+          onCancel={() => setMode('idle')}
+          onApplied={() => {
+            setMode('idle');
+            onDone(`Refreshed the metadata for ${provider.slug}. The confirmed trust state is now stored.`);
+          }}
+          onFailure={onFailure}
+        />
+      ) : null}
+
+      {mode === 'remove' ? (
+        <div className="danger-zone">
+          <p className="danger-zone__hint">
+            Removing {provider.slug} deletes every session authenticated through it and
+            withdraws it from the advertised sign-in methods. Locally-authenticated,
+            local-floor access is unaffected. Linked identities from this provider stop
+            resolving to a sign-in. This cannot be undone.
+          </p>
+          <TypedNameConfirm
+            label={`Type ${provider.slug} to remove this provider`}
+            expect={provider.slug}
+            action="Remove provider"
+            hint="The provider slug, exactly."
+            busy={remove.isPending}
+            onConfirm={() =>
+              remove.mutate(provider.slug, {
+                onSuccess: () => {
+                  setMode('idle');
+                  onDone(`Removed SAML provider ${provider.slug}; its sessions are swept and it no longer advertises.`);
+                },
+                onError: (error) => onFailure(error, 'delete-provider'),
+              })
+            }
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ProviderPolicyForm({
+  provider,
+  onCancel,
+  onSaved,
+  onFailure,
+}: {
+  provider: SamlProvider;
+  onCancel: () => void;
+  onSaved: (message: string) => void;
+  onFailure: ReportFailure;
+}) {
+  const patch = usePatchSamlProvider();
+  const nameId = useId();
+  const assuranceId = useId();
+  const [displayName, setDisplayName] = useState(provider.display_name);
+  const [assurance, setAssurance] = useState((provider.assurance_policy ?? []).join('\n'));
+  const [allowEmail, setAllowEmail] = useState(provider.allow_email_nameid);
+  const [forceSign, setForceSign] = useState(provider.force_sign_requests);
+  const [enabled, setEnabled] = useState(provider.enabled);
+
+  const submit = () => {
+    const trimmedName = displayName.trim();
+    if (trimmedName === '') return onFailure(new ApiError(400, 'invalid'), 'update-provider');
+    const policy = assurance
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+    patch.mutate(
+      {
+        slug: provider.slug,
+        patch: {
+          display_name: trimmedName,
+          assurance_policy: policy.length === 0 ? null : policy,
+          allow_email_nameid: allowEmail,
+          force_sign_requests: forceSign,
+          enabled,
+        },
+      },
+      {
+        onSuccess: () =>
+          onSaved(
+            enabled
+              ? `Updated ${provider.slug} policy.`
+              : `Disabled ${provider.slug}; its sessions are swept and it no longer advertises for sign-in.`,
+          ),
+        onError: (error) => onFailure(error, 'update-provider'),
+      },
+    );
+  };
+
+  return (
+    <div className="saml-editor">
+      <p className="field__hint">
+        Policy and disable ride PATCH: the entity ID and pinned metadata are not
+        touched, so no unreadable XML is required to disable a provider.
+      </p>
+      <div className="field">
+        <label htmlFor={nameId}>Display name</label>
+        <input id={nameId} value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
+      </div>
+      <div className="field">
+        <label htmlFor={assuranceId}>Accepted AuthnContextClassRef values (one per line; empty = single-factor)</label>
+        <textarea id={assuranceId} className="mono" rows={2} value={assurance} onChange={(event) => setAssurance(event.target.value)} />
+      </div>
+      <div className="field chk">
+        <input id={`${nameId}-email`} type="checkbox" checked={allowEmail} onChange={(event) => setAllowEmail(event.target.checked)} />
+        <label htmlFor={`${nameId}-email`}>Allow opaque emailAddress NameID values</label>
+      </div>
+      <div className="field chk">
+        <input id={`${nameId}-sign`} type="checkbox" checked={forceSign} onChange={(event) => setForceSign(event.target.checked)} />
+        <label htmlFor={`${nameId}-sign`}>Force signed AuthnRequests</label>
+      </div>
+      <div className="field chk">
+        <input id={`${nameId}-enabled`} type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
+        <label htmlFor={`${nameId}-enabled`}>Enabled (advertises for sign-in)</label>
+      </div>
+      <div className="panel__actions">
+        <button type="button" className="btn" onClick={onCancel}>Cancel</button>
+        <button type="button" className="btn btn--primary" disabled={patch.isPending} onClick={submit}>Save policy</button>
+      </div>
+    </div>
+  );
+}
+
+function MetadataDiff({ diff }: { diff: SamlMetadataDiff }) {
+  const rows: [string, readonly string[]][] = [
+    ['New endpoints', diff.endpoints_added],
+    ['Removed endpoints', diff.endpoints_removed],
+    ['New signing certificates', diff.certs_added_fps],
+    ['Removed signing certificates', diff.certs_removed_fps],
+  ];
+  const anyChange = rows.some(([, values]) => values.length > 0);
+  return (
+    <div className="policy-impact" role="alert">
+      <p>
+        This metadata changes trust state. Nothing has been applied yet — confirm to
+        commit exactly the changes below.
+      </p>
+      {anyChange ? (
+        rows
+          .filter(([, values]) => values.length > 0)
+          .map(([label, values]) => (
+            <div key={label}>
+              <strong>{label}</strong>
+              <ul>{values.map((value) => <li key={value} className="mono">{value}</li>)}</ul>
+            </div>
+          ))
+      ) : (
+        <p>No endpoint or certificate change; only the validity window moves.</p>
+      )}
+      {diff.valid_until ? (
+        <p className="field__hint mono">valid until {new Date(diff.valid_until).toLocaleString()}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type PendingDiff = {
+  readonly diff: SamlMetadataDiff;
+  readonly fingerprints: readonly string[];
+  readonly endpoints: readonly string[];
+};
+
+function RefreshMetadataForm({
+  provider,
+  onCancel,
+  onApplied,
+  onFailure,
+}: {
+  provider: SamlProvider;
+  onCancel: () => void;
+  onApplied: () => void;
+  onFailure: ReportFailure;
+}) {
+  const refresh = useRefreshSamlMetadata();
+  const documentId = useId();
+  const fileBacked = provider.metadata_source === 'file';
+  const [replacement, setReplacement] = useState('');
+  // The pending diff carries the exact document it was computed for; confirming
+  // resends that snapshot, never the live textarea.
+  const [pending, setPending] = useState<{ diff: PendingDiff; document: string | null } | null>(null);
+
+  // Never leave the write-only replacement document behind once the ceremony ends.
+  const finish = () => {
+    setReplacement('');
+    setPending(null);
+    refresh.reset();
+  };
+  const cancel = () => {
+    finish();
+    onCancel();
+  };
+
+  const submit = (document: string | null, confirm: PendingDiff | null) => {
+    refresh.mutate(
+      {
+        slug: provider.slug,
+        metadataDocument: document,
+        ...(confirm ? { confirmedFingerprints: confirm.fingerprints, confirmedEndpoints: confirm.endpoints } : {}),
+      },
+      {
+        onSuccess: (result) => {
+          if (result.applied) {
+            finish();
+            onApplied();
+            return;
+          }
+          setPending({
+            diff: {
+              diff: result.diff,
+              fingerprints: result.required_fingerprints,
+              endpoints: result.required_endpoints,
+            },
+            document,
+          });
+        },
+        onError: (error) => onFailure(error, 'refresh-metadata'),
+      },
+    );
+  };
+
+  const preview = () => {
+    if (fileBacked && replacement.trim() === '') {
+      return onFailure(new ApiError(400, 'missing document'), 'refresh-metadata');
+    }
+    submit(fileBacked ? replacement : null, null);
+  };
+  const confirm = () => {
+    if (pending === null) return;
+    submit(pending.document, pending.diff);
+  };
+
+  return (
+    <div className="saml-editor">
+      <p className="field__hint">
+        {fileBacked
+          ? 'File-backed provider: paste the replacement metadata document.'
+          : 'URL-backed provider: refreshing performs one WebPKI fetch. Off-origin redirects are refused.'}
+      </p>
+      {fileBacked ? (
+        <div className="field">
+          <label htmlFor={documentId}>Replacement metadata XML</label>
+          <textarea
+            id={documentId}
+            className="mono"
+            rows={4}
+            value={replacement}
+            onChange={(event) => {
+              setPending(null);
+              setReplacement(event.target.value);
+            }}
+          />
+        </div>
+      ) : null}
+      {pending ? <MetadataDiff diff={pending.diff.diff} /> : null}
+      <div className="panel__actions">
+        {/* Disabled while a request is in flight: cancel resets the mutation,
+            and resetting a still-pending request would leave it to settle later
+            with the document in cache. */}
+        <button type="button" className="btn" disabled={refresh.isPending} onClick={cancel}>Cancel</button>
+        {pending ? (
+          <button type="button" className="btn btn--danger" disabled={refresh.isPending} onClick={confirm}>
+            Confirm and apply the trust change
+          </button>
+        ) : (
+          <button type="button" className="btn btn--primary" disabled={refresh.isPending} onClick={preview}>
+            {fileBacked ? 'Preview metadata change' : 'Fetch and preview metadata'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProviderCreateForm({
+  onCancel,
+  onCreated,
+  onFailure,
+}: {
+  onCancel: () => void;
+  onCreated: (slug: string) => void;
+  onFailure: ReportFailure;
+}) {
+  const put = usePutSamlProvider();
+  const ids = {
+    slug: useId(),
+    name: useId(),
+    entity: useId(),
+    source: useId(),
+    document: useId(),
+    url: useId(),
+    assurance: useId(),
+  };
+  const [slug, setSlug] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [entityId, setEntityId] = useState('');
+  const [metadataSource, setMetadataSource] = useState<SamlMetadataSource>('file');
+  const [metadataDocument, setMetadataDocument] = useState('');
+  const [metadataUrl, setMetadataUrl] = useState('');
+  const [assurance, setAssurance] = useState('');
+  const [allowEmail, setAllowEmail] = useState(false);
+  const [forceSign, setForceSign] = useState(false);
+  const [enabled, setEnabled] = useState(true);
+  const [clientErrors, setClientErrors] = useState<readonly string[]>([]);
+  // The pending diff carries the EXACT draft it was computed for. Confirming
+  // resends that snapshot, never the live form state — so an edit made while a
+  // preview is in flight can never be applied under an earlier diff's
+  // confirmation (it forces a fresh preview instead).
+  const [pending, setPending] = useState<{ diff: PendingDiff; draft: SamlProviderInputDraft } | null>(null);
+
+  // Never leave the write-only metadata document in the form, the pending
+  // snapshot, or React Query's mutation variables once the ceremony ends.
+  const finish = () => {
+    setMetadataDocument('');
+    setPending(null);
+    put.reset();
+  };
+  const cancel = () => {
+    finish();
+    onCancel();
+  };
+  const clearPending = () => setPending(null);
+
+  const preview = () => {
+    const errors = samlProviderInputErrors({
+      creating: true,
+      slug,
+      displayName,
+      entityId,
+      metadataSource,
+      metadataDocument,
+      metadataUrl,
+    });
+    setClientErrors(errors);
+    if (errors.length > 0) return;
+    const policy = assurance
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+    submit({
+      slug,
+      displayName,
+      entityId,
+      metadataSource,
+      metadataDocument,
+      metadataUrl,
+      assurancePolicy: policy.length === 0 ? null : policy,
+      allowEmailNameid: allowEmail,
+      forceSignRequests: forceSign,
+      enabled,
+    });
+  };
+
+  const confirm = () => {
+    if (pending === null) return;
+    submit({
+      ...pending.draft,
+      confirmedFingerprints: pending.diff.fingerprints,
+      confirmedEndpoints: pending.diff.endpoints,
+    });
+  };
+
+  const submit = (draft: SamlProviderInputDraft) => {
+    put.mutate(draft, {
+      onSuccess: (result) => {
+        if (result.applied) {
+          const created = draft.slug;
+          finish();
+          onCreated(created);
+          return;
+        }
+        setPending({
+          diff: {
+            diff: result.diff,
+            fingerprints: result.required_fingerprints,
+            endpoints: result.required_endpoints,
+          },
+          draft,
+        });
+      },
+      onError: (error) => onFailure(error, 'save-provider'),
+    });
+  };
+
+  return (
+    <div className="saml-editor" data-saml-create>
+      <h3>Configure a SAML provider</h3>
+      <div className="field">
+        <label htmlFor={ids.slug}>Slug (immutable; addresses this provider)</label>
+        <input id={ids.slug} className="mono" value={slug} onChange={(event) => { clearPending(); setSlug(event.target.value); }} />
+      </div>
+      <div className="field">
+        <label htmlFor={ids.name}>Display name</label>
+        <input id={ids.name} value={displayName} onChange={(event) => { clearPending(); setDisplayName(event.target.value); }} />
+      </div>
+      <div className="field">
+        <label htmlFor={ids.entity}>IdP entityID (byte-exact; immutable after create)</label>
+        <input id={ids.entity} className="mono" value={entityId} onChange={(event) => { clearPending(); setEntityId(event.target.value); }} />
+      </div>
+      <div className="field">
+        <label htmlFor={ids.source}>Metadata source</label>
+        <select id={ids.source} value={metadataSource} onChange={(event) => { clearPending(); setMetadataSource(metadataSourceOf(event.target.value)); }}>
+          <option value="file">file — paste XML</option>
+          <option value="url">url — one-shot https fetch</option>
+        </select>
+      </div>
+      {metadataSource === 'file' ? (
+        <div className="field">
+          <label htmlFor={ids.document}>Metadata XML</label>
+          <textarea id={ids.document} className="mono" rows={4} value={metadataDocument} onChange={(event) => { clearPending(); setMetadataDocument(event.target.value); }} />
+        </div>
+      ) : (
+        <div className="field">
+          <label htmlFor={ids.url}>Metadata URL (https only)</label>
+          <input id={ids.url} className="mono" value={metadataUrl} onChange={(event) => { clearPending(); setMetadataUrl(event.target.value); }} />
+        </div>
+      )}
+      <div className="field">
+        <label htmlFor={ids.assurance}>Accepted AuthnContextClassRef values (one per line; empty = single-factor)</label>
+        <textarea id={ids.assurance} className="mono" rows={2} value={assurance} onChange={(event) => setAssurance(event.target.value)} />
+      </div>
+      <div className="field chk">
+        <input id={`${ids.slug}-email`} type="checkbox" checked={allowEmail} onChange={(event) => setAllowEmail(event.target.checked)} />
+        <label htmlFor={`${ids.slug}-email`}>Allow opaque emailAddress NameID values</label>
+      </div>
+      <div className="field chk">
+        <input id={`${ids.slug}-sign`} type="checkbox" checked={forceSign} onChange={(event) => setForceSign(event.target.checked)} />
+        <label htmlFor={`${ids.slug}-sign`}>Force signed AuthnRequests</label>
+      </div>
+      <div className="field chk">
+        <input id={`${ids.slug}-enabled`} type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
+        <label htmlFor={`${ids.slug}-enabled`}>Enabled (advertises for sign-in)</label>
+      </div>
+      {clientErrors.length > 0 ? <Alert>{clientErrors.join(' ')}</Alert> : null}
+      {pending ? <MetadataDiff diff={pending.diff.diff} /> : null}
+      <div className="panel__actions">
+        {/* Disabled while a request is in flight: see RefreshMetadataForm. */}
+        <button type="button" className="btn" disabled={put.isPending} onClick={cancel}>Cancel</button>
+        {pending ? (
+          <button type="button" className="btn btn--danger" disabled={put.isPending} onClick={confirm}>
+            Confirm trust and configure provider
+          </button>
+        ) : (
+          <button type="button" className="btn btn--primary" disabled={put.isPending} onClick={preview}>
+            Preview and configure
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/SamlSpKeysPanel.tsx
+++ b/web/src/routes/SamlSpKeysPanel.tsx
@@ -1,0 +1,213 @@
+import type { SamlSpKey } from '@hikyo/client';
+import { useState } from 'react';
+
+import { ApiError } from '../api/client.ts';
+import {
+  samlFailureText,
+  useCompromiseRetireSamlSpKey,
+  useRetireSamlSpKey,
+  useRotateSamlSpKey,
+  useSamlSpKeys,
+  type SamlAction,
+} from '../api/samlProviders.ts';
+import { Alert, Done, Panel, TypedNameConfirm } from './Sections.tsx';
+
+const secondFactor = (error: unknown) => error instanceof ApiError && error.status === 403;
+const nondisclosed = (error: unknown) => error instanceof ApiError && error.status === 404;
+
+/**
+ * SAML SP signing-key lifecycle (#500), a panel on `instance-admin`.
+ *
+ * Two retirements with distinct ceremonies and consequences: ordinary
+ * retirement erases an already-`retiring` key (rotate first, hence the active
+ * key refuses retirement), and compromise-retirement erases and replaces the
+ * ACTIVE key with no overlap window. Only fingerprints and lifecycle state are
+ * ever shown — private key material never leaves the server.
+ */
+export function SamlSpKeysPanel() {
+  const keys = useSamlSpKeys();
+  const [feedback, setFeedback] = useState<{ failure: string | null; done: string | null }>({
+    failure: null,
+    done: null,
+  });
+  const rotate = useRotateSamlSpKey();
+  const report = (error: unknown, action: SamlAction) =>
+    setFeedback({ failure: samlFailureText(error, action), done: null });
+  const ok = (message: string) => setFeedback({ failure: null, done: message });
+  const clear = () => setFeedback({ failure: null, done: null });
+
+  return (
+    <Panel id="instance-saml-sp-keys" title="SAML SP signing keys">
+      <p>
+        The service provider signs its AuthnRequests with these keys. Both the
+        active and any overlap-retiring certificate stay published in SP metadata
+        until the retiring one is explicitly erased, so an IdP never rejects a
+        signature mid-rotation.
+      </p>
+      {keys.isPending ? <p role="status">Loading SP signing keys…</p> : null}
+      {secondFactor(keys.error) ? (
+        <Alert>
+          Reading SP signing keys needs a second factor and this authority. If
+          you hold it, present your authenticator code or passkey in the banner
+          above.
+        </Alert>
+      ) : null}
+      {nondisclosed(keys.error) ? (
+        <p role="status">SP signing keys are not disclosed to this session.</p>
+      ) : null}
+      {keys.isError && !secondFactor(keys.error) && !nondisclosed(keys.error) ? (
+        <Alert>{samlFailureText(keys.error, 'list')}</Alert>
+      ) : null}
+
+      {feedback.failure !== null ? <Alert>{feedback.failure}</Alert> : null}
+      {feedback.done !== null ? <Done>{feedback.done}</Done> : null}
+
+      {keys.isSuccess
+        ? keys.data.keys.map((key) => (
+            <SpKeyRow key={key.fingerprint} spKey={key} onDone={ok} onFailure={report} onBusy={clear} />
+          ))
+        : null}
+
+      <div className="panel__actions">
+        <button
+          type="button"
+          className="btn btn--primary"
+          disabled={rotate.isPending || !keys.isSuccess}
+          onClick={() => {
+            clear();
+            rotate.mutate(undefined, {
+              onSuccess: (result) =>
+                ok(
+                  `Rotated the SP signing key. The new active key is ${result.fingerprint}; the previous key is now retiring and stays in metadata until you retire it.`,
+                ),
+              onError: (error) => report(error, 'rotate-key'),
+            });
+          }}
+        >
+          Rotate the active signing key
+        </button>
+        <code className="instance-cli">$ hikyo saml sp-key rotate</code>
+      </div>
+      <p className="field__hint">
+        Rotation marks the current active key retiring and publishes a new active
+        key. Both certificates remain in SP metadata for the overlap window, so
+        signature validation never breaks. Retire the old key once every IdP has
+        seen the new one.
+      </p>
+    </Panel>
+  );
+}
+
+function SpKeyRow({
+  spKey,
+  onDone,
+  onFailure,
+  onBusy,
+}: {
+  spKey: SamlSpKey;
+  onDone: (message: string) => void;
+  onFailure: (error: unknown, action: SamlAction) => void;
+  onBusy: () => void;
+}) {
+  const [mode, setMode] = useState<'idle' | 'retire' | 'compromise'>('idle');
+  const retire = useRetireSamlSpKey();
+  const compromise = useCompromiseRetireSamlSpKey();
+  const active = spKey.state === 'active';
+
+  return (
+    <div className="settings-row settings-row--stacked" data-sp-key={spKey.fingerprint}>
+      <div className="settings-row__copy">
+        <span className="settings-row__title mono">{spKey.fingerprint}</span>
+        <span className="settings-row__detail">
+          {active
+            ? 'Active: signs every AuthnRequest right now.'
+            : 'Retiring: still published in metadata for the overlap window; erase it once every IdP trusts the new active key.'}
+        </span>
+        <span className="settings-row__detail mono">created {new Date(spKey.created_at).toLocaleString()}</span>
+      </div>
+      <span className="settings-row__spacer" />
+      <span className={active ? 'settings-tag' : 'settings-tag settings-tag--danger'}>{spKey.state}</span>
+      <div className="panel__actions">
+        {active ? (
+          <button
+            type="button"
+            className="btn btn--danger"
+            onClick={() => {
+              onBusy();
+              setMode((current) => (current === 'compromise' ? 'idle' : 'compromise'));
+            }}
+          >
+            Compromise-retire
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn btn--danger"
+            onClick={() => {
+              onBusy();
+              setMode((current) => (current === 'retire' ? 'idle' : 'retire'));
+            }}
+          >
+            Retire
+          </button>
+        )}
+      </div>
+
+      {mode === 'retire' ? (
+        <div className="danger-zone">
+          <p className="danger-zone__hint">
+            Retiring erases this key and removes its certificate from SP metadata now.
+            An IdP that has not yet seen the current active key will start rejecting
+            signatures. This is the ordinary end of an overlap window and cannot be
+            undone.
+          </p>
+          <TypedNameConfirm
+            label="Type the fingerprint to erase this retiring key"
+            expect={spKey.fingerprint}
+            action="Retire key"
+            hint="The full sha256: fingerprint, exactly."
+            busy={retire.isPending}
+            onConfirm={() =>
+              retire.mutate(spKey.fingerprint, {
+                onSuccess: () => {
+                  setMode('idle');
+                  onDone(`Retired ${spKey.fingerprint}; it is erased and gone from SP metadata.`);
+                },
+                onError: (error) => onFailure(error, 'retire-key'),
+              })
+            }
+          />
+        </div>
+      ) : null}
+
+      {mode === 'compromise' ? (
+        <div className="danger-zone">
+          <p className="danger-zone__hint">
+            Compromise retirement erases this active key immediately and mints a
+            replacement with NO overlap window. Any AuthnRequest already in flight
+            signed with this key will fail. Use this only when the private key may be
+            exposed; for a planned rotation, rotate instead. This cannot be undone.
+          </p>
+          <TypedNameConfirm
+            label="Type the fingerprint to erase and replace the compromised key"
+            expect={spKey.fingerprint}
+            action="Compromise-retire key"
+            hint="The full sha256: fingerprint, exactly."
+            busy={compromise.isPending}
+            onConfirm={() =>
+              compromise.mutate(spKey.fingerprint, {
+                onSuccess: (result) => {
+                  setMode('idle');
+                  onDone(
+                    `Erased the compromised key and minted a replacement. The new active key is ${result.fingerprint}, published with no overlap window.`,
+                  );
+                },
+                onError: (error) => onFailure(error, 'compromise-retire-key'),
+              })
+            }
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #500.

## What

Adds full browser administration of SAML identity providers and SP signing keys as two panels on the existing `instance-admin` surface. **WebUI-only** — the Go backend and generated TS operations already existed on `main`; no server code, no `api/openapi.yaml` change, no codegen, no new route (so no registry/CI-grouping surface added).

## Providers (`SamlProvidersPanel`)

- Inventory with freshness/status and certificate/metadata warnings, safely rendered (metadata & cert material are public-class).
- **Create** through the metadata diff-and-confirm ceremony (`PUT`): a first request previews the trust diff; confirming reruns with `confirmed_fingerprints`/`confirmed_endpoints`.
- **Replace** trust material through the same ceremony (`refresh-metadata`) — file-backed supplies a replacement document, URL-backed re-fetches.
- **Policy / disable** via `PATCH` so no unreadable metadata is demanded to disable.
- **Delete** behind a typed-name gate stating the session-sweep and local-floor-preserving consequence.

## SP keys (`SamlSpKeysPanel`)

- Active/retiring inventory explaining each state and rotation consequence.
- **Rotate** with an overlap window.
- **Ordinary retire** (offered only on `retiring` keys — the server 409s the active key, surfaced as "rotate first") and **compromise-retire** (offered only on the `active` key) as distinct protected ceremonies with distinct refusal copy.

## Contract decisions (no server change)

- **Endpoint-to-action mapping** follows the contract's own intent: PUT create-only, refresh-metadata for trust replacement, PATCH for policy/disable, DELETE for removal.
- **The delete "impact preview" is ceremony copy, not a computed preview** — no impact-preview API exists (matches OIDC delete). Documented so it is not read as unimplemented.
- **Write-only discipline**: metadata XML is only ever an input — cleared from the form, the pending snapshot, and React Query's mutation cache (`gcTime: 0` + `reset()`, with Cancel disabled while a request is in flight) once the ceremony ends. The state machine confirms the exact previewed document, never live form state, so an edit mid-preview forces a fresh preview.
- **Refusals**: a 403 preserves the grant-refusal-or-step-up ambiguity; only a 400 carries a caller-safe detail.

## Regenerated artifacts

None — no codegen.

## Tests

- `web/src/api/samlProviders.test.ts` — validation + per-action failure text.
- `web/src/routes/SamlAdmin.test.tsx` — the diff-and-confirm state machine (incl. the mutation-cache and in-flight-edit properties) and state-gated retirement.
- `web/e2e/flows/instance-admin.spec.ts` — end-to-end journey (create → refresh → login-availability probe via public `/auth/methods` → rotate → retire → compromise-retire → delete → availability gone), plus the two new panels in the password-only second-factor refusal array.

## Validation

- `pnpm --dir web typecheck` — clean.
- `pnpm --dir web test` — 71 files / 573 tests green.
- `pnpm --dir web build` — clean.
- Playwright instance-admin journey — desktop + mobile green (separate instances).
- Cross-model review (Codex, high effort, 3 rounds) — **CLEAN**.

Handoff: `docs/handoff/500-saml-admin-webui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)