### PR TITLE
perf(ci): shorten validation critical path

### DIFF
--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -26,7 +26,9 @@ jobs:
   # Permanent required context. This job and its success criteria are loaded
   # from the base branch, so a PR cannot redefine its own merge gate.
   ci-required:
-    if: always()
+    # Ordinary validation failures still reach this gate. A superseded run
+    # skips it so workflow concurrency releases the next PR head immediately.
+    if: always() && !cancelled()
     needs: validation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
         run: ./scripts/ci/check-dco_test.sh
       - name: Required-jobs fixture
         run: ./scripts/ci/check-required-jobs_test.sh
+      - name: API freeze guard fixture
+        run: ./scripts/ci/check-api-freeze_test.sh
       - name: Changed-path classifier fixture
         run: ./scripts/ci/classify-changed-paths_test.sh
       - name: CI job registry and workflow bijection fixture
@@ -490,6 +492,31 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ steps.generated-go-cache.outputs.cache-primary-key }}
+
+  # Dormant until the first stable release tag exists. After v1.0.0, every
+  # OpenAPI revision is checked against that immutable contract baseline.
+  freeze-guard:
+    needs: changes
+    if: ${{ fromJSON(needs.changes.outputs.plan)['freeze-guard'] }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: go-mod-v2-${{ runner.os }}-
+      - name: Enforce frozen API surface
+        run: ./scripts/ci/check-api-freeze.sh
 
   # The TypeScript half of the contract chain. It is a separate job because it
   # needs a different toolchain, and because a Go-only change must not be able
@@ -1464,6 +1491,7 @@ jobs:
       - compose-demo
       - dco
       - docs
+      - freeze-guard
       - fuzz
       - generated
       - headline-guarantee

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
         run: |
           mkdir -p ci-artifacts
           go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo
+          go build -o ci-artifacts/oidctest-idp ./internal/oidctest/cmd
       - name: Upload app build for downstream validation
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -292,6 +293,7 @@ jobs:
           path: |
             internal/webui/dist/
             ci-artifacts/hikyo-ui
+            ci-artifacts/oidctest-idp
           if-no-files-found: error
           overwrite: true
           retention-days: 1
@@ -527,6 +529,10 @@ jobs:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).docs }}
     runs-on: ubuntu-latest
+    container:
+      # Exact Playwright release from docs/site/package.json. Browser and OS
+      # dependencies are part of this digest-pinned multi-architecture image.
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -535,29 +541,12 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
-      # verify-docs.sh installs Chromium for the docs site's own browser gates.
-      # Same payload, same cache directory as the `web` job, but keyed on the
-      # docs lockfile because that is what pins the docs site's Playwright.
-      - name: Restore Playwright browsers
-        id: playwright-browsers
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-docs-${{ runner.os }}-${{ hashFiles('docs/site/pnpm-lock.yaml') }}
       - name: Typecheck, build, and assert O4-O6 policy content
         env:
           POSTHOG_REQUIRED: true
           PUBLIC_POSTHOG_HOST: ${{ vars.PUBLIC_POSTHOG_HOST }}
           PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ vars.PUBLIC_POSTHOG_PROJECT_TOKEN }}
         run: ./scripts/ci/verify-docs.sh
-      - name: Save Playwright browsers
-        if: >-
-          success() && steps.playwright-browsers.outputs.cache-hit != 'true' &&
-          github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-browsers.outputs.cache-primary-key }}
 
   compose-demo:
     needs: changes
@@ -609,24 +598,30 @@ jobs:
     needs: [changes, app-build]
     if: ${{ fromJSON(needs.changes.outputs.plan).web }}
     runs-on: ubuntu-latest
+    container:
+      # Exact @playwright/test release from web/package.json. Browser and OS
+      # dependencies are part of this digest-pinned multi-architecture image.
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
     # A leg runs ~4 flows serially (~3–4 min); the cap is headroom over that, not
     # the runner default of 360. A browser/MFA-ceremony hang here would otherwise
-    # stall web-closure and the whole gate for up to 6×360 runner-minutes.
+    # stall web-closure and the whole gate for up to 8×360 runner-minutes.
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         project: [desktop, mobile]
-        group: [1, 2, 3]
+        group: [1, 2, 3, 4]
         # Weight-balanced by test count + MFA-ceremony cost. Every flow in
         # e2e/registry.ts appears in exactly one group; the aggregator proves it.
         include:
           - group: 1
             specs: e2e/flows/reveal.spec.ts e2e/flows/members.spec.ts e2e/flows/login.spec.ts e2e/flows/scanning.spec.ts
           - group: 2
-            specs: e2e/flows/settings.spec.ts e2e/flows/history.spec.ts e2e/flows/workspace.spec.ts e2e/flows/matrix.spec.ts
+            specs: e2e/flows/settings.spec.ts e2e/flows/history.spec.ts e2e/flows/workspace.spec.ts
           - group: 3
             specs: e2e/flows/shell.spec.ts e2e/flows/instance-admin.spec.ts e2e/flows/machine-access.spec.ts e2e/flows/account.spec.ts
+          - group: 4
+            specs: e2e/flows/matrix.spec.ts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -638,32 +633,11 @@ jobs:
           name: hikyo-app-${{ github.run_id }}
       # Actions artifacts intentionally normalize file modes. Restore execute
       # permission before the browser harness starts the downloaded binary.
-      - name: Prepare the prebuilt app
-        run: chmod +x ci-artifacts/hikyo-ui
+      - name: Prepare prebuilt browser binaries
+        run: chmod +x ci-artifacts/hikyo-ui ci-artifacts/oidctest-idp
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Restore shared Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
-          restore-keys: go-mod-v2-${{ runner.os }}-
-      - name: Select runner cache ABI
-        id: runner-cache-abi
-        run: ./scripts/ci/export-runner-cache-abi.sh
-      - name: Restore web Go cache
-        id: web-go-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/go-build
-          key: go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
-          restore-keys: |
-            go-web-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
       - name: Install Corepack and enable pnpm
         run: ./scripts/ci/install-corepack.sh
 
@@ -688,28 +662,6 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      # The ui-tagged govulncheck and Go tests that used to run here inline moved
-      # to the `web-go` job so they run CONCURRENTLY with the browser legs rather
-      # than serially inside each of them. Go stays set up above because global
-      # setup still builds the oidctest IdP from source at flow time.
-
-      # The browser payload is ~130 MB pulled from cdn.playwright.dev on every
-      # leg, and both matrix legs pay it. Only the apt half (`install-deps`)
-      # genuinely has to run on a fresh runner; the download half is keyed on
-      # the lockfile that pins @playwright/test, so a version bump is the only
-      # thing that re-downloads it.
-      - name: Restore Playwright browsers
-        id: playwright-browsers
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-web-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
-      - name: Install Chromium
-        working-directory: web
-        run: |
-          pnpm exec playwright install-deps chromium
-          pnpm exec playwright install chromium
-
       # `playwright test` directly, not `pnpm run e2e`: the script rebuilds the
       # SPA so a developer cannot run the flows against a stale bundle, and
       # app-build already supplied this run's exact bundle and binary.
@@ -720,10 +672,11 @@ jobs:
         working-directory: web
         env:
           HIKYO_E2E_BINARY: ${{ github.workspace }}/ci-artifacts/hikyo-ui
