### PR TITLE
feat(web): operate remote cryptographic maintenance from the WebUI (#503)

### DIFF
--- a/web/e2e/fixtures/seed.ts
+++ b/web/e2e/fixtures/seed.ts
@@ -364,6 +364,13 @@ export async function seedTenant(
     // neither is covered by `reveal`.
     'pin',
     'reveal-history',
+    // Remote cryptographic maintenance (#503). `rotate-dek` authorizes the DEK
+    // rotations (and rides for the token/scanning rotations); `reencrypt` is the
+    // operator authority the instance and project re-encryption walks take. Both
+    // are content-invisible — they re-wrap ciphertext without touching plaintext
+    // — so granting them to the fixture principal disturbs no other flow.
+    'rotate-dek',
+    'reencrypt',
   ]) {
     runAdminGrant(['--principal', principal, '--capability', capability]);
   }

--- a/web/e2e/flows/instance-admin.spec.ts
+++ b/web/e2e/flows/instance-admin.spec.ts
@@ -45,9 +45,12 @@ import { test } from '../fixtures/passkey.ts';
  *  - the instance grant listing shows origins, so a break-glass grant is
  *    distinguishable from an ordinary one after an incident. The fixture's own
  *    seeding grants are break-glass, which is what makes this assertable;
- *  - the SystemProof local set is stated as absent rather than drawn as
- *    disabled controls, and the one key operation that does have a network
- *    surface warns before it runs.
+ *  - the genuinely host-only SystemProof set (init, migrate, restore
+ *    reconciliation, break-glass, host-file custody, startup-only key material)
+ *    is stated as absent rather than drawn as disabled controls, while every
+ *    remotely operable rotation and re-encryption job (#503) warns before it
+ *    runs and the two content-invisible ones (DEK rotation, re-encryption) run
+ *    for real, resuming across a reload.
  */
 
 const seed = readSeed();
@@ -125,11 +128,13 @@ test.describe('instance administration', () => {
     page,
   }) => {
     const keys = page.locator('#instance-keys');
-    // The local-host-authority set is named as absent, not drawn as disabled
-    // buttons: they have no network surface at all, by ADR.
+    // The genuinely host-only set is named as absent, not drawn as disabled
+    // buttons: init, migrate, restore reconciliation and break-glass have no
+    // network surface at all, by ADR.
     await expect(keys).toContainText('local host authority');
     await expect(keys).toContainText('CLI-at-the-box, not CLI-over-network');
-    await expect(keys.getByRole('button', { name: /rotate/i })).toHaveCount(1);
+    await expect(keys).toContainText('init');
+    await expect(keys).toContainText('break-glass');
 
     await keys.getByRole('button', { name: 'Rotate the change-token key' }).click();
     const dialog = page.getByRole('dialog');
@@ -138,6 +143,62 @@ test.describe('instance administration', () => {
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(page.getByRole('dialog')).toBeHidden();
     await expect(keys.getByRole('button', { name: 'Rotate the change-token key' })).toBeFocused();
+  });
+
+  test('names the consequences of the master-key and root-key jobs before running', async ({
+    page,
+  }) => {
+    const keys = page.locator('#instance-keys');
+
+    await keys.getByRole('button', { name: 'Rotate the master key' }).click();
+    let dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('re-wrapped under it');
+    await expect(dialog).toContainText('finalize the root rotation first');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+
+    // The root-key rotation is a three-phase job; prepare names the host step
+    // and the crash-safety fact before anything is sealed.
+    await keys.getByRole('button', { name: 'Prepare' }).click();
+    dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('No key material crosses the wire');
+    await expect(dialog).toContainText('install the new root at the primary source');
+    await expect(dialog).toContainText('bootable under either root');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+
+  test('rotates the instance DEK and re-encrypts, resuming across a reload', async ({ page }) => {
+    const keys = page.locator('#instance-keys');
+
+    // Rotate the instance DEK for real. It appends a version and is
+    // content-invisible: no other flow's plaintext moves. This leaves the
+    // instance's credential ciphertext PENDING re-encryption onto the new
+    // version — an incomplete rotation.
+    await keys.getByRole('button', { name: 'Rotate the instance DEK' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('incomplete until');
+    await dialog.getByRole('button', { name: 'Rotate the DEK' }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page.locator('.notice')).toContainText('The instance DEK was rotated');
+
+    // Reload BEFORE any re-encryption: the pending walk now lives only in the
+    // server's cursor, with no client state to carry it. A fresh page must be
+    // able to pick it up and drive it to a clean, complete end — the real
+    // interrupted-then-resumed recovery, not a re-run of an already-finished job.
+    await page.reload();
+    await expect(
+      page.getByRole('heading', { name: 'Instance administration', level: 1 }),
+    ).toBeVisible();
+    await keys.getByRole('button', { name: 'Re-encrypt the instance' }).click();
+    await expect(page.locator('.notice')).toContainText('Instance re-encryption complete');
+
+    // Idempotent: everything now sits on the active version, so a further run
+    // moves nothing and says so.
+    await keys.getByRole('button', { name: 'Re-encrypt the instance' }).click();
+    await expect(page.locator('.notice')).toContainText(
+      'nothing to move; all ciphertext is already on the active DEK version',
+    );
   });
 
   test('reads and saves the machine-credential ceiling', async ({ page }) => {

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -311,6 +311,34 @@ test.describe('project settings', () => {
     await expect(page).toHaveURL(before);
   });
 
+  test('rotates the project DEK and re-encrypts, resuming across a reload', async () => {
+    // The project-scoped half of remote cryptographic maintenance (#503),
+    // against the real server. Both jobs are content-invisible: they re-wrap
+    // this project's ciphertext without touching its plaintext.
+    await page.goto(`/orgs/${seed.org}/projects/${drillProject}/settings`);
+    const keys = page.locator('#project-keys');
+
+    await keys.getByRole('button', { name: 'Rotate the project DEK' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('incomplete until');
+    await dialog.getByRole('button', { name: 'Rotate the DEK' }).click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page.locator('.notice')).toContainText("This project's DEK was rotated");
+
+    // Reload BEFORE re-encrypting: the pending walk lives only in the server's
+    // cursor now. A fresh page with no client state must resume it to a clean
+    // complete end — the interrupted-then-resumed recovery.
+    await page.reload();
+    await keys.getByRole('button', { name: 'Re-encrypt the project' }).click();
+    await expect(page.locator('.notice')).toContainText('Project re-encryption complete');
+
+    // Idempotent: a further run moves nothing.
+    await keys.getByRole('button', { name: 'Re-encrypt the project' }).click();
+    await expect(page.locator('.notice')).toContainText(
+      'nothing to move; all ciphertext is already on the active DEK version',
+    );
+  });
+
   test('protects an environment through the compact policy controls', async () => {
     const settingsPath = `${base()}/environments/${drillEnv}/settings`;
     const original = await browserApi(page, 'GET', settingsPath, zEnvironmentSettings);

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -15,9 +15,15 @@ import {
   listOrgsOp,
   listProjectsOp,
   renameEnvironmentOp,
+  reencryptInstanceOp,
+  reencryptProjectOp,
   renameOrgOp,
   renameProjectOp,
   reorderEnvironmentsOp,
+  rotateDekOp,
+  rotateMasterKeyOp,
+  rotateRootKeyOp,
+  rotateScanningKeyOp,
   rotateTokenKeyOp,
   setEnvironmentSettingsOp,
   setOrgRetentionOp,
@@ -685,15 +691,61 @@ export function cloneEnvironmentRefusalText(error: unknown): string {
 }
 
 /**
- * useRotateTokenKey is the one key operation with a network surface.
+ * Remotely operable cryptographic maintenance (#503).
  *
- * Root, master and DEK rotation, `init`, `migrate`, restore reconciliation and
- * break-glass are LOCAL HOST AUTHORITY by the system-proof ADR and deliberately
- * have no UI and no API — the prototype's "Keys & crypto" card says so rather
- * than showing controls that could not exist.
+ * Every rotation and re-encryption job below is a grant-evaluated network
+ * operation carrying the `human-session` artifact: it runs from the CLI *or*
+ * the WebUI, guarded by capability plus session second-factor assurance, never
+ * bound to a purpose-specific passkey ceremony. No key material crosses the
+ * wire on any of them.
+ *
+ * The genuinely host-only set — `init`, `migrate`, restore reconciliation,
+ * break-glass, host-file custody, and startup-only key material — has no
+ * network surface at all, by the system-proof ADR. The "Keys & crypto" card
+ * names that set as absent rather than drawing controls that could not exist.
  */
 export function useRotateTokenKey() {
   return useMutation({ mutationFn: () => parsed(rotateTokenKeyOp, {}) });
+}
+
+export function useRotateScanningKey() {
+  return useMutation({ mutationFn: () => parsed(rotateScanningKeyOp, {}) });
+}
+
+export function useRotateMasterKey() {
+  return useMutation({ mutationFn: () => parsed(rotateMasterKeyOp, {}) });
+}
+
+/** Run one phase of the crash-safe three-phase root-key rotation. */
+export function useRotateRootKey() {
+  return useMutation({
+    mutationFn: (phase: 'prepare' | 'verify' | 'finalize') =>
+      parsed(rotateRootKeyOp, { body: { phase } }),
+  });
+}
+
+/** Append a new DEK version for one project or the instance scope. */
+export function useRotateDek() {
+  return useMutation({
+    mutationFn: (input: { scope: 'instance' } | { scope: 'project'; org: string; project: string }) =>
+      parsed(rotateDekOp, {
+        body: input.scope === 'project'
+          ? { scope: 'project', org: input.org, project: input.project }
+          : { scope: 'instance' },
+      }),
+  });
+}
+
+/** Walk the instance credential ciphertext onto the active DEK version. Resumable — re-run until it moves no rows. */
+export function useReencryptInstance() {
+  return useMutation({ mutationFn: () => parsed(reencryptInstanceOp, {}) });
+}
+
+/** Walk a project's ciphertext onto the active DEK version. Resumable — re-run until it moves no rows. */
+export function useReencryptProject(org: string, project: string) {
+  return useMutation({
+    mutationFn: () => parsed(reencryptProjectOp, { path: { org, project } }),
+  });
 }
 
 // --- environment policy -----------------------------------------------------
@@ -854,7 +906,13 @@ export type SettingsOperation =
   | 'set-project-retention'
   | 'set-environment-settings'
   | 'set-definitions-settings'
-  | 'rotate-token-key';
+  | 'rotate-token-key'
+  | 'rotate-scanning-key'
+  | 'rotate-master-key'
+  | 'rotate-root-key'
+  | 'rotate-dek'
+  | 'reencrypt-instance'
+  | 'reencrypt-project';
 
 class SettingsOperationFailure extends Error {
   readonly operation: SettingsOperation;
@@ -874,6 +932,25 @@ export function settingsOperationFailure(
   error: unknown,
 ): Error {
   return new SettingsOperationFailure(operation, error);
+}
+
+/**
+ * Failure text for the remotely operable cryptographic-maintenance jobs (#503).
+ *
+ * These are MFA-mandatory instance and tenant operations, so a 403 carries the
+ * same reading every other instance-admin surface gives it: the session is
+ * short of second-factor assurance, not permanently forbidden. It points at the
+ * step-up banner — which the shell keeps visible above the content whenever the
+ * session is password-only — rather than claiming an authorization failure that
+ * signing in again could not fix. Every other status defers to
+ * settingsFailureText.
+ */
+export function cryptoFailureText(error: unknown, operation: SettingsOperation): string {
+  const failure = error instanceof SettingsOperationFailure ? error.reason : error;
+  if (failure instanceof ApiError && failure.status === 403) {
+    return 'This operation needs a second factor. This session does not have sufficient second-factor assurance; present your authenticator code or passkey in the banner above.';
+  }
+  return settingsFailureText(error, operation);
 }
 
 /** Map each refusal using the operation that declared the status. */
@@ -935,6 +1012,18 @@ function settingsAction(operation: SettingsOperation | undefined): string {
       return 'change this project definitions source';
     case 'rotate-token-key':
       return 'rotate the change-token key';
+    case 'rotate-scanning-key':
+      return 'rotate the secret-scanning key';
+    case 'rotate-master-key':
+      return 'rotate the master key';
+    case 'rotate-root-key':
+      return 'rotate the root key';
+    case 'rotate-dek':
+      return 'rotate the data-encryption key';
+    case 'reencrypt-instance':
+      return 're-encrypt the instance ciphertext';
+    case 'reencrypt-project':
+      return 're-encrypt this project';
     default:
       return 'perform this settings operation';
   }
@@ -958,6 +1047,10 @@ function invalidSettingsText(operation: SettingsOperation | undefined): string {
       return 'The definitions source is invalid.';
     case 'set-credential-policy':
       return 'The machine-credential policy is invalid.';
+    case 'rotate-dek':
+      return 'The DEK rotation request is invalid; a project scope needs its organisation and project.';
+    case 'rotate-root-key':
+      return 'The root-key rotation phase is invalid; run prepare, then verify, then finalize.';
     default:
       return 'The server refused this request as invalid.';
   }
@@ -988,6 +1081,18 @@ function unavailableSettingsText(operation: SettingsOperation | undefined): stri
       return 'Retention health is unavailable.';
     case 'rotate-token-key':
       return 'The change-token key rotation is unavailable.';
+    case 'rotate-scanning-key':
+      return 'The secret-scanning key rotation is unavailable.';
+    case 'rotate-master-key':
+      return 'The master-key rotation is unavailable.';
+    case 'rotate-root-key':
+      return 'The root-key rotation is unavailable.';
+    case 'rotate-dek':
+      return 'The DEK rotation is unavailable, or its project does not exist.';
+    case 'reencrypt-instance':
+      return 'Instance re-encryption is unavailable.';
+    case 'reencrypt-project':
+      return 'This project re-encryption is unavailable, or the project does not exist.';
     default:
       return 'This settings resource is unavailable or does not exist.';
   }
@@ -1007,6 +1112,10 @@ function conflictingSettingsText(operation: SettingsOperation | undefined): stri
       return 'Deletion never cascades: this project still holds environments or folders.';
     case 'set-environment-settings':
       return 'The current environment state refused this policy change. Reload before retrying.';
+    case 'rotate-master-key':
+      return 'The root key is still dual-wrapped. Finalize the root-key rotation before rotating the master key.';
+    case 'rotate-root-key':
+      return 'The root-key rotation cannot run this phase from the current state. Reload before retrying.';
     default:
       return 'The current resource state refused this settings change. Reload before retrying.';
   }

--- a/web/src/routes/InstanceAdmin.crypto.test.tsx
+++ b/web/src/routes/InstanceAdmin.crypto.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthProvider } from '../app/AuthProvider.tsx';
+import { renderForm, settleTask } from '../testkit/renderForm.tsx';
+import { InstanceAdmin } from './InstanceAdmin.tsx';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/**
+ * The instance-scoped cryptographic maintenance surface (#503). Every GET the
+ * page fires that we do not care about returns 404 so its panel lands in an
+ * honest "not disclosed" state; we drive only the rotation and re-encryption
+ * POSTs.
+ */
+function mountInstanceAdmin(
+  handler: (request: Request, path: string) => Response | null,
+): ReturnType<typeof renderForm> {
+  const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+    const input = args[0];
+    const request = input instanceof Request ? input : new Request(input, args[1]);
+    const path = new URL(request.url, 'http://localhost').pathname;
+    const specific = handler(request, path);
+    if (specific !== null) return Promise.resolve(specific);
+    // whoami and every other GET: refuse, so no panel crashes and none of the
+    // crypto controls depends on a disclosed directory.
+    return Promise.resolve(new Response(null, { status: 404 }));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return renderForm(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/instance']}>
+        <Routes>
+          <Route path="/instance" element={<InstanceAdmin />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+function requests(mock: ReturnType<typeof vi.fn>): Request[] {
+  return mock.mock.calls.map(([input, init]) =>
+    input instanceof Request ? input : new Request(input as string, init as RequestInit),
+  );
+}
+
+function button(root: ParentNode, text: string): HTMLButtonElement {
+  const match = [...root.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+  if (!(match instanceof HTMLButtonElement)) {
+    throw new Error(`${text} button is missing`);
+  }
+  return match;
+}
+
+function dialog(container: HTMLElement): HTMLElement {
+  const found = container.ownerDocument.querySelector('dialog.ceremony');
+  if (!(found instanceof HTMLElement)) {
+    throw new Error('the ceremony dialog is missing');
+  }
+  return found;
+}
+
+describe('instance crypto maintenance', () => {
+  it('rotates the instance DEK only after the consequences dialog is confirmed', async () => {
+    const fetchMock = vi.fn();
+    const view = mountInstanceAdmin((request, path) => {
+      fetchMock(request, path);
+      if (request.method === 'POST' && path === '/api/v1/instance/rotate-dek') {
+        return new Response(JSON.stringify({ scope: 'instance', key_version: 4 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+
+      // Nothing is posted just by rendering the panel.
+      expect(fetchMock.mock.calls.some(([, p]) => p === '/api/v1/instance/rotate-dek')).toBe(false);
+
+      await act(async () => button(container, 'Rotate the instance DEK').click());
+      expect(dialog(container).textContent).toContain('incomplete until');
+
+      await act(async () => button(container, 'Rotate the DEK').click());
+      await settleTask();
+
+      const rotate = requests(fetchMock).find(
+        (r) => r.method === 'POST' && new URL(r.url).pathname === '/api/v1/instance/rotate-dek',
+      );
+      if (rotate === undefined) throw new Error('the rotate-dek request is missing');
+      expect(await rotate.json()).toEqual({ scope: 'instance' });
+      expect(container.textContent).toContain('version 4');
+      expect(container.textContent).toContain('run the instance re-encryption');
+    } finally {
+      await unmount();
+    }
+  });
+
+  it('drains instance re-encryption across runs until a run moves no rows', async () => {
+    let calls = 0;
+    const fetchMock = vi.fn();
+    const view = mountInstanceAdmin((request, path) => {
+      fetchMock(request, path);
+      if (request.method === 'POST' && path === '/api/v1/instance/reencrypt') {
+        calls += 1;
+        const rowsMoved = calls === 1 ? 5 : 0;
+        return new Response(JSON.stringify({ scope: 'instance', rows_moved: rowsMoved }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+      await act(async () => button(container, 'Re-encrypt the instance').click());
+      await settleTask();
+
+      const reencrypts = requests(fetchMock).filter(
+        (r) => r.method === 'POST' && new URL(r.url).pathname === '/api/v1/instance/reencrypt',
+      );
+      // First run moves rows, so the loop runs again; the second moves none and stops.
+      expect(reencrypts).toHaveLength(2);
+      expect(container.textContent).toContain('moved 5 ciphertext rows');
+      expect(container.textContent).toContain('2 runs');
+    } finally {
+      await unmount();
+    }
+  });
+
+  it('keeps the committed row count when a later re-encryption run fails', async () => {
+    let calls = 0;
+    const view = mountInstanceAdmin((request, path) => {
+      if (request.method === 'POST' && path === '/api/v1/instance/reencrypt') {
+        calls += 1;
+        if (calls === 1) {
+          return new Response(JSON.stringify({ scope: 'instance', rows_moved: 5 }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(null, { status: 500 });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+      await act(async () => button(container, 'Re-encrypt the instance').click());
+      await settleTask();
+
+      // The committed 5 rows are not lost when the second run fails; the failure
+      // text names them and says the idempotent walk resumes on re-run.
+      expect(container.textContent).toContain('5 ciphertext rows moved across 1 run before this failure');
+      expect(container.textContent).toContain('re-running resumes');
+    } finally {
+      await unmount();
+    }
+  });
+
+  it('reads a 403 on a crypto job as a session step-up requirement, not a permanent refusal', async () => {
+    const view = mountInstanceAdmin((request, path) => {
+      if (request.method === 'POST' && path === '/api/v1/instance/rotate-dek') {
+        return new Response(null, { status: 403 });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+      await act(async () => button(container, 'Rotate the instance DEK').click());
+      await act(async () => button(container, 'Rotate the DEK').click());
+      await settleTask();
+
+      const text = dialog(container).textContent ?? '';
+      expect(text).toContain('needs a second factor');
+      expect(text).toContain('present your authenticator code or passkey in the banner above');
+      expect(text).not.toContain('You are not permitted');
+    } finally {
+      await unmount();
+    }
+  });
+
+  it('maps a master-key 409 to the finalize-root-rotation-first refusal', async () => {
+    const view = mountInstanceAdmin((request, path) => {
+      if (request.method === 'POST' && path === '/api/v1/instance/rotate-master-key') {
+        return new Response(JSON.stringify({}), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+      await act(async () => button(container, 'Rotate the master key').click());
+      await act(async () => button(container, 'Rotate the key').click());
+      await settleTask();
+
+      expect(dialog(container).textContent).toContain('Finalize the root-key rotation before rotating the master key.');
+    } finally {
+      await unmount();
+    }
+  });
+
+  it('sends the prepare phase for the root-key rotation with its crash-safety copy', async () => {
+    const fetchMock = vi.fn();
+    const view = mountInstanceAdmin((request, path) => {
+      fetchMock(request, path);
+      if (request.method === 'POST' && path === '/api/v1/instance/rotate-root-key') {
+        return new Response(JSON.stringify({ phase: 'prepare', root_key_epoch: 2 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return null;
+    });
+    const { container, unmount } = await view;
+    try {
+      await settleTask();
+      await act(async () => button(container, 'Prepare').click());
+      const ceremony = dialog(container);
+      expect(ceremony.textContent).toContain('No key material crosses the wire');
+      expect(ceremony.textContent).toContain('install the new root at the primary source');
+
+      await act(async () => button(ceremony, 'Prepare').click());
+      await settleTask();
+
+      const prepare = requests(fetchMock).find(
+        (r) =>
+          r.method === 'POST' && new URL(r.url).pathname === '/api/v1/instance/rotate-root-key',
+      );
+      if (prepare === undefined) throw new Error('the rotate-root-key request is missing');
+      expect(await prepare.json()).toEqual({ phase: 'prepare' });
+      expect(container.textContent).toContain('epoch 2');
+    } finally {
+      await unmount();
+    }
+  });
+});

--- a/web/src/routes/InstanceAdmin.tsx
+++ b/web/src/routes/InstanceAdmin.tsx
@@ -22,10 +22,16 @@ import { ApiError, parsed } from '../api/client.ts';
 import type { Grant } from '../api/identities.ts';
 import { retentionBanner } from '../api/retention.ts';
 import {
+  cryptoFailureText,
   settingsFailureText,
   settingsOperationFailure,
   useCreateOrg,
   useInstanceOrgs,
+  useReencryptInstance,
+  useRotateDek,
+  useRotateMasterKey,
+  useRotateRootKey,
+  useRotateScanningKey,
   useRotateTokenKey,
 } from '../api/settings.ts';
 import { notifySuccess } from '../app/notifications.tsx';
@@ -34,8 +40,9 @@ import { FederationIssuersPanel } from './FederationIssuersPanel.tsx';
 import { OidcProvidersPanel } from './OidcProvidersPanel.tsx';
 import { SamlProvidersPanel } from './SamlProvidersPanel.tsx';
 import { SamlSpKeysPanel } from './SamlSpKeysPanel.tsx';
-import { Alert, Done, JumpIndex, Panel } from './Sections.tsx';
-import { useFeedback, useModalDialog } from './useModalDialog.ts';
+import { Alert, ConsequencesDialog, Done, JumpIndex, Panel } from './Sections.tsx';
+import { useFeedback } from './useModalDialog.ts';
+import { useReencryptDrain } from './useReencryptDrain.ts';
 
 const prototypeMode = import.meta.env.MODE === 'prototype';
 
@@ -87,7 +94,6 @@ export function InstanceAdmin() {
   const createGrants = useCreateGrants();
   const applyTemplate = useApplyTemplate();
   const revokeGrant = useRevokeGrant();
-  const rotate = useRotateTokenKey();
   const nameId = useId();
   const principalId = useId();
   const { failure, done, report, ok } = useFeedback(instanceFailureText);
@@ -100,8 +106,6 @@ export function InstanceAdmin() {
     notifySuccess(message);
     ok(message);
   });
-  const [confirmRotate, setConfirmRotate] = useState(false);
-  const rotationFeedback = useFeedback((error) => settingsFailureText(error, 'rotate-token-key'));
   const [grantPrincipal, setGrantPrincipal] = useState('');
   const [grantTemplate, setGrantTemplate] = useState('');
   const [selectedCapabilities, setSelectedCapabilities] = useState<readonly string[]>([]);
@@ -229,14 +233,10 @@ export function InstanceAdmin() {
     <Panel id="instance-keys" title="Keys &amp; crypto">
       {prototypeMode ? <>
         <div className="settings-row"><div className="settings-row__copy"><span className="settings-row__title">Master key</span><span className="settings-row__detail">rotated 2026-06-20 · all tier-3 keys wrapped current</span></div><span className="settings-row__spacer" /><code>$ hikyo rotate-master-key</code><button type="button" className="btn">rotate</button></div>
-        <div className="settings-row"><div className="settings-row__copy"><span className="settings-row__title">Change-token key</span><span className="settings-row__detail">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div><span className="settings-row__spacer" /><code>$ hikyo rotate-token-key</code><button type="button" className="btn" onClick={() => setConfirmRotate(true)}>rotate</button></div>
+        <div className="settings-row"><div className="settings-row__copy"><span className="settings-row__title">Change-token key</span><span className="settings-row__detail">warned operation: every client cursor invalidates, next fetch is full, no restart wave</span></div><span className="settings-row__spacer" /><code>$ hikyo rotate-token-key</code><button type="button" className="btn">rotate</button></div>
         <div className="settings-row"><div className="settings-row__copy"><span className="settings-row__title">Re-encryption</span><span className="settings-row__detail">background, resumable, per-row</span></div><span className="settings-row__spacer" /><span>idle</span></div>
         <p className="settings-note">Root-key rotation, <code>init</code>, <code>migrate</code>, restore reconciliation and break-glass are local host authority (SystemProof, #23/#25): deliberately absent from every network surface, UI and API alike. That set is the one parity exception, and it is CLI-at-the-box, not CLI-over-network.</p>
-      </> : <>
-        <p><strong>Change-token key.</strong> Rotating it invalidates every client cursor: the next fetch from every workload is a full fetch. There is no restart wave or downtime.</p>
-        <div className="panel__actions"><button type="button" className="btn" onClick={() => setConfirmRotate(true)}>Rotate the change-token key</button></div>
-        <p className="field__hint">Root-key rotation, master-key rotation, re-encryption, <span className="mono">init</span>, <span className="mono">migrate</span>, restore reconciliation and break-glass are local host authority. They are deliberately absent from every network surface — CLI-at-the-box, not CLI-over-network.</p>
-      </>}
+      </> : <CryptoMaintenance onDone={ok} onFailure={report} />}
     </Panel>
     {prototypeMode ? null : <SamlProvidersPanel />}
     {prototypeMode ? null : <SamlSpKeysPanel />}
@@ -249,10 +249,6 @@ export function InstanceAdmin() {
       </> : <p role="status">Connected-instance discovery is not available yet.</p>}
       <p className="settings-note"><strong>Open question, own wayfinder ticket:</strong> Portainer-style: one MAIN instance connects to and manages others. Undecided: what “manage” means (proxy the API? sync orgs? just deep-link?), the credential model (#17 federation? per-instance context pins from #25?), tenant-isolation and threat-model consequences, and whether it is v1 at all (→ MVP boundary). This card exists to react to, not a decision.</p>
     </Panel>
-    {confirmRotate ? <RotateDialog busy={rotate.isPending} failure={rotationFeedback.failure} onCancel={() => { rotationFeedback.clear(); setConfirmRotate(false); }} onConfirm={() => {
-      rotationFeedback.clear();
-      rotate.mutate(undefined, { onSuccess: () => { ok('The change-token key was rotated. Every client cursor is invalid; the next fetch from each workload is a full one.'); setConfirmRotate(false); }, onError: rotationFeedback.report });
-    }} /> : null}
   </div>;
 }
 
@@ -314,12 +310,133 @@ function CredentialPolicyPanel({ query, onDone, onFailure }: { query: ReturnType
   </Panel>;
 }
 
-function RotateDialog({ busy, failure, onCancel, onConfirm }: { busy: boolean; failure: string | null; onCancel: () => void; onConfirm: () => void }) {
-  const dialog = useModalDialog();
-  return <dialog className="ceremony" ref={dialog} aria-labelledby="rotate-title" onCancel={(event) => { event.preventDefault(); if (!busy) onCancel(); }}>
-    <h2 id="rotate-title">Rotate the change-token key?</h2>
-    <p className="ceremony__lede">Every conditional-fetch cursor in circulation stops matching. The next fetch from every workload is a full one, and nothing restarts. This cannot be undone by rotating back.</p>
-    {busy ? <p role="status">Rotating the key…</p> : null}{failure === null ? null : <Alert>{failure}</Alert>}
-    <div className="ceremony__actions"><button type="button" className="btn" onClick={onCancel} disabled={busy}>Cancel</button><button type="button" className="btn btn--danger" onClick={onConfirm} disabled={busy}>Rotate the key</button></div>
-  </dialog>;
+type CryptoCeremony =
+  | 'token'
+  | 'scanning'
+  | 'master'
+  | 'dek-instance'
+  | 'root-prepare'
+  | 'root-verify'
+  | 'root-finalize';
+
+/**
+ * CryptoMaintenance exposes every remotely operable rotation and re-encryption
+ * job (#503). Each is the same grant-evaluated network operation the CLI verb
+ * calls; the host-only set (`init`, `migrate`, restore reconciliation,
+ * break-glass, host-file custody, startup-only key material) stays absent.
+ */
+function CryptoMaintenance({ onDone, onFailure }: { onDone: (message: string) => void; onFailure: (error: unknown) => void }) {
+  const token = useRotateTokenKey();
+  const scanning = useRotateScanningKey();
+  const master = useRotateMasterKey();
+  const dek = useRotateDek();
+  const reencrypt = useReencryptInstance();
+  const root = useRotateRootKey();
+  const titleId = useId();
+  const [ceremony, setCeremony] = useState<CryptoCeremony | null>(null);
+  const [dialogFailure, setDialogFailure] = useState<string | null>(null);
+  const open = (which: CryptoCeremony) => { setDialogFailure(null); setCeremony(which); };
+  const close = () => { setDialogFailure(null); setCeremony(null); };
+
+  const drain = useReencryptDrain(reencrypt, { operation: 'reencrypt-instance', noun: 'Instance', onDone });
+
+  const busy = token.isPending || scanning.isPending || master.isPending || dek.isPending || root.isPending;
+
+  return <div className="crypto-maintenance">
+    <div className="settings-row">
+      <div className="settings-row__copy"><span className="settings-row__title">Change-token key</span><span className="settings-row__detail">Rotating it invalidates every client cursor: the next fetch from every workload is a full one. No restart wave, no downtime.</span></div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo rotate-token-key</code>
+      <button type="button" className="btn" onClick={() => open('token')}>Rotate the change-token key</button>
+    </div>
+
+    <div className="settings-row">
+      <div className="settings-row__copy"><span className="settings-row__title">Secret-scanning key</span><span className="settings-row__detail">Rotating it drops every scan dismissal in the same transaction; suppressed warns re-fire, because their fingerprints are no longer recomputable.</span></div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo rotate-scanning-key</code>
+      <button type="button" className="btn" onClick={() => open('scanning')}>Rotate the scanning key</button>
+    </div>
+
+    <div className="settings-row">
+      <div className="settings-row__copy"><span className="settings-row__title">Master key</span><span className="settings-row__detail">Re-wraps every tier-3 key (all DEKs and the root token key) under a new master, then retires the old one. Refused while the root key is dual-wrapped — finalize the root rotation first.</span></div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo rotate-master-key</code>
+      <button type="button" className="btn" onClick={() => open('master')}>Rotate the master key</button>
+    </div>
+
+    <div className="settings-row">
+      <div className="settings-row__copy"><span className="settings-row__title">Data-encryption key (instance)</span><span className="settings-row__detail">Appends a new instance DEK version. New writes seal under it immediately; existing ciphertext stays readable until you re-encrypt. A rotation is incomplete without the re-encryption below.</span></div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo rotate-dek --scope instance</code>
+      <button type="button" className="btn" onClick={() => open('dek-instance')}>Rotate the instance DEK</button>
+    </div>
+
+    <div className="settings-row">
+      <div className="settings-row__copy"><span className="settings-row__title">Instance re-encryption</span><span className="settings-row__detail">Walks every instance credential ciphertext onto the active DEK version and retires the superseded ones — the completion of an instance DEK rotation. Chunked and resumable: safe to re-run, and complete once it moves no rows.</span></div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo reencrypt</code>
+      <button type="button" className="btn" disabled={drain.running} onClick={drain.run}>{drain.running ? 'Re-encrypting…' : 'Re-encrypt the instance'}</button>
+    </div>
+    {drain.running ? <p role="status" className="field__hint">Re-encrypting… run {drain.runs}, {String(drain.total)} row{drain.total === 1n ? '' : 's'} moved so far. Safe to leave and resume later.</p> : null}
+    {drain.failure === null ? null : <Alert>{drain.failure}</Alert>}
+
+    <div className="settings-row">
+      <div className="settings-row__copy">
+        <span className="settings-row__title">Root-key rotation</span>
+        <span className="settings-row__detail">Three crash-safe phases over a dual-wrapped master. No key material crosses the wire. Between <strong>prepare</strong> and <strong>verify</strong> you install the new root at the primary source on the host. The instance stays bootable under either root and warns on every start until <strong>finalize</strong>. Run the phases in order — the server refuses one run out of turn.</span>
+      </div>
+      <span className="settings-row__spacer" /><code className="instance-cli">$ hikyo rotate-root-key</code>
+      <div className="crypto-phases">
+        <button type="button" className="btn" onClick={() => open('root-prepare')}>Prepare</button>
+        <button type="button" className="btn" onClick={() => open('root-verify')}>Verify</button>
+        <button type="button" className="btn" onClick={() => open('root-finalize')}>Finalize</button>
+      </div>
+    </div>
+
+    <p className="field__hint"><span className="mono">init</span>, <span className="mono">migrate</span>, restore reconciliation, break-glass, host-file custody and startup-only key material are local host authority. They are deliberately absent from every network surface — CLI-at-the-box, not CLI-over-network.</p>
+
+    {ceremony === 'token' ? <ConsequencesDialog titleId={titleId} title="Rotate the change-token key?" confirmLabel="Rotate the key" busyLabel="Rotating the change-token key…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      token.mutate(undefined, { onSuccess: (result) => { onDone(`The change-token key was rotated (version ${String(result.token_key_version)}). Every client cursor is invalid; the next fetch from each workload is a full one.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-token-key')) });
+    }}>
+      <p>Every conditional-fetch cursor in circulation stops matching. The next fetch from every workload is a full one, and nothing restarts. This cannot be undone by rotating back.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'scanning' ? <ConsequencesDialog titleId={titleId} title="Rotate the secret-scanning key?" confirmLabel="Rotate the key" busyLabel="Rotating the scanning key…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      scanning.mutate(undefined, { onSuccess: (result) => { onDone(`The secret-scanning key was rotated (version ${String(result.scanning_key_version)}). ${String(result.dismissals_dropped)} dismissal${result.dismissals_dropped === 1n ? ' was' : 's were'} dropped; their warns will re-fire.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-scanning-key')) });
+    }}>
+      <p>Every stored scan fingerprint becomes unrecomputable under the new key, so every dismissal is dropped in the same transaction and the warns they suppressed will fire again. This cannot be undone.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'master' ? <ConsequencesDialog titleId={titleId} title="Rotate the master key?" confirmLabel="Rotate the key" busyLabel="Rotating the master key…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      master.mutate(undefined, { onSuccess: (result) => { onDone(`The master key was rotated (version ${String(result.key_version)}). Every tier-3 key is now wrapped under it.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-master-key')) });
+    }}>
+      <p>A new master key is generated, every tier-3 key is re-wrapped under it, and the old master is retired after a zero-reference check. This is refused while the root key is dual-wrapped — finalize the root rotation first.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'dek-instance' ? <ConsequencesDialog titleId={titleId} title="Rotate the instance DEK?" confirmLabel="Rotate the DEK" busyLabel="Rotating the instance DEK…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      dek.mutate({ scope: 'instance' }, { onSuccess: (result) => { onDone(`The instance DEK was rotated (version ${String(result.key_version)}). New writes seal under it; existing ciphertext stays readable until you run the instance re-encryption to complete the rotation.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-dek')) });
+    }}>
+      <p>A new instance DEK version is appended. New writes seal under it immediately; existing ciphertext stays readable under the previous version until the instance re-encryption walks it forward. The rotation is incomplete until you run that re-encryption.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'root-prepare' ? <ConsequencesDialog titleId={titleId} title="Prepare the root-key rotation?" confirmLabel="Prepare" busyLabel="Preparing the root-key rotation…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      root.mutate('prepare', { onSuccess: (result) => { onDone(`Root-key rotation prepared (epoch ${String(result.root_key_epoch)}). Install the new root at the primary source on the host, then run verify. The instance stays bootable under either root and warns on every start until finalize.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-root-key')) });
+    }}>
+      <p>Prepare reads the new root from the server-side source and seals a second master wrapper. No key material crosses the wire. After this you must install the new root at the primary source on the host, then run verify. The instance stays bootable under either root until you finalize.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'root-verify' ? <ConsequencesDialog titleId={titleId} title="Verify the root-key rotation?" confirmLabel="Verify" busyLabel="Verifying the root-key rotation…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      root.mutate('verify', { onSuccess: (result) => { onDone(`Root-key rotation verified (epoch ${String(result.root_key_epoch)}). The primary source now unwraps the new root. Run finalize to retire the old wrapper.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-root-key')) });
+    }}>
+      <p>Verify re-reads the primary source and confirms it now unwraps the new wrapper you sealed in prepare. Run this only after installing the new root at the primary source on the host. If it has not been installed yet, this phase is refused.</p>
+    </ConsequencesDialog> : null}
+
+    {ceremony === 'root-finalize' ? <ConsequencesDialog titleId={titleId} title="Finalize the root-key rotation?" confirmLabel="Finalize" busyLabel="Finalizing the root-key rotation…" busy={busy} failure={dialogFailure} onCancel={close} onConfirm={() => {
+      setDialogFailure(null);
+      root.mutate('finalize', { onSuccess: (result) => { onDone(`Root-key rotation finalized (epoch ${String(result.root_key_epoch)}). The old wrapper is retired and the startup warning clears.`); close(); }, onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-root-key')) });
+    }}>
+      <p>Finalize retires the old master wrapper, leaving the instance wrapped under the new root only. The startup warning clears. Run this only after verify has succeeded.</p>
+    </ConsequencesDialog> : null}
+  </div>;
 }

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -215,6 +215,93 @@ describe('environment creation', () => {
   });
 });
 
+describe('project crypto maintenance', () => {
+  it('rotates the project DEK after confirmation, then drains re-encryption across runs', async () => {
+    let reencryptCalls = 0;
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const input = args[0];
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url, 'http://localhost').pathname;
+      if (request.method === 'GET' && path === '/api/v1/auth/whoami') {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (request.method === 'POST' && path === '/api/v1/instance/rotate-dek') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ scope: 'project', key_version: 2 }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (
+        request.method === 'POST' &&
+        path === '/api/v1/orgs/org_1/projects/project_1/reencrypt'
+      ) {
+        reencryptCalls += 1;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ scope: 'project', rows_moved: reencryptCalls === 1 ? 3 : 0 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }
+      const json = settingsResponse(request.method, path, 'db');
+      return Promise.resolve(
+        new Response(JSON.stringify(json), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = await renderForm(
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/orgs/org_1/projects/project_1/settings']}>
+          <Routes>
+            <Route path="/orgs/:org/projects/:project/settings" element={<ProjectSettings />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    try {
+      await settleTask();
+
+      await act(async () => button(view.container, 'Rotate the project DEK').click());
+      const dialog = view.container.ownerDocument.querySelector('dialog.ceremony');
+      expect(dialog?.textContent).toContain('incomplete until');
+      await act(async () => button(view.container, 'Rotate the DEK').click());
+      await settleTask();
+
+      const rotate = fetchMock.mock.calls
+        .map(([input]) => (input instanceof Request ? input : new Request(input)))
+        .find(
+          (r) => r.method === 'POST' && new URL(r.url).pathname === '/api/v1/instance/rotate-dek',
+        );
+      if (rotate === undefined) throw new Error('the rotate-dek request is missing');
+      expect(await rotate.json()).toEqual({ scope: 'project', org: 'org_1', project: 'project_1' });
+      expect(view.container.textContent).toContain('version 2');
+
+      await act(async () => button(view.container, 'Re-encrypt the project').click());
+      await settleTask();
+
+      const reencrypts = fetchMock.mock.calls
+        .map(([input]) => (input instanceof Request ? input : new Request(input)))
+        .filter(
+          (r) =>
+            r.method === 'POST' &&
+            new URL(r.url).pathname === '/api/v1/orgs/org_1/projects/project_1/reencrypt',
+        );
+      expect(reencrypts).toHaveLength(2);
+      expect(view.container.textContent).toContain('moved 3 ciphertext rows');
+      expect(view.container.textContent).toContain('2 runs');
+    } finally {
+      await view.unmount();
+    }
+  });
+});
+
 function settingsResponse(
   method: string,
   path: string,

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -10,6 +10,7 @@ import {
 } from '../api/definitions.ts';
 import {
   createEnvironmentRefusalText,
+  cryptoFailureText,
   retentionSentence,
   settingsFailureText,
   settingsOperationFailure,
@@ -20,7 +21,9 @@ import {
   useOrgRetention,
   useProject,
   useProjectRetention,
+  useReencryptProject,
   useRenameProject,
+  useRotateDek,
   useSetEnvironmentSettings,
   useSetProjectRetention,
   type ProjectRetentionPolicy,
@@ -29,8 +32,9 @@ import {
 } from '../api/settings.ts';
 import { surfaceById } from '../app/navigation.ts';
 import { ChromeIdentityControls } from './ChromeIdentityControls.tsx';
-import { Alert, Done, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
+import { Alert, ConsequencesDialog, Done, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
 import { useFeedback } from './useModalDialog.ts';
+import { useReencryptDrain } from './useReencryptDrain.ts';
 
 const prototypeMode = import.meta.env.MODE === 'prototype';
 
@@ -90,6 +94,7 @@ export function ProjectSettings() {
           { id: 'project-environments', label: 'Environments' },
           { id: 'project-policy', label: 'Policy' },
           { id: 'project-access', label: 'Access' },
+          ...(prototypeMode ? [] : [{ id: 'project-keys', label: 'Keys & crypto' }]),
           { id: 'project-danger', label: 'Danger zone' },
         ]}
       />
@@ -260,6 +265,17 @@ export function ProjectSettings() {
         </p>
       </Panel>
 
+      {prototypeMode ? null : (
+        <Panel id="project-keys" title="Keys &amp; crypto">
+          <ProjectCryptoMaintenance
+            org={org}
+            project={project}
+            disabled={current === undefined}
+            onDone={feedback.ok}
+          />
+        </Panel>
+      )}
+
       <Panel id="project-danger" title="Danger zone" danger>
         {prototypeMode ? (
           <div className="settings-row">
@@ -301,6 +317,102 @@ export function ProjectSettings() {
         />
       </Panel>
     </div>
+  );
+}
+
+/**
+ * ProjectCryptoMaintenance exposes the project-scoped half of the remotely
+ * operable cryptographic jobs (#503): rotate this project's DEK, then walk its
+ * ciphertext onto the new version. The two are paired — a DEK rotation is
+ * incomplete until the re-encryption runs — and both are the same
+ * grant-evaluated network operations the CLI verbs call.
+ */
+function ProjectCryptoMaintenance({
+  org,
+  project,
+  disabled,
+  onDone,
+}: {
+  org: string;
+  project: string;
+  disabled: boolean;
+  onDone: (text: string) => void;
+}) {
+  const dek = useRotateDek();
+  const reencrypt = useReencryptProject(org, project);
+  const titleId = useId();
+  const [confirmRotate, setConfirmRotate] = useState(false);
+  const [dialogFailure, setDialogFailure] = useState<string | null>(null);
+
+  const drain = useReencryptDrain(reencrypt, { operation: 'reencrypt-project', noun: 'Project', onDone });
+
+  return (
+    <>
+      <p className="settings-note">
+        Both jobs run over the network, guarded by capability plus session second-factor assurance;
+        no key material crosses the wire. A DEK rotation is incomplete until the re-encryption below
+        walks the project&apos;s ciphertext forward.
+      </p>
+      <div className="settings-row">
+        <div className="settings-row__copy">
+          <span className="settings-row__title">Data-encryption key (project)</span>
+          <span className="settings-row__detail">
+            Appends a new DEK version for this project. New writes seal under it immediately; existing
+            ciphertext stays readable until you re-encrypt.
+          </span>
+        </div>
+        <span className="settings-row__spacer" />
+        <code className="instance-cli">$ hikyo rotate-dek --scope project</code>
+        <button type="button" className="btn" disabled={disabled} onClick={() => { setDialogFailure(null); setConfirmRotate(true); }}>
+          Rotate the project DEK
+        </button>
+      </div>
+      <div className="settings-row">
+        <div className="settings-row__copy">
+          <span className="settings-row__title">Project re-encryption</span>
+          <span className="settings-row__detail">
+            Walks every ciphertext in this project onto the active DEK version and retires the
+            superseded ones. Chunked and resumable: safe to re-run, and complete once it moves no rows.
+          </span>
+        </div>
+        <span className="settings-row__spacer" />
+        <code className="instance-cli">$ hikyo reencrypt --project</code>
+        <button type="button" className="btn" disabled={disabled || drain.running} onClick={drain.run}>
+          {drain.running ? 'Re-encrypting…' : 'Re-encrypt the project'}
+        </button>
+      </div>
+      {drain.running ? <p role="status" className="field__hint">Re-encrypting… run {drain.runs}, {String(drain.total)} row{drain.total === 1n ? '' : 's'} moved so far. Safe to leave and resume later.</p> : null}
+      {drain.failure === null ? null : <Alert>{drain.failure}</Alert>}
+
+      {confirmRotate ? (
+        <ConsequencesDialog
+          titleId={titleId}
+          title="Rotate this project's DEK?"
+          confirmLabel="Rotate the DEK"
+          busyLabel="Rotating the project DEK…"
+          busy={dek.isPending}
+          failure={dialogFailure}
+          onCancel={() => { setDialogFailure(null); setConfirmRotate(false); }}
+          onConfirm={() => {
+            setDialogFailure(null);
+            dek.mutate({ scope: 'project', org, project }, {
+              onSuccess: (result) => {
+                onDone(`This project's DEK was rotated (version ${String(result.key_version)}). New writes seal under it; existing ciphertext stays readable until you run the project re-encryption to complete the rotation.`);
+                setConfirmRotate(false);
+              },
+              onError: (error) => setDialogFailure(cryptoFailureText(error, 'rotate-dek')),
+            });
+          }}
+        >
+          <p>
+            A new DEK version is appended for this project. New writes seal under it immediately;
+            existing ciphertext stays readable under the previous version until the project
+            re-encryption walks it forward. The rotation is incomplete until you run that
+            re-encryption.
+          </p>
+        </ConsequencesDialog>
+      ) : null}
+    </>
   );
 }
 

--- a/web/src/routes/Sections.tsx
+++ b/web/src/routes/Sections.tsx
@@ -1,5 +1,7 @@
 import { useId, useState, type ReactNode } from 'react';
 
+import { useModalDialog } from './useModalDialog.ts';
+
 /**
  * The sectioned-surface parts every chrome settings surface is built from
  * (#60, locked prototype app-chrome iteration 15).
@@ -157,6 +159,64 @@ export function TypedNameConfirm({
         {action}
       </button>
     </div>
+  );
+}
+
+/**
+ * ConsequencesDialog is the impact ceremony a destructive, remotely operable
+ * operation passes through before it commits (#503): it names the exact
+ * operation and its irreversible consequences, keeps its danger button INSIDE
+ * the dialog (never on an always-rendered surface, which trips the forced-colors
+ * contrast contract), and shows the busy state and any refusal inline.
+ *
+ * Reauthentication is bound at the session level — a 403 surfaces the step-up
+ * banner — so the dialog itself carries only consequence and confirmation.
+ */
+export function ConsequencesDialog({
+  titleId,
+  title,
+  confirmLabel,
+  busyLabel,
+  busy,
+  failure,
+  onCancel,
+  onConfirm,
+  children,
+}: {
+  titleId: string;
+  title: string;
+  confirmLabel: string;
+  busyLabel: string;
+  busy: boolean;
+  failure: string | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+  children: ReactNode;
+}) {
+  const dialog = useModalDialog();
+  return (
+    <dialog
+      className="ceremony"
+      ref={dialog}
+      aria-labelledby={titleId}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) onCancel();
+      }}
+    >
+      <h2 id={titleId}>{title}</h2>
+      <div className="ceremony__lede">{children}</div>
+      {busy ? <p role="status">{busyLabel}</p> : null}
+      {failure === null ? null : <Alert>{failure}</Alert>}
+      <div className="ceremony__actions">
+        <button type="button" className="btn" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+        <button type="button" className="btn btn--danger" onClick={onConfirm} disabled={busy}>
+          {confirmLabel}
+        </button>
+      </div>
+    </dialog>
   );
 }
 

--- a/web/src/routes/useReencryptDrain.ts
+++ b/web/src/routes/useReencryptDrain.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { cryptoFailureText, type SettingsOperation } from '../api/settings.ts';
+
+/**
+ * useReencryptDrain drives a chunked, idempotent re-encryption to completion
+ * (#503). The server walks the ciphertext in bounded chunks, returning how many
+ * rows a run moved; the drain re-invokes until a run moves nothing, which is the
+ * only honest "complete" signal (there is no status endpoint). It is safe to
+ * re-run after a refresh, disconnect or crash — the server resumes from its own
+ * cursor.
+ *
+ * Lifecycle correctness the loop must hold:
+ *  - abort on unmount is re-checked AFTER every await, so a request that resolves
+ *    for an unmounted page neither updates state nor emits a completion notice;
+ *  - committed progress survives a mid-drain failure: `runs` and `total` count
+ *    only successful runs (a throwing run increments neither), and the failure
+ *    text carries that partial total so the operator sees what already moved and
+ *    that re-running resumes rather than restarts.
+ */
+export function useReencryptDrain(
+  reencrypt: { mutateAsync: () => Promise<{ rows_moved: bigint }> },
+  options: { operation: SettingsOperation; noun: 'Instance' | 'Project'; onDone: (message: string) => void },
+): { running: boolean; runs: number; total: bigint; failure: string | null; run: () => void } {
+  const [state, setState] = useState<{ running: boolean; runs: number; total: bigint }>({
+    running: false,
+    runs: 0,
+    total: 0n,
+  });
+  const [failure, setFailure] = useState<string | null>(null);
+  const abort = useRef(false);
+  useEffect(() => () => { abort.current = true; }, []);
+
+  const run = () => {
+    void (async () => {
+      setFailure(null);
+      setState({ running: true, runs: 0, total: 0n });
+      let runs = 0;
+      let total = 0n;
+      try {
+        for (;;) {
+          const result = await reencrypt.mutateAsync();
+          if (abort.current) return;
+          runs += 1;
+          total += result.rows_moved;
+          setState({ running: true, runs, total });
+          if (result.rows_moved === 0n) break;
+        }
+        setState({ running: false, runs, total });
+        options.onDone(
+          total === 0n
+            ? `${options.noun} re-encryption complete: nothing to move; all ciphertext is already on the active DEK version.`
+            : `${options.noun} re-encryption complete: moved ${total} ciphertext row${total === 1n ? '' : 's'} onto the active DEK version across ${runs} run${runs === 1 ? '' : 's'}.`,
+        );
+      } catch (error) {
+        if (abort.current) return;
+        setState((current) => ({ ...current, running: false }));
+        const base = cryptoFailureText(error, options.operation);
+        setFailure(
+          total > 0n
+            ? `${base} ${total} ciphertext row${total === 1n ? '' : 's'} moved across ${runs} run${runs === 1 ? '' : 's'} before this failure; the walk is idempotent, so re-running resumes rather than restarts.`
+            : base,
+        );
+      }
+    })();
+  };
+
+  return { running: state.running, runs: state.runs, total: state.total, failure, run };
+}


### PR DESCRIPTION
Closes #503.

## What

Exposes every remotely operable cryptographic rotation and re-encryption job through the protected instance and project administration surfaces. The server already implemented all seven operations as grant-evaluated, human-session network verbs (rotate token/scanning/master/DEK/root-key, reencrypt instance/project) and the generated TS client already exposed them — only token-key rotation had a WebUI entry point. This is **WebUI-only**: hooks + UI + impact ceremonies + tests. No server change, no client regen.

### Entry points
- **Instance › Keys & crypto**: change-token, secret-scanning, master-key and instance-DEK rotation; instance re-encryption; three-phase crash-safe root-key rotation (prepare → host installs new root → verify → finalize).
- **Project › Keys & crypto**: project-DEK rotation paired with project re-encryption (a rotation is incomplete until its re-encryption runs — both scopes say so).

### Contracts preserved
- **Reauth is session-level**: a 403 surfaces the step-up banner, matching the token-key precedent and the locked API contract (endpoints declare capability + a `human-session` artifact, nothing purpose-bound). No new purpose-bound passkey ceremony, no server reauth-binding change.
- **Impact ceremony** (shared `ConsequencesDialog`): every destructive job names its exact irreversible consequences and scope before commit; the danger button stays inside the dialog (forced-colors contrast contract).
- **Resumable jobs**: re-encryption is an idempotent chunked walk — the runner loops until a run moves 0 rows, reports cumulative rows + run count, aborts on unmount, and is safe to re-run after refresh/disconnect/crash. Root rotation phase order is enforced server-side (409); the UI cannot know the phase after refresh by design, so out-of-order runs fail closed with the server's actionable detail.
- **No secret material** enters browser state, URLs, logs, toasts, DOM diagnostics or storage. Audit bookkeeping (key versions, root epoch, rows moved, dismissals dropped) is surfaced in completion copy.

### Doctrine narrowed
The stale note that named root/master/DEK/re-encryption as host-only is narrowed to the genuinely host-only set: `init`, `migrate`, restore reconciliation, break-glass, host-file custody, startup-only key material.

## Regenerated artifacts
None — the OpenAPI spec and generated TS client already carried all seven operations.

## Validation
- `pnpm --dir web typecheck` ✅
- `pnpm --dir web test` ✅ (607 unit tests; new instance + project ceremony, refusal-mapping and resume-loop coverage)
- `pnpm --dir web build` ✅
- Targeted Playwright (desktop, real server): instance-scoped **and** project-scoped DEK rotation + re-encryption run for real and resume across a reload; consequence/cancel coverage for the invisible jobs. The e2e seed grants the fixture principal `rotate-dek` and `reencrypt` (both content-invisible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)