### PR TITLE
feat(web): surface terminal update-job failures as alerts #457

### DIFF
--- a/web/src/api/updates.test.tsx
+++ b/web/src/api/updates.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import { forgetWorkspace, rememberWorkspace } from './workspace.ts';
 import {
   type InstanceUpdateJob,
+  jobReadErrorVisible,
   updateJobOutcome,
   useRemoteUpdateJob,
   useServerVersion,
@@ -54,6 +55,18 @@ test('updateJobOutcome passes failure_code through on a terminal failure', () =>
   expect(updateJobOutcome(job({ state: 'succeeded', failure_code: 'ignored' }))).toEqual({
     kind: 'succeeded',
   });
+});
+
+test('jobReadErrorVisible suppresses the read-error alert behind a terminal failure', () => {
+  // No error → never shown, whatever is cached.
+  expect(jobReadErrorVisible(false, undefined)).toBe(false);
+  expect(jobReadErrorVisible(false, job({ state: 'failed' }))).toBe(false);
+  // Error with no cached job, or a non-failure cached job → shown.
+  expect(jobReadErrorVisible(true, undefined)).toBe(true);
+  expect(jobReadErrorVisible(true, job({ state: 'succeeded' }))).toBe(true);
+  // Error while a terminal-failure read is still cached → suppressed; the
+  // failure alert already covers it, so the two must not double up.
+  expect(jobReadErrorVisible(true, job({ state: 'rollback-failed' }))).toBe(false);
 });
 
 test('server version reads server_version from the contract meta endpoint', async () => {

--- a/web/src/api/updates.test.tsx
+++ b/web/src/api/updates.test.tsx
@@ -5,7 +5,12 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { forgetWorkspace, rememberWorkspace } from './workspace.ts';
-import { useRemoteUpdateJob, useServerVersion } from './updates.ts';
+import {
+  type InstanceUpdateJob,
+  updateJobOutcome,
+  useRemoteUpdateJob,
+  useServerVersion,
+} from './updates.ts';
 
 const origin = 'https://remote.example';
 
@@ -16,6 +21,39 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   document.body.replaceChildren();
+});
+
+function job(overrides: Partial<InstanceUpdateJob>): InstanceUpdateJob {
+  return {
+    id: 'job_1',
+    backend: 'flux',
+    version: '1.4.0',
+    state: 'queued',
+    phase: 'queued',
+    requested_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('updateJobOutcome collapses the six job states into three outcomes', () => {
+  expect(updateJobOutcome(job({ state: 'queued' })).kind).toBe('running');
+  expect(updateJobOutcome(job({ state: 'running' })).kind).toBe('running');
+  expect(updateJobOutcome(job({ state: 'succeeded' })).kind).toBe('succeeded');
+  expect(updateJobOutcome(job({ state: 'failed' })).kind).toBe('failed');
+  expect(updateJobOutcome(job({ state: 'rolled-back' })).kind).toBe('failed');
+  expect(updateJobOutcome(job({ state: 'rollback-failed' })).kind).toBe('failed');
+});
+
+test('updateJobOutcome passes failure_code through on a terminal failure', () => {
+  expect(updateJobOutcome(job({ state: 'rollback-failed', failure_code: 'health_probe' }))).toEqual(
+    { kind: 'failed', failureCode: 'health_probe' },
+  );
+  // A failure without a code carries no failureCode rather than an empty string.
+  expect(updateJobOutcome(job({ state: 'failed' })).failureCode).toBeUndefined();
+  // Success and in-flight outcomes never carry a code.
+  expect(updateJobOutcome(job({ state: 'succeeded', failure_code: 'ignored' }))).toEqual({
+    kind: 'succeeded',
+  });
 });
 
 test('server version reads server_version from the contract meta endpoint', async () => {

--- a/web/src/api/updates.ts
+++ b/web/src/api/updates.ts
@@ -42,6 +42,18 @@ export function updateJobOutcome(job: InstanceUpdateJob): UpdateJobOutcome {
       return { kind: 'failed', failureCode: job.failure_code };
   }
 }
+
+/**
+ * Whether to show the "job status could not be read" alert. A refetch error can
+ * land while the last successful read — a terminal `failed` job — is still
+ * cached; in that case the failure alert already tells the operator the job is
+ * broken, so the read-error alert is suppressed to avoid a double-up. It shows
+ * only when there is a live read error and no terminal-failure outcome to
+ * supersede it.
+ */
+export function jobReadErrorVisible(isError: boolean, job: InstanceUpdateJob | undefined): boolean {
+  return isError && (job === undefined || updateJobOutcome(job).kind !== 'failed');
+}
 export type RemoteUpdateProbe = {
   origin: string;
   status: UpdateStatus | null | undefined;

--- a/web/src/api/updates.ts
+++ b/web/src/api/updates.ts
@@ -15,6 +15,33 @@ import { createWorkspaceClient } from './workspaceClient.ts';
 
 export type UpdateStatus = z.infer<typeof zUpdateStatus>;
 export type InstanceUpdateJob = z.infer<typeof zInstanceUpdateJob>;
+
+/**
+ * The three lifecycle outcomes a consumer renders differently: still working,
+ * clean success, or a terminal failure that needs operator attention.
+ * `rolled-back` and `rollback-failed` are both failures — the instance did not
+ * reach the requested version — so they collapse into `failed` and carry the
+ * diagnostic `failure_code` through. Centralizing the six-state → three-outcome
+ * mapping here keeps the enum from drifting out of the contract in the view.
+ */
+export type UpdateJobOutcome = {
+  kind: 'running' | 'succeeded' | 'failed';
+  failureCode?: string;
+};
+
+export function updateJobOutcome(job: InstanceUpdateJob): UpdateJobOutcome {
+  switch (job.state) {
+    case 'queued':
+    case 'running':
+      return { kind: 'running' };
+    case 'succeeded':
+      return { kind: 'succeeded' };
+    case 'failed':
+    case 'rolled-back':
+    case 'rollback-failed':
+      return { kind: 'failed', failureCode: job.failure_code };
+  }
+}
 export type RemoteUpdateProbe = {
   origin: string;
   status: UpdateStatus | null | undefined;

--- a/web/src/routes/Remotes.test.tsx
+++ b/web/src/routes/Remotes.test.tsx
@@ -91,7 +91,7 @@ describe('UpdateJobStatus', () => {
     const rendered = await renderForm(
       <UpdateJobStatus
         jobID="job_9"
-        job={updateJob({ state: 'rollback-failed', failure_code: 'health_probe' })}
+        job={updateJob({ state: 'rollback-failed', phase: 'rollback', failure_code: 'health_probe' })}
       />,
     );
     cleanups.push(rendered.unmount);
@@ -100,6 +100,7 @@ describe('UpdateJobStatus', () => {
     expect(alert).not.toBeNull();
     expect(alert?.textContent).toContain('job_9');
     expect(alert?.textContent).toContain('rollback-failed');
+    expect(alert?.textContent).toContain('(rollback)');
     expect(alert?.textContent).toContain('health_probe');
   });
 

--- a/web/src/routes/Remotes.test.tsx
+++ b/web/src/routes/Remotes.test.tsx
@@ -2,8 +2,9 @@
 import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { InstanceUpdateJob } from '../api/updates.ts';
 import { renderForm, settleTask, typeInto } from '../testkit/renderForm.tsx';
-import { AddRemote } from './Remotes.tsx';
+import { AddRemote, UpdateJobStatus } from './Remotes.tsx';
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -72,6 +73,47 @@ async function submit(container: HTMLElement): Promise<void> {
   });
   await settleTask();
 }
+
+describe('UpdateJobStatus', () => {
+  function updateJob(overrides: Partial<InstanceUpdateJob>): InstanceUpdateJob {
+    return {
+      id: 'job_1',
+      backend: 'flux',
+      version: '1.4.0',
+      state: 'queued',
+      phase: 'queued',
+      requested_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('renders a rollback-failed job as an alert carrying the failure code', async () => {
+    const rendered = await renderForm(
+      <UpdateJobStatus
+        jobID="job_9"
+        job={updateJob({ state: 'rollback-failed', failure_code: 'health_probe' })}
+      />,
+    );
+    cleanups.push(rendered.unmount);
+
+    const alert = rendered.container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toContain('job_9');
+    expect(alert?.textContent).toContain('rollback-failed');
+    expect(alert?.textContent).toContain('health_probe');
+  });
+
+  it('renders a succeeded job as a plain status line, not an alert', async () => {
+    const rendered = await renderForm(
+      <UpdateJobStatus jobID="job_9" job={updateJob({ state: 'succeeded', phase: 'complete' })} />,
+    );
+    cleanups.push(rendered.unmount);
+
+    expect(rendered.container.querySelector('[role="alert"]')).toBeNull();
+    expect(rendered.container.textContent).toContain('succeeded');
+    expect(rendered.container.textContent).toContain('(complete)');
+  });
+});
 
 describe('AddRemote', () => {
   it('blocks an existing origin before starting the mutation', async () => {

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -27,6 +27,7 @@ import { useOrgs } from '../api/session.ts';
 import { WorkspaceContextProvider, withRemote } from '../api/transport.tsx';
 import {
   type InstanceUpdateJob,
+  jobReadErrorVisible,
   updateJobOutcome,
   useRemoteUpdateJob,
   useRemoteUpdateStatuses,
@@ -274,7 +275,7 @@ function RemoteCard({ remote }: { remote: Remote }) {
       ) : null}
 
       {live !== undefined && update?.available === true ? (
-        <div className="remote__update" role="status">
+        <div className="remote__update">
           <p>
             Hikyo <span className="mono">{update.latest_version}</span> is available on the{' '}
             {update.channel} channel.
@@ -299,7 +300,7 @@ function RemoteCard({ remote }: { remote: Remote }) {
           {updateJobID === undefined ? null : (
             <UpdateJobStatus jobID={updateJobID} job={updateJob.data} />
           )}
-          {updateJob.isError && updateOutcome?.kind !== 'failed' ? (
+          {jobReadErrorVisible(updateJob.isError, updateJob.data) ? (
             <p className="alert" role="alert">
               The update job status could not be read. Inspect the remote instance logs before retrying.
             </p>
@@ -385,6 +386,7 @@ export function UpdateJobStatus({
         </span>
         <span>
           Update job <span className="mono">{jobID}</span> {job?.state}
+          {job?.phase === undefined ? '' : ` (${job.phase})`}
           {outcome.failureCode === undefined ? '' : ` — ${outcome.failureCode}`}. Inspect the
           remote instance logs.
         </span>
@@ -392,7 +394,7 @@ export function UpdateJobStatus({
     );
   }
   return (
-    <p>
+    <p role="status">
       Update job <span className="mono">{jobID}</span>: {job?.state ?? 'queued'}
       {job?.phase === undefined ? '' : ` (${job.phase})`}
     </p>

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -26,6 +26,8 @@ import {
 import { useOrgs } from '../api/session.ts';
 import { WorkspaceContextProvider, withRemote } from '../api/transport.tsx';
 import {
+  type InstanceUpdateJob,
+  updateJobOutcome,
   useRemoteUpdateJob,
   useRemoteUpdateStatuses,
   useRequestRemoteUpdate,
@@ -135,6 +137,8 @@ function RemoteCard({ remote }: { remote: Remote }) {
   const requestUpdate = useRequestRemoteUpdate();
   const [updateJobID, setUpdateJobID] = useState<string>();
   const updateJob = useRemoteUpdateJob(origin, updateJobID);
+  const updateOutcome =
+    updateJob.data === undefined ? undefined : updateJobOutcome(updateJob.data);
   const staleness = stalenessText(remote);
   useWorkspaceLiveness(live, () => setEnded(true));
   const handoffAction = workspaceHandoffAction(
@@ -282,11 +286,7 @@ function RemoteCard({ remote }: { remote: Remote }) {
               className="btn btn--primary"
               type="button"
               onClick={applyUpdate}
-              disabled={
-                requestUpdate.isPending ||
-                updateJob.data?.state === 'queued' ||
-                updateJob.data?.state === 'running'
-              }
+              disabled={requestUpdate.isPending || updateOutcome?.kind === 'running'}
             >
               {requestUpdate.isPending ? 'Submitting…' : `Update remote to ${update.latest_version}`}
             </button>
@@ -297,13 +297,9 @@ function RemoteCard({ remote }: { remote: Remote }) {
             </p>
           )}
           {updateJobID === undefined ? null : (
-            <p>
-              Update job <span className="mono">{updateJobID}</span>:{' '}
-              {updateJob.data?.state ?? 'queued'}
-              {updateJob.data?.phase === undefined ? '' : ` (${updateJob.data.phase})`}
-            </p>
+            <UpdateJobStatus jobID={updateJobID} job={updateJob.data} />
           )}
-          {updateJob.isError ? (
+          {updateJob.isError && updateOutcome?.kind !== 'failed' ? (
             <p className="alert" role="alert">
               The update job status could not be read. Inspect the remote instance logs before retrying.
             </p>
@@ -360,6 +356,46 @@ function RemoteCard({ remote }: { remote: Remote }) {
         </p>
       ) : null}
     </li>
+  );
+}
+
+/**
+ * Renders a terminal update-job outcome. A `failed` outcome (`failed`,
+ * `rolled-back`, or `rollback-failed`) surfaces as an `alert` region carrying
+ * the diagnostic `failure_code` — the instance did not reach the requested
+ * version and needs an operator. Everything else stays a plain status line.
+ * The `isError` alert (query could not read the job) is a separate concern the
+ * caller renders — and the caller suppresses it while this shows a `failed`
+ * outcome, since a refetch error can arrive with the last terminal `data` still
+ * cached and the two must not double up.
+ */
+export function UpdateJobStatus({
+  jobID,
+  job,
+}: {
+  jobID: string;
+  job: InstanceUpdateJob | undefined;
+}) {
+  const outcome = job === undefined ? undefined : updateJobOutcome(job);
+  if (outcome?.kind === 'failed') {
+    return (
+      <p className="alert" role="alert">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          Update job <span className="mono">{jobID}</span> {job?.state}
+          {outcome.failureCode === undefined ? '' : ` — ${outcome.failureCode}`}. Inspect the
+          remote instance logs.
+        </span>
+      </p>
+    );
+  }
+  return (
+    <p>
+      Update job <span className="mono">{jobID}</span>: {job?.state ?? 'queued'}
+      {job?.phase === undefined ? '' : ` (${job.phase})`}
+    </p>
   );
 }
 


### PR DESCRIPTION
Closes #457.

## Problem
Terminal update-job outcomes (`failed` / `rolled-back` / `rollback-failed`) rendered as a benign status line inside the info-styled `role="status"` block — visually identical to `succeeded` — and the diagnostic `failure_code` was dropped. The two most important negative outcomes looked like success; `rollback-failed` (instance left in a broken half-updated state) got no alert treatment at all.

## Change
- **`web/src/api/updates.ts`**: new exported `updateJobOutcome(job)` collapsing the six contract states into three outcomes (`running` / `succeeded` / `failed`) with `failure_code` passthrough. The exhaustive `switch` (no `default`) makes a future contract state a compile error, so the enum can't silently drift out of the view.
- **`web/src/routes/Remotes.tsx`**: extracted a presentational `UpdateJobStatus` component. A `failed` outcome now renders in the existing `alert` / `role="alert"` treatment carrying `failure_code`; `succeeded` / `running` are unchanged. The apply button now gates on `updateOutcome?.kind === 'running'` instead of raw states. The pre-existing "could not be read" `isError` alert is suppressed while a terminal-failure alert shows, so the two can't double up (a refetch error can arrive with the last terminal `data` still cached).

## Validation
- `updateJobOutcome` unit tests over all six states + `failure_code` passthrough.
- `UpdateJobStatus` render tests: a `rollback-failed` job renders in `role="alert"` showing the failure code; a `succeeded` job stays a plain status line.
- `node --run typecheck` clean; full web suite green (606 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)