+          HIKYO_E2E_OIDC_BINARY: ${{ github.workspace }}/ci-artifacts/oidctest-idp
         run: pnpm exec playwright test --project=${{ matrix.project }} ${{ matrix.specs }}
 
       # Each leg's pinned-assertion run log, for the aggregator to merge. Named
-      # per (project, group) so the six logs never collide on download.
+      # per (project, group) so the eight logs never collide on download.
       - name: Upload flow run log
         if: success()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -739,34 +692,10 @@ jobs:
           name: playwright-traces-${{ matrix.project }}-${{ matrix.group }}
           path: web/test-results/
           retention-days: 7
-      # One leg writes the cache. Both legs compile the same packages against
-      # the same key, so the second upload is 378 MB spent to lose a race.
-      - name: Save web Go cache
-        if: >-
-          success() && steps.web-go-cache.outputs.cache-hit != 'true' &&
-          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-          matrix.project == 'desktop' && matrix.group == 1
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/go-build
-          key: ${{ steps.web-go-cache.outputs.cache-primary-key }}
-      # Same single-writer rule as the Go cache above, and the same reason PR
-      # runs never write: this graph executes untrusted PR code, so only a main
-      # push is trusted to publish a browser payload every later run restores.
-      - name: Save Playwright browsers
-        if: >-
-          success() && steps.playwright-browsers.outputs.cache-hit != 'true' &&
-          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-          matrix.project == 'desktop' && matrix.group == 1
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-browsers.outputs.cache-primary-key }}
-
   # Flow-registry EXECUTION closure, enforced once over every leg. Splitting the
   # flows across legs means no single leg runs them all, so the per-leg teardown
   # check is skipped (positional-spec filter); this job restores its force. It
-  # merges the six legs' run logs and asserts every flow×surface×theme claim ran
+  # merges the eight legs' run logs and asserts every flow×surface×theme claim ran
   # for BOTH viewports. `needs: web` so it runs only when all legs passed — a
   # failed leg already fails the gate, and a partial log here would be a false
   # negative. No pnpm install: the checker imports only registry.ts and the pure
@@ -850,7 +779,9 @@ jobs:
         # but always execute against a fresh build.
         run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
 
-  test:
+  # Fast package/build checks stay together; the historically dominant
+  # internal/isolation package runs on three independent PostgreSQL runners.
+  test_core:
     needs: changes
     if: ${{ fromJSON(needs.changes.outputs.plan).test }}
     runs-on: ubuntu-latest
@@ -923,12 +854,20 @@ jobs:
           go build -o "$RUNNER_TEMP/hikyo" ./cmd/hikyo
           ./scripts/ci/run-go-tool.sh govulncheck -mode=binary "$RUNNER_TEMP/hikyo"
 
-      - name: Test (sqlite + postgres conformance)
+      - name: Test all packages except the sharded isolation suite
         env:
           HIKYO_TEST_POSTGRES_DSN: postgres://hikyo:hikyo@127.0.0.1:5432/hikyo_test
         # Compile from restored GOCACHE, but never replay results: PostgreSQL
         # conformance must exercise this run's fresh service container.
-        run: go test -count=1 ./...
+        run: |
+          isolation_package=$(go list ./internal/isolation)
+          packages="$RUNNER_TEMP/test-core-packages"
+          go list ./... | grep -Fvx "$isolation_package" >"$packages"
+          if [ ! -s "$packages" ] || grep -Fx "$isolation_package" "$packages"; then
+            echo 'test core: isolation package exclusion failed' >&2
+            exit 1
+          fi
+          xargs go test -count=1 <"$packages"
       # The secret-scanning benchmark regression guard (#74, SS1). Relative, not
       # absolute-ms — CI runners are not the Pi-class calibration floor, so this
       # only proves BenchmarkScan compiles and runs to completion; the absolute
@@ -1019,16 +958,19 @@ jobs:
           key: ${{ steps.k8s-e2e-go-cache.outputs.cache-primary-key }}
 
   # The workflow graph is trusted base-branch code, but every validation job
-  # checks out the untrusted PR head. Build both shard plans once from a copy of
-  # the planner at BASE_SHA so a PR cannot omit its own package or fuzz target.
+  # checks out the untrusted PR head. Build every shard plan once from a copy of
+  # the planner at BASE_SHA so a PR cannot omit its own package, fuzz target, or
+  # top-level isolation test.
   analysis_shards:
     needs: changes
     if: >-
