### PR TITLE
feat(web): complete federated workload identity administration in the WebUI (#497)

### DIFF
--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -735,8 +735,9 @@ test.describe('instance administration', () => {
 
     // Configure a NEW, never-bound issuer. Discovery mode needs no JWKS
     // document, and the create runs no outbound fetch, so an unreachable host
-    // is fine here.
-    const newIssuer = 'https://e2e-federation.example.org';
+    // is fine here. The host carries the project name so the desktop and mobile
+    // runs never name the same issuer.
+    const newIssuer = `https://e2e-federation-${test.info().project.name}.example.org`;
     await federation.getByRole('button', { name: 'Configure issuer' }).click();
     const createForm = federation.locator('fieldset', {
       hasText: 'Configure a federation issuer',
@@ -759,14 +760,18 @@ test.describe('instance administration', () => {
     await editForm.getByRole('button', { name: 'Save issuer' }).click();
     await expect(federation.locator('.notice')).toContainText('Updated');
 
-    // The seeded issuer's delete FAILS CLOSED: a binding still names it.
-    await seedRow.getByRole('button', { name: 'Delete' }).click();
-    await seedRow.getByRole('button', { name: 'Delete issuer' }).click();
-    await expect(federation.getByRole('alert')).toContainText('live or revoked');
+    // The seeded issuer FAILS CLOSED: a binding names it, so the confirmation
+    // explains deletion is permanently unavailable and offers NO destructive
+    // action. A revoked binding would still count, so this can never reach zero.
+    await seedRow.getByRole('button', { name: 'Delete', exact: true }).click();
+    await expect(seedRow).toContainText('cannot be deleted');
+    await expect(seedRow.getByRole('button', { name: 'Delete issuer' })).toHaveCount(0);
+    await seedRow.getByRole('button', { name: 'Close' }).click();
     await expect(federation).toContainText(seed.machine.issuer);
 
-    // The never-bound issuer deletes cleanly.
-    await newRow.getByRole('button', { name: 'Delete' }).click();
+    // The never-bound issuer deletes cleanly — the destructive action is
+    // present only because its census is zero.
+    await newRow.getByRole('button', { name: 'Delete', exact: true }).click();
     await newRow.getByRole('button', { name: 'Delete issuer' }).click();
     await expect(federation.locator('.notice')).toContainText('Deleted');
     await expect(federation.locator('li.settings-row', { hasText: newIssuer })).toHaveCount(0);

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -547,6 +547,7 @@ test.describe('instance administration', () => {
         ['#instance-oidc', 'needs a second factor', '+ add identity provider'],
         ['#instance-saml-providers', 'needs a second factor', 'No SAML providers are configured'],
         ['#instance-saml-sp-keys', 'needs a second factor', 'signs every AuthnRequest'],
+        ['#instance-federation', 'needs a second factor', 'Configure issuer'],
       ] as const;
       for (const [selector, refusalText, forbiddenText] of panels) {
         const panel = page.locator(selector);
@@ -719,6 +720,56 @@ test.describe('instance administration', () => {
     await editor.getByLabel('Client secret').fill('whatever-secret');
     await editor.getByRole('button', { name: 'Save provider' }).click();
     await expect(panel.getByRole('alert')).toContainText('changed underneath you');
+  });
+
+  test('configures, edits and deletes a federation issuer, and fails closed while one is bound', async ({
+    page,
+  }) => {
+    const federation = page.locator('#instance-federation');
+
+    // The seeded issuer is listed with the census that fails a delete closed:
+    // web-api is bound to it, so at least one binding names it.
+    await expect(federation).toContainText(seed.machine.issuer);
+    const seedRow = federation.locator('li.settings-row', { hasText: seed.machine.issuer });
+    await expect(seedRow).toContainText('binding');
+
+    // Configure a NEW, never-bound issuer. Discovery mode needs no JWKS
+    // document, and the create runs no outbound fetch, so an unreachable host
+    // is fine here.
+    const newIssuer = 'https://e2e-federation.example.org';
+    await federation.getByRole('button', { name: 'Configure issuer' }).click();
+    const createForm = federation.locator('fieldset', {
+      hasText: 'Configure a federation issuer',
+    });
+    await createForm.getByLabel('Issuer (https URL, matched byte-for-byte)').fill(newIssuer);
+    await createForm.getByLabel('Platform type').selectOption('github-actions');
+    await createForm.getByLabel('Refused audiences, one per line').fill('example-owner');
+    await createForm.getByRole('button', { name: 'Configure issuer' }).click();
+
+    await expect(federation.locator('.notice')).toContainText('Configured');
+    const newRow = federation.locator('li.settings-row', { hasText: newIssuer });
+    await expect(newRow).toContainText('no bindings name it');
+
+    // Edit the mutable half: the issuer string and platform type are shown
+    // read-only, and only the refused audiences move.
+    await newRow.getByRole('button', { name: 'Edit' }).click();
+    const editForm = federation.locator('fieldset', { hasText: `Edit ${newIssuer}` });
+    await expect(editForm.getByRole('textbox', { name: 'Issuer' })).toHaveCount(0);
+    await editForm.getByLabel('Refused audiences, one per line').fill('example-owner\nsecond-owner');
+    await editForm.getByRole('button', { name: 'Save issuer' }).click();
+    await expect(federation.locator('.notice')).toContainText('Updated');
+
+    // The seeded issuer's delete FAILS CLOSED: a binding still names it.
+    await seedRow.getByRole('button', { name: 'Delete' }).click();
+    await seedRow.getByRole('button', { name: 'Delete issuer' }).click();
+    await expect(federation.getByRole('alert')).toContainText('live or revoked');
+    await expect(federation).toContainText(seed.machine.issuer);
+
+    // The never-bound issuer deletes cleanly.
+    await newRow.getByRole('button', { name: 'Delete' }).click();
+    await newRow.getByRole('button', { name: 'Delete issuer' }).click();
+    await expect(federation.locator('.notice')).toContainText('Deleted');
+    await expect(federation.locator('li.settings-row', { hasText: newIssuer })).toHaveCount(0);
   });
 
   for (const scheme of ['dark', 'light'] as const) {

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -442,6 +442,58 @@ test.describe('machine access', () => {
     await expect(dialog).toBeHidden();
   });
 
+  test('replaces a binding atomically, then revokes it', async () => {
+    // A binding is matched globally on (issuer, subject), so a subject unique to
+    // this Playwright project keeps the desktop and mobile runs from colliding
+    // on the same identity. The test revokes what it minted at the end.
+    const subject = `system:serviceaccount:hikyo-system:e2e-replace-${test.info().project.name}`;
+    const account = seed.machine.mintable;
+
+    await page.getByRole('tab', { name: 'Federation' }).click();
+    await page.getByRole('button', { name: 'New binding' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Bind on the mintable account — it has no grants, so the replacement's
+    // post-state reach is empty and no reauthentication ceremony runs. The
+    // Kubernetes preset fills the configured issuer and the required UID pin.
+    await dialog.getByLabel('Service account').selectOption({ label: account });
+    await expect(dialog.getByLabel('Issuer')).toHaveValue(seed.machine.issuer);
+    await dialog.getByLabel('Subject, matched byte-for-byte').fill(subject);
+    await dialog.getByLabel(/ServiceAccount UID/).fill('e2e-replace-uid');
+    await dialog.getByLabel('Audience').fill(seed.machine.audience);
+    await dialog.getByRole('button', { name: 'Bind this identity' }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page.locator('.notice').filter({ hasText: 'Bound' })).toBeVisible();
+
+    const card = page.locator('.bindrow', { hasText: subject });
+    await expect(card).toBeVisible();
+
+    // Replace: the dialog is retitled, the account is LOCKED to the
+    // predecessor's, and the fields are seeded from it. The server revokes the
+    // predecessor and inserts the successor in one transaction.
+    await card.getByRole('button', { name: `Replace binding on ${account}` }).click();
+    const replace = page.getByRole('dialog');
+    await expect(
+      replace.getByRole('heading', { name: 'Replace federated binding' }),
+    ).toBeVisible();
+    await expect(replace.getByLabel('Service account')).toBeDisabled();
+    await expect(replace.getByLabel('Issuer')).toHaveValue(seed.machine.issuer);
+    await expect(replace.getByLabel('Subject, matched byte-for-byte')).toHaveValue(subject);
+    await replace.getByLabel('Binding lifetime').selectOption('90d');
+    await replace.getByRole('button', { name: 'Replace this binding' }).click();
+    await expect(replace).toBeHidden();
+    await expect(page.locator('.notice').filter({ hasText: 'Replaced' })).toBeVisible();
+
+    // Exactly one live binding carries the subject now — the predecessor was
+    // revoked, so it is gone from the list. Revoke the successor to leave the
+    // seed inventory as it was.
+    const successor = page.locator('.bindrow', { hasText: subject });
+    await expect(successor).toHaveCount(1);
+    await successor.getByRole('button', { name: `Revoke binding on ${account}` }).click();
+    await expect(page.locator('.bindrow', { hasText: subject })).toHaveCount(0);
+  });
+
   for (const scheme of ['dark', 'light'] as const) {
     test(`meets the pinned assertion set on the inventory (${scheme})`, async () => {
       await page.emulateMedia({ colorScheme: scheme });

--- a/web/src/api/federationIssuers.test.ts
+++ b/web/src/api/federationIssuers.test.ts
@@ -84,8 +84,9 @@ describe('issuer refusal mappers', () => {
     expect(text).not.toMatch(/disclosure/);
   });
 
-  it('has no duplicate case on update — the issuer string cannot move', () => {
-    expect(issuerUpdateRefusalText(new ApiError(404, 'x'))).toMatch(/no longer here/);
+  it('reads a 404 as the ambiguous absent-or-masked shape, not a bare deletion', () => {
+    expect(issuerUpdateRefusalText(new ApiError(404, 'x'))).toMatch(/not disclosed to this session/);
+    expect(issuerDeleteRefusalText(new ApiError(404, 'x'))).toMatch(/not disclosed to this session/);
   });
 
   it('names a delete 409 as the still-naming bindings, live or revoked', () => {

--- a/web/src/api/federationIssuers.test.ts
+++ b/web/src/api/federationIssuers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './client.ts';
+import {
+  isHttpsIssuer,
+  issuerCreateRefusalText,
+  issuerDeleteRefusalText,
+  issuerFieldRefusal,
+  issuerUpdateRefusalText,
+} from './federationIssuers.ts';
+
+/**
+ * The federation-issuer surface's pure gates. Each is where a wrong answer is a
+ * SECURITY statement — an http issuer admitted, a delete promised that the
+ * server refuses, a default-audience list left empty — so they are pinned here
+ * rather than inferred from a screenshot.
+ */
+
+describe('isHttpsIssuer', () => {
+  it('accepts an https URL with a host and nothing else', () => {
+    expect(isHttpsIssuer('https://token.actions.githubusercontent.com')).toBe(true);
+    expect(isHttpsIssuer('https://kubernetes.default.svc.cluster.local')).toBe(true);
+  });
+
+  it('refuses http, so federation trust never rests on the network path', () => {
+    expect(isHttpsIssuer('http://token.actions.githubusercontent.com')).toBe(false);
+  });
+
+  it('refuses userinfo, query and fragment — each would be disclosed byte-exact', () => {
+    expect(isHttpsIssuer('https://user:secret@host')).toBe(false);
+    expect(isHttpsIssuer('https://host?x=1')).toBe(false);
+    expect(isHttpsIssuer('https://host#frag')).toBe(false);
+  });
+
+  it('refuses a non-URL and an empty host', () => {
+    expect(isHttpsIssuer('not a url')).toBe(false);
+    expect(isHttpsIssuer('https://')).toBe(false);
+  });
+});
+
+describe('issuerFieldRefusal', () => {
+  const base = {
+    jwksMode: 'discovery' as const,
+    staticJwks: '',
+    refusedAudiences: ['sts.amazonaws.com'],
+  };
+
+  it('passes a well-formed create', () => {
+    expect(issuerFieldRefusal({ issuer: 'https://host', ...base })).toBeNull();
+  });
+
+  it('passes an update, which supplies no issuer to validate', () => {
+    expect(issuerFieldRefusal(base)).toBeNull();
+  });
+
+  it('refuses a non-https issuer only when the issuer is supplied', () => {
+    expect(issuerFieldRefusal({ issuer: 'http://host', ...base })).toMatch(/https/);
+  });
+
+  it('refuses an empty refused-audience list', () => {
+    expect(issuerFieldRefusal({ ...base, refusedAudiences: [''] })).toMatch(/refused audience/);
+  });
+
+  it('refuses an audience carrying a line break — newline is the separator', () => {
+    expect(issuerFieldRefusal({ ...base, refusedAudiences: ['a\nb'] })).toMatch(/line break/);
+  });
+
+  it('requires the JWKS document under static mode, and only then', () => {
+    expect(issuerFieldRefusal({ ...base, jwksMode: 'static', staticJwks: '   ' })).toMatch(/Static/);
+    expect(
+      issuerFieldRefusal({ ...base, jwksMode: 'static', staticJwks: '{"keys":[]}' }),
+    ).toBeNull();
+  });
+});
+
+describe('issuer refusal mappers', () => {
+  it('names a create 409 as a duplicate byte-exact issuer', () => {
+    expect(issuerCreateRefusalText(new ApiError(409, 'x'))).toMatch(/already configured/);
+  });
+
+  it('names a create 403 as the instance-config second factor, never a disclosure', () => {
+    const text = issuerCreateRefusalText(new ApiError(403, 'x'));
+    expect(text).toMatch(/second factor/);
+    expect(text).not.toMatch(/disclosure/);
+  });
+
+  it('has no duplicate case on update — the issuer string cannot move', () => {
+    expect(issuerUpdateRefusalText(new ApiError(404, 'x'))).toMatch(/no longer here/);
+  });
+
+  it('names a delete 409 as the still-naming bindings, live or revoked', () => {
+    expect(issuerDeleteRefusalText(new ApiError(409, 'x'))).toMatch(/live or revoked/);
+  });
+});

--- a/web/src/api/federationIssuers.ts
+++ b/web/src/api/federationIssuers.ts
@@ -171,7 +171,7 @@ export function issuerUpdateRefusalText(error: unknown): string {
       case 403:
         return 'Editing a federation issuer is instance-config work and needs a second factor. Present your authenticator code or passkey in the banner above. Nothing was changed.';
       case 404:
-        return 'That issuer is no longer here — someone may have deleted it already. Nothing was changed.';
+        return 'That issuer is absent, or not disclosed to this session — the two are the same uniform response. Nothing was changed.';
       case 429:
         return 'Too many requests right now. Wait a moment and try again.';
       default:
@@ -195,9 +195,9 @@ export function issuerDeleteRefusalText(error: unknown): string {
       case 403:
         return 'Deleting a federation issuer is instance-config work and needs a second factor. Present your authenticator code or passkey in the banner above.';
       case 404:
-        return 'That issuer is no longer here — someone may have deleted it already.';
+        return 'That issuer is absent, or not disclosed to this session — the two are the same uniform response.';
       case 409:
-        return 'This issuer still has bindings naming it — live or revoked. Revoke every one from Machine Access first; the delete stays refused until none remain, because erasing the issuer erases what those bindings trusted.';
+        return 'This issuer has bindings naming it — live or revoked — so it cannot be deleted. That binding history is append-only and never reaches zero once an issuer has been used, because erasing the issuer would erase what those bindings trusted.';
       case 429:
         return 'Too many requests right now. Wait a moment and try again.';
       default:

--- a/web/src/api/federationIssuers.ts
+++ b/web/src/api/federationIssuers.ts
@@ -1,0 +1,258 @@
+import {
+  createFederationIssuerOp,
+  deleteFederationIssuerOp,
+  listFederationIssuersOp,
+  updateFederationIssuerOp,
+} from '@hikyo/operations';
+import { zFederationIssuerList } from '@hikyo/zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { z } from 'zod';
+
+import { ApiError, ok, parsed } from './client.ts';
+
+/**
+ * The federation-issuer surface, instance-scoped and MFA-mandatory
+ * (`instance-config@instance`). It is deliberately NOT the project machine
+ * surface: an issuer is one external authority the whole instance trusts, and
+ * an org- or project-scoped issuer would let a tenant admit a new external
+ * identity provider the instance never reviewed.
+ *
+ * Two rules the ADRs put here rather than in the component:
+ *
+ *  - **`static_jwks` never round-trips.** The read shape has no such member —
+ *    the document is configuration an operator supplied and can re-supply — so
+ *    the editor field is always blank and, under `static` mode, always
+ *    re-entered. There is no keep-the-old-document path, and there cannot be
+ *    one that silently retains a key set nobody rotates.
+ *  - **Delete is fail-closed on every naming binding, live OR historical.** The
+ *    server refuses a delete while any binding names the issuer, revoked
+ *    included: erasing the issuer a past binding trusted erases what it trusted.
+ *    The `live_bindings` count carries that same census so an operator sees the
+ *    blast radius before attempting a delete.
+ */
+
+export type FederationIssuer = z.infer<typeof zFederationIssuerList>['items'][number];
+export type FederationIssuerType = FederationIssuer['issuer_type'];
+export type FederationJwksMode = FederationIssuer['jwks_mode'];
+
+const issuersKey = ['federation-issuers'] as const;
+
+export function useFederationIssuers() {
+  return useQuery({
+    queryKey: issuersKey,
+    queryFn: () => parsed(listFederationIssuersOp, {}),
+    retry: false,
+  });
+}
+
+/**
+ * useCreateFederationIssuer configures one issuer. `static_jwks` is sent IFF
+ * the mode is `static`: the wire schema refuses additional properties, so a
+ * document carried under `discovery` would be a 400, and a document dropped
+ * under `static` is the key set nobody rotates.
+ */
+export function useCreateFederationIssuer() {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      issuer: string;
+      issuerType: FederationIssuerType;
+      jwksMode: FederationJwksMode;
+      staticJwks?: string;
+      refusedAudiences: readonly string[];
+    }) =>
+      parsed(createFederationIssuerOp, {
+        body: {
+          issuer: input.issuer,
+          issuer_type: input.issuerType,
+          jwks_mode: input.jwksMode,
+          ...(input.jwksMode === 'static' && input.staticJwks !== undefined
+            ? { static_jwks: input.staticJwks }
+            : {}),
+          refused_audiences: [...input.refusedAudiences],
+        },
+      }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: issuersKey });
+    },
+  });
+}
+
+/**
+ * useUpdateFederationIssuer moves the MUTABLE half only — the JWKS source and
+ * the refused audiences. The issuer string and platform type are absent on
+ * purpose: changing either is a replacement, not an edit, and the request
+ * schema has no member for them.
+ */
+export function useUpdateFederationIssuer() {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      id: string;
+      jwksMode: FederationJwksMode;
+      staticJwks?: string;
+      refusedAudiences: readonly string[];
+    }) =>
+      parsed(updateFederationIssuerOp, {
+        path: { issuer: input.id },
+        body: {
+          jwks_mode: input.jwksMode,
+          ...(input.jwksMode === 'static' && input.staticJwks !== undefined
+            ? { static_jwks: input.staticJwks }
+            : {}),
+          refused_audiences: [...input.refusedAudiences],
+        },
+      }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: issuersKey });
+    },
+  });
+}
+
+/**
+ * useDeleteFederationIssuer removes one configuration. The server refuses it
+ * with a 409 while any binding names the issuer — live or historical — so the
+ * caller shows the `live_bindings` census first and revokes those bindings
+ * before the delete can land.
+ */
+export function useDeleteFederationIssuer() {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      ok(deleteFederationIssuerOp, {
+        path: { issuer: id },
+      }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: issuersKey });
+    },
+  });
+}
+
+/**
+ * issuerCreateRefusalText names a create refusal in the create verb's OWN
+ * vocabulary — every status, never delegating. A 409 is a duplicate issuer
+ * (matched byte-exact); a 403 is the instance-config second factor, never a
+ * disclosure capability; a 404 is the authorization mask.
+ */
+export function issuerCreateRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return 'The server refused that issuer. Check the https URL, the JWKS document under static mode, and that every refused audience is a non-empty single line. Nothing was configured.';
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before configuring an issuer.';
+      case 403:
+        return 'Configuring a federation issuer is instance-config work and needs a second factor. Present your authenticator code or passkey in the banner above. Nothing was configured.';
+      case 404:
+        return 'You may not administer this instance’s configuration. Nothing was configured.';
+      case 409:
+        return 'An issuer with that exact URL is already configured. The match is byte-exact, so a trailing slash is a different issuer. Nothing was configured.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The issuer could not be configured (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The issuer could not be configured.';
+}
+
+/**
+ * issuerUpdateRefusalText names an update refusal. It has no 409: the issuer
+ * string and platform type cannot move, so there is no duplicate to conflict
+ * with. A 404 means the issuer was deleted underneath the edit.
+ */
+export function issuerUpdateRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return 'The server refused that change. Check the JWKS document under static mode and that every refused audience is a non-empty single line. Nothing was changed.';
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before editing an issuer.';
+      case 403:
+        return 'Editing a federation issuer is instance-config work and needs a second factor. Present your authenticator code or passkey in the banner above. Nothing was changed.';
+      case 404:
+        return 'That issuer is no longer here — someone may have deleted it already. Nothing was changed.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The issuer could not be changed (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The issuer could not be changed.';
+}
+
+/**
+ * issuerDeleteRefusalText names a delete refusal. The 409 is the load-bearing
+ * one: the delete is refused while any binding names the issuer, live or
+ * revoked, because erasing the issuer a past binding trusted erases what it
+ * trusted. The operator revokes those bindings first.
+ */
+export function issuerDeleteRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before deleting an issuer.';
+      case 403:
+        return 'Deleting a federation issuer is instance-config work and needs a second factor. Present your authenticator code or passkey in the banner above.';
+      case 404:
+        return 'That issuer is no longer here — someone may have deleted it already.';
+      case 409:
+        return 'This issuer still has bindings naming it — live or revoked. Revoke every one from Machine Access first; the delete stays refused until none remain, because erasing the issuer erases what those bindings trusted.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The issuer could not be deleted (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The issuer could not be deleted.';
+}
+
+/**
+ * issuerFieldRefusal is the create/update form's client-side gate, refused HERE
+ * rather than as a 400 so an operator meets each rule as a form. It mirrors the
+ * server's `checkIssuerRequest` byte-for-byte: an https URL with a host and no
+ * userinfo, query or fragment, and at least one non-empty single-line refused
+ * audience. The issuer is only validated when supplied (create), since update
+ * cannot move it.
+ */
+export function issuerFieldRefusal(input: {
+  issuer?: string;
+  jwksMode: FederationJwksMode;
+  staticJwks: string;
+  refusedAudiences: readonly string[];
+}): string | null {
+  if (input.issuer !== undefined) {
+    if (!isHttpsIssuer(input.issuer)) {
+      return 'The issuer must be an https URL with a host and nothing else — no user, no query, no fragment. Discovery and JWKS are fetched from it, so http would rest the instance’s whole federation trust on the network path. Nothing was saved.';
+    }
+  }
+  const audiences = input.refusedAudiences.filter((a) => a !== '');
+  if (audiences.length === 0) {
+    return 'At least one refused audience is required: the default-audience rule turns on the instance knowing what the default is, and it is not derivable. Nothing was saved.';
+  }
+  if (audiences.some((a) => /[\n\r]/.test(a))) {
+    return 'A refused audience may not contain a line break — newline is the storage separator, so one value would split into two. Nothing was saved.';
+  }
+  if (input.jwksMode === 'static' && input.staticJwks.trim() === '') {
+    return 'Static mode requires the JWKS document: it is the key set this instance verifies against, and there is no discovery endpoint to fetch it from. Nothing was saved.';
+  }
+  return null;
+}
+
+/** isHttpsIssuer mirrors the server's OIDC issuer grammar exactly. */
+export function isHttpsIssuer(issuer: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(issuer);
+  } catch {
+    return false;
+  }
+  return (
+    url.protocol === 'https:' &&
+    url.host !== '' &&
+    url.username === '' &&
+    url.password === '' &&
+    url.search === '' &&
+    url.hash === ''
+  );
+}

--- a/web/src/api/identities.ts
+++ b/web/src/api/identities.ts
@@ -330,6 +330,13 @@ export function useCreateBinding(p: ProjectRef) {
       audience: string;
       requiredClaims: readonly FederatedClaimPin[];
       lifetimeSeconds?: number;
+      // The predecessor this mint supersedes. Bindings are IMMUTABLE, so a
+      // change is a replacement mint naming `replaces`: the server revokes the
+      // predecessor and inserts the successor in ONE transaction, so there is
+      // never a gap with no binding nor an overlap with two. It is not a
+      // client-side revoke-then-create — that would be exactly the reviewed gap
+      // the atomic replacement exists to prevent.
+      replaces?: string;
     }) =>
       parsed(createFederatedBindingOp, {
           path: { org: p.org, project: p.project, serviceAccount: input.serviceAccount },
@@ -341,6 +348,7 @@ export function useCreateBinding(p: ProjectRef) {
             ...(input.lifetimeSeconds === undefined
               ? {}
               : { lifetime_seconds: input.lifetimeSeconds }),
+            ...(input.replaces === undefined ? {} : { replaces: input.replaces }),
           },
         }),
     onSuccess: (_result, input) => {

--- a/web/src/routes/FederationIssuersPanel.tsx
+++ b/web/src/routes/FederationIssuersPanel.tsx
@@ -109,7 +109,10 @@ export function FederationIssuersPanel() {
         <p role="status">Federation issuers are not disclosed to this session.</p>
       ) : null}
       {issuers.isError && !secondFactor(issuers.error) && !nondisclosed(issuers.error) ? (
-        <Alert>{issuerCreateRefusalText(issuers.error)}</Alert>
+        <Alert>
+          The federation issuers could not be listed, so none are shown. This is not the same as
+          there being none.
+        </Alert>
       ) : null}
 
       {issuers.isSuccess ? (
@@ -146,9 +149,14 @@ export function FederationIssuersPanel() {
                   >
                     Edit
                   </button>
+                  {/* Neutral until the confirmation opens: the danger button
+                      is the destructive act itself, shown only after this one
+                      reveals it — the same reveal-then-danger shape every other
+                      surface uses, which also keeps the low-contrast danger
+                      treatment out of the always-rendered page. */}
                   <button
                     type="button"
-                    className="btn btn--danger"
+                    className="btn"
                     disabled={busy}
                     onClick={() => {
                       setFailure(null);
@@ -166,7 +174,7 @@ export function FederationIssuersPanel() {
                     <p>
                       {issuer.live_bindings === 0
                         ? `Delete ${issuer.issuer}? No binding names it, so nothing that authenticates depends on it.`
-                        : `${String(issuer.live_bindings)} binding${issuer.live_bindings === 1 ? '' : 's'} — live or revoked — still name ${issuer.issuer}. The delete is refused until every one is revoked from Machine Access, because erasing the issuer erases what those bindings trusted.`}
+                        : `${String(issuer.live_bindings)} binding${issuer.live_bindings === 1 ? '' : 's'} — live or revoked — name ${issuer.issuer}, so it cannot be deleted. That history is append-only: even a revoked binding still records what this issuer was trusted for, and erasing the issuer would erase what it trusted. Deletion is only ever available for an issuer that was never bound.`}
                     </p>
                     <div className="panel__actions">
                       <button
@@ -175,16 +183,18 @@ export function FederationIssuersPanel() {
                         disabled={busy}
                         onClick={() => setConfirmDelete(null)}
                       >
-                        Cancel
+                        {issuer.live_bindings === 0 ? 'Cancel' : 'Close'}
                       </button>
-                      <button
-                        type="button"
-                        className="btn btn--danger"
-                        disabled={busy}
-                        onClick={() => doDelete(issuer)}
-                      >
-                        Delete issuer
-                      </button>
+                      {issuer.live_bindings === 0 ? (
+                        <button
+                          type="button"
+                          className="btn btn--danger"
+                          disabled={busy}
+                          onClick={() => doDelete(issuer)}
+                        >
+                          Delete issuer
+                        </button>
+                      ) : null}
                     </div>
                   </div>
                 ) : null}
@@ -339,7 +349,11 @@ function IssuerForm({
       </legend>
 
       <div className="field">
-        <label htmlFor={issuerId}>Issuer (https URL, matched byte-for-byte)</label>
+        {editing ? (
+          <span className="field__label">Issuer (https URL, matched byte-for-byte)</span>
+        ) : (
+          <label htmlFor={issuerId}>Issuer (https URL, matched byte-for-byte)</label>
+        )}
         {editing ? (
           <p className="field__hint mono">{issuer.issuer}</p>
         ) : (
@@ -360,7 +374,11 @@ function IssuerForm({
       </div>
 
       <div className="field">
-        <label htmlFor={typeId}>Platform type</label>
+        {editing ? (
+          <span className="field__label">Platform type</span>
+        ) : (
+          <label htmlFor={typeId}>Platform type</label>
+        )}
         {editing ? (
           <p className="field__hint mono">{issuer.issuer_type}</p>
         ) : (
@@ -389,7 +407,16 @@ function IssuerForm({
         <select
           id={modeId}
           value={mode}
-          onChange={(event) => setMode(event.target.value as FederationJwksMode)}
+          onChange={(event) => {
+            const next = event.target.value as FederationJwksMode;
+            setMode(next);
+            // Do not carry a JWKS document out of static mode: under discovery
+            // it is not sent (the wire schema refuses it), and holding it in
+            // form state past that point serves nothing.
+            if (next !== 'static') {
+              setStaticJwks('');
+            }
+          }}
         >
           {JWKS_MODES.map((entry) => (
             <option key={entry.id} value={entry.id}>

--- a/web/src/routes/FederationIssuersPanel.tsx
+++ b/web/src/routes/FederationIssuersPanel.tsx
@@ -1,0 +1,459 @@
+import { useId, useState } from 'react';
+
+import { ApiError } from '../api/client.ts';
+import {
+  issuerCreateRefusalText,
+  issuerDeleteRefusalText,
+  issuerFieldRefusal,
+  issuerUpdateRefusalText,
+  useCreateFederationIssuer,
+  useDeleteFederationIssuer,
+  useFederationIssuers,
+  useUpdateFederationIssuer,
+  type FederationIssuer,
+  type FederationIssuerType,
+  type FederationJwksMode,
+} from '../api/federationIssuers.ts';
+import { notifySuccess } from '../app/notifications.tsx';
+import { Alert, Done, Panel } from './Sections.tsx';
+
+const secondFactor = (error: unknown) => error instanceof ApiError && error.status === 403;
+const nondisclosed = (error: unknown) => error instanceof ApiError && error.status === 404;
+
+const ISSUER_TYPES: ReadonlyArray<{ readonly id: FederationIssuerType; readonly label: string }> = [
+  { id: 'kubernetes', label: 'Kubernetes' },
+  { id: 'forgejo', label: 'Forgejo Actions' },
+  { id: 'github-actions', label: 'GitHub Actions' },
+];
+
+const JWKS_MODES: ReadonlyArray<{ readonly id: FederationJwksMode; readonly label: string }> = [
+  { id: 'discovery', label: 'Discovery — fetch and cache the keys' },
+  { id: 'static', label: 'Static — supply the JWKS document' },
+];
+
+/** audiencesFrom splits the one-per-line textarea into trimmed, non-empty lines. */
+function audiencesFrom(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '');
+}
+
+/**
+ * FederationIssuersPanel is the instance-scoped issuer lifecycle: configure,
+ * inspect, edit the mutable half, and delete an OIDC federation issuer. It is
+ * MFA-mandatory (`instance-config`), so a password-only session reads every
+ * mutation as the second-factor refusal it is.
+ *
+ * The create/edit split follows the contract: `issuer` and `issuer_type` are
+ * immutable and shown read-only on edit; only the JWKS source and refused
+ * audiences move. The JWKS document never round-trips, so its field is always
+ * blank and, under static mode, always re-entered.
+ */
+export function FederationIssuersPanel() {
+  const issuers = useFederationIssuers();
+  const create = useCreateFederationIssuer();
+  const update = useUpdateFederationIssuer();
+  const remove = useDeleteFederationIssuer();
+
+  // One editor at a time: 'create', or an issuer id being edited, or null.
+  const [editor, setEditor] = useState<'create' | { id: string } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<FederationIssuer | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  const busy = create.isPending || update.isPending || remove.isPending;
+
+  const closeAll = () => {
+    setEditor(null);
+    setConfirmDelete(null);
+  };
+
+  const doDelete = (issuer: FederationIssuer) => {
+    setFailure(null);
+    remove.mutate(issuer.id, {
+      onSuccess: () => {
+        const message = `Deleted the issuer ${issuer.issuer}. No binding named it, so nothing that authenticated has been orphaned.`;
+        closeAll();
+        setDone(message);
+        notifySuccess(message);
+      },
+      onError: (error) => {
+        setConfirmDelete(null);
+        setFailure(issuerDeleteRefusalText(error));
+      },
+    });
+  };
+
+  return (
+    <Panel id="instance-federation" title="Federation issuers · instance-config">
+      <p className="settings-note">
+        Each issuer is one external OpenID Connect authority this whole instance trusts. It is
+        instance-scoped on purpose: an org- or project-scoped issuer would let a tenant admit a new
+        identity provider the instance never reviewed. The issuer string is matched byte-for-byte,
+        so a trailing slash is a different issuer.
+      </p>
+
+      {failure !== null ? <Alert>{failure}</Alert> : null}
+      {done !== null ? <Done>{done}</Done> : null}
+
+      {issuers.isPending ? <p role="status">Loading federation issuers…</p> : null}
+      {secondFactor(issuers.error) ? (
+        <Alert>
+          Listing federation issuers is instance-config work and needs a second factor. This session
+          does not have sufficient second-factor assurance; present your authenticator code or
+          passkey in the banner above.
+        </Alert>
+      ) : null}
+      {nondisclosed(issuers.error) ? (
+        <p role="status">Federation issuers are not disclosed to this session.</p>
+      ) : null}
+      {issuers.isError && !secondFactor(issuers.error) && !nondisclosed(issuers.error) ? (
+        <Alert>{issuerCreateRefusalText(issuers.error)}</Alert>
+      ) : null}
+
+      {issuers.isSuccess ? (
+        issuers.data.items.length === 0 ? (
+          <p className="settings-note">
+            No federation issuers configured. Nothing external can present a token here until one
+            exists.
+          </p>
+        ) : (
+          <ul className="settings-list">
+            {issuers.data.items.map((issuer) => (
+              <li key={issuer.id} className="settings-row settings-row--stacked">
+                <div className="settings-row__copy">
+                  <code className="settings-row__title mono">{issuer.issuer}</code>
+                  <span className="settings-row__detail">
+                    {issuer.issuer_type} · JWKS {issuer.jwks_mode} · refuses{' '}
+                    {issuer.refused_audiences.join(', ')} ·{' '}
+                    {issuer.live_bindings === 0
+                      ? 'no bindings name it'
+                      : `${String(issuer.live_bindings)} binding${issuer.live_bindings === 1 ? '' : 's'} name it (live or historical)`}
+                  </span>
+                </div>
+                <div className="panel__actions">
+                  <button
+                    type="button"
+                    className="btn"
+                    disabled={busy}
+                    onClick={() => {
+                      setFailure(null);
+                      setDone(null);
+                      setConfirmDelete(null);
+                      setEditor({ id: issuer.id });
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn--danger"
+                    disabled={busy}
+                    onClick={() => {
+                      setFailure(null);
+                      setDone(null);
+                      setEditor(null);
+                      setConfirmDelete(issuer);
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
+
+                {confirmDelete?.id === issuer.id ? (
+                  <div className="policy-impact" role="alert">
+                    <p>
+                      {issuer.live_bindings === 0
+                        ? `Delete ${issuer.issuer}? No binding names it, so nothing that authenticates depends on it.`
+                        : `${String(issuer.live_bindings)} binding${issuer.live_bindings === 1 ? '' : 's'} — live or revoked — still name ${issuer.issuer}. The delete is refused until every one is revoked from Machine Access, because erasing the issuer erases what those bindings trusted.`}
+                    </p>
+                    <div className="panel__actions">
+                      <button
+                        type="button"
+                        className="btn"
+                        disabled={busy}
+                        onClick={() => setConfirmDelete(null)}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn--danger"
+                        disabled={busy}
+                        onClick={() => doDelete(issuer)}
+                      >
+                        Delete issuer
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {typeof editor === 'object' && editor?.id === issuer.id ? (
+                  <IssuerForm
+                    key={`edit-${issuer.id}`}
+                    issuer={issuer}
+                    busy={busy}
+                    onCancel={() => setEditor(null)}
+                    onSubmit={(input) => {
+                      const refusal = issuerFieldRefusal({
+                        jwksMode: input.jwksMode,
+                        staticJwks: input.staticJwks,
+                        refusedAudiences: input.refusedAudiences,
+                      });
+                      if (refusal !== null) {
+                        setFailure(refusal);
+                        return;
+                      }
+                      setFailure(null);
+                      update.mutate(
+                        {
+                          id: issuer.id,
+                          jwksMode: input.jwksMode,
+                          ...(input.jwksMode === 'static'
+                            ? { staticJwks: input.staticJwks }
+                            : {}),
+                          refusedAudiences: input.refusedAudiences,
+                        },
+                        {
+                          onSuccess: () => {
+                            const message = `Updated ${issuer.issuer}. The issuer string and platform type are unchanged — those are a replacement, not an edit.`;
+                            setEditor(null);
+                            setDone(message);
+                            notifySuccess(message);
+                          },
+                          onError: (error) => setFailure(issuerUpdateRefusalText(error)),
+                        },
+                      );
+                    }}
+                  />
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+
+      {issuers.isSuccess && editor !== 'create' ? (
+        <div className="panel__actions">
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={busy}
+            onClick={() => {
+              setFailure(null);
+              setDone(null);
+              setConfirmDelete(null);
+              setEditor('create');
+            }}
+          >
+            Configure issuer
+          </button>
+        </div>
+      ) : null}
+
+      {editor === 'create' ? (
+        <IssuerForm
+          key="create"
+          issuer={null}
+          busy={busy}
+          onCancel={() => setEditor(null)}
+          onSubmit={(input) => {
+            const refusal = issuerFieldRefusal({
+              issuer: input.issuer,
+              jwksMode: input.jwksMode,
+              staticJwks: input.staticJwks,
+              refusedAudiences: input.refusedAudiences,
+            });
+            if (refusal !== null) {
+              setFailure(refusal);
+              return;
+            }
+            setFailure(null);
+            create.mutate(
+              {
+                issuer: input.issuer,
+                issuerType: input.issuerType,
+                jwksMode: input.jwksMode,
+                ...(input.jwksMode === 'static' ? { staticJwks: input.staticJwks } : {}),
+                refusedAudiences: input.refusedAudiences,
+              },
+              {
+                onSuccess: (result) => {
+                  const message = `Configured ${result.issuer}. It can now take federated bindings from Machine Access.`;
+                  setEditor(null);
+                  setDone(message);
+                  notifySuccess(message);
+                },
+                onError: (error) => setFailure(issuerCreateRefusalText(error)),
+              },
+            );
+          }}
+        />
+      ) : null}
+    </Panel>
+  );
+}
+
+type IssuerFormValue = {
+  readonly issuer: string;
+  readonly issuerType: FederationIssuerType;
+  readonly jwksMode: FederationJwksMode;
+  readonly staticJwks: string;
+  readonly refusedAudiences: string[];
+};
+
+/**
+ * IssuerForm is create and edit in one shape. On edit the issuer string and
+ * platform type are read-only — the contract has no member to move them — and
+ * the JWKS document field is blank because the read shape never returns it.
+ */
+function IssuerForm({
+  issuer,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  issuer: FederationIssuer | null;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (value: IssuerFormValue) => void;
+}) {
+  const editing = issuer !== null;
+  const issuerId = useId();
+  const typeId = useId();
+  const modeId = useId();
+  const jwksId = useId();
+  const audiencesId = useId();
+
+  const [url, setUrl] = useState(issuer?.issuer ?? '');
+  const [type, setType] = useState<FederationIssuerType>(issuer?.issuer_type ?? 'kubernetes');
+  const [mode, setMode] = useState<FederationJwksMode>(issuer?.jwks_mode ?? 'discovery');
+  const [staticJwks, setStaticJwks] = useState('');
+  const [audiences, setAudiences] = useState(issuer?.refused_audiences.join('\n') ?? '');
+
+  return (
+    <fieldset className="machine__lock" disabled={busy}>
+      <legend className="machine__subhead">
+        {editing ? `Edit ${issuer.issuer}` : 'Configure a federation issuer'}
+      </legend>
+
+      <div className="field">
+        <label htmlFor={issuerId}>Issuer (https URL, matched byte-for-byte)</label>
+        {editing ? (
+          <p className="field__hint mono">{issuer.issuer}</p>
+        ) : (
+          <input
+            id={issuerId}
+            className="mono"
+            value={url}
+            placeholder="https://token.actions.githubusercontent.com"
+            onChange={(event) => setUrl(event.target.value)}
+          />
+        )}
+        {editing ? (
+          <p className="field__hint">
+            Immutable: changing the issuer re-points every binding underneath at a different
+            authority, which is a replacement, not an edit.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="field">
+        <label htmlFor={typeId}>Platform type</label>
+        {editing ? (
+          <p className="field__hint mono">{issuer.issuer_type}</p>
+        ) : (
+          <select
+            id={typeId}
+            value={type}
+            onChange={(event) => setType(event.target.value as FederationIssuerType)}
+          >
+            {ISSUER_TYPES.map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.label}
+              </option>
+            ))}
+          </select>
+        )}
+        {editing ? (
+          <p className="field__hint">
+            Immutable: the per-platform binding rules differ, so the type is declared, never
+            inferred, and cannot move under existing bindings.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="field">
+        <label htmlFor={modeId}>JWKS source</label>
+        <select
+          id={modeId}
+          value={mode}
+          onChange={(event) => setMode(event.target.value as FederationJwksMode)}
+        >
+          {JWKS_MODES.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {mode === 'static' ? (
+        <div className="field">
+          <label htmlFor={jwksId}>JWKS document</label>
+          <textarea
+            id={jwksId}
+            className="mono"
+            rows={5}
+            value={staticJwks}
+            placeholder='{"keys":[…]}'
+            onChange={(event) => setStaticJwks(event.target.value)}
+          />
+          <p className="field__hint">
+            The key set this instance verifies against. It is never returned by any read, so it is
+            always entered here in full — there is no keep-the-old-document path, and there cannot be
+            one that silently retains a key set nobody rotates.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="field">
+        <label htmlFor={audiencesId}>Refused audiences, one per line</label>
+        <textarea
+          id={audiencesId}
+          className="mono"
+          rows={3}
+          value={audiences}
+          onChange={(event) => setAudiences(event.target.value)}
+        />
+        <p className="field__hint">
+          The issuer&apos;s default audiences, which no binding may name and no token may carry. At
+          least one is required: the default-audience rule turns on the instance knowing what the
+          default is, and it is not derivable.
+        </p>
+      </div>
+
+      <div className="panel__actions">
+        <button type="button" className="btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn btn--primary"
+          onClick={() =>
+            onSubmit({
+              issuer: url,
+              issuerType: type,
+              jwksMode: mode,
+              staticJwks,
+              refusedAudiences: audiencesFrom(audiences),
+            })
+          }
+        >
+          {editing ? 'Save issuer' : 'Configure issuer'}
+        </button>
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/routes/InstanceAdmin.tsx
+++ b/web/src/routes/InstanceAdmin.tsx
@@ -30,6 +30,7 @@ import {
 } from '../api/settings.ts';
 import { notifySuccess } from '../app/notifications.tsx';
 import { surfaceById } from '../app/navigation.ts';
+import { FederationIssuersPanel } from './FederationIssuersPanel.tsx';
 import { OidcProvidersPanel } from './OidcProvidersPanel.tsx';
 import { SamlProvidersPanel } from './SamlProvidersPanel.tsx';
 import { SamlSpKeysPanel } from './SamlSpKeysPanel.tsx';
@@ -127,6 +128,7 @@ export function InstanceAdmin() {
       { id: 'instance-orgs', label: 'Organizations' },
       { id: 'instance-settings', label: 'Settings' },
       ...(prototypeMode ? [] : [{ id: 'instance-oidc', label: 'Identity providers' }]),
+      ...(prototypeMode ? [] : [{ id: 'instance-federation', label: 'Federation' }]),
       { id: 'instance-keys', label: 'Keys & crypto' },
       ...(prototypeMode ? [] : [
         { id: 'instance-saml-providers', label: 'SAML providers' },
@@ -210,6 +212,8 @@ export function InstanceAdmin() {
     <CredentialPolicyPanel query={policy} onDone={ok} onFailure={report} />
 
     {prototypeMode ? null : <OidcProvidersPanel />}
+
+    {prototypeMode ? null : <FederationIssuersPanel />}
 
     {prototypeMode ? null : <Panel id="instance-retention" title="Retention health">
       {health.isPending ? <p role="status">Loading retention health…</p> : null}

--- a/web/src/routes/MachineAccess.binding.test.ts
+++ b/web/src/routes/MachineAccess.binding.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MachineCredential } from '../api/identities.ts';
+import { presetForBinding, seedClaims } from './MachineAccess.tsx';
+
+/**
+ * The replace form's seeding. A replacement inherits the predecessor's platform
+ * and pinned claims; a wrong answer here would render the wrong fields or,
+ * worse, silently drop a numeric pin — an int64 repository id that rounded
+ * through a float would bind the wrong repository — so both are pinned here.
+ */
+
+const binding = (claims: MachineCredential['required_claims']): MachineCredential => ({
+  id: 'mcr_00000000-0000-0000-0000-000000000000',
+  kind: 'oidc-federation',
+  lifetime: 'finite',
+  created_at: '2026-08-01T00:00:00Z',
+  created_by: 'pr_00000000-0000-0000-0000-000000000000',
+  expiring_soon: false,
+  issuer: 'https://token.actions.githubusercontent.com',
+  subject: 'repo:owner/repo:ref:refs/heads/main',
+  audience: 'hikyo',
+  required_claims: claims,
+});
+
+describe('presetForBinding', () => {
+  it('detects GitHub Actions from its numeric repository pins', () => {
+    const credential = binding([
+      { claim: 'repository_id', number_value: 42n },
+      { claim: 'repository_owner_id', number_value: 7n },
+      { claim: 'event_name', string_value: 'push' },
+    ]);
+    expect(presetForBinding(credential).id).toBe('github-actions');
+  });
+
+  it('detects Kubernetes from its ServiceAccount UID pointer', () => {
+    const credential = binding([
+      { claim: '/kubernetes.io/serviceaccount/uid', string_value: 'abc' },
+    ]);
+    expect(presetForBinding(credential).id).toBe('kubernetes');
+  });
+
+  it('falls back to Kubernetes when nothing matches, never crashing', () => {
+    expect(presetForBinding(binding(undefined)).id).toBe('kubernetes');
+  });
+});
+
+describe('seedClaims', () => {
+  it('stringifies a 64-bit repository id losslessly, past the float boundary', () => {
+    const bigId = 9007199254740993n; // 2^53 + 1: unrepresentable as a JS number.
+    const credential = binding([
+      { claim: 'repository_id', number_value: bigId },
+      { claim: 'repository_owner_id', number_value: 7n },
+      { claim: 'event_name', string_value: 'push' },
+    ]);
+    const seeded = seedClaims(presetForBinding(credential), credential);
+    expect(seeded['repository_id']).toBe('9007199254740993');
+    expect(seeded['event_name']).toBe('push');
+  });
+
+  it('leaves a preset field blank when the predecessor did not pin it', () => {
+    const credential = binding([{ claim: 'event_name', string_value: 'push' }]);
+    const seeded = seedClaims(presetForBinding(credential), credential);
+    expect(seeded['event_name']).toBe('push');
+    expect(Object.values(seeded).some((value) => value === '')).toBe(true);
+  });
+});

--- a/web/src/routes/MachineAccess.binding.test.ts
+++ b/web/src/routes/MachineAccess.binding.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { MachineCredential } from '../api/identities.ts';
-import { presetForBinding, seedClaims } from './MachineAccess.tsx';
+import { carriedClaims, presetForBinding, seedClaims } from './MachineAccess.tsx';
 
 /**
  * The replace form's seeding. A replacement inherits the predecessor's platform
@@ -63,5 +63,36 @@ describe('seedClaims', () => {
     const seeded = seedClaims(presetForBinding(credential), credential);
     expect(seeded['event_name']).toBe('push');
     expect(Object.values(seeded).some((value) => value === '')).toBe(true);
+  });
+});
+
+describe('carriedClaims', () => {
+  it('preserves a custom pin no preset field renders, so replacement never weakens it', () => {
+    const credential = binding([
+      { claim: 'repository_id', number_value: 42n },
+      { claim: 'repository_owner_id', number_value: 7n },
+      { claim: 'event_name', string_value: 'push' },
+      // A claim the operator added via the CLI, beyond the GitHub preset.
+      { claim: 'environment', string_value: 'production' },
+      { claim: 'ref_protected', bool_value: true },
+    ]);
+    const preset = presetForBinding(credential);
+    const carried = carriedClaims(preset, credential);
+    // The three preset claims are rendered as fields; the two extras are carried.
+    expect(carried).toEqual([
+      { claim: 'environment', string_value: 'production' },
+      { claim: 'ref_protected', bool_value: true },
+    ]);
+    // And the preset fields are NOT double-counted in the carried set.
+    for (const field of preset.claims) {
+      expect(carried.some((pin) => pin.claim === field.claim)).toBe(false);
+    }
+  });
+
+  it('carries nothing when every pin is a preset field', () => {
+    const credential = binding([
+      { claim: '/kubernetes.io/serviceaccount/uid', string_value: 'abc' },
+    ]);
+    expect(carriedClaims(presetForBinding(credential), credential)).toEqual([]);
   });
 });

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -1204,6 +1204,58 @@ export function seedClaims(
 }
 
 /**
+ * carriedClaims are the predecessor's pins that no preset field renders — a
+ * custom claim a CLI operator added beyond the platform's required set. A
+ * replacement must carry EVERY one of them verbatim: dropping a pin the form
+ * cannot show would silently weaken the successor's identity constraints, which
+ * is precisely the re-point-without-review the immutable-binding rule forbids.
+ * The form displays them read-only so the preservation is visible, not silent.
+ */
+export function carriedClaims(
+  preset: FederationPreset,
+  credential: MachineCredential,
+): FederatedClaimPin[] {
+  const rendered = new Set(preset.claims.map((field) => field.claim));
+  return (credential.required_claims ?? [])
+    .filter((pin) => !rendered.has(pin.claim))
+    .map(toRequestPin);
+}
+
+/**
+ * toRequestPin converts one READ-shape pin (whose `number_value` is a bigint)
+ * to the REQUEST shape (a plain number). The int64→number narrowing is the
+ * generated client's own boundary — the wire type is a number — so it is no
+ * lossier here than a first mint of the same claim, and a real repository id
+ * sits far below the safe-integer ceiling.
+ */
+function toRequestPin(pin: ClaimPin): FederatedClaimPin {
+  if (pin.string_value !== undefined) {
+    return { claim: pin.claim, string_value: pin.string_value };
+  }
+  if (pin.number_value !== undefined) {
+    return { claim: pin.claim, number_value: Number(pin.number_value) };
+  }
+  if (pin.bool_value !== undefined) {
+    return { claim: pin.claim, bool_value: pin.bool_value };
+  }
+  return { claim: pin.claim };
+}
+
+/** requestPinText renders a request-shape pin for the read-only preserved list. */
+function requestPinText(pin: FederatedClaimPin): string {
+  if (pin.string_value !== undefined) {
+    return pin.string_value;
+  }
+  if (pin.number_value !== undefined) {
+    return String(pin.number_value);
+  }
+  if (pin.bool_value !== undefined) {
+    return String(pin.bool_value);
+  }
+  return 'unpinned';
+}
+
+/**
  * useNavigationGuard keeps navigation from destroying what dismissal is not
  * allowed to.
  *
@@ -1534,6 +1586,9 @@ function BindingDialog({
   // pinned; a fresh binding starts on Kubernetes. The account is locked to the
   // row the replace was launched from, because a binding belongs to one.
   const seedPreset = replaces === undefined ? KUBERNETES_PRESET : presetForBinding(replaces);
+  // Predecessor pins no form field renders — carried verbatim so a replacement
+  // never silently drops an identity constraint the form could not show.
+  const carried = replaces === undefined ? [] : carriedClaims(seedPreset, replaces);
   const [account, setAccount] = useState(initial.id);
   const [preset, setPreset] = useState<FederationPreset>(seedPreset);
   const [issuer, setIssuer] = useState(replaces?.issuer ?? seedPreset.issuer);
@@ -1627,6 +1682,10 @@ function BindingDialog({
       setFailure(pins);
       return;
     }
+    // Carried pins are appended, never merged: a preset field and a carried
+    // claim can never share a name (carried is exactly the complement), so
+    // there is nothing to reconcile.
+    const allPins = [...pins, ...carried];
     setBusy(true);
     setFailure(null);
     // Same issued-vs-nothing-happened line the mint draws: once the request
@@ -1651,7 +1710,7 @@ function BindingDialog({
         issuer,
         subject,
         audience,
-        requiredClaims: pins,
+        requiredClaims: allPins,
         ...(seconds === undefined ? {} : { lifetimeSeconds: seconds }),
         ...(replaces === undefined ? {} : { replaces: replaces.id }),
       });
@@ -1815,6 +1874,22 @@ function BindingDialog({
           </div>
         ),
       )}
+
+      {carried.length > 0 ? (
+        <div className="field">
+          <span className="field__label">
+            Preserved pins, carried byte-for-byte from the binding being replaced
+          </span>
+          <dl className="kv">
+            {carried.map((pin) => (
+              <div className="kv__pair" key={pin.claim}>
+                <dt>{pin.claim}</dt>
+                <dd className="mono">{requestPinText(pin)}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
 
       <div className="field">
         <label htmlFor="binding-lifetime">Binding lifetime</label>

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -98,7 +98,7 @@ import { useModalDialog } from './useModalDialog.ts';
 type Tab = 'accounts' | 'federation' | 'kubernetes';
 
 type Dialog =
-  | { kind: 'binding'; account: ServiceAccount }
+  | { kind: 'binding'; account: ServiceAccount; replaces?: MachineCredential }
   | { kind: 'grant'; account: ServiceAccount }
   | { kind: 'create' }
   | { kind: 'delete'; account: ServiceAccount };
@@ -474,6 +474,9 @@ export function MachineAccess() {
                         onBind={() => setDialog({ kind: 'binding', account: sa })}
                         onGrant={() => setDialog({ kind: 'grant', account: sa })}
                         onRevoke={(credential) => doRevoke(sa, credential)}
+                        onReplaceBinding={(credential) =>
+                          setDialog({ kind: 'binding', account: sa, replaces: credential })
+                        }
                         onDelete={() => setDialog({ kind: 'delete', account: sa })}
                       />
                     </ExpandableRow>
@@ -535,7 +538,16 @@ export function MachineAccess() {
               <ul className="machine__bindings">
                 {allBindings.map(({ account, credential }) => (
                   <li key={credential.id}>
-                    <BindingCard account={account} credential={credential} now={now} />
+                    <BindingCard
+                      account={account}
+                      credential={credential}
+                      now={now}
+                      ready={inputsReady}
+                      onReplace={(predecessor) =>
+                        setDialog({ kind: 'binding', account, replaces: predecessor })
+                      }
+                      onRevoke={(target) => doRevoke(account, target)}
+                    />
                   </li>
                 ))}
               </ul>
@@ -573,14 +585,15 @@ export function MachineAccess() {
           project={project}
           accounts={accounts}
           initial={dialog.account}
+          replaces={dialog.replaces}
           reachFor={(accountId) => {
             const sa = accounts.find((candidate) => candidate.id === accountId);
             return sa === undefined ? [] : postStateReach(scopeFor(sa));
           }}
           onClose={() => setDialog(null)}
-          onCreated={(subject) => {
+          onCreated={(message) => {
             setDialog(null);
-            setNotice(`Bound. The binding matches ${subject} byte-for-byte and nothing else.`);
+            setNotice(message);
           }}
         />
       ) : null}
@@ -908,6 +921,7 @@ function ExpansionBody({
   onBind,
   onGrant,
   onRevoke,
+  onReplaceBinding,
   onDelete,
 }: {
   account: ServiceAccount;
@@ -929,6 +943,7 @@ function ExpansionBody({
   onBind: () => void;
   onGrant: () => void;
   onRevoke: (credential: MachineCredential) => void;
+  onReplaceBinding: (credential: MachineCredential) => void;
   onDelete: () => void;
 }) {
   const journey = setupJourney(account.kind, scope, machineReveal);
@@ -972,7 +987,14 @@ function ExpansionBody({
               <ul className="machine__bindings">
                 {bindings.map((credential) => (
                   <li key={credential.id}>
-                    <BindingCard account={account} credential={credential} now={now} />
+                    <BindingCard
+                      account={account}
+                      credential={credential}
+                      now={now}
+                      ready={ready}
+                      onReplace={onReplaceBinding}
+                      onRevoke={onRevoke}
+                    />
                   </li>
                 ))}
               </ul>
@@ -1054,10 +1076,22 @@ function BindingCard({
   account,
   credential,
   now,
+  ready,
+  onReplace,
+  onRevoke,
 }: {
   account: ServiceAccount;
   credential: MachineCredential;
   now: Date;
+  /**
+   * Every query the replacement's warning is computed from has succeeded.
+   * Replace mints a new binding, so it carries the same post-state reach the
+   * first mint did; revoke is a narrowing and needs no such read, so it is not
+   * gated on it.
+   */
+  ready: boolean;
+  onReplace: (credential: MachineCredential) => void;
+  onRevoke: (credential: MachineCredential) => void;
 }) {
   return (
     <div className="bindrow">
@@ -1097,6 +1131,19 @@ function BindingCard({
           </span>
         </p>
       )}
+      <div className="machine__actions">
+        <button
+          className="btn"
+          type="button"
+          disabled={!ready}
+          onClick={() => onReplace(credential)}
+        >
+          {`Replace binding on ${account.name}`}
+        </button>
+        <button className="btn" type="button" onClick={() => onRevoke(credential)}>
+          {`Revoke binding on ${account.name}`}
+        </button>
+      </div>
     </div>
   );
 }
@@ -1112,6 +1159,48 @@ function claimText(pin: ClaimPin): string {
     return String(pin.bool_value);
   }
   return 'unpinned';
+}
+
+/**
+ * presetForBinding recovers the platform of a binding being replaced. The
+ * credential row carries no platform type — that lives on the issuer, not the
+ * binding — so the platform is inferred from the claims it pinned: the preset
+ * whose required claims the predecessor pins the most of. It is only ever used
+ * to choose which fields the replace form renders; the claim VALUES are seeded
+ * straight from the predecessor, so a misdetection would show a spare field,
+ * never bind the wrong identity.
+ */
+export function presetForBinding(credential: MachineCredential): FederationPreset {
+  const pinned = new Set((credential.required_claims ?? []).map((pin) => pin.claim));
+  let best = KUBERNETES_PRESET;
+  let bestScore = -1;
+  for (const candidate of FEDERATION_PRESETS) {
+    const score = candidate.claims.filter((field) => pinned.has(field.claim)).length;
+    if (score > bestScore) {
+      best = candidate;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+/**
+ * seedClaims fills the replace form's claim inputs from the predecessor. The
+ * read-shape `number_value` is a bigint (an int64 repository id does not
+ * survive a float), and `claimText` stringifies it losslessly, so the seeded
+ * text round-trips back through the numeric parse on submit.
+ */
+export function seedClaims(
+  preset: FederationPreset,
+  credential: MachineCredential,
+): Record<string, string> {
+  const byClaim = new Map((credential.required_claims ?? []).map((pin) => [pin.claim, pin] as const));
+  const seeded: Record<string, string> = {};
+  for (const field of preset.claims) {
+    const pin = byClaim.get(field.claim);
+    seeded[field.claim] = pin === undefined ? '' : claimText(pin);
+  }
+  return seeded;
 }
 
 /**
@@ -1407,6 +1496,7 @@ function BindingDialog({
   project,
   accounts,
   initial,
+  replaces,
   reachFor,
   onClose,
   onCreated,
@@ -1414,6 +1504,16 @@ function BindingDialog({
   project: ProjectRef;
   accounts: readonly ServiceAccount[];
   initial: ServiceAccount;
+  /**
+   * The binding this mint supersedes, when the operator chose Replace. Bindings
+   * are IMMUTABLE, so a replacement is a fresh mint naming `replaces`: the
+   * server revokes the predecessor and inserts the successor in ONE
+   * transaction, so there is never a gap with no binding nor an overlap with
+   * two. The form pre-seeds from it and locks the target account — the
+   * predecessor belongs to exactly one — and hides the platform picker, since
+   * the platform cannot move under a replacement.
+   */
+  replaces?: MachineCredential;
   /**
    * The selected account's post-state reach. A binding is a mint (#62), so the
    * server demands the same disclosure formula the credential mint does: one
@@ -1424,17 +1524,24 @@ function BindingDialog({
    */
   reachFor: (accountId: string) => readonly MachineEnvScope[];
   onClose: () => void;
-  onCreated: (subject: string) => void;
+  onCreated: (message: string) => void;
 }) {
   const dialog = useModalDialog();
   const create = useCreateBinding(project);
   const refresh = useRefreshAccount(project);
+  const replacing = replaces !== undefined;
+  // A replacement's platform is the predecessor's, detected from the claims it
+  // pinned; a fresh binding starts on Kubernetes. The account is locked to the
+  // row the replace was launched from, because a binding belongs to one.
+  const seedPreset = replaces === undefined ? KUBERNETES_PRESET : presetForBinding(replaces);
   const [account, setAccount] = useState(initial.id);
-  const [preset, setPreset] = useState<FederationPreset>(KUBERNETES_PRESET);
-  const [issuer, setIssuer] = useState(KUBERNETES_PRESET.issuer);
-  const [subject, setSubject] = useState(KUBERNETES_PRESET.subject);
-  const [audience, setAudience] = useState('');
-  const [claims, setClaims] = useState<Record<string, string>>(() => blankClaims(KUBERNETES_PRESET));
+  const [preset, setPreset] = useState<FederationPreset>(seedPreset);
+  const [issuer, setIssuer] = useState(replaces?.issuer ?? seedPreset.issuer);
+  const [subject, setSubject] = useState(replaces?.subject ?? seedPreset.subject);
+  const [audience, setAudience] = useState(replaces?.audience ?? '');
+  const [claims, setClaims] = useState<Record<string, string>>(() =>
+    replaces === undefined ? blankClaims(KUBERNETES_PRESET) : seedClaims(seedPreset, replaces),
+  );
   const [lifetime, setLifetime] = useState('default');
   const [deliberate, setDeliberate] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
@@ -1539,15 +1646,23 @@ function BindingDialog({
       }
       const seconds = BINDING_LIFETIMES.find((entry) => entry.id === lifetime)?.seconds;
       issued = true;
-      await create.mutateAsync({
+      const result = await create.mutateAsync({
         serviceAccount: account,
         issuer,
         subject,
         audience,
         requiredClaims: pins,
         ...(seconds === undefined ? {} : { lifetimeSeconds: seconds }),
+        ...(replaces === undefined ? {} : { replaces: replaces.id }),
       });
-      onCreated(subject);
+      const clampNote = result.clamped
+        ? ' The instance ceiling shortened the requested lifetime.'
+        : '';
+      onCreated(
+        replacing
+          ? `Replaced. The predecessor was revoked and the successor inserted in one transaction — no gap, no overlap. The new binding matches ${subject} byte-for-byte.${clampNote}`
+          : `Bound. The binding matches ${subject} byte-for-byte and nothing else.${clampNote}`,
+      );
     } catch (error) {
       if (issued) {
         refresh(account);
@@ -1572,12 +1687,12 @@ function BindingDialog({
       }
     }}>
       <h2 className="ceremony__title" id="binding-title">
-        Add federated binding
+        {replacing ? 'Replace federated binding' : 'Add federated binding'}
       </h2>
       <p className="ceremony__lede">
-        A byte-exact (issuer, subject) pair naming exactly one service account. The audience is
-        mandatory and may not be the issuer&apos;s default: a token minted for another consumer must
-        not authenticate here.
+        {replacing
+          ? 'Bindings are immutable, so this replaces the predecessor: the server revokes it and inserts this successor in one transaction — no gap with no binding, no overlap with two. The fields are seeded from the predecessor; change what the replacement should carry.'
+          : 'A byte-exact (issuer, subject) pair naming exactly one service account. The audience is mandatory and may not be the issuer’s default: a token minted for another consumer must not authenticate here.'}
       </p>
 
       {/* One native latch for the whole target: an issued request is for the
@@ -1585,25 +1700,30 @@ function BindingDialog({
           otherwise the success or failure sentence describes one account while
           the operator is looking at another. */}
       <fieldset className="machine__lock" disabled={busy}>
-      <div className="machine__presets">
-        {FEDERATION_PRESETS.map((entry) => (
-          <button
-            key={entry.id}
-            className="btn"
-            type="button"
-            aria-pressed={preset.id === entry.id}
-            onClick={() => choose(entry)}
-          >
-            {entry.label}
-          </button>
-        ))}
-      </div>
+      {replacing ? null : (
+        <div className="machine__presets">
+          {FEDERATION_PRESETS.map((entry) => (
+            <button
+              key={entry.id}
+              className="btn"
+              type="button"
+              aria-pressed={preset.id === entry.id}
+              onClick={() => choose(entry)}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="field">
         <label htmlFor="binding-account">Service account</label>
         <select
           id="binding-account"
           value={account}
+          // A replacement belongs to exactly one account — the predecessor's —
+          // so the target is fixed and the selector is locked.
+          disabled={replacing}
           onChange={(event) => {
             // The acknowledgement is consent for ONE account's fetch authority.
             // A different target is a different decision, so it does not carry.
@@ -1755,7 +1875,13 @@ function BindingDialog({
 
       <div className="ceremony__actions">
         <button className="btn btn--primary" type="button" disabled={busy} onClick={() => void submit()}>
-          {busy ? 'Binding…' : 'Bind this identity'}
+          {busy
+            ? replacing
+              ? 'Replacing…'
+              : 'Binding…'
+            : replacing
+              ? 'Replace this binding'
+              : 'Bind this identity'}
         </button>
         <button className="btn" type="button" onClick={onClose} disabled={busy}>
           Cancel

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3979,6 +3979,15 @@ select {
   padding: 10px 0;
   border-top: 1px solid var(--panel-line);
 }
+.settings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.settings-row--stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
 
 .settings-row:first-of-type {
   border-top: 0;

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -107,7 +107,8 @@ select {
   gap: 6px;
 }
 
-.field label {
+.field label,
+.field .field__label {
   color: var(--tx-dim);
   font-size: 13px;
 }


### PR DESCRIPTION
Closes #497.

## What

Completes the browser workload-federation journey. A fresh browser-only install can now configure an issuer, create a service account, bind it, inspect its constraints, replace the binding, and retire it — all without the CLI.

### Instance administrators — Federation issuers panel (instance-admin)
- Configure, inspect, edit and delete OIDC federation issuers. New `Federation` panel; **WebUI-only** — the `internal/server/federation.go` routes and generated TS clients already existed, nothing regenerated.
- Issuer string and platform type are immutable and shown read-only on edit; only the JWKS source and refused audiences move.
- The static JWKS document never round-trips (public key material, never returned by any read), so its field is always re-entered under static mode and cleared when static mode is left.
- Deletion previews the naming-binding census and **fails closed**: a bound issuer (live **or** revoked — the count never reaches zero once used, since binding history is append-only) shows the truth and offers no destructive action. The 409 mapper remains for the concurrent-race path.

### Project operators — binding replace + revoke (Machine Access)
- **Replace** reuses the binding form seeded from the predecessor, locks the target account, and passes `replaces` so the server revokes the predecessor and inserts the successor in **one transaction** — no unreviewed gap or overlap. Every predecessor claim outside the platform preset is carried verbatim and shown read-only, so a replacement never silently weakens the successor.
- **Revoke** retires a binding through the same credentials route.

### Redaction
Tokens, assertions and write-only credentials stay out of browser storage, URLs, logs and diagnostic DOM: the read shapes carry none, and per-verb refusal mappers never echo server causes.

## Contract / migration decisions
None. No `api/` change, no codegen, no migration. Uses the existing locked API, authorization, refusal, redaction and audit contracts. No generated client was hand-edited.

## Regenerated artifacts
None.

## Validation
- `pnpm --dir web typecheck` — clean
- `pnpm --dir web test` — 566 passing (adds issuer field-gate/refusal-mapper coverage and replace-form seeding incl. the int64 repository-id float boundary and claim-preservation)
- `pnpm --dir web build` — clean
- Playwright desktop + mobile for `instance-admin` and `machine-access`: issuer lifecycle (configure, edit, fail-closed delete, clean delete), the binding replace-then-revoke journey, and the password-only authorization refusal.

Reviewed cross-model (Codex, high effort); round-1 findings folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)