### PR TITLE
Configure datastore connection pool limits #518

### DIFF
--- a/docs/handoff/518-datastore-pool-sizing.md
+++ b/docs/handoff/518-datastore-pool-sizing.md
@@ -1,4 +1,4 @@
-# Issue #518 — datastore pool sizing
+# Issue #518 - datastore pool sizing
 
 **State: implemented.** Hikyo no longer inherits unbounded SQLite reader
 connections or pgx's host-dependent default pool size.

--- a/docs/handoff/518-datastore-pool-sizing.md
+++ b/docs/handoff/518-datastore-pool-sizing.md
@@ -1,0 +1,36 @@
+# Issue #518 — datastore pool sizing
+
+**State: implemented.** Hikyo no longer inherits unbounded SQLite reader
+connections or pgx's host-dependent default pool size.
+
+## Delivered behavior
+
+- SQLite keeps the locked engine shape: one writer and four WAL readers.
+- PostgreSQL defaults to 10 connections, as fixed by `ops-spec` §10.
+- `HIKYO_PG_POOL_MAX` accepts a positive 32-bit integer for larger instances;
+  zero, negatives, overflow, malformed values, and use with SQLite refuse boot.
+- PostgreSQL's `pool_max_conns` DSN parameter remains an alternative. The
+  dedicated environment variable wins when both are configured.
+- Server and local-admin startup log the effective pool maximum after the
+  datastore has opened and passed its boot checks.
+
+## Decision note
+
+The issue suggested CPU-derived examples (`GOMAXPROCS*4` for PostgreSQL and
+`GOMAXPROCS*2` for SQLite). Those examples conflict with the locked operational
+values in `docs/adr/ops-spec.md`: PostgreSQL 10 and SQLite 1+4. The locked
+values win; PostgreSQL retains explicit instance configuration for larger
+hardware.
+
+## Verification
+
+- Focused config/store/startup tests cover validation, typo recognition,
+  SQLite caps, logged effective values, and the store-owned reporting boundary.
+- PostgreSQL 18 conformance passed 73 tests covering the default, DSN
+  parameter, explicit override precedence, and the complete behavior corpus.
+- Race-instrumented PostgreSQL 18 isolation passed all 2,200 tests. The same
+  package passed all 2,200 tests without race instrumentation and within its
+  default timeout.
+- `go build ./...`, `go vet ./...`, docs Astro check, and the two-axis
+  standards/spec review passed. CI remains the source of truth for the
+  repository-wide parallel release gates.

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -26,6 +26,7 @@ Do not use `--dev` for real secret material or any non-loopback deployment.
 | Variable | Meaning |
 | --- | --- |
 | `HIKYO_DB` | Required: `sqlite:PATH` or `postgres://...` datastore. |
+| `HIKYO_PG_POOL_MAX` | Optional positive PostgreSQL connection-pool maximum. |
 | `HIKYO_EXTERNAL_ORIGIN` | Set explicitly to the canonical public HTTPS origin. |
 | `HIKYO_TLS_CERT_FILE`, `HIKYO_TLS_KEY_FILE` | Native TLS pair; both or neither. |
 | `HIKYO_OPERATIONAL_LISTEN` | Separate operational bind; default `127.0.0.1:8081`. |
@@ -109,11 +110,17 @@ outside the backup identity's custody store.
 ## Datastore
 
 SQLite uses `HIKYO_DB=sqlite:/absolute/path/hikyo.db`. Ensure the service user
-owns the parent directory and no other user can read it.
+owns the parent directory and no other user can read it. The write pool uses one
+connection and the WAL read pool is capped at four, so concurrent readers cannot
+open unlimited connections or retain unbounded WAL snapshots.
 
 Remote PostgreSQL must name one host explicitly and use
 `sslmode=verify-full` or `sslmode=verify-ca`. Multi-host DSNs and remote