-      ${{ fromJSON(needs.changes.outputs.plan).race ||
+      ${{ fromJSON(needs.changes.outputs.plan).test ||
+      fromJSON(needs.changes.outputs.plan).race ||
       fromJSON(needs.changes.outputs.plan).fuzz }}
     runs-on: ubuntu-latest
     outputs:
       fuzz_plan: ${{ steps.plan.outputs.fuzz_plan }}
+      isolation_plan: ${{ steps.plan.outputs.isolation_plan }}
       race_plan: ${{ steps.plan.outputs.race_plan }}
       shards: ${{ steps.plan.outputs.shards }}
     steps:
@@ -1041,7 +983,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - name: Plan complete race and fuzz shards
+      - name: Plan complete test, race, and fuzz shards
         id: plan
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -1057,6 +999,7 @@ jobs:
 
           race_plan='[]'
           fuzz_plan='[]'
+          isolation_plan='[]'
           shard_count=3
           shard=0
           while [ "$shard" -lt "$shard_count" ]; do
@@ -1064,23 +1007,110 @@ jobs:
               --shard "$shard" --shards "$shard_count" | jq -Rsc 'split("\n") | map(select(length > 0))')
             fuzz_shard=$(go run "$trusted_planner" fuzz --root . \
               --shard "$shard" --shards "$shard_count" | jq -Rsc 'split("\n") | map(select(length > 0))')
+            isolation_shard=$(go run "$trusted_planner" isolation --root . \
+              --shard "$shard" --shards "$shard_count" | jq -Rsc 'split("\n") | map(select(length > 0))')
             race_plan=$(jq -cn --argjson plan "$race_plan" --argjson shard "$race_shard" \
               '$plan + [$shard]')
             fuzz_plan=$(jq -cn --argjson plan "$fuzz_plan" --argjson shard "$fuzz_shard" \
+              '$plan + [$shard]')
+            isolation_plan=$(jq -cn --argjson plan "$isolation_plan" --argjson shard "$isolation_shard" \
               '$plan + [$shard]')
             shard=$((shard + 1))
           done
 
           if [ "$(printf '%s' "$race_plan" | jq 'flatten | length')" -eq 0 ] ||
-            [ "$(printf '%s' "$fuzz_plan" | jq 'flatten | length')" -eq 0 ]; then
-            echo 'analysis shards: race or fuzz plan was empty' >&2
+            [ "$(printf '%s' "$fuzz_plan" | jq 'flatten | length')" -eq 0 ] ||
+            [ "$(printf '%s' "$isolation_plan" | jq 'flatten | length')" -eq 0 ]; then
+            echo 'analysis shards: test, race, or fuzz plan was empty' >&2
             exit 1
           fi
           {
             echo "race_plan=$race_plan"
             echo "fuzz_plan=$fuzz_plan"
+            echo "isolation_plan=$isolation_plan"
             echo "shards=$(printf '%s' "$race_plan" | jq -c 'keys')"
           } >>"$GITHUB_OUTPUT"
+
+  isolation_shard:
+    name: isolation shard (${{ matrix.shard }})
+    needs:
+      - analysis_shards
+      - changes
+    if: ${{ fromJSON(needs.changes.outputs.plan).test }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.analysis_shards.outputs.shards) }}
+    services:
+      postgres:
+        image: postgres:18@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+        env:
+          POSTGRES_USER: hikyo
+          POSTGRES_PASSWORD: hikyo
+          POSTGRES_DB: hikyo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U hikyo"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore shared Go module cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-v2-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: go-mod-v2-${{ runner.os }}-
+      - name: Select runner cache ABI
+        id: runner-cache-abi
+        run: ./scripts/ci/export-runner-cache-abi.sh
+      - name: Restore test Go cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-test-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-${{ hashFiles('go.mod', 'go.sum', 'scripts/ci/go-tool-modules.txt') }}
+          restore-keys: |
+            go-test-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-cache-abi.outputs.value }}-
+      - name: Test assigned isolation cases on SQLite and PostgreSQL
+        env:
+          HIKYO_TEST_POSTGRES_DSN: postgres://hikyo:hikyo@127.0.0.1:5432/hikyo_test
+          ISOLATION_PLAN: ${{ needs.analysis_shards.outputs.isolation_plan }}
+          ISOLATION_SHARD: ${{ matrix.shard }}
+        run: |
+          tests=$(printf '%s\n' "$ISOLATION_PLAN" |
+            jq -r --argjson shard "$ISOLATION_SHARD" '.[$shard] | join("|")')
+          if [ -z "$tests" ]; then
+            echo "isolation: shard $ISOLATION_SHARD has no tests" >&2
+            exit 1
+          fi
+          go test -count=1 ./internal/isolation/ -run "^(${tests})$"
+
+  test:
+    needs:
+      - changes
+      - isolation_shard
+      - test_core
+    if: ${{ always() && !cancelled() && fromJSON(needs.changes.outputs.plan).test }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require core checks and every isolation shard
+        env:
+          ISOLATION_SHARD_RESULT: ${{ needs.isolation_shard.result }}
+          TEST_CORE_RESULT: ${{ needs.test_core.result }}
+        run: |
+          test "$TEST_CORE_RESULT" = success
+          test "$ISOLATION_SHARD_RESULT" = success
 
   # Race detector as its own context: a concurrent server with transaction
   # retry and a single-writer SQLite pool gets its data races found here, not
@@ -1164,7 +1194,7 @@ jobs:
     needs:
       - changes
       - race_shard
-    if: ${{ always() && fromJSON(needs.changes.outputs.plan).race }}
+    if: ${{ always() && !cancelled() && fromJSON(needs.changes.outputs.plan).race }}
     runs-on: ubuntu-latest
     steps:
       - name: Require every race shard
@@ -1313,7 +1343,7 @@ jobs:
     needs:
       - changes
       - fuzz_shard
-    if: ${{ always() && fromJSON(needs.changes.outputs.plan).fuzz }}
+    if: ${{ always() && !cancelled() && fromJSON(needs.changes.outputs.plan).fuzz }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -1425,7 +1455,9 @@ jobs:
   # The permanent required context. Every validation job is named here so a
   # future job split cannot accidentally weaken branch protection.
   ci-required:
-    if: always()
+    # Keep failure aggregation, but do not queue an obsolete aggregate job for
+    # a workflow GitHub already cancelled in favor of a newer PR head.
+    if: always() && !cancelled()
     needs:
       - changes
       - client

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,9 @@ jobs:
       contents: read
       pages: write
     runs-on: ubuntu-latest
+    container:
+      # Exact @playwright/test release from docs/site/package.json.
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,29 @@ env:
   GOFLAGS: -mod=readonly
 
 jobs:
+  docs:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    container:
+      # Exact @playwright/test release from docs/site/package.json.
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Assert O4-O6 docs and governance release gates
+        env:
+          POSTHOG_REQUIRED: true
+          PUBLIC_POSTHOG_HOST: ${{ vars.PUBLIC_POSTHOG_HOST }}
+          PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ vars.PUBLIC_POSTHOG_PROJECT_TOKEN }}
+        run: ./scripts/ci/verify-docs.sh
+
   build-unsigned-draft:
+    needs: docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -100,13 +122,8 @@ jobs:
           go test ./...
           ./scripts/release/test-fixtures.sh
 
-      - name: Assert O4-O6 docs and governance release gates
-        env:
-          POSTHOG_REQUIRED: true
-          PUBLIC_POSTHOG_HOST: ${{ vars.PUBLIC_POSTHOG_HOST }}
-          PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ vars.PUBLIC_POSTHOG_PROJECT_TOKEN }}
+      - name: Assert fallback channel and live docs release gates
         run: |
-          ./scripts/ci/verify-docs.sh
           ./scripts/ci/check-fallback-channel-test.sh \
             release/repository/fallback-channel-test.json \
             security@developwent.io

--- a/docs/handoff/ci-critical-path-optimization.md
+++ b/docs/handoff/ci-critical-path-optimization.md
@@ -1,0 +1,55 @@
+# CI critical-path optimization handoff
+
+## Outcome
+
+- `internal/isolation` is excluded from the monolithic `test_core` job and its
+  514 top-level tests are assigned exactly once across three independent
+  PostgreSQL-backed runners. The existing `test` job ID is now the aggregate,
+  so the required-gate contract does not change.
+- CI, Pages, and release docs jobs plus web browser jobs run in the
+  digest-pinned Playwright 1.62.1 Noble image. This removes per-leg browser
+  downloads and `apt` dependency installs. Release docs verification is an
+  explicit prerequisite job, leaving the release build on its normal runner.
+- The browser matrix has four groups per viewport. The long matrix flow is
+  isolated in group 4, and `app-build` supplies both the UI binary and fake OIDC
+  provider so browser legs perform no Go setup or compilation.
+- Both `ci-required` gates and the test/race/fuzz fan-in jobs retain ordinary
+  failure aggregation but skip after workflow cancellation, allowing a
+  superseding pull-request head to acquire concurrency immediately.
+
+## Coverage and trust model
+
+- The base-controlled planner discovers valid top-level `Test*` declarations
+  from the checked-out head with the Go parser. Stable FNV-1a assignment keeps
+  every test on exactly one shard without adding `t.Parallel()` to stateful
+  integration tests.
+- Pull requests use the planner from their base SHA, preventing head code from
+  omitting its own validation. Main uses the checked-in planner directly.
+- Browser and docs images use the same exact Playwright version declared by
+  their package manifests and a multi-architecture image-index digest.
+- Docs PWA and container live-site checks share a Zod-backed JSON validator;
+  fallback-channel fixtures generate their invalid variants without a parser.
+  The browser image therefore needs no live `jq` or `apt` provisioning step.
+- Browser artifacts remain run-scoped and exact-head. Missing prebuilt OIDC
+  binaries fail before a browser flow starts; local development retains the
+  source-build fallback.
+
+## Timing boundary
+
+The previous observed critical path was 8m52s for `internal/isolation`; browser
+runs also suffered fresh-runner `apt` stalls above ten minutes. The new graph
+removes both serialized costs, but hosted-runner timing is pending the first
+post-merge main run. Do not present local timings as production evidence.
+
+## Verification
+
+- Planner fixture and an independent `go test -list` comparison proved all 514
+  current isolation tests are complete and disjoint (180/163/171 targets).
+- Actionlint; ShellCheck; registry, trusted-script, cache-policy,
+  artifact-reuse, required-job, and changed-path fixtures passed.
+- Web TypeScript typecheck and all 602 unit tests passed on Node 26.7.0.
+- The exact Playwright image digest resolved on arm64 and contained Chromium.
+- The complete docs verifier passed inside that image, including the offline
+  Chromium route, live-site fixtures, and fallback-channel fixtures.
+- Full PostgreSQL-backed `go test -count=1 ./...` passed; the unchanged
+  monolithic isolation baseline completed in 554.444 seconds.

