### PR TITLE
feat(web): degrade forbidden matrix columns instead of blanking the grid #451

### DIFF
--- a/web/src/api/matrix.test.ts
+++ b/web/src/api/matrix.test.ts
@@ -41,8 +41,8 @@ const environmentProd = {
   display_order: 1,
 };
 
-function query<T>(data: T | undefined, isPending = false, isError = false) {
-  return { data, isPending, isError };
+function query<T>(data: T | undefined, isPending = false, isError = false, error: unknown = undefined) {
+  return { data, isPending, isError, error };
 }
 
 function environmentQuery<T>(
@@ -264,6 +264,43 @@ describe('environment-keyed matrix rows', () => {
     expect(error).toEqual({ status: 'error' });
     expect(stale).toEqual({ status: 'stale', data: devValues });
     expect(ready).toEqual({ status: 'ready', data: prodValues });
+  });
+
+  it('maps a 403 to forbidden, a non-403 to error, and forbids even a cached column', () => {
+    const [forbidden, forbiddenCached, otherError] = bindMatrixEnvironmentQueries(
+      'values',
+      [environmentDev, { ...environmentDev, id: 'env_cached' }, { ...environmentDev, id: 'env_500' }],
+      [
+        query(undefined, false, true, new ApiError(403, 'forbidden')),
+        // A revoked column blanks (fail-closed): a cached copy does not soften a
+        // 403 into 'stale'.
+        query({ environmentId: 'env_cached', value: devValues }, false, true, new ApiError(403, 'forbidden')),
+        query(undefined, false, true, new ApiError(500, 'boom')),
+      ],
+    ).map((entry) => entry.query);
+
+    expect(forbidden).toEqual({ status: 'forbidden' });
+    expect(forbiddenCached).toEqual({ status: 'forbidden' });
+    expect(otherError).toEqual({ status: 'error' });
+  });
+
+  it('ranks a mixed row as forbidden when one column is denied and another errors', () => {
+    const [row] = assembleMatrixEnvironmentRows([environmentDev], {
+      values: [{ environmentId: envDev, query: { status: 'forbidden' } }],
+      signals: [{ environmentId: envDev, query: { status: 'error' } }],
+      settings: [environmentQuery(envDev, devSettings)],
+      pendingDrafts: [environmentQuery(envDev, drafts)],
+    });
+    expect(row?.readiness).toBe('forbidden');
+
+    const [loadingRow] = assembleMatrixEnvironmentRows([environmentDev], {
+      values: [{ environmentId: envDev, query: { status: 'forbidden' } }],
+      signals: [environmentQuery<typeof devSignals>(envDev, undefined, true)],
+      settings: [environmentQuery(envDev, devSettings)],
+      pendingDrafts: [environmentQuery(envDev, drafts)],
+    });
+    // Pending still outranks forbidden — the column may yet resolve.
+    expect(loadingRow?.readiness).toBe('pending');
   });
 
   it('derives one row readiness with loading precedence and includes stale pending drafts', () => {

--- a/web/src/api/matrix.ts
+++ b/web/src/api/matrix.ts
@@ -102,10 +102,15 @@ type MatrixEnvironmentSettings = z.infer<typeof zEnvironmentSettings>;
 type MatrixValueList = z.infer<typeof zValueList>;
 type MatrixPendingDraftList = z.infer<typeof zPendingDraftList>;
 
-export type MatrixQueryStatus = 'pending' | 'error' | 'stale' | 'ready';
+export type MatrixQueryStatus = 'pending' | 'forbidden' | 'error' | 'stale' | 'ready';
 
 export type MatrixQueryState<T> =
   | { readonly status: 'pending'; readonly data?: undefined }
+  // A per-environment 403: the caller may not read this column. Distinct from
+  // 'error' because a denial never heals on retry, so the surface must say so
+  // rather than offering a reload. Fail-closed — it carries no data even when a
+  // stale copy is cached, because a revoked column must blank, not linger.
+  | { readonly status: 'forbidden'; readonly data?: undefined }
   | { readonly status: 'error'; readonly data?: undefined }
   | { readonly status: 'stale'; readonly data: T }
   | { readonly status: 'ready'; readonly data: T };
@@ -114,6 +119,7 @@ type MatrixQueryResult<T> = {
   readonly data: T | undefined;
   readonly isPending: boolean;
   readonly isError: boolean;
+  readonly error: unknown;
 };
 
 export type MatrixEnvironmentQuery<T> = {
@@ -216,6 +222,12 @@ function matrixRowReadiness(
   if (states.some((state) => state.status === 'pending')) {
     return 'pending';
   }
+  // Forbidden outranks error: both degrade the row, but a denial is the more
+  // specific fact and carries its own message, so a row that is part-forbidden,
+  // part-error reads as forbidden.
+  if (states.some((state) => state.status === 'forbidden')) {
+    return 'forbidden';
+  }
   if (states.some((state) => state.status === 'error')) {
     return 'error';
   }
@@ -230,6 +242,12 @@ function matrixQueryState<T>(query: MatrixQueryResult<T>): MatrixQueryState<T> {
     return { status: 'pending' };
   }
   if (query.isError) {
+    // A 403 is a permission denial, not a transient failure: retrying never
+    // resolves it, so it maps to 'forbidden' even when a stale copy is cached
+    // (fail-closed — a revoked column blanks rather than lingering as 'stale').
+    if (query.error instanceof ApiError && query.error.status === 403) {
+      return { status: 'forbidden' };
+    }
     return query.data === undefined
       ? { status: 'error' }
       : { status: 'stale', data: query.data };
@@ -265,6 +283,7 @@ export function bindMatrixEnvironmentQueries<T>(
         data: query.data?.value,
         isPending: query.isPending,
         isError: query.isError,
+        error: query.error,
       }),
     };
   });

--- a/web/src/routes/Matrix.degraded.test.tsx
+++ b/web/src/routes/Matrix.degraded.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment happy-dom
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '../api/client.ts';
+import { renderForm } from '../testkit/renderForm.tsx';
+import { Matrix } from './Matrix.tsx';
+
+const holder = vi.hoisted(() => ({ project: undefined as unknown }));
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { readonly count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index, end: index + 1 })),
+    getTotalSize: () => count,
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn(),
+  }),
+}));
+
+vi.mock('../api/transport.tsx', async (importActual) => {
+  const actual = await importActual<typeof import('../api/transport.tsx')>();
+  return { ...actual, useWorkspaceContext: () => null };
+});
+
+vi.mock('../api/matrix.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../api/matrix.ts')>();
+  return {
+    ...actual,
+    useMatrixProject: () => holder.project,
+    useStageMatrixValue: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    useClearMatrixValue: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    usePublishMatrix: () => ({ mutate: vi.fn(), isPending: false, isError: false, error: null }),
+    useCopyMatrixConfig: () => ({ mutate: vi.fn(), isPending: false }),
+    useReclassifyKey: () => ({ mutateAsync: vi.fn() }),
+  };
+});
+
+const environment = (id: string, name: string, order: number) => ({
+  id,
+  org_id: 'org_a',
+  project_id: 'project_a',
+  name,
+  display_order: order,
+  created_at: '2026-08-24T08:00:00Z',
+});
+
+const key = {
+  id: 'key_a',
+  org_id: 'org_a',
+  project_id: 'project_a',
+  name: 'LOG_LEVEL',
+  folder_path: '',
+  classification: 'config' as const,
+  description: '',
+  deprecated: false,
+  deprecation_note: '',
+  declaration: { rule: { type: 'string' as const, allow_empty: true } },
+  // required_in: all is the case that would fabricate a false "missing value"
+  // problem for a forbidden column if it were not excluded from detection.
+  presence: { required_in: { mode: 'all' as const }, forbidden_in: { mode: 'none' as const } },
+  group_id: '',
+  created_at: '2026-08-24T08:00:00Z',
+};
+
+const readyCatalogue = {
+  environments: {
+    data: { items: [environment('env_a', 'development', 0), environment('env_b', 'production', 1)], count: 2 },
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+  },
+  keys: { data: { items: [key], count: 1 }, isPending: false, isError: false, isSuccess: true, error: null },
+  groups: { data: { items: [], count: 0 }, isPending: false, isError: false, isSuccess: true, error: null },
+};
+
+const readyRow = {
+  environmentId: 'env_a',
+  environment: environment('env_a', 'development', 0),
+  readiness: 'ready' as const,
+  values: {
+    status: 'ready' as const,
+    data: {
+      items: [{ key_id: 'key_a', name: 'LOG_LEVEL', classification: 'config' as const, set: true, revealed: true, value: 'info' }],
+      count: 1,
+    },
+  },
+  signals: { status: 'ready' as const, data: { environment_id: 'env_a', revision: 1n, cells: [] } },
+  settings: { status: 'ready' as const, data: { protected: false } },
+  pendingDrafts: { status: 'ready' as const, data: { items: [], count: 0 } },
+};
+
+const forbiddenRow = {
+  environmentId: 'env_b',
+  environment: environment('env_b', 'production', 1),
+  readiness: 'forbidden' as const,
+  values: { status: 'forbidden' as const },
+  signals: { status: 'forbidden' as const },
+  settings: { status: 'forbidden' as const },
+  pendingDrafts: { status: 'forbidden' as const },
+};
+
+const forbiddenCatalogueQuery = {
+  data: undefined,
+  isPending: false,
+  isError: true,
+  isSuccess: false,
+  error: new ApiError(403, 'forbidden'),
+};
+
+function renderMatrix() {
+  return renderForm(
+    <MemoryRouter initialEntries={['/orgs/org_a/projects/project_a/matrix']}>
+      <Routes>
+        <Route path="/orgs/:org/projects/:project/matrix" element={<Matrix />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function alertText(container: HTMLElement): string {
+  return [...container.querySelectorAll('[role="alert"]')].map((node) => node.textContent).join(' ');
+}
+
+describe('Matrix per-environment degradation (#451)', () => {
+  it('renders the grid with one column degraded when a single environment is forbidden', async () => {
+    holder.project = { ...readyCatalogue, environmentRows: [readyRow, forbiddenRow] };
+    const view = await renderMatrix();
+
+    // The grid rendered — the catalogue loaded, so no whole-grid failure.
+    expect(view.container.textContent).not.toContain('could not be loaded');
+    // The forbidden column names its state, in words, in the header.
+    expect(view.container.textContent).toContain('No access to this environment');
+    // The readable column stays interactive; the forbidden one does not.
+    const cellButtons = [...view.container.querySelectorAll('button')].filter((button) =>
+      button.getAttribute('aria-label')?.includes('LOG_LEVEL'),
+    );
+    expect(cellButtons).toHaveLength(1);
+    expect(cellButtons[0]?.getAttribute('aria-label')).toContain('development');
+    // The forbidden column is excluded from problem detection: a required_in:all
+    // key must not fabricate a "missing value" problem for a column we cannot read.
+    expect(view.container.textContent).not.toContain('problem');
+
+    await view.unmount();
+  });
+
+  it('does not offer a degraded column for publish even when its signals still carry a pending draft', async () => {
+    // Mixed-family degradation: settings failed (→ readiness forbidden) while
+    // signals still hold a pending draft. The column must not be publishable —
+    // it would lose its protected marker and confirmation ceremony (#451).
+    const mixedForbiddenRow = {
+      ...forbiddenRow,
+      settings: { status: 'forbidden' as const },
+      signals: {
+        status: 'ready' as const,
+        data: {
+          environment_id: 'env_b',
+          revision: 3n,
+          cells: [
+            {
+              key_id: 'key_a',
+              name: 'LOG_LEVEL',
+              classification: 'config' as const,
+              pending_by_others: false,
+              pending: { versionId: 'ver_pending', operation: 'set' as const },
+            },
+          ],
+        },
+      },
+    };
+    holder.project = { ...readyCatalogue, environmentRows: [readyRow, mixedForbiddenRow] };
+    const view = await renderMatrix();
+
+    // No publish pill: the only pending draft rides a degraded column, so it is
+    // not counted as publishable.
+    expect(view.container.querySelector('.matrix__drafts')).toBeNull();
+    expect(view.container.textContent).toContain('No access to this environment');
+
+    await view.unmount();
+  });
+
+  it('renders a permission page, not a reload prompt, when the whole catalogue is forbidden', async () => {
+    holder.project = {
+      environments: forbiddenCatalogueQuery,
+      keys: forbiddenCatalogueQuery,
+      groups: forbiddenCatalogueQuery,
+      environmentRows: [],
+    };
+    const view = await renderMatrix();
+
+    expect(alertText(view.container)).toContain('do not have permission');
+    expect(view.container.textContent).not.toContain('Reload to try again');
+
+    await view.unmount();
+  });
+});

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -61,6 +61,12 @@ import {
 
 type MatrixKey = MatrixKeyList['items'][number];
 type Environment = EnvironmentList['items'][number];
+
+/** A catalogue query that failed with a 403 — the caller may not read the whole
+ *  project, so the grid renders a permission page rather than "reload" (#451). */
+function isForbidden(query: { readonly isError: boolean; readonly error: unknown }): boolean {
+  return query.isError && query.error instanceof ApiError && query.error.status === 403;
+}
 type Selection = { readonly keyId: string; readonly environmentId?: string };
 
 type DisplayGroup = {
@@ -128,6 +134,32 @@ export function Matrix({
 
   const environmentRows = matrix.environmentRows;
   const environments = environmentRows.map((row) => row.environment);
+  // Per-environment degradation (#451): a column whose reads failed or were
+  // denied. The catalogue loaded, so the grid renders; these columns show a
+  // header banner and non-interactive cells instead of blanking the whole grid.
+  // Declared here (above the problems memo) because they must be excluded from
+  // every derivation that reads per-cell values — an absent value in a column we
+  // cannot read is not "unset", so it must not fabricate a required-value problem.
+  const degradedByEnvironment = useMemo<ReadonlyMap<string, 'forbidden' | 'error'>>(() => {
+    const degraded = new Map<string, 'forbidden' | 'error'>();
+    for (const row of environmentRows) {
+      if (row.readiness === 'forbidden') {
+        degraded.set(row.environmentId, 'forbidden');
+      } else if (row.readiness === 'error') {
+        degraded.set(row.environmentId, 'error');
+      }
+    }
+    return degraded;
+  }, [environmentRows]);
+  // The environments whose per-cell state can be trusted. A degraded column's
+  // reads failed or were denied, so it must be excluded from every derivation
+  // that reads a value/signal/settings cell — problem detection, publish
+  // selection, and the history drawer's "current state" all fabricate a wrong
+  // answer (a false "absent", a lost protected marker) if they consume it (#451).
+  const readableEnvironments = useMemo(
+    () => environments.filter((environment) => !degradedByEnvironment.has(environment.id)),
+    [degradedByEnvironment, environments],
+  );
   const keys = matrix.keys.data?.items ?? [];
   const keyGroups = matrix.groups.data?.items ?? [];
   const [visibleEnvironmentIds, setVisibleEnvironmentIds] = useState<readonly string[]>([]);
@@ -259,6 +291,17 @@ export function Matrix({
     setMutationError(null);
   }, [ref.org, ref.project, environmentSignature]);
 
+  // #451: the row editor opens from a cell, and a degraded cell is not
+  // interactive — but a column can degrade WHILE its editor is open (a refetch
+  // turns the read into a 403/error). Close it rather than leave a writable
+  // editor addressed to a column whose reads no longer succeed.
+  useEffect(() => {
+    if (selection?.environmentId !== undefined && degradedByEnvironment.has(selection.environmentId)) {
+      setSelection(null);
+      setMutationError(null);
+    }
+  }, [degradedByEnvironment, selection]);
+
   const valuesByCell = useMemo(() => {
     const cells = new Map<string, ValueCell>();
     for (const row of environmentRows) {
@@ -323,12 +366,16 @@ export function Matrix({
       })),
     [keys],
   );
+  // #451: a degraded column has no trustworthy value data, so it is excluded from
+  // problem detection entirely. Including it would read every key as unset and
+  // fabricate a "required value missing" problem for a column we simply cannot
+  // read — inflating the sidebar counts, group badges and the problems filter.
   const problems = useMemo(
     () =>
       computeMatrixProblems({
         keys: stateKeys,
-        environmentIds: environments.map((environment) => environment.id),
-        values: environments.flatMap((environment) =>
+        environmentIds: readableEnvironments.map((environment) => environment.id),
+        values: readableEnvironments.flatMap((environment) =>
           keys.map((key) => ({
             keyId: key.id,
             environmentId: environment.id,
@@ -338,7 +385,7 @@ export function Matrix({
         ),
         validationErrors,
       }),
-    [environments, keys, signalsByCell, stateKeys, validationErrors, valuesByCell],
+    [keys, readableEnvironments, signalsByCell, stateKeys, validationErrors, valuesByCell],
   );
   const problemCounts = useMemo(() => groupProblemCounts(problems), [problems]);
   const problemsByCell = useMemo(() => indexMatrixProblems(problems), [problems]);
@@ -422,6 +469,13 @@ export function Matrix({
   const pendingByEnvironment = useMemo(() => {
     const pending = new Map<string, readonly MatrixPendingEntry[]>();
     for (const row of environmentRows) {
+      // #451: a degraded column is not publishable — even if its signals read
+      // succeeded, another family (values/settings) failed, so its protected
+      // marker and ceremony cannot be trusted. Offer no drafts to publish.
+      if (degradedByEnvironment.has(row.environmentId)) {
+        pending.set(row.environmentId, []);
+        continue;
+      }
       const rows: MatrixPendingEntry[] = [];
       for (const signal of row.signals.data?.cells ?? []) {
         if (signal.pending !== undefined) {
@@ -438,7 +492,7 @@ export function Matrix({
       pending.set(row.environmentId, rows);
     }
     return pending;
-  }, [draftsByVersion, environmentRows]);
+  }, [degradedByEnvironment, draftsByVersion, environmentRows]);
   const pendingCount = [...pendingByEnvironment.values()].reduce(
     (total, entries) => total + entries.length,
     0,
@@ -453,8 +507,13 @@ export function Matrix({
     }
     return revisions;
   }, [environmentRows]);
+  // #451: a degraded column is never offered for publish (see pendingByEnvironment),
+  // so it must not appear here either — a settings-unreadable column must not be
+  // presented as "not protected", which would drop its confirmation ceremony.
   const protectedEnvironmentIds = environmentRows.flatMap((row) =>
-    row.settings.data?.protected === true ? [row.environmentId] : [],
+    !degradedByEnvironment.has(row.environmentId) && row.settings.data?.protected === true
+      ? [row.environmentId]
+      : [],
   );
   const pendingCountByEnvironment = useMemo<ReadonlyMap<string, number>>(
     () =>
@@ -469,19 +528,26 @@ export function Matrix({
   const pendingByOthersByEnvironment = useMemo<ReadonlyMap<string, number>>(() => {
     const counts = new Map<string, number>();
     for (const row of environmentRows) {
+      // #451: a degraded column's signal counts are not trustworthy — omit it.
+      if (degradedByEnvironment.has(row.environmentId)) {
+        continue;
+      }
       counts.set(
         row.environmentId,
         (row.signals.data?.cells ?? []).filter((cell) => cell.pending_by_others).length,
       );
     }
     return counts;
-  }, [environmentRows]);
+  }, [degradedByEnvironment, environmentRows]);
   // The history drawer needs the CURRENT cell state to enumerate the ceremony
   // unit a restore will need: the comparison opens current secret plaintext only
   // where a set secret is being replaced.
   const cellsByEnvironment = useMemo<ReadonlyMap<string, readonly HistoryCurrentCell[]>>(() => {
     const cells = new Map<string, readonly HistoryCurrentCell[]>();
-    for (const environment of environments) {
+    // #451: a degraded column has no readable values, so it is omitted rather
+    // than reported as all-absent — a fabricated "absent" would understate the
+    // secret-replacement comparison a restore needs.
+    for (const environment of readableEnvironments) {
       cells.set(
         environment.id,
         keys.map((key) => ({
@@ -492,26 +558,37 @@ export function Matrix({
       );
     }
     return cells;
-  }, [environments, keys, valuesByCell]);
+  }, [keys, readableEnvironments, valuesByCell]);
   const currentValuesByEnvironment = useMemo<
     ReadonlyMap<string, readonly ValueCell[]>
   >(() => {
     const values = new Map<string, readonly ValueCell[]>();
     for (const row of environmentRows) {
+      // #451: omit a degraded column entirely rather than defaulting its
+      // unreadable values to an empty (all-absent) list.
+      if (degradedByEnvironment.has(row.environmentId)) {
+        continue;
+      }
       values.set(row.environmentId, row.values.data?.items ?? []);
     }
     return values;
-  }, [environmentRows]);
+  }, [degradedByEnvironment, environmentRows]);
   const loading =
     matrix.environments.isPending ||
     matrix.keys.isPending ||
     matrix.groups.isPending ||
     environmentRows.some((row) => row.readiness === 'pending');
+  // The whole-grid gate is the project CATALOGUE only (environments/keys/groups).
+  // A single environment column failing no longer blanks the grid — that column
+  // degrades in place (#451), so its 'error'/'forbidden' readiness is handled per
+  // column below, not here.
+  const catalogueForbidden =
+    isForbidden(matrix.environments) || isForbidden(matrix.keys) || isForbidden(matrix.groups);
   const loadError =
-    (matrix.environments.isError && matrix.environments.data === undefined) ||
-    (matrix.keys.isError && matrix.keys.data === undefined) ||
-    (matrix.groups.isError && matrix.groups.data === undefined) ||
-    environmentRows.some((row) => row.readiness === 'error');
+    !catalogueForbidden &&
+    ((matrix.environments.isError && matrix.environments.data === undefined) ||
+      (matrix.keys.isError && matrix.keys.data === undefined) ||
+      (matrix.groups.isError && matrix.groups.data === undefined));
   const backgroundRefreshError =
     (matrix.environments.isError && matrix.environments.data !== undefined) ||
     (matrix.keys.isError && matrix.keys.data !== undefined) ||
@@ -537,6 +614,13 @@ export function Matrix({
     ]);
 
   const publishSelected = (selectedEnvironmentIds: readonly string[]) => {
+    // #451: defence in depth — a degraded environment is already excluded from
+    // pendingByEnvironment, so it cannot reach here with drafts, but reject it
+    // explicitly rather than address a publish at a column we cannot read.
+    const degradedSelection = selectedEnvironmentIds.find((id) => degradedByEnvironment.has(id));
+    if (degradedSelection !== undefined) {
+      throw new Error(`cannot publish the degraded environment ${degradedSelection}`);
+    }
     const addressedEnvironment = selectedEnvironmentIds[0];
     if (addressedEnvironment === undefined) {
       throw new Error('publish action has no selected environment');
@@ -749,6 +833,14 @@ export function Matrix({
 
   if (loading) {
     return <p role="status">Loading environment matrix…</p>;
+  }
+  if (catalogueForbidden) {
+    return (
+      <p className="alert" role="alert">
+        <span className="alert__glyph" aria-hidden="true">!</span>
+        <span>You do not have permission to view this project's environment matrix.</span>
+      </p>
+    );
   }
   if (loadError) {
     return (
@@ -985,6 +1077,7 @@ export function Matrix({
                     </th>
                     {visibleEnvironments.map((environment) => {
                       const revision = revisionsByEnvironment.get(environment.id);
+                      const degraded = degradedByEnvironment.get(environment.id);
                       return (
                         <th scope="col" key={environment.id}>
                           <span>{environment.name}</span>
@@ -994,7 +1087,17 @@ export function Matrix({
                           {protectedEnvironmentIds.includes(environment.id) ? (
                             <span className="matrix__protected">PROTECTED</span>
                           ) : null}
-                          {revision === undefined ? null : (
+                          {/* #451: this column's reads failed or were denied. Name
+                              which — a denial and a load failure need different
+                              words — instead of blanking the whole grid. */}
+                          {degraded === undefined ? null : (
+                            <span className="matrix__degraded" role="status">
+                              {degraded === 'forbidden'
+                                ? 'No access to this environment'
+                                : 'Values could not be loaded'}
+                            </span>
+                          )}
+                          {degraded !== undefined || revision === undefined ? null : (
                             <Link
                               className="btn matrix__history-link"
                               data-history-environment={environment.id}
@@ -1120,6 +1223,17 @@ export function Matrix({
                         </th>
                         {visibleEnvironments.map((environment) => {
                           const id = cellID(key.id, environment.id);
+                          // #451: a degraded column has no trustworthy cell data —
+                          // render a non-interactive placeholder, not an editable
+                          // cell that would open the row editor on a column the
+                          // caller cannot read.
+                          if (degradedByEnvironment.has(environment.id)) {
+                            return (
+                              <td key={environment.id} className="matrix__cell--degraded">
+                                <span aria-hidden="true">—</span>
+                              </td>
+                            );
+                          }
                           return (
                             <td key={environment.id}>
                               <MatrixCell
@@ -1164,6 +1278,10 @@ export function Matrix({
               environmentId: row.environmentId,
               environment: row.environment,
               protected: row.settings.data?.protected === true,
+              // #451: a degraded column's value/signal reads failed or were
+              // denied, so the editor must not offer it as a copy destination
+              // or a bulk-edit target.
+              degraded: degradedByEnvironment.has(row.environmentId),
               cell: valuesByCell.get(cellID(selectedKey.id, row.environmentId)),
               signal,
               draftPreview: pendingConfigPreview(signal, draftsByVersion),
@@ -1179,6 +1297,17 @@ export function Matrix({
           }}
           onApply={async (changes) => {
             setMutationError(null);
+            // #451: preflight — never apply a change to a column that degraded
+            // after it was queued. Reject the whole batch before any mutation so
+            // a since-denied environment is never written blind.
+            const degradedChange = changes.find((change) =>
+              degradedByEnvironment.has(change.environmentId),
+            );
+            if (degradedChange !== undefined) {
+              throw new Error(
+                `cannot apply a change to the degraded environment ${degradedChange.environmentId}`,
+              );
+            }
             let normalizedCount = 0;
             const warnItems: ScanWarnItem[] = [];
             for (const change of changes) {
@@ -1278,10 +1407,14 @@ export function Matrix({
       {!importOpen ? null : (
         <ImportWizard
           matrixRef={ref}
-          environments={environments.map((environment) => ({
-            id: environment.id,
-            name: environment.name,
-          }))}
+          // #451: a degraded column cannot be an import target — its reads are
+          // denied or failed, so it never appears in the selectable set.
+          environments={environments
+            .filter((environment) => !degradedByEnvironment.has(environment.id))
+            .map((environment) => ({
+              id: environment.id,
+              name: environment.name,
+            }))}
           gitManaged={gitManaged}
           onClose={() => setImportOpen(false)}
         />
@@ -1334,7 +1467,9 @@ export function Matrix({
       {historyOpen ? (
         <HistoryDrawer
           refData={ref}
-          environments={environments}
+          // #451: a degraded column is not selectable for history — its current
+          // state is unreadable, so it never enters the drawer's environment set.
+          environments={readableEnvironments}
           keys={keys}
           currentRevisions={revisionsByEnvironment}
           protectedEnvironmentIds={protectedEnvironmentIds}

--- a/web/src/routes/MatrixRowEditor.test.tsx
+++ b/web/src/routes/MatrixRowEditor.test.tsx
@@ -42,6 +42,7 @@ const rows: MatrixRowEditorProps['rows'] = [{
   environmentId,
   environment,
   protected: false,
+  degraded: false,
   cell: {
     key_id: keyRecord.id,
     name: keyRecord.name,
@@ -135,6 +136,78 @@ async function renderEditor() {
     unmount: async () => act(async () => root.unmount()),
   };
 }
+
+describe('MatrixRowEditor degraded columns (#451)', () => {
+  const degradedRows: MatrixRowEditorProps['rows'] = [
+    rows[0]!,
+    {
+      environmentId: 'env_01989abc-def0-7123-8123-1234567890ff',
+      environment: { ...environment, id: 'env_01989abc-def0-7123-8123-1234567890ff', name: 'production' },
+      protected: false,
+      degraded: true,
+      cell: undefined,
+      signal: undefined,
+      draftPreview: undefined,
+      problems: [],
+    },
+  ];
+
+  async function renderWith(rowsInput: MatrixRowEditorProps['rows']) {
+    const onApply = vi
+      .fn<(changes: readonly MatrixEditorChange[]) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    const onCopy = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      const queries = new QueryClient({ defaultOptions: { queries: { enabled: false } } });
+      root.render(
+        <QueryClientProvider client={queries}>
+          <MemoryRouter>
+            <MatrixRowEditor
+              refData={{ org: 'org-a', project: 'project-a' }}
+              keyRecord={keyRecord}
+              environmentId={environmentId}
+              rows={rowsInput}
+              busy={false}
+              mutationError={null}
+              onClose={vi.fn()}
+              onApply={onApply}
+              onCopy={onCopy}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    return { container, onApply, onCopy, unmount: async () => act(async () => root.unmount()) };
+  }
+
+  it('excludes a degraded column from bulk edit and copy destinations', async () => {
+    const view = await renderWith(degradedRows);
+
+    const editAll = [...view.container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Edit all environments',
+    );
+    if (editAll === undefined) throw new Error('edit-all toggle missing');
+    await act(async () => editAll.click());
+
+    // Only the readable source column is editable — the degraded column is not.
+    expect(view.container.querySelectorAll('textarea')).toHaveLength(1);
+    expect(view.container.textContent).not.toContain('production');
+
+    const copyToggle = [...view.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.startsWith('Copy'),
+    );
+    if (copyToggle !== undefined) {
+      await act(async () => copyToggle.click());
+      // The degraded column is not offered as a copy destination.
+      expect(view.container.textContent).not.toContain('production');
+    }
+
+    await view.unmount();
+  });
+});
 
 function typeInto(textarea: HTMLTextAreaElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;

--- a/web/src/routes/MatrixRowEditor.tsx
+++ b/web/src/routes/MatrixRowEditor.tsx
@@ -41,6 +41,10 @@ type EditorRow = {
   readonly environmentId: string;
   readonly environment: Environment;
   readonly protected: boolean;
+  // #451: this column's value/signal reads failed or were denied. It is excluded
+  // from bulk edit and copy destinations — the caller cannot read it, so writing
+  // to it blind would be a silent guess.
+  readonly degraded: boolean;
   readonly cell: ValueCell | undefined;
   readonly signal: MatrixSignalCell | undefined;
   readonly draftPreview: string | undefined;
@@ -114,7 +118,29 @@ export function MatrixRowEditor({
   const workspace = useWorkspaceContext();
   const sourceSet = sourceRow.cell?.set === true;
   const disclosure = useCellDisclosure(refData, keyRecord, sourceRow);
-  const visibleRows = editAll ? rows : [sourceRow];
+  // Degraded columns (#451) are never editable here: bulk edit and fill-all
+  // target only the columns whose reads succeeded.
+  const editableRows = rows.filter((row) => !row.degraded);
+  const visibleRows = editAll ? editableRows : [sourceRow];
+  const degradedEnvironmentIds = rows.flatMap((row) => (row.degraded ? [row.environmentId] : []));
+  const degradedSignature = degradedEnvironmentIds.join('/');
+  // A copy destination or a queued bulk edit chosen before its column degraded
+  // would otherwise linger in `destinations`/`edits` and reach the copy or apply
+  // call for a column we can no longer read. Prune both when a column degrades so
+  // the selectable set and every pending change stay in sync (#451).
+  useEffect(() => {
+    const degraded = new Set(degradedSignature === '' ? [] : degradedSignature.split('/'));
+    setDestinations((current) => {
+      const pruned = current.filter((id) => !degraded.has(id));
+      return pruned.length === current.length ? current : pruned;
+    });
+    setEdits((current) => {
+      if (![...current.keys()].some((id) => degraded.has(id))) {
+        return current;
+      }
+      return new Map([...current].filter(([id]) => !degraded.has(id)));
+    });
+  }, [degradedSignature]);
   const protectedConfirmationRequired = copyRequiresProtectedConfirmation(
     destinations,
     protectedEnvironmentIds,
@@ -139,8 +165,11 @@ export function MatrixRowEditor({
     }
   }
 
+  // Derived from editableRows, not rows: a change is only ever applied to a
+  // column whose reads succeed, even if a stale edit for a since-degraded column
+  // has not yet been pruned from `edits` (#451).
   const changes = matrixDraftChanges(
-    rows.map((row) => row.environmentId),
+    editableRows.map((row) => row.environmentId),
     edits,
   );
 
@@ -230,7 +259,7 @@ export function MatrixRowEditor({
                 disabled={fillAll === '' || busy || applying}
                 onClick={() => {
                   setEdits(new Map<string, MatrixDraftEdit>(
-                    rows.map((row) => [row.environmentId, { op: 'set', value: fillAll }]),
+                    editableRows.map((row) => [row.environmentId, { op: 'set', value: fillAll }]),
                   ));
                 }}
               >
@@ -405,7 +434,7 @@ export function MatrixRowEditor({
             <fieldset className="matrix-editor__copy">
               <legend>Copy independent published value to</legend>
               {rows
-                .filter((row) => row.environmentId !== environmentId)
+                .filter((row) => row.environmentId !== environmentId && !row.degraded)
                 .map((row) => (
                   <label key={row.environmentId}>
                     <input

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1641,6 +1641,23 @@ select {
   margin-left: auto;
 }
 
+/* #451: a column whose reads failed or were denied. A word in the header, same
+   as the protected marker — the state is legible read aloud and without colour.
+   Uses the ordinary muted text token so it passes contrast on any surface. */
+.matrix__degraded {
+  display: block;
+  color: var(--tx-dim);
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.matrix__cell--degraded {
+  text-align: center;
+  color: var(--tx-faint);
+}
+
 .matrix__key-heading {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #451.

## Problem
The matrix load-gate flattened per-environment readiness: one environment's `values`/`signals` read failing (or being denied) blanked the **entire** grid, and a per-environment 403 was rendered as "Reload to try again" — actively misleading, since reloading never resolves a denial.

## Change
- **`web/src/api/matrix.ts`** — thread `ApiError.status` into the per-environment query union. A 403 now maps to a distinct `forbidden` status (fail-closed: a revoked column blanks even when a stale copy is cached). `matrixRowReadiness` ranks `pending > forbidden > error > stale > ready`, mirroring the established `settings.ts` `environmentSettingsReadState` precedent.
- **`web/src/routes/Matrix.tsx`** — the whole-grid error gate now covers only the project **catalogue** (environments/keys/groups). A whole-catalogue 403 renders a permission page, not a reload prompt. Individual environment columns whose reads failed or were denied **degrade in place** — a header banner naming the state + non-interactive cells — instead of blanking the grid. Degraded columns are excluded from:
  - problem detection (so a `required_in: all` key does not fabricate a "missing value" problem for a column that simply cannot be read),
  - import targets,
  - the row editor's bulk-edit and copy-destination sets.
- **`app.css`** — degraded banner/cell styles reuse the established muted text tokens (`--tx-dim`/`--tx-faint`) for contrast safety.

## Tests
- `matrix.test.ts`: 403→forbidden mapping, cached-column fail-closed, mixed-row precedence.
- New `Matrix.degraded.test.tsx`: degraded-column render, whole-catalogue forbidden page (not reload), and the no-false-problem regression.
- Full web suite green; typecheck clean; SPA build clean.

## Deliberate scope note
`matrixImpactReady` continues to fail closed (disarming delete/reclassify while any column is degraded) — correct per its documented contract.

**e2e/axe for the degraded state is intentionally omitted** and called out here rather than skipped silently: reproducing a per-env 403 in the e2e harness needs a new principal with an environment-scoped grant topology and its own sign-in journey, which is disproportionate to this change. The behavior is covered by the vitest render + state-machine tests; contrast is handled by reusing established safe tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)