-plaintext connections are refused.
+plaintext connections are refused. The connection-pool maximum defaults to 10.
+Set `HIKYO_PG_POOL_MAX` to a positive 32-bit integer for larger hardware, or put
+`pool_max_conns=N` in the PostgreSQL DSN. The environment variable takes
+precedence when both are present. Hikyo logs the effective pool maximum once at
+startup for either datastore.
 
 ## Authentication cost controls
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,9 +62,10 @@ func Logger(dev bool) *slog.Logger {
 
 func storeConfig(cfg *config.Config) store.Config {
 	return store.Config{
-		Engine: store.Engine(cfg.Store.Engine),
-		Path:   cfg.Store.Path,
-		DSN:    cfg.Store.DSN,
+		Engine:          store.Engine(cfg.Store.Engine),
+		Path:            cfg.Store.Path,
+		DSN:             cfg.Store.DSN,
+		PostgresPoolMax: cfg.Store.PostgresPoolMax,
 	}
 }
 
@@ -305,6 +306,7 @@ func openKeyed(ctx context.Context, cfg *config.Config, log *slog.Logger, sc sto
 		return nil, nil, err
 	}
 	guard.add(func() error { return resources.closeDatabase(db) })
+	logDatastorePoolSizes(log, db)
 
 	// LoadKeyring consumes root: it is zeroed before this returns.
 	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
@@ -318,6 +320,21 @@ func openKeyed(ctx context.Context, cfg *config.Config, log *slog.Logger, sc sto
 		log.Warn("root key rotation is UNFINISHED: the master is dual-wrapped under the old and new roots; run `hikyo rotate-root-key --verify` then `--finalize` to complete it")
 	}
 	return db, kr, nil
+}
+
+func logDatastorePoolSizes(log *slog.Logger, db *store.DB) {
+	limits := db.ConnectionPoolLimits()
+	switch db.Engine() {
+	case store.EngineSQLite:
+		log.Info("datastore connection pools configured",
+			"engine", db.Engine(),
+			"write_max_connections", limits.Primary,
+			"read_max_connections", limits.ReadOnly)
+	case store.EnginePostgres:
+		log.Info("datastore connection pool configured",
+			"engine", db.Engine(),
+			"max_connections", limits.Primary)
+	}
 }
 
 // Boot runs the fail-closed startup sequence: process hardening before any

--- a/internal/app/boot_cleanup_test.go
+++ b/internal/app/boot_cleanup_test.go
@@ -1,15 +1,42 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
+
+func TestBootLogsEffectiveSQLitePoolSizes(t *testing.T) {
+	var output bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&output, nil))
+	resources := recordingBootResources(&bootResourceRecord{})
+	injected := errors.New("stop after datastore startup")
+	resources.listen = func(string, string) (net.Listener, error) { return nil, injected }
+
+	_, err := boot(t.Context(), devConfig(t), log, resources)
+	if !errors.Is(err, injected) {
+		t.Fatalf("boot error = %v, want injected listener error", err)
+	}
+	logged := output.String()
+	for _, want := range []string{
+		"msg=\"datastore connection pools configured\"",
+		"engine=sqlite",
+		"write_max_connections=1",
+		"read_max_connections=",
+	} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("startup log missing %q:\n%s", want, logged)
+		}
+	}
+}
 
 type bootResourceRecord struct {
 	database       *store.DB

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,9 +29,10 @@ const (
 
 // Datastore is the parsed, validated datastore selection.
 type Datastore struct {
-	Engine Engine
-	Path   string // sqlite file path
-	DSN    string // postgres DSN
+	Engine          Engine
+	Path            string // sqlite file path
+	DSN             string // postgres DSN
+	PostgresPoolMax int32  // HIKYO_PG_POOL_MAX override; zero uses DSN/locked default
 }
 
 type Config struct {
@@ -132,6 +133,7 @@ type Config struct {
 // knownEnv is the closed set of HIKYO_* keys this build understands.
 var knownEnv = map[string]bool{
 	"HIKYO_DB":                         true,
+	"HIKYO_PG_POOL_MAX":                true,
 	"HIKYO_LISTEN":                     true,
 	"HIKYO_OPERATIONAL_LISTEN":         true,
 	"HIKYO_TLS_CERT_FILE":              true,
@@ -393,6 +395,16 @@ func Load(subcommand string, args []string, getenv func(string) string, environ 
 		cfg.Store = Datastore{Engine: EngineSQLite, Path: devSQLitePath}
 	default:
 		return nil, nil, fmt.Errorf("no datastore configured: set HIKYO_DB (sqlite:PATH or postgres://...) or pass --dev for zero-config sqlite evaluation")
+	}
+	if raw := strings.TrimSpace(getenv("HIKYO_PG_POOL_MAX")); raw != "" {
+		if cfg.Store.Engine != EnginePostgres {
+			return nil, nil, errors.New("HIKYO_PG_POOL_MAX requires a PostgreSQL datastore")
+		}
+		poolMax, err := strconv.ParseInt(raw, 10, 32)
+		if err != nil || poolMax <= 0 {
+			return nil, nil, fmt.Errorf("HIKYO_PG_POOL_MAX: %q is not a positive 32-bit integer", raw)
+		}
+		cfg.Store.PostgresPoolMax = int32(poolMax)
 	}
 	return cfg, warnings, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,41 @@ func TestPostgresLoopbackAllowed(t *testing.T) {
 	}
 }
 
+func TestPostgresPoolMaxConfig(t *testing.T) {
+	cfg, warnings, err := Load("server", nil,
+		env("HIKYO_DB", "postgres://u:p@localhost/hikyo", "HIKYO_PG_POOL_MAX", "17"),
+		environFrom("HIKYO_DB", "postgres://u:p@localhost/hikyo", "HIKYO_PG_POOL_MAX", "17"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("configured pool maximum must be recognized, got warnings %v", warnings)
+	}
+	if cfg.Store.PostgresPoolMax != 17 {
+		t.Fatalf("PostgresPoolMax = %d, want 17", cfg.Store.PostgresPoolMax)
+	}
+}
+
+func TestPostgresPoolMaxInvalidValuesRefuse(t *testing.T) {
+	for _, value := range []string{"0", "-1", "2147483648", "many"} {
+		t.Run(value, func(t *testing.T) {
+			_, _, err := Load("server", nil,
+				env("HIKYO_DB", "postgres://u:p@localhost/hikyo", "HIKYO_PG_POOL_MAX", value), nil)
+			if err == nil || !strings.Contains(err.Error(), "HIKYO_PG_POOL_MAX") {
+				t.Fatalf("HIKYO_PG_POOL_MAX=%q error = %v, want named refusal", value, err)
+			}
+		})
+	}
+}
+
+func TestPostgresPoolMaxRefusedForSQLite(t *testing.T) {
+	_, _, err := Load("server", nil,
+		env("HIKYO_DB", "sqlite:/data/hikyo.db", "HIKYO_PG_POOL_MAX", "8"), nil)
+	if err == nil || !strings.Contains(err.Error(), "requires a PostgreSQL datastore") {
+		t.Fatalf("SQLite with HIKYO_PG_POOL_MAX error = %v, want backend mismatch refusal", err)
+	}
+}
+
 func TestPostgresRemotePlaintextRefuses(t *testing.T) {
 	for _, dsn := range []string{
 		"postgres://u:p@db.example.com/hikyo",
@@ -109,9 +144,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
-		"postgres:///hikyo", // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
+		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -144,9 +144,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
-		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
+		"postgres:///hikyo", // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/config/knownenv_test.go
+++ b/internal/config/knownenv_test.go
@@ -90,8 +90,10 @@ func TestConsumedServerEnvKeysDoNotWarn(t *testing.T) {
 	pairs := []string{
 		"HIKYO_NEW_ROOT_KEY_FILE", newRootKeyFile,
 		"HIKYO_DIRECTORY_PROXY", directoryProxy,
+		"HIKYO_PG_POOL_MAX", "17",
 	}
-	cfg, warnings, err := Load("server", []string{"--dev"}, env(pairs...), environFrom(pairs...))
+	cfg, warnings, err := Load("server", nil,
+		env(append(pairs, "HIKYO_DB", "postgres://u:p@localhost/hikyo")...), environFrom(pairs...))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,5 +105,8 @@ func TestConsumedServerEnvKeysDoNotWarn(t *testing.T) {
 	}
 	if cfg.DirectoryProxy != directoryProxy {
 		t.Fatalf("DirectoryProxy = %q, want %q", cfg.DirectoryProxy, directoryProxy)
+	}
+	if cfg.Store.PostgresPoolMax != 17 {
+		t.Fatalf("PostgresPoolMax = %d, want 17", cfg.Store.PostgresPoolMax)
 	}
 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -135,13 +136,7 @@ func TestSQLiteActiveDomainEnforced(t *testing.T) {
 }
 
 func TestConformancePostgres(t *testing.T) {
-	dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
-	if dsn == "" {
-		if os.Getenv("CI") != "" {
-			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres conformance leg must not silently skip in CI")
-		}
-		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
-	}
+	dsn := postgresTestDSN(t)
 	cfg := store.Config{Engine: store.EnginePostgres, DSN: dsn}
 	resetPostgres(t, cfg)
 	if err := migrate.Run(t.Context(), cfg); err != nil {
@@ -154,6 +149,82 @@ func TestConformancePostgres(t *testing.T) {
 	t.Cleanup(func() { db.Close() })
 	seedAdmin(t, db)
 	runCorpus(t, db)
+}
+
+func TestPostgresPoolSizing(t *testing.T) {
+	dsn := postgresTestDSN(t)
+
+	t.Run("locked default is applied", func(t *testing.T) {
+		db, err := store.Open(t.Context(), store.Config{
+			Engine: store.EnginePostgres,
+			DSN:    postgresDSNWithPoolMax(t, dsn, ""),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if got := db.PG().Config().MaxConns; got != 10 {
+			t.Fatalf("default postgres pool maximum = %d, want 10", got)
+		}
+	})
+
+	t.Run("DSN parameter is honored", func(t *testing.T) {
+		db, err := store.Open(t.Context(), store.Config{
+			Engine: store.EnginePostgres,
+			DSN:    postgresDSNWithPoolMax(t, dsn, "6"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if got := db.PG().Config().MaxConns; got != 6 {
+			t.Fatalf("postgres DSN pool maximum = %d, want 6", got)
+		}
+	})
+
+	t.Run("explicit config takes precedence over DSN", func(t *testing.T) {
+		const configuredMax = int32(7)
+		db, err := store.Open(t.Context(), store.Config{
+			Engine:          store.EnginePostgres,
+			DSN:             postgresDSNWithPoolMax(t, dsn, "6"),
+			PostgresPoolMax: configuredMax,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if got := db.PG().Config().MaxConns; got != configuredMax {
+			t.Fatalf("postgres configured pool maximum = %d, want %d", got, configuredMax)
+		}
+	})
+}
+
+func postgresTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres conformance leg must not silently skip in CI")
+		}
+		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
+	}
+	return dsn
+}
+
+func postgresDSNWithPoolMax(t *testing.T, dsn, poolMax string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal("HIKYO_TEST_POSTGRES_DSN is not a valid URL")
+	}
+	query := u.Query()
+	if poolMax == "" {
+		query.Del("pool_max_conns")
+	} else {
+		query.Set("pool_max_conns", poolMax)
+	}
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 // resetPostgres drops the whole public schema, as the isolation harness does

--- a/internal/store/pool_test.go
+++ b/internal/store/pool_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenSQLiteCapsConnectionPools(t *testing.T) {
+	db, err := Open(t.Context(), Config{Engine: EngineSQLite, Path: filepath.Join(t.TempDir(), "pool.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if got := db.SQLiteWrite().Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("write pool maximum = %d, want 1", got)
+	}
+	if got := db.SQLiteRead().Stats().MaxOpenConnections; got != 4 {
+		t.Fatalf("read pool maximum = %d, want 4", got)
+	}
+	if got := db.ConnectionPoolLimits(); got != (ConnectionPoolLimits{Primary: 1, ReadOnly: 4}) {
+		t.Fatalf("ConnectionPoolLimits() = %+v, want primary 1 and read-only 4", got)
+	}
+}
+
+func TestOpenPostgresRejectsNegativePoolMaximum(t *testing.T) {
+	_, err := Open(t.Context(), Config{
+		Engine:          EnginePostgres,
+		DSN:             "postgres://u:p@localhost/hikyo",
+		PostgresPoolMax: -1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "pool maximum must be positive") {
+		t.Fatalf("Open() error = %v, want pool maximum refusal", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,10 +34,11 @@ const (
 // Config selects and locates the datastore. Exactly one of Path (sqlite) or
 // DSN (postgres) is used, per Engine.
 type Config struct {
-	Engine       Engine
-	Path         string
-	DSN          string
-	SQLiteDriver string // optional database/sql driver name for test instrumentation
+	Engine          Engine
+	Path            string
+	DSN             string
+	PostgresPoolMax int32  // zero selects DSN pool_max_conns or the locked default
+	SQLiteDriver    string // optional database/sql driver name for test instrumentation
 }
 
 // Org is the tenancy boundary. Creation, listing and counting are
@@ -867,6 +868,29 @@ func (d *DB) SQLiteWrite() *sql.DB { return d.sqWrite }
 func (d *DB) SQLiteRead() *sql.DB  { return d.sqRead }
 func (d *DB) PG() *pgxpool.Pool    { return d.pool }
 
+// ConnectionPoolLimits reports the effective datastore-owned limits without
+// requiring callers to reach through the raw driver accessors. Primary is the
+// PostgreSQL general pool or SQLite write pool; ReadOnly is the SQLite read
+// pool and zero for PostgreSQL.
+type ConnectionPoolLimits struct {
+	Primary  int
+	ReadOnly int
+}
+
+func (d *DB) ConnectionPoolLimits() ConnectionPoolLimits {
+	switch d.engine {
+	case EngineSQLite:
+		return ConnectionPoolLimits{
+			Primary:  d.sqWrite.Stats().MaxOpenConnections,
+			ReadOnly: d.sqRead.Stats().MaxOpenConnections,
+		}
+	case EnginePostgres:
+		return ConnectionPoolLimits{Primary: int(d.pool.Config().MaxConns)}
+	default:
+		return ConnectionPoolLimits{}
+	}
+}
+
 // AuditExportSnapshotTime returns the authoritative upper time bound for an
 // unbounded audit export. Postgres event inserts use the same server clock, so
 // a transaction that inserted before this cutoff remains in the snapshot even
@@ -938,7 +962,10 @@ func Open(ctx context.Context, cfg Config) (*DB, error) {
 	case EngineSQLite:
 		return openSQLite(ctx, cfg.Path, cfg.SQLiteDriver)
 	case EnginePostgres:
-		return openPostgres(ctx, cfg.DSN)
+		if cfg.PostgresPoolMax < 0 {
+			return nil, errors.New("store: postgres pool maximum must be positive when configured")
+		}
+		return openPostgres(ctx, cfg.DSN, cfg.PostgresPoolMax)
 	default:
 		return nil, fmt.Errorf("store: unknown engine %q", cfg.Engine)
 	}
@@ -961,6 +988,10 @@ func openSQLite(ctx context.Context, path, driverName string) (*DB, error) {
 		write.Close()
 		return nil, fmt.Errorf("store: open sqlite read pool: %w", err)
 	}
+	// The ops-spec fixes the SQLite engine shape at one writer plus four WAL
+	// readers. The finite read pool prevents bursts from opening unbounded
+	// connections that can retain WAL snapshots.
+	read.SetMaxOpenConns(sqliteReadPoolMaxConnections)
 	d := &DB{engine: EngineSQLite, sqWrite: write, sqRead: read}
 	for name, pool := range map[string]*sql.DB{"write": write, "read": read} {
 		if err := verifySQLitePragmas(ctx, pool); err != nil {
@@ -997,8 +1028,17 @@ func verifySQLitePragmas(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func openPostgres(ctx context.Context, dsn string) (*DB, error) {
-	pool, err := pgxpool.New(ctx, dsn)
+func openPostgres(ctx context.Context, dsn string, configuredMax int32) (*DB, error) {
+	poolConfig, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("store: parse postgres pool config: %w", err)
+	}
+	if configuredMax > 0 {
+		poolConfig.MaxConns = configuredMax
+	} else if !postgresDSNHasPoolMax(dsn) {
+		poolConfig.MaxConns = postgresPoolDefaultMaxConnections
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return nil, fmt.Errorf("store: open postgres pool: %w", err)
 	}
@@ -1011,6 +1051,19 @@ func openPostgres(ctx context.Context, dsn string) (*DB, error) {
 		return nil, err
 	}
 	return &DB{engine: EnginePostgres, pool: pool}, nil
+}
+
+// Locked by ops-spec §10: larger PostgreSQL deployments use explicit
+// instance configuration; SQLite keeps its fixed single-writer/four-reader
+// engine shape on every host.
+const (
+	postgresPoolDefaultMaxConnections int32 = 10
+	sqliteReadPoolMaxConnections            = 4
+)
+
+func postgresDSNHasPoolMax(dsn string) bool {
+	u, err := url.Parse(dsn)
+	return err == nil && u.Query().Has("pool_max_conns")
 }
 
 // pgSettingQuerier is the seam verifyPGDurability tests through: the fsync


### PR DESCRIPTION
## Summary

- fix SQLite at its locked one-writer/four-reader pool shape
- default PostgreSQL to 10 connections with validated `HIKYO_PG_POOL_MAX` and DSN override support
- log effective pool limits and document operator controls
- add config, startup, SQLite, PostgreSQL conformance, and race-isolation coverage

## Design

The ticket suggested CPU-derived example values, but locked `docs/adr/ops-spec.md` fixes PostgreSQL at 10 and SQLite at 1+4. This implementation follows the locked operational contract and retains explicit PostgreSQL configuration for larger hardware.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./internal/config ./internal/store ./internal/app -count=1`
- PostgreSQL 18 conformance: 73 passed
- `go test -race -count=1 -timeout 150m ./internal/isolation/`: 2200 passed
- `go test -count=1 ./internal/isolation/`: 2200 passed
- docs Astro check: 0 diagnostics
- standards/spec review: CLEAN

Closes #518