### PR TITLE
docs(architecture): document sanctioned store alias seam #516

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,17 @@ the authority the code cites ships with the code; `docs/adr/` on `main` is the
 canonical copy from that date. The frozen UI prototypes the ui-spec refers to
 stay on that branch (`prototype/`), as do the research notes' images.
 
+**The sanctioned store→transport alias seam.** `internal/service` exposes a
+small set of Go aliases to store-owned types: `AdapterTarget`,
+`AdapterConflictEntry`, `AdapterConflictArtifact`, `AdapterRecord`, and
+`AdapterMove` in `adapters.go`, plus `RetentionConsequence` in `pins.go`. These
+types are intentionally shared with transport mapping instead of restated as
+service-owned views. The system-architecture ADR owns the import direction,
+and `internal/boundary/boundary_test.go` mechanically forbids handlers from
+importing `internal/store`; transport therefore cannot reach the datastore
+directly. Piloting service-owned views remains a separate decision
+([#516](https://github.com/Hikyo-Org/Hikyo/issues/516) option b).
+
 Read every ADR **through its amendment banners**: the banner text wins over
 the body below it. A change that contradicts a locked ADR reopens the ADR
 (amendment banner, cross-model review) rather than diverging silently — the

--- a/docs/handoff/516-sanctioned-store-transport-alias-seam.md
+++ b/docs/handoff/516-sanctioned-store-transport-alias-seam.md
@@ -1,0 +1,23 @@
+# Issue #516: sanctioned store-to-transport alias seam
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/516. Base:
+`82eb89c35c7641370aaadc291b0b70223f1568f2`.
+
+## Contract
+
+- Six `internal/service` aliases intentionally expose store-owned types to the
+  transport-mapping layer: five adapter types and `RetentionConsequence`.
+- Every alias declaration names this sanctioned seam and cites the
+  system-architecture ADR plus its mechanical enforcement.
+- `internal/boundary/boundary_test.go` prevents handlers from importing
+  `internal/store` directly; the aliases do not weaken that import direction.
+- Service-owned view types remain a separate, optional decision. This change
+  does not alter runtime behavior.
+
+## Verification
+
+- `go test ./...`: 4,046 passed across 69 packages.
+- `go test ./internal/boundary/ ./internal/service/`: 353 passed.
+- Two-axis review: Standards CLEAN; Spec CLEAN.
+- Native Codex adversarial review at high effort: CLEAN after the required
+  fix-verification loop.

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -55,10 +55,29 @@ type AdapterView struct {
 	TargetConflicts map[string][]store.AdapterConflictArtifact
 }
 
+// AdapterTarget intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type AdapterTarget = store.AdapterTarget
+
+// AdapterConflictEntry intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type AdapterConflictEntry = store.AdapterConflictEntry
+
+// AdapterConflictArtifact intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type AdapterConflictArtifact = store.AdapterConflictArtifact
+
+// AdapterRecord intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type AdapterRecord = store.AdapterRecord
+
+// AdapterMove intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type AdapterMove = store.AdapterMove
 
 type AdapterTargetInput struct {

--- a/internal/service/pins.go
+++ b/internal/service/pins.go
@@ -71,6 +71,9 @@ type SetPinResult struct {
 	Pin    PinView
 }
 
+// RetentionConsequence intentionally shares a store-owned type with transport mapping.
+// This sanctioned seam follows the system-architecture ADR; boundary_test.go
+// enforces that handlers never import internal/store directly.
 type RetentionConsequence = store.RetentionConsequence
 
 const (


### PR DESCRIPTION
## Summary

- document all six sanctioned store-to-transport aliases in internal/service
- name the alias bridge and boundary-test enforcement in the ADR index
- record issue contract and verification in the handoff

## Validation

- go test ./... (4,046 tests across 69 packages)
- go test ./internal/boundary/ ./internal/service/ (353 tests)
- Standards review: CLEAN
- Spec review: CLEAN
- native Codex adversarial review: CLEAN after three rounds

Closes #516