--- a/docs/site/scripts/validate-ci-json.mjs
+++ b/docs/site/scripts/validate-ci-json.mjs
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+
+import { z } from 'zod';
+
+const iconSchema = z.object({
+  src: z.string(),
+  sizes: z.string(),
+  type: z.string().optional(),
+});
+
+const manifestSchema = z.object({
+  id: z.literal('/'),
+  start_url: z.literal('/'),
+  scope: z.literal('/'),
+  display: z.literal('standalone'),
+  icons: z.array(iconSchema),
+});
+
+const builtManifestSchema = manifestSchema.extend({
+  name: z.literal('Hikyo — fully open secrets and configuration'),
+  short_name: z.literal('Hikyo'),
+  theme_color: z.literal('#1b2225'),
+});
+
+const dnsResponseSchema = z.object({
+  Status: z.literal(0),
+  Answer: z.array(
+    z.object({
+      type: z.number(),
+      data: z.string(),
+    }),
+  ),
+});
+
+const [mode, inputPath] = process.argv.slice(2);
+const input = inputPath === undefined ? readFileSync(0, 'utf8') : readFileSync(inputPath, 'utf8');
+
+function hasIcon(manifest, src, sizes, requireType) {
+  return manifest.icons.some(
+    (icon) =>
+      icon.src === src &&
+      icon.sizes === sizes &&
+      (!requireType || icon.type === 'image/png'),
+  );
+}
+
+try {
+  if (mode === 'built-manifest') {
+    const manifest = builtManifestSchema.parse(JSON.parse(input));
+    if (
+      !hasIcon(manifest, '/pwa-192x192.png', '192x192', true) ||
+      !hasIcon(manifest, '/pwa-512x512.png', '512x512', true)
+    ) {
+      process.exitCode = 1;
+    }
+  } else if (mode === 'live-manifest') {
+    const manifest = manifestSchema.parse(JSON.parse(input));
+    if (
+      !hasIcon(manifest, '/pwa-192x192.png', '192x192', false) ||
+      !hasIcon(manifest, '/pwa-512x512.png', '512x512', false)
+    ) {
+      process.exitCode = 1;
+    }
+  } else if (mode === 'dns-mx') {
+    const response = dnsResponseSchema.parse(JSON.parse(input));
+    if (!response.Answer.some((answer) => answer.type === 15 && answer.data.length > 0)) {
+      process.exitCode = 1;
+    }
+  } else {
+    throw new Error(`unknown validation mode: ${String(mode)}`);
+  }
+} catch {
+  process.exitCode = 1;
+}

--- a/scripts/ci/analysis-shards-go/main.go
+++ b/scripts/ci/analysis-shards-go/main.go
@@ -37,6 +37,10 @@ type fuzzTarget struct {
 	relativeDir string
 }
 
+type isolationTest struct {
+	name string
+}
+
 type options struct {
 	root       string
 	shard      int
@@ -71,8 +75,8 @@ func main() {
 }
 
 func run(args []string, output io.Writer) error {
-	if len(args) == 0 || (args[0] != "race" && args[0] != "fuzz") {
-		return errors.New("usage: analysis-shards race|fuzz --root DIR --shard N --shards N")
+	if len(args) == 0 || (args[0] != "race" && args[0] != "fuzz" && args[0] != "isolation") {
+		return errors.New("usage: analysis-shards race|fuzz|isolation --root DIR --shard N --shards N")
 	}
 	kind := args[0]
 	flags := flag.NewFlagSet(kind, flag.ContinueOnError)
@@ -103,6 +107,8 @@ func run(args []string, output io.Writer) error {
 		return writeRaceShard(output, packages, opts)
 	case "fuzz":
 		return writeFuzzShard(output, packages, opts)
+	case "isolation":
+		return writeIsolationShard(output, packages, opts)
 	default:
 		panic("unreachable analysis kind")
 	}
@@ -192,6 +198,65 @@ func writeFuzzShard(output io.Writer, packages []packageInfo, opts options) erro
 	return nil
 }
 
+func writeIsolationShard(output io.Writer, packages []packageInfo, opts options) error {
+	tests, err := discoverIsolationTests(packages)
+	if err != nil {
+		return err
+	}
+	if len(tests) == 0 {
+		return errors.New("no Test* target discovered in internal/isolation")
+	}
+	for _, test := range tests {
+		if shardFor("isolation", test.name, opts.shardCount) != opts.shard {
+			continue
+		}
+		if _, err := fmt.Fprintln(output, test.name); err != nil {
+			return fmt.Errorf("write isolation shard: %w", err)
+		}
+	}
+	return nil
+}
+
+func discoverIsolationTests(packages []packageInfo) ([]isolationTest, error) {
+	var isolationPackage *packageInfo
+	for index := range packages {
+		if packages[index].relativePath == "internal/isolation" {
+			isolationPackage = &packages[index]
+			break
+		}
+	}
+	if isolationPackage == nil {
+		return nil, errors.New("internal/isolation package was not found")
+	}
+
+	tests := make([]isolationTest, 0)
+	seen := make(map[string]string)
+	files := append(append([]string(nil), isolationPackage.TestGoFiles...), isolationPackage.XTestGoFiles...)
+	sort.Strings(files)
+	for _, name := range files {
+		path := filepath.Join(isolationPackage.Dir, name)
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv != nil || !isTestName(function.Name.Name) {
+				continue
+			}
+			if previous, exists := seen[function.Name.Name]; exists {
+				return nil, fmt.Errorf("duplicate isolation test %s in %s and %s", function.Name.Name, previous, path)
+			}
+			seen[function.Name.Name] = path
+			tests = append(tests, isolationTest{name: function.Name.Name})
+		}
+	}
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].name < tests[j].name
+	})
+	return tests, nil
+}
+
 func discoverFuzzTargets(packages []packageInfo) ([]fuzzTarget, error) {
 	targets := make([]fuzzTarget, 0)
 	seen := make(map[string]string)
@@ -232,10 +297,18 @@ func discoverFuzzTargets(packages []packageInfo) ([]fuzzTarget, error) {
 }
 
 func isFuzzName(name string) bool {
-	if !strings.HasPrefix(name, "Fuzz") || len(name) == len("Fuzz") {
+	return isGoTargetName(name, "Fuzz")
+}
+
+func isTestName(name string) bool {
+	return name != "TestMain" && isGoTargetName(name, "Test")
+}
+
+func isGoTargetName(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) || len(name) == len(prefix) {
 		return false
 	}
-	first, _ := utf8.DecodeRuneInString(name[len("Fuzz"):])
+	first, _ := utf8.DecodeRuneInString(name[len(prefix):])
 	return !unicode.IsLower(first)
 }
 

--- a/scripts/ci/analysis-shards_test.sh
+++ b/scripts/ci/analysis-shards_test.sh
@@ -44,6 +44,18 @@ package isolation
 import "testing"
 
 func FuzzIsolation(f *testing.F) { f.Fuzz(func(*testing.T, []byte) {}) }
+func TestAlpha(t *testing.T)      {}
+func TestBravo(t *testing.T)      {}
+func TestCharlie(t *testing.T)    {}
+func TestDelta(t *testing.T)      {}
+func TestEcho(t *testing.T)       {}
+func TestFoxtrot(t *testing.T)    {}
+func TestGolf(t *testing.T)       {}
+func TestHotel(t *testing.T)      {}
+func TestIndia(t *testing.T)      {}
+
+// Go does not discover a lowercase rune after the Test prefix.
+func Testlower(t *testing.T) {}
 EOF
 
 cat >"$fixture_dir/internal/service/service_test.go" <<'EOF'
@@ -56,8 +68,10 @@ EOF
 
 race_actual=$fixture_dir/race-actual
 fuzz_actual=$fixture_dir/fuzz-actual
+isolation_actual=$fixture_dir/isolation-actual
 : >"$race_actual"
 : >"$fuzz_actual"
+: >"$isolation_actual"
 
 shard=0
 while [ "$shard" -lt 3 ]; do
@@ -65,6 +79,8 @@ while [ "$shard" -lt 3 ]; do
 		awk -v shard="$shard" '{ print shard "\t" $0 }' >>"$race_actual"
 	"$planner" fuzz --root "$fixture_dir" --shard "$shard" --shards 3 |
 		awk -v shard="$shard" '{ print shard "\t" $0 }' >>"$fuzz_actual"
+	"$planner" isolation --root "$fixture_dir" --shard "$shard" --shards 3 |
+		awk -v shard="$shard" '{ print shard "\t" $0 }' >>"$isolation_actual"
 	shard=$((shard + 1))
 done
 
@@ -74,6 +90,10 @@ if [ -n "$(cut -f2 "$race_actual" | sort | uniq -d)" ]; then
 fi
 if [ -n "$(cut -f2- "$fuzz_actual" | sort | uniq -d)" ]; then
 	printf 'analysis shard fixture failed: fuzz target assigned more than once\n' >&2
+	exit 1
+fi
+if [ -n "$(cut -f2 "$isolation_actual" | sort | uniq -d)" ]; then
+	printf 'analysis shard fixture failed: isolation test assigned more than once\n' >&2
 	exit 1
 fi
 
@@ -96,6 +116,20 @@ example.com/shards/internal/service	FuzzService
 EOF
 cmp "$fixture_dir/fuzz-expected" "$fixture_dir/fuzz-targets"
 
+cut -f2 "$isolation_actual" | sort >"$fixture_dir/isolation-tests"
+cat >"$fixture_dir/isolation-expected" <<'EOF'
+TestAlpha
+TestBravo
+TestCharlie
+TestDelta
+TestEcho
+TestFoxtrot
+TestGolf
+TestHotel
+TestIndia
+EOF
+cmp "$fixture_dir/isolation-expected" "$fixture_dir/isolation-tests"
+
 crypto_shards=$(awk -F '\t' '$2 == "example.com/shards/internal/crypto" { print $1 }' \
 	"$fuzz_actual" | sort -u | wc -l | tr -d ' ')
 [ "$crypto_shards" -eq 1 ] || {
@@ -108,4 +142,4 @@ if "$planner" race --root "$fixture_dir" --shard 3 --shards 3 >/dev/null 2>&1; t
 	exit 1
 fi
 
-printf 'analysis shard fixture: complete, disjoint race packages and fuzz targets passed\n'
+printf 'analysis shard fixture: complete, disjoint race packages, fuzz targets, and isolation tests passed\n'

--- a/scripts/ci/check-build-artifact-reuse_test.sh
+++ b/scripts/ci/check-build-artifact-reuse_test.sh
@@ -25,13 +25,17 @@ require_line() {
 app_block=$(sed -n '/^  app-build:/,/^  no-egress:/p' "$workflow")
 no_egress_block=$(sed -n '/^  no-egress:/,/^  release-snapshot:/p' "$workflow")
 release_block=$(sed -n '/^  release-snapshot:/,/^  generated:/p' "$workflow")
-web_block=$(sed -n '/^  web:/,/^  test:/p' "$workflow")
+web_block=$(sed -n '/^  web:/,/^  web-closure:/p' "$workflow")
 
 [ -n "$app_block" ] || fail 'app-build job is missing'
 printf '%s\n' "$app_block" | grep -F 'run: ./scripts/ci/build-spa.sh --verify' >/dev/null ||
 	fail 'app-build does not verify and build the SPA through the shared script'
 printf '%s\n' "$app_block" | grep -F 'go build -tags ui -o ci-artifacts/hikyo-ui ./cmd/hikyo' >/dev/null ||
 	fail 'app-build does not produce the release-shaped CI binary'
+printf '%s\n' "$app_block" | grep -F 'go build -o ci-artifacts/oidctest-idp ./internal/oidctest/cmd' >/dev/null ||
+	fail 'app-build does not produce the browser IdP helper'
+printf '%s\n' "$app_block" | grep -F 'ci-artifacts/oidctest-idp' >/dev/null ||
+	fail 'app-build does not upload the browser IdP helper'
 printf '%s\n' "$app_block" | grep -Fx '          name: hikyo-app-${{ github.run_id }}' >/dev/null ||
 	fail 'app-build artifact is not scoped to this workflow run'
 if printf '%s\n' "$app_block" | grep -F 'github.run_attempt' >/dev/null; then
@@ -70,6 +74,17 @@ printf '%s\n' "$web_block" | grep -F 'actions/download-artifact@3e5f45b2cfb91720
 	fail 'web does not use the repository-pinned download-artifact action'
 printf '%s\n' "$web_block" | grep -F 'run: chmod +x ci-artifacts/hikyo-ui' >/dev/null ||
 	fail 'web does not restore execute permission after artifact download'
+printf '%s\n' "$web_block" | grep -F 'chmod +x ci-artifacts/hikyo-ui ci-artifacts/oidctest-idp' >/dev/null ||
+	fail 'web does not restore both artifact executable modes'
+printf '%s\n' "$web_block" | grep -F 'HIKYO_E2E_OIDC_BINARY: ${{ github.workspace }}/ci-artifacts/oidctest-idp' >/dev/null ||
+	fail 'web does not pass the prebuilt IdP helper to the browser harness'
+if printf '%s\n' "$web_block" | grep -E 'actions/setup-go|go build|\.cache/go-build|~/go/pkg/mod' >/dev/null; then
+	fail 'a browser shard still provisions Go or compiles a helper'
+fi
+printf '%s\n' "$web_block" | grep -F 'group: [1, 2, 3, 4]' >/dev/null ||
+	fail 'browser matrix is not split across four groups'
+printf '%s\n' "$web_block" | grep -F 'specs: e2e/flows/matrix.spec.ts' >/dev/null ||
+	fail 'heavy matrix flow does not have its own browser group'
 
 if printf '%s\n' "$web_block" |
 	grep -E 'pnpm run (typecheck|test|build)|pnpm build' >/dev/null; then
@@ -114,6 +129,7 @@ upload_line=$(grep -nF 'name: Upload unsigned development snapshot' "$workflow" 
 [ -n "$validate_line" ] && [ "$validate_line" -lt "$upload_line" ] ||
 	fail 'development snapshot is uploaded before non-mutating manifest validation'
 require_line "$fixture" "process.env.HIKYO_E2E_BINARY"
+require_line "$fixture" "process.env.HIKYO_E2E_OIDC_BINARY"
 
 if grep -Eq 'gh release|action-gh-release' "$workflow"; then
 	fail 'ordinary CI publishes a GitHub Release and bypasses the signing ceremony'

--- a/scripts/ci/check-cache-policy_test.sh
+++ b/scripts/ci/check-cache-policy_test.sh
@@ -21,6 +21,16 @@ require_line() {
 		fail "missing $expected in $(basename "$file")"
 }
 
+workflow_job_block() {
+	file=$1
+	job=$2
+	awk -v header="  $job:" '
+		$0 == header { found = 1 }
+		found && $0 != header && $0 ~ /^  [A-Za-z0-9_-]+:/ { exit }
+		found { print }
+	' "$file"
+}
+
 set --
 for candidate in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
 	[ -f "$candidate" ] || continue
@@ -91,6 +101,32 @@ grep -F 'key: go-release-snapshot-v2-' "$workflow" |
 	grep -F "hashFiles('go.mod', 'go.sum', '.goreleaser.yaml')" >/dev/null ||
 	fail 'release-snapshot cache does not include GoReleaser configuration'
 require_line "$repo_root/.github/workflows/race-isolation.yml" 'name: Restore race Go cache'
+
+# Browser jobs run inside the exact Playwright image matching both lockfiles.
+# No live apt mirror belongs on the critical path.
+web_playwright=$(jq -r '.devDependencies["@playwright/test"]' "$repo_root/web/package.json")
+docs_playwright=$(jq -r '.devDependencies["@playwright/test"]' "$repo_root/docs/site/package.json")
+[ "$web_playwright" = "$docs_playwright" ] ||
+	fail 'web and docs Playwright versions differ'
+playwright_image="mcr.microsoft.com/playwright:v${web_playwright}-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e"
+ci_docs_block=$(workflow_job_block "$workflow" docs)
+ci_web_block=$(workflow_job_block "$workflow" web)
+pages_docs_block=$(workflow_job_block "$repo_root/.github/workflows/docs.yml" build)
+release_docs_block=$(workflow_job_block "$repo_root/.github/workflows/release.yml" docs)
+for block in "$ci_docs_block" "$pages_docs_block" "$release_docs_block"; do
+	printf '%s\n' "$block" | grep -F "image: $playwright_image" >/dev/null ||
+		fail 'a verify-docs job does not own the exact digest-pinned Playwright image'
+	printf '%s\n' "$block" | grep -F 'run: ./scripts/ci/verify-docs.sh' >/dev/null ||
+		fail 'expected verify-docs invocation is outside its pinned-image job'
+done
+printf '%s\n' "$ci_web_block" | grep -F "image: $playwright_image" >/dev/null ||
+	fail 'web browser job does not own the exact digest-pinned Playwright image'
+printf '%s\n' "$release_docs_block" | grep -F 'contents: read' >/dev/null ||
+	fail 'release docs validation inherited workflow write permissions'
+if grep -F 'playwright install-deps' "$@" >/dev/null ||
+	grep -F 'playwright install --with-deps' "$repo_root/scripts/ci/verify-docs.sh" >/dev/null; then
+	fail 'live Playwright OS dependency installation remains on the CI path'
+fi
 
 # Every cache writer must be trusted-main-only and must skip an upload after an
 # exact hit. This covers Go, module, and Playwright writers alike.

--- a/scripts/ci/check-docs-live.sh
+++ b/scripts/ci/check-docs-live.sh
@@ -9,8 +9,11 @@ fi
 docs_origin=${1%/}
 fallback_email=$2
 CURL_BIN=${CURL_BIN:-curl}
-JQ_BIN=${JQ_BIN:-jq}
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
 NODE_BIN=${NODE_BIN:-node}
+JQ_BIN=${JQ_BIN:-jq}
+json_validator="$repo_root/docs/site/scripts/validate-ci-json.mjs"
 docs_cache_bust=${DOCS_CACHE_BUST:-}
 docs_attempts=${DOCS_ATTEMPTS:-1}
 docs_retry_delay_seconds=${DOCS_RETRY_DELAY_SECONDS:-10}
@@ -183,14 +186,20 @@ require_asset "$docs_stylesheet" stylesheet
 require_asset "$docs_module" module
 
 pwa_manifest=$(fetch "$docs_origin/manifest.webmanifest")
-printf '%s\n' "$pwa_manifest" | "$JQ_BIN" -e '
-  .id == "/" and
-  .start_url == "/" and
-  .scope == "/" and
-  .display == "standalone" and
-  any(.icons[]; .src == "/pwa-192x192.png" and .sizes == "192x192") and
-  any(.icons[]; .src == "/pwa-512x512.png" and .sizes == "512x512")
-' >/dev/null || {
+if [ -d "$repo_root/docs/site/node_modules/zod" ]; then
+	manifest_valid=$(printf '%s\n' "$pwa_manifest" |
+		"$NODE_BIN" "$json_validator" live-manifest >/dev/null 2>&1 && printf yes || printf no)
+else
+	manifest_valid=$(printf '%s\n' "$pwa_manifest" | "$JQ_BIN" -e '
+    .id == "/" and
+    .start_url == "/" and
+    .scope == "/" and
+    .display == "standalone" and
+    any(.icons[]; .src == "/pwa-192x192.png" and .sizes == "192x192") and
+    any(.icons[]; .src == "/pwa-512x512.png" and .sizes == "512x512")
+  ' >/dev/null 2>&1 && printf yes || printf no)
+fi
+[ "$manifest_valid" = yes ] || {
 	printf 'live docs gate: PWA manifest is incomplete or invalid\n' >&2
 	exit 1
 }
@@ -253,8 +262,15 @@ mx_response=$("$CURL_BIN" --fail --location --silent --show-error \
 	--header 'Accept: application/dns-json' \
 	"https://cloudflare-dns.com/dns-query?name=$fallback_domain&type=MX")
 
-printf '%s\n' "$mx_response" | "$JQ_BIN" -e \
-	'.Status == 0 and any(.Answer[]?; .type == 15 and (.data | length > 0))' >/dev/null || {
+if [ -d "$repo_root/docs/site/node_modules/zod" ]; then
+	mx_valid=$(printf '%s\n' "$mx_response" |
+		"$NODE_BIN" "$json_validator" dns-mx >/dev/null 2>&1 && printf yes || printf no)
+else
+	mx_valid=$(printf '%s\n' "$mx_response" | "$JQ_BIN" -e \
+		'.Status == 0 and any(.Answer[]?; .type == 15 and (.data | type == "string") and (.data | length > 0))' \
+		>/dev/null 2>&1 && printf yes || printf no)
+fi
+[ "$mx_valid" = yes ] || {
 	printf 'live docs gate: fallback domain %s has no reachable MX route\n' "$fallback_domain" >&2
 	exit 1
 }

--- a/scripts/ci/check-docs-live_test.sh
+++ b/scripts/ci/check-docs-live_test.sh
@@ -115,6 +115,8 @@ case "$url" in
 	*cloudflare-dns.com*)
 		if [ "${FAKE_NO_MX:-0}" -eq 1 ]; then
 			printf '%s\n' '{"Status":0,"Answer":[]}'
+		elif [ "${FAKE_BAD_MX_DATA:-0}" -eq 1 ]; then
+			printf '%s\n' '{"Status":0,"Answer":[{"type":15,"data":123}]}'
 		else
 			printf '%s\n' '{"Status":0,"Answer":[{"type":15,"data":"1 aspmx.l.google.com."}]}'
 		fi
@@ -135,6 +137,13 @@ if FAKE_NO_MX=1 CURL_BIN="$fixture_dir/curl" \
 	"$repo_root/scripts/ci/check-docs-live.sh" \
 	https://hikyo.app security@developwent.io >/dev/null 2>&1; then
 	printf 'live docs fixture failed: fallback domain without MX was accepted\n' >&2
+	exit 1
+fi
+
+if FAKE_BAD_MX_DATA=1 CURL_BIN="$fixture_dir/curl" \
+	"$repo_root/scripts/ci/check-docs-live.sh" \
+	https://hikyo.app security@developwent.io >/dev/null 2>&1; then
+	printf 'live docs fixture failed: malformed numeric MX data was accepted\n' >&2
 	exit 1
 fi
 

--- a/scripts/ci/check-docs-pwa.sh
+++ b/scripts/ci/check-docs-pwa.sh
@@ -8,7 +8,8 @@ fi
 
 repo_root=$1
 site_root=$2
-JQ_BIN=${JQ_BIN:-jq}
+NODE_BIN=${NODE_BIN:-node}
+json_validator="$repo_root/docs/site/scripts/validate-ci-json.mjs"
 
 require_file() {
 	[ -f "$1" ] || {
@@ -36,17 +37,8 @@ for path in manifest.webmanifest pwa-192x192.png pwa-512x512.png; do
 done
 
 require_file "$site_root/sw.js"
-"$JQ_BIN" -e '
-  .id == "/" and
-  .name == "Hikyo — fully open secrets and configuration" and
-  .short_name == "Hikyo" and
-  .start_url == "/" and
-  .scope == "/" and
-  .display == "standalone" and
-  .theme_color == "#1b2225" and
-  any(.icons[]; .src == "/pwa-192x192.png" and .sizes == "192x192" and .type == "image/png") and
-  any(.icons[]; .src == "/pwa-512x512.png" and .sizes == "512x512" and .type == "image/png")
-' "$site_root/manifest.webmanifest" >/dev/null || {
+"$NODE_BIN" "$json_validator" built-manifest \
+	"$site_root/manifest.webmanifest" >/dev/null 2>&1 || {
 	printf 'docs PWA gate: manifest is incomplete or invalid\n' >&2
 	exit 1
 }

--- a/scripts/ci/check-fallback-channel-test_test.sh
+++ b/scripts/ci/check-fallback-channel-test_test.sh
@@ -21,7 +21,8 @@ HIKYO_FALLBACK_TEST_NOW=2026-08-09T00:00:00Z \
 	"$repo_root/scripts/ci/check-fallback-channel-test.sh" \
 	"$fixture_dir/passed.json" security@developwent.io
 
-jq '.status = "pending"' "$fixture_dir/passed.json" >"$fixture_dir/pending.json"
+sed 's/"status": "passed"/"status": "pending"/' \
+	"$fixture_dir/passed.json" >"$fixture_dir/pending.json"
 if HIKYO_FALLBACK_TEST_NOW=2026-08-10T00:00:00Z \
 	"$repo_root/scripts/ci/check-fallback-channel-test.sh" \
 	"$fixture_dir/pending.json" security@developwent.io >/dev/null 2>&1; then
@@ -29,7 +30,9 @@ if HIKYO_FALLBACK_TEST_NOW=2026-08-10T00:00:00Z \
 	exit 1
 fi
 
-jq '.sent_at = "2026-04-01T10:00:00Z" | .received_at = "2026-04-01T10:05:00Z"' \
+sed \
+	-e 's/2026-08-01T10:00:00Z/2026-04-01T10:00:00Z/' \
+	-e 's/2026-08-01T10:05:00Z/2026-04-01T10:05:00Z/' \
 	"$fixture_dir/passed.json" >"$fixture_dir/stale.json"
 if HIKYO_FALLBACK_TEST_NOW=2026-08-09T00:00:00Z \
 	"$repo_root/scripts/ci/check-fallback-channel-test.sh" \
@@ -38,7 +41,7 @@ if HIKYO_FALLBACK_TEST_NOW=2026-08-09T00:00:00Z \
 	exit 1
 fi
 
-jq '.received_at = "2026-08-09T10:01:00Z"' \
+sed 's/2026-08-01T10:05:00Z/2026-08-09T10:01:00Z/' \
 	"$fixture_dir/passed.json" >"$fixture_dir/late.json"
 if HIKYO_FALLBACK_TEST_NOW=2026-08-10T00:00:00Z \
 	"$repo_root/scripts/ci/check-fallback-channel-test.sh" \

--- a/scripts/ci/check-trusted-ci-scripts_test.sh
+++ b/scripts/ci/check-trusted-ci-scripts_test.sh
@@ -29,6 +29,12 @@ require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/check-required-jobs.s
 require_line "$workflow" "CI_JOB_REGISTRY=\"\$trusted_registry\" \"\$trusted_checker\" --supports-plan-v2"
 require_line "$workflow" "CI_JOB_REGISTRY=\"\$trusted_registry\" \"\$trusted_checker\" \"\$GITHUB_EVENT_NAME\" \"\$NEEDS_JSON\" \"\$PLAN_JSON\""
 require_line "$workflow" "git show \"\$BASE_SHA:scripts/ci/analysis-shards-go/main.go\" >\"\$trusted_planner\""
+# shellcheck disable=SC2016
+require_line "$workflow" 'isolation_shard=$(go run "$trusted_planner" isolation --root .'
+# shellcheck disable=SC2016
+require_line "$workflow" 'ISOLATION_SHARD_RESULT: ${{ needs.isolation_shard.result }}'
+# shellcheck disable=SC2016
+require_line "$workflow" 'go list ./... | grep -Fvx "$isolation_package" >"$packages"'
 require_line "$workflow" 'name: Upload shard fuzz reproducers'
 require_line "$workflow" 'name: Download shard fuzz reproducers'
 require_line "$workflow" 'name: Upload minimized fuzz reproducers'
@@ -59,6 +65,23 @@ if ! grep -F 'pull_request_target:' "$controller" >/dev/null ||
 	printf 'trusted CI scripts fixture failed: base-controlled entrypoint is missing\n' >&2
 	exit 1
 fi
+
+# Superseded PR runs must release workflow concurrency immediately. Aggregate
+# gates still run after ordinary failures, but cancellation must skip them.
+workflow_gate=$(sed -n '/^  ci-required:/,$p' "$workflow")
+controller_gate=$(sed -n '/^  ci-required:/,$p' "$controller")
+for gate in "$workflow_gate" "$controller_gate"; do
+	if ! printf '%s\n' "$gate" |
+		grep -Fx '    if: always() && !cancelled()' >/dev/null; then
+		printf 'trusted CI scripts fixture failed: aggregate gate survives cancellation\n' >&2
+		exit 1
+	fi
+done
+# Shard fan-in jobs aggregate ordinary failures too, so cancellation must skip
+# them without weakening their path-plan condition.
+for plan_job in test race fuzz; do
+	require_line "$workflow" "if: \${{ always() && !cancelled() && fromJSON(needs.changes.outputs.plan).$plan_job }}"
+done
 
 # The untrusted validation graph (ci.yml, ci-control.yml) holds NO issue/PR write
 # anywhere: executing attacker-influenced PR code must never reach a write token.

--- a/scripts/ci/ci-job-registry.json
+++ b/scripts/ci/ci-job-registry.json
@@ -6,6 +6,7 @@
       "client",
       "compose-demo",
       "docs",
+      "freeze-guard",
       "fuzz",
       "generated",
       "headline-guarantee",
@@ -21,6 +22,7 @@
     "api": [
       "client",
       "compose-demo",
+      "freeze-guard",
       "generated",
       "headline-guarantee",
       "release-snapshot",
@@ -105,6 +107,10 @@
     },
     "client": {"required_gate": "planned", "plan_jobs": ["client"]},
     "docs": {"required_gate": "planned", "plan_jobs": ["docs"]},
+    "freeze-guard": {
+      "required_gate": "planned",
+      "plan_jobs": ["freeze-guard"]
+    },
     "compose-demo": {
       "required_gate": "planned",
       "plan_jobs": ["compose-demo"]

--- a/scripts/ci/ci-job-registry.json
+++ b/scripts/ci/ci-job-registry.json
@@ -119,7 +119,12 @@
     },
     "analysis_shards": {
       "required_gate": "indirect",
-      "plan_jobs": ["race", "fuzz"]
+      "plan_jobs": ["test", "race", "fuzz"]
+    },
+    "test_core": {"required_gate": "indirect", "plan_jobs": ["test"]},
+    "isolation_shard": {
+      "required_gate": "indirect",
+      "plan_jobs": ["test"]
     },
     "race_shard": {"required_gate": "indirect", "plan_jobs": ["race"]},
     "race": {"required_gate": "planned", "plan_jobs": ["race"]},

--- a/scripts/ci/ci_job_registry_test.go
+++ b/scripts/ci/ci_job_registry_test.go
@@ -86,7 +86,7 @@ func TestCIJobRegistryRejectsWorkflowDrift(t *testing.T) {
     if: ${{ fromJSON(needs.changes.outputs.plan).test }}
     runs-on: ubuntu-latest
   ci-required:
-    if: always()
+    if: always() && !cancelled()
     needs: [changes, test]
     runs-on: ubuntu-latest
 `)
@@ -129,7 +129,7 @@ func TestCIJobRegistryRejectsWorkflowDrift(t *testing.T) {
 			},
 			workflow: baseWorkflow,
 		},
-		"aggregate without always": {
+		"aggregate without cancellation guard": {
 			workflow: []byte(`jobs:
   changes:
     runs-on: ubuntu-latest
@@ -138,6 +138,7 @@ func TestCIJobRegistryRejectsWorkflowDrift(t *testing.T) {
     if: ${{ fromJSON(needs.changes.outputs.plan).test }}
     runs-on: ubuntu-latest
   ci-required:
+    if: always()
     needs: [changes, test]
     runs-on: ubuntu-latest
 `),
@@ -220,7 +221,7 @@ func validateRegistry(gotRegistry registry, workflowData []byte) error {
 			if len(rule.PlanJobs) != 0 {
 				return fmt.Errorf("job %q gate %q cannot name plan jobs", job, rule.RequiredGate)
 			}
-			if condition != "always()" {
+			if condition != "always() && !cancelled()" {
 				return fmt.Errorf("aggregate job %q has condition %q", job, condition)
 			}
 		case "planned":
@@ -271,7 +272,7 @@ func validateRegistry(gotRegistry registry, workflowData []byte) error {
 	}
 
 	const shardMatrix = "${{ fromJSON(needs.analysis_shards.outputs.shards) }}"
-	for _, job := range []string{"race_shard", "fuzz_shard"} {
+	for _, job := range []string{"isolation_shard", "race_shard", "fuzz_shard"} {
 		if _, registered := gotRegistry.Jobs[job]; !registered {
 			continue
 		}

--- a/scripts/ci/verify-docs.sh
+++ b/scripts/ci/verify-docs.sh
@@ -21,9 +21,6 @@ pnpm --dir "$repo_root/docs/site" install --frozen-lockfile
 node "$repo_root/scripts/ci/check-doc-status.mjs" --check --root "$repo_root"
 "$repo_root/scripts/ci/check-doc-status_test.sh"
 pnpm --dir "$repo_root/docs/site" peers check
-if [ -n "${CI:-}" ]; then
-	pnpm --dir "$repo_root/docs/site" exec playwright install --with-deps chromium
-fi
 pnpm --dir "$repo_root/docs/site" run verify
 "$repo_root/scripts/ci/check-oss-policy_test.sh"
 "$repo_root/scripts/ci/check-docs-live_test.sh"

--- a/web/e2e/fixtures/instance.ts
+++ b/web/e2e/fixtures/instance.ts
@@ -217,8 +217,15 @@ async function spawnIdP(
   if (await portTaken('127.0.0.1', port)) {
     throw new Error(`something is already listening on 127.0.0.1:${String(port)}`);
   }
-  const binary = join(dir, `oidctest-idp-${String(port)}`);
-  run('go', ['build', '-o', binary, './internal/oidctest/cmd'], { cwd: repoRoot });
+  const prebuiltBinary = process.env.HIKYO_E2E_OIDC_BINARY;
+  const binary = prebuiltBinary ?? join(dir, `oidctest-idp-${String(port)}`);
+  if (prebuiltBinary !== undefined) {
+    if (!existsSync(prebuiltBinary)) {
+      throw new Error(`HIKYO_E2E_OIDC_BINARY does not exist: ${prebuiltBinary}`);
+    }
+  } else {
+    run('go', ['build', '-o', binary, './internal/oidctest/cmd'], { cwd: repoRoot });
+  }
   const args = ['-listen', `127.0.0.1:${String(port)}`, '-amr', 'mfa,otp'];
   for (const redirect of redirects) {
     args.push('-redirect-uri', redirect);


### PR DESCRIPTION
## Summary

- shard the 514-test isolation suite across three independent PostgreSQL runners
- run docs and browser jobs in a digest-pinned Playwright image and reuse the prebuilt OIDC helper
- rebalance Playwright into eight legs and skip aggregate jobs after cancellation
- keep Pages/release docs validation blocking, read-only, and container-native

## Validation

- `CI=true HIKYO_TEST_POSTGRES_DSN=... go test -count=1 ./...`
- web TypeScript typecheck and 602 Vitest tests
- full docs verifier inside the pinned Playwright image, including offline Chromium
- Actionlint, ShellCheck, CI registry/policy/path/release fixtures
- two-axis standards/spec review; all findings resolved