### PR TITLE
Arm dormant API freeze guard #520

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
         run: ./scripts/ci/check-dco_test.sh
       - name: Required-jobs fixture
         run: ./scripts/ci/check-required-jobs_test.sh
+      - name: API freeze guard fixture
+        run: ./scripts/ci/check-api-freeze_test.sh
       - name: Changed-path classifier fixture
         run: ./scripts/ci/classify-changed-paths_test.sh
       - name: CI job registry and workflow bijection fixture
@@ -488,6 +490,31 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ steps.generated-go-cache.outputs.cache-primary-key }}
+
+  # Dormant until the first stable release tag exists. After v1.0.0, every
+  # OpenAPI revision is checked against that immutable contract baseline.
+  freeze-guard:
+    needs: changes
+    if: ${{ fromJSON(needs.changes.outputs.plan)['freeze-guard'] }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: go-mod-v2-${{ runner.os }}-
+      - name: Enforce frozen API surface
+        run: ./scripts/ci/check-api-freeze.sh
 
   # The TypeScript half of the contract chain. It is a separate job because it
   # needs a different toolchain, and because a Go-only change must not be able
@@ -1432,6 +1459,7 @@ jobs:
       - compose-demo
       - dco
       - docs
+      - freeze-guard
       - fuzz
       - generated
       - headline-guarantee

--- a/api/freeze.go
+++ b/api/freeze.go
@@ -25,12 +25,10 @@ import (
 // removals after a deprecation window this promise does not offer. Severity
 // is oasdiff's opinion; the allowlist is Hikyo's policy.
 //
-// State of this gate today: NO FREEZE TAG EXISTS, so there is no immutable
-// base to diff against and the gate cannot bind the live contract yet. It is
-// therefore FIXTURE-PROVEN NOW AND FREEZE-ARMED LATER — the fixtures below
-// exercise every rule against synthetic base/revised pairs, so the machinery
-// is known to work on the day the tag is cut rather than being written that
-// day.
+// The freeze-guard CI job is armed against the v1.0.0 tag. Until that tag
+// exists it reports a documented dormant success; after the tag is cut it
+// loads api/openapi.yaml from that immutable commit and applies this gate to
+// every proposed revision.
 
 // PermittedChanges is the fail-closed allowlist: the oasdiff change ids that
 // count as permitted additions under the version promise.

--- a/docs/handoff/520-api-freeze-guard.md
+++ b/docs/handoff/520-api-freeze-guard.md
@@ -1,0 +1,21 @@
+# Issue #520 - dormant API freeze guard
+
+Status: implemented on t3code/impl-520.
+
+## Contract
+
+- v1.0.0 is the sole API freeze tag, matching the locked API/CLI ADR.
+- Before that tag exists, freeze-guard succeeds with an explicit dormant
+  message. Prerelease tags do not arm it.
+- A v1.0.0 ref that cannot resolve to a commit fails closed.
+- After that tag exists, CI reads api/openapi.yaml from the tagged commit and
+  runs the existing fail-closed api.CheckFreeze policy against the proposed
+  document.
+- freeze-guard is a planned required job for full and API change plans.
+
+## Verification
+
+scripts/ci/check-api-freeze_test.sh creates an isolated local repository and
+proves dormant, malformed-tag refusal, identical-spec pass, and breaking-spec
+refusal paths without pushing a tag. The refusal fixture removes a deprecated
+endpoint and must report api-path-removed-with-deprecation.

--- a/scripts/ci/api-freeze-guard/main.go
+++ b/scripts/ci/api-freeze-guard/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Hikyo-Org/hikyo/api"
+)
+
+func main() {
+	basePath := flag.String("base", "", "path to the frozen OpenAPI document")
+	revisedPath := flag.String("revised", "", "path to the revised OpenAPI document")
+	flag.Parse()
+
+	if *basePath == "" || *revisedPath == "" || flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: api-freeze-guard --base <path> --revised <path>")
+		os.Exit(2)
+	}
+
+	base, err := os.ReadFile(*basePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "API freeze guard: read base: %v\n", err)
+		os.Exit(1)
+	}
+	revised, err := os.ReadFile(*revisedPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "API freeze guard: read revised: %v\n", err)
+		os.Exit(1)
+	}
+
+	violations, err := api.CheckFreeze(base, revised)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "API freeze guard: %v\n", err)
+		os.Exit(1)
+	}
+	if len(violations) == 0 {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "API freeze guard failed:")
+	for _, violation := range violations {
+		fmt.Fprintf(os.Stderr, "  %s\n", violation)
+	}
+	os.Exit(1)
+}

--- a/scripts/ci/check-api-freeze.sh
+++ b/scripts/ci/check-api-freeze.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
+cd "$repo_root"
+
+freeze_tag=v1.0.0
+freeze_ref="refs/tags/$freeze_tag"
+if ! matched_ref=$(git for-each-ref --format='%(refname)' "$freeze_ref"); then
+	printf '%s\n' "API freeze guard: failed to inspect $freeze_ref" >&2
+	exit 1
+fi
+if [ -z "$matched_ref" ]; then
+	printf '%s\n' "API freeze guard dormant: $freeze_tag does not exist"
+	exit 0
+fi
+if [ "$matched_ref" != "$freeze_ref" ]; then
+	printf '%s\n' "API freeze guard: unexpected ref lookup result: $matched_ref" >&2
+	exit 1
+fi
+if ! freeze_commit=$(git rev-parse --verify "$freeze_ref^{commit}" 2>/dev/null); then
+	printf '%s\n' "API freeze guard: $freeze_ref does not resolve to a commit" >&2
+	exit 1
+fi
+
+base_spec=$(mktemp)
+trap 'rm -f "$base_spec"' EXIT HUP INT TERM
+git show "$freeze_commit:api/openapi.yaml" >"$base_spec"
+
+go run ./scripts/ci/api-freeze-guard \
+	--base "$base_spec" \
+	--revised api/openapi.yaml
+printf '%s\n' "API freeze guard passed: api/openapi.yaml is compatible with $freeze_tag"

--- a/scripts/ci/check-api-freeze_test.sh
+++ b/scripts/ci/check-api-freeze_test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
+fixture_root="$repo_root/api/testdata/freeze/delete-deprecated-endpoint-fails"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+git clone --quiet --shared --no-tags "$repo_root" "$tmp/repo"
+cp "$repo_root/scripts/ci/check-api-freeze.sh" "$tmp/repo/scripts/ci/"
+mkdir -p "$tmp/repo/scripts/ci/api-freeze-guard"
+cp "$repo_root/scripts/ci/api-freeze-guard/main.go" \
+	"$tmp/repo/scripts/ci/api-freeze-guard/"
+guard="$tmp/repo/scripts/ci/check-api-freeze.sh"
+cd "$tmp/repo"
+git config user.name 'API freeze fixture'
+git config user.email 'api-freeze-fixture@invalid.example'
+git config commit.gpgsign false
+git tag v1.0.0-rc.1
+
+dormant_output=$($guard)
+printf '%s\n' "$dormant_output" | grep -F \
+	'API freeze guard dormant: v1.0.0 does not exist' >/dev/null
+
+blob=$(printf '%s' 'not a release commit' | git hash-object -w --stdin)
+git tag v1.0.0 "$blob"
+if invalid_tag_output=$($guard 2>&1); then
+	printf '%s\n' 'API freeze fixture failed: non-commit tag passed' >&2
+	exit 1
+fi
+printf '%s\n' "$invalid_tag_output" | grep -F \
+	'refs/tags/v1.0.0 does not resolve to a commit' >/dev/null
+git tag --delete v1.0.0 >/dev/null
+
+cp "$fixture_root/base.yaml" api/openapi.yaml
+git add api/openapi.yaml
+git commit --quiet -m 'test: install synthetic freeze base'
+git tag v1.0.0
+
+active_output=$($guard)
+printf '%s\n' "$active_output" | grep -F \
+	'API freeze guard passed: api/openapi.yaml is compatible with v1.0.0' >/dev/null
+
+cp "$fixture_root/revised.yaml" api/openapi.yaml
+if failure_output=$($guard 2>&1); then
+	printf '%s\n' 'API freeze fixture failed: breaking change passed' >&2
+	exit 1
+fi
+printf '%s\n' "$failure_output" | grep -F 'API freeze guard failed:' >/dev/null
+printf '%s\n' "$failure_output" | grep -F \
+	'[api-path-removed-with-deprecation]' >/dev/null
+
+printf '%s\n' \
+	'API freeze fixture: dormant, invalid-tag refusal, active-pass, and active-refusal paths passed'

--- a/scripts/ci/check-required-jobs_test.sh
+++ b/scripts/ci/check-required-jobs_test.sh
@@ -35,6 +35,7 @@ all_plan='{
 	"client":true,
 	"compose-demo":true,
 	"docs":true,
+	"freeze-guard":true,
 	"fuzz":true,
 	"generated":true,
 	"headline-guarantee":true,
@@ -54,6 +55,7 @@ all_success='{
 	"compose-demo":{"result":"success"},
 	"dco":{"result":"success"},
 	"docs":{"result":"success"},
+	"freeze-guard":{"result":"success"},
 	"fuzz":{"result":"success"},
 	"generated":{"result":"success"},
 	"headline-guarantee":{"result":"success"},
@@ -73,6 +75,7 @@ docs_plan=$(printf '%s' "$all_plan" | jq 'map_values(false) | .docs = true')
 docs_success=$(printf '%s' "$all_success" | jq '
 	.client.result = "skipped" |
 	.["compose-demo"].result = "skipped" |
+	.["freeze-guard"].result = "skipped" |
 	.fuzz.result = "skipped" |
 	.generated.result = "skipped" |
 	.["headline-guarantee"].result = "skipped" |
@@ -108,7 +111,7 @@ done
 expect_accept 'main push with skipped DCO' push \
 	"$(printf '%s' "$all_success" | jq '.dco.result = "skipped"')" "$all_plan"
 
-for job in client compose-demo fuzz no-egress race; do
+for job in client compose-demo freeze-guard fuzz no-egress race; do
 	for result in failure cancelled skipped; do
 		expect_reject "selected $job with $result result" pull_request \
 			"$(printf '%s' "$all_success" | jq --arg job "$job" --arg result "$result" '.[ $job ].result = $result')" \

--- a/scripts/ci/ci-job-registry.json
+++ b/scripts/ci/ci-job-registry.json
@@ -6,6 +6,7 @@
       "client",
       "compose-demo",
       "docs",
+      "freeze-guard",
       "fuzz",
       "generated",
       "headline-guarantee",
@@ -21,6 +22,7 @@
     "api": [
       "client",
       "compose-demo",
+      "freeze-guard",
       "generated",
       "headline-guarantee",
       "release-snapshot",
@@ -105,6 +107,10 @@
     },
     "client": {"required_gate": "planned", "plan_jobs": ["client"]},
     "docs": {"required_gate": "planned", "plan_jobs": ["docs"]},
+    "freeze-guard": {
+      "required_gate": "planned",
+      "plan_jobs": ["freeze-guard"]
+    },
     "compose-demo": {
       "required_gate": "planned",
       "plan_jobs": ["compose-demo"]

--- a/scripts/ci/classify-changed-paths_test.sh
+++ b/scripts/ci/classify-changed-paths_test.sh
@@ -45,7 +45,7 @@ expect_plan 'core' \
 	'["fuzz","generated","headline-guarantee","race","release-snapshot","test","web-go"]' \
 	'internal/service/values.go'
 expect_plan 'API' \
-	'["client","compose-demo","generated","headline-guarantee","release-snapshot","test","web-go"]' \
+	'["client","compose-demo","freeze-guard","generated","headline-guarantee","release-snapshot","test","web-go"]' \
 	'api/openapi.yaml'
 expect_plan 'client' '["client","release-snapshot","web-go"]' \
 	'clients/ts/src/generated/types.gen.ts'


### PR DESCRIPTION
## Summary

- add a required, read-only `freeze-guard` CI job
- remain dormant until the canonical `v1.0.0` freeze tag exists
- fail closed on invalid tags and incompatible OpenAPI changes
- register the job in CI plan and required-job enforcement

## Local evidence

- `./scripts/ci/check-api-freeze_test.sh`: dormant, invalid-tag refusal, active pass, breaking-change refusal
- `go test ./...`: 4,056 tests passed across 70 packages
- required-job, classifier, registry-bijection, shellcheck, and actionlint checks passed
- Standards review: CLEAN
- Spec review: CLEAN

No public or remote freeze tag was created; the simulated tag lived only in a disposable local repository.

Closes #520