### PR TITLE
feat(api): executable WebUI parity registry for every public operation #490

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         run: ./scripts/ci/check-required-jobs_test.sh
       - name: API freeze guard fixture
         run: ./scripts/ci/check-api-freeze_test.sh
+      - name: Parity registry issue liveness fixture
+        run: ./scripts/ci/check-parity-issues_test.sh
       - name: Changed-path classifier fixture
         run: ./scripts/ci/classify-changed-paths_test.sh
       - name: CI job registry and workflow bijection fixture
@@ -517,6 +519,14 @@ jobs:
           restore-keys: go-mod-v2-${{ runner.os }}-
       - name: Enforce frozen API surface
         run: ./scripts/ci/check-api-freeze.sh
+      # WebUI parity (#490): every `issue:` row in api/parity.yaml must still be
+      # open. Public-repo issue reads need only the workflow token; the script
+      # fails loud on a denied read rather than guessing.
+      - name: Parity registry references only open issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: ./scripts/ci/check-parity-issues.sh
 
   # The TypeScript half of the contract chain. It is a separate job because it
   # needs a different toolchain, and because a Go-only change must not be able
@@ -804,7 +814,10 @@ jobs:
       - name: Go tests (transport, serving rules, browser session)
         # Restored GOCACHE may contain passing test results. Compile from cache,
         # but always execute against a fresh build.
-        run: go test -count=1 -tags ui ./internal/server/... ./internal/webui/...
+        # `./api` rides here too: its parity registry tests read web/src, so a
+        # web-only change that drops an operation import must fail on this
+        # plan, not on the next Go change.
+        run: go test -count=1 -tags ui ./api/... ./internal/server/... ./internal/webui/...
 
   # Fast package/build checks stay together; the historically dominant
   # internal/isolation package runs on three independent PostgreSQL runners.

--- a/api/parity.yaml
+++ b/api/parity.yaml
@@ -1,0 +1,370 @@
+# WebUI parity registry (#490).
+#
+# Every operation in openapi.yaml appears here exactly once, keyed by its
+# operationId, with ONE disposition:
+#
+#   webui: <surface>          The SPA reaches this operation itself. <surface>
+#                             is an id from web/src/app/navigation.ts SURFACES,
+#                             the same closed list the Playwright flow registry
+#                             closes over. Evidence is the generated
+#                             `<operationId>Op` import somewhere under web/src
+#                             (tests and the test kit excluded); `reach: path`
+#                             switches the evidence to a literal `/api/v1` path
+#                             for the few plain fetches (download links,
+#                             cross-origin workspace calls).
+#   webui: <surface>, via: [] The SAME USER OUTCOME is delivered through the
+#                             listed operations, which must themselves be direct
+#                             webui rows. This is the registry's line between
+#                             equivalent outcomes and literal CLI mirroring: a
+#                             `get` whose list already shows the row, a batch
+#                             verb whose cells the matrix edits one by one.
+#   exception: <class>        One of the closed classes below. Membership is a
+#                             predicate over the contract's own metadata
+#                             (parity_test.go), not the word alone.
+#   issue: <n>                An OPEN implementation issue. CI fails when it is
+#                             closed without the row flipping to webui
+#                             (scripts/ci/check-parity-issues.sh), and fails
+#                             when the SPA starts importing the operation while
+#                             the row still says issue.
+#
+# Closed exception classes (api-cli-surface ADR § The parity principle and its
+# amendments; docs/spec/api-cli-spellings.md § identity-protocol endpoints):
+#
+#   identity-protocol              Protocol-shaped, client-specific by nature:
+#                                  the CLI's own legs of a handoff, an OIDC
+#                                  callback, a SAML ACS, the SCIM wire an IdP
+#                                  drives. Paths under /api/v1/auth/ or /scim/v2/.
+#   client-local-delivery          The machine delivery wire: acts on the box the
+#                                  credential lives on and admits no human session.
+#   host-local-authority           init, migrate, restore reconcile, break-glass.
+#                                  No HTTP endpoint by ADR, so no member here by
+#                                  construction; a row claiming it is a spec
+#                                  review event.
+#   k8s-controller-reconciliation  The operator reconciles through the delivery
+#                                  wire above, so likewise no HTTP member; kept
+#                                  named so the closure is stated in one place.
+#
+# What the gate proves: the operation is reached from the SPA's runtime source
+# and the named surface is served. It does not prove the journey is complete or
+# reached from that particular surface; the browser-acceptance half is #504.
+# Frequency orders delivery, it never excuses a missing surface: administrative
+# operations for OIDC, SAML, SCIM, federation, remotes, adapters, audit and
+# remote crypto are dispositioned like any other.
+#
+# Adding an operation: add its row here in the same commit, or `go test ./api`
+# fails naming it.
+
+operations:
+
+  # meta
+  getMeta:                     {webui: overview}
+
+  # auth
+  establishCredential:         {issue: 568}
+  localLogin:                  {webui: login}
+  logout:                      {webui: overview}
+  whoami:                      {webui: overview}
+  enrolTotpStart:              {webui: settings}
+  enrolTotpConfirm:            {webui: settings}
+  stepUpTotp:                  {webui: overview}
+  reauthTotp:                  {webui: values}
+  startCLIReauth:              {exception: identity-protocol}
+  showCLIReauthTransaction:    {webui: cli-reauth}
+  approveCLIReauth:            {webui: cli-reauth}
+  redeemCLIReauth:             {exception: identity-protocol}
+  getTotpStatus:               {webui: settings}
+  removeTotp:                  {webui: settings}
+  regenerateRecoveryCodes:     {webui: settings}
+  beginRecovery:               {issue: 571}
+
+  # orgs
+  listOrgs:                    {webui: overview}
+  createOrg:                   {webui: overview}
+
+  # hierarchy
+  getOrg:                      {webui: org-settings}
+  renameOrg:                   {webui: org-settings}
+  deleteOrg:                   {webui: org-settings}
+  listProjects:                {webui: projects}
+  createProject:               {webui: projects}
+  getOrgRetention:             {webui: org-settings}
+  setOrgRetention:             {webui: org-settings}
+  getProject:                  {webui: project-settings}
+  renameProject:               {webui: project-settings}
+  deleteProject:               {webui: project-settings}
+  listEnvironments:            {webui: project-settings}
+  createEnvironment:           {webui: project-settings}
+  cloneEnvironment:            {webui: project-settings}
+  reorderEnvironments:         {webui: project-settings}
+  getEnvironment:              {webui: project-settings, via: [listEnvironments]}
+  renameEnvironment:           {webui: project-settings}
+  deleteEnvironment:           {webui: project-settings}
+  getProjectRetention:         {webui: project-settings}
+  setProjectRetention:         {webui: project-settings}
+  listFolders:                 {webui: matrix}
+  createFolder:                {webui: key-detail}
+  getFolder:                   {webui: key-detail, via: [listFolders]}
+  renameFolder:                {webui: key-detail}
+  deleteFolder:                {webui: key-detail}
+
+  # access
+  listInstanceGrants:          {webui: instance-members}
+  createInstanceGrant:         {webui: instance-members}
+  revokeInstanceGrant:         {webui: instance-members}
+  applyInstanceTemplate:       {webui: instance-members}
+  listOrgGrants:               {webui: members}
+  createOrgGrant:              {webui: members}
+  revokeOrgGrant:              {webui: members}
+  applyOrgTemplate:            {webui: members}
+  listProjectGrants:           {webui: machine-access}
+  createProjectGrant:          {webui: members}
+  revokeProjectGrant:          {webui: members}
+  applyProjectTemplate:        {webui: members}
+  createEnvGrant:              {webui: machine-access}
+  revokeEnvGrant:              {webui: members}
+  applyEnvTemplate:            {webui: members}
+  getEnvironmentSettings:      {webui: project-settings}
+  setEnvironmentSettings:      {webui: project-settings}
+
+  # definitions
+  # The bundle verbs are the repository's path into the same catalogue the
+  # key-detail editor writes directly (source-of-truth ADR § Git-governed
+  # projects: db mode edits through the UI as normal; git mode renders the UI
+  # read-only by design and accepts writes only through apply).
+  exportDefinitions:           {webui: key-detail, via: [listKeys, getKey, listFolders, listKeyGroups]}
+  checkDefinitions:            {webui: key-detail, via: [listKeys, getKey, listFolders, listKeyGroups]}
+  createDefinitionsPlan:       {webui: key-detail, via: [createKey, updateKeyDeclaration, deleteKey]}
+  getDefinitionsPlan:          {webui: key-detail, via: [createKey, updateKeyDeclaration, deleteKey]}
+  applyDefinitionsPlan:        {webui: key-detail, via: [createKey, updateKeyDeclaration, deleteKey]}
+  getDefinitionsSettings:      {webui: project-settings}
+  setDefinitionsSettings:      {webui: project-settings}
+
+  # access
+  getMachineReveal:            {webui: machine-access}
+  setMachineReveal:            {webui: machine-access}
+
+  # keys
+  listKeys:                    {webui: matrix}
+  createKey:                   {webui: matrix}
+  getKey:                      {webui: key-detail}
+  updateKeyMetadata:           {webui: key-detail}
+  deleteKey:                   {webui: key-detail}
+  renameKey:                   {webui: key-detail}
+  updateKeyDeclaration:        {webui: key-detail}
+  reclassifyKey:               {webui: key-detail}
+  setKeyGroup:                 {webui: key-detail}
+  listKeyGroups:               {webui: matrix}
+  createKeyGroup:              {webui: key-detail}
+  getKeyGroup:                 {webui: key-detail, via: [listKeyGroups]}
+  renameKeyGroup:              {webui: key-detail}
+  deleteKeyGroup:              {webui: key-detail}
+
+  # values
+  listValues:                  {webui: matrix}
+  getValue:                    {webui: matrix, via: [listValues]}
+  setValue:                    {webui: matrix}
+  clearValue:                  {webui: matrix}
+  # One value into several environments: the matrix row editor sets the
+  # cells and copy-values fans an environment out; no relationship between the
+  # copies either way.
+  declareValues:               {webui: matrix, via: [setValue, copyValues]}
+  copyValues:                  {webui: matrix}
+  # The matrix IS the side-by-side comparison of environments.
+  diffValues:                  {webui: matrix, via: [listValues]}
+  getRevealWindow:             {webui: values}
+  listValueOccurrences:        {webui: matrix}
+  importValues:                {webui: matrix}
+  revealValues:                {webui: values}
+  revealValue:                 {webui: values}
+  revealValueDiff:             {webui: values, via: [revealValues]}
+
+  # auth
+  authMethods:                 {webui: login}
+  oidcStart:                   {webui: login}
+  oidcCallback:                {exception: identity-protocol}
+  samlStart:                   {webui: login}
+  samlACS:                     {exception: identity-protocol}
+  samlMetadata:                {exception: identity-protocol}
+  listMyOrgs:                  {webui: overview}
+  listIdentities:              {webui: settings}
+  linkIdentity:                {webui: settings}
+  unlinkIdentity:              {webui: settings}
+
+  # accounts
+  resetCredential:             {issue: 568}
+
+  # auth
+  enrolPasskeyStart:           {webui: settings}
+  enrolPasskeyFinish:          {webui: settings}
+  passkeyLoginStart:           {webui: login}
+  passkeyLoginFinish:          {webui: login}
+  stepUpPasskeyStart:          {webui: overview}
+  stepUpPasskeyFinish:         {webui: overview}
+  reauthPasskeyStart:          {webui: values}
+  reauthPasskeyFinish:         {webui: values}
+  listPasskeys:                {webui: settings}
+  removePasskey:               {webui: settings}
+
+  # instance
+  listOidcProviders:           {webui: instance-admin}
+  getOidcProvider:             {webui: instance-admin, via: [listOidcProviders]}
+  putOidcProvider:             {webui: instance-admin}
+  deleteOidcProvider:          {webui: instance-admin}
+  getRetentionHealth:          {webui: instance-admin}
+  getUpdateStatus:             {webui: instance-admin}
+  requestInstanceUpdate:       {webui: instance-admin}
+  getInstanceUpdateJob:        {webui: instance-admin}
+  listSamlProviders:           {webui: instance-admin}
+  getSamlProvider:             {webui: instance-admin, via: [listSamlProviders]}
+  putSamlProvider:             {webui: instance-admin}
+  patchSamlProvider:           {webui: instance-admin}
+  deleteSamlProvider:          {webui: instance-admin}
+  refreshSamlProviderMetadata: {webui: instance-admin}
+  listSamlSpKeys:              {webui: instance-admin}
+  rotateSamlSpKey:             {webui: instance-admin}
+  retireSamlSpKey:             {webui: instance-admin}
+  compromiseRetireSamlSpKey:   {webui: instance-admin}
+
+  # identities
+  listServiceAccounts:         {webui: machine-access}
+  createServiceAccount:        {webui: machine-access}
+  deleteServiceAccount:        {webui: machine-access}
+  listMachineCredentials:      {webui: machine-access}
+  mintMachineCredential:       {webui: machine-access}
+  revokeMachineCredential:     {webui: machine-access}
+
+  # instance
+  getCredentialPolicy:         {webui: instance-admin}
+  setCredentialPolicy:         {webui: instance-admin}
+  listFederationIssuers:       {webui: instance-admin}
+  createFederationIssuer:      {webui: instance-admin}
+  updateFederationIssuer:      {webui: instance-admin}
+  deleteFederationIssuer:      {webui: instance-admin}
+
+  # identities
+  createFederatedBinding:      {webui: machine-access}
+
+  # delivery
+  fetchDelivery:               {exception: client-local-delivery}
+  reconcileOfflineRecords:     {exception: client-local-delivery}
+
+  # scim
+  listScimBindings:            {webui: scim}
+  createScimBinding:           {webui: scim}
+  getScimBinding:              {webui: scim}
+  deleteScimBinding:           {webui: scim}
+  listScimMappings:            {webui: scim}
+  createScimMapping:           {webui: scim}
+  updateScimMapping:           {webui: scim}
+  deleteScimMapping:           {webui: scim}
+  listScimCredentials:         {webui: scim}
+  mintScimCredential:          {webui: scim}
+  getScimCredential:           {webui: scim, via: [listScimCredentials]}
+  revokeScimCredential:        {webui: scim}
+  listScimDirectoryUsers:      {webui: scim}
+  listScimDirectoryGroups:     {webui: scim}
+
+  # scim-protocol
+  scimServiceProviderConfig:   {exception: identity-protocol}
+  scimResourceTypes:           {exception: identity-protocol}
+  scimSchemas:                 {exception: identity-protocol}
+  scimListUsers:               {exception: identity-protocol}
+  scimCreateUser:              {exception: identity-protocol}
+  scimGetUser:                 {exception: identity-protocol}
+  scimReplaceUser:             {exception: identity-protocol}
+  scimPatchUser:               {exception: identity-protocol}
+  scimDeleteUser:              {exception: identity-protocol}
+  scimListGroups:              {exception: identity-protocol}
+  scimCreateGroup:             {exception: identity-protocol}
+  scimGetGroup:                {exception: identity-protocol}
+  scimReplaceGroup:            {exception: identity-protocol}
+  scimPatchGroup:              {exception: identity-protocol}
+  scimDeleteGroup:             {exception: identity-protocol}
+  scimBulk:                    {exception: identity-protocol}
+  scimMe:                      {exception: identity-protocol}
+  scimSearchUsers:             {exception: identity-protocol}
+  scimSearchGroups:            {exception: identity-protocol}
+
+  # instance
+  # The directory a connected instance pulls is this instance's own org and
+  # project names and counts, which the shell already lists.
+  serveDirectory:              {webui: remotes, via: [listOrgs, listProjects]}
+  listRemotes:                 {webui: remotes}
+  addRemote:                   {webui: remotes}
+  showRemote:                  {webui: remotes, via: [listRemotes]}
+  renameRemote:                {webui: remotes}
+  removeRemote:                {webui: remotes}
+  listInstanceConnections:     {webui: remotes}
+  mintInstanceConnection:      {webui: remotes}
+  showInstanceConnection:      {webui: remotes, via: [listInstanceConnections]}
+  revokeInstanceConnection:    {webui: remotes}
+  listWorkspaceOrigins:        {webui: remotes}
+  addWorkspaceOrigin:          {webui: remotes}
+  removeWorkspaceOrigin:       {webui: remotes}
+
+  # auth
+  # The SPA is the workspace client here: it calls the remote origin with a
+  # plain fetch (web/src/api/workspace.ts) because the cookie-carrying client
+  # must never cross an origin.
+  startWorkspaceHandoff:       {webui: remotes, reach: path}
+  approveWorkspaceHandoff:     {webui: workspace-approve}
+  redeemWorkspaceHandoff:      {webui: remotes, reach: path}
+  showWorkspaceHandoff:        {webui: workspace-approve}
+  listMySessions:              {webui: settings}
+  revokeMySession:             {webui: settings}
+
+  # revisions
+  publishPendingChanges:       {webui: matrix}
+  getEnvironmentSignals:       {webui: matrix}
+  listPendingDrafts:           {webui: matrix}
+  rollbackRevision:            {webui: history}
+  listRevisionPins:            {webui: history}
+  createRevisionPin:           {webui: history}
+  releaseRevisionPin:          {webui: history}
+  listRevisions:               {webui: history}
+  getRevision:                 {webui: history}
+
+  # values
+  exportValues:                {webui: history}
+
+  # revisions
+  watchProjectEvents:          {webui: matrix}
+
+  # audit
+  queryOrgAudit:               {webui: audit}
+  # A plain same-origin download link; the browser streams the JSONL itself.
+  exportOrgAudit:              {webui: audit, reach: path}
+  queryProjectAudit:           {issue: 572}
+  exportProjectAudit:          {issue: 572}
+  queryEnvAudit:               {issue: 572}
+  exportEnvAudit:              {issue: 572}
+
+  # instance
+  rotateTokenKey:              {webui: instance-admin}
+  rotateDEK:                   {webui: instance-admin}
+  reencryptInstance:           {webui: instance-admin}
+  rotateMasterKey:             {webui: instance-admin}
+  rotateRootKey:               {webui: instance-admin}
+  reencryptProject:            {webui: instance-admin}
+  rotateScanningKey:           {webui: instance-admin}
+
+  # adapters
+  listAdapters:                {issue: 157}
+  createAdapter:               {issue: 157}
+  showAdapter:                 {issue: 157}
+  updateAdapterOrigin:         {issue: 157}
+  deleteAdapter:               {issue: 157}
+  showAdapterMove:             {issue: 157}
+  resumeAdapterMove:           {issue: 157}
+  cancelAdapterMove:           {issue: 157}
+  setAdapterCredential:        {issue: 157}
+  revokeAdapterCredential:     {issue: 157}
+  listAdapterTargets:          {issue: 157}
+  addAdapterTarget:            {issue: 157}
+  showAdapterTarget:           {issue: 157}
+  updateAdapterTarget:         {issue: 157}
+  removeAdapterTarget:         {issue: 157}
+  planAdapterTarget:           {issue: 157}
+  syncAdapterTarget:           {issue: 157}
+  testAdapterTarget:           {issue: 157}
+  adoptAdapterTargetNames:     {issue: 157}

--- a/api/parity_test.go
+++ b/api/parity_test.go
@@ -1,0 +1,524 @@
+package api_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/Hikyo-Org/hikyo/api"
+	"gopkg.in/yaml.v3"
+)
+
+// The WebUI parity registry (#490).
+//
+// `parity.yaml` beside the contract gives every operation exactly one
+// disposition: a browser surface, one member of the closed exception set, or
+// an open implementation issue. These tests are what make the file executable
+// rather than a table someone once filled in:
+//
+//   - the registry is keyed by the contract's operationIds, both directions, so
+//     a new operation fails CI until it is dispositioned and a deleted one
+//     cannot leave a stale row behind;
+//   - a `webui` disposition is checked against the SPA's own source (the
+//     generated `<id>Op` import, or a literal `/api/v1` path for the few plain
+//     fetches) and against the router's surface list, so "we have a page for
+//     that" is a claim the build verifies;
+//   - the symmetry holds too: an operation the SPA reaches cannot sit under an
+//     exception or an issue, so landing a surface forces the registry to say so;
+//   - exception classes are a closed enum admitted by a predicate over the
+//     contract's own metadata, never by the string alone.
+//
+// Issue liveness (a referenced issue must still be open) needs the network and
+// lives in scripts/ci/check-parity-issues.sh.
+
+const parityPath = "parity.yaml"
+
+// Paths are relative to this package directory, which is where `go test` runs.
+const (
+	spaSourceRoot       = "../web/src"
+	spaNavigationSource = "../web/src/app/navigation.ts"
+	generatedOperations = "../clients/ts/src/generated/operations.gen.ts"
+)
+
+// The closed exception set. Membership is decided by the predicate, and the
+// registry may only name a class listed here.
+//
+// Two of the four classes the parity programme names have no HTTP member by
+// construction: host-local authority (init, migrate, restore reconcile,
+// break-glass) acts on the server's own host and has no endpoint at all
+// (api-cli-surface ADR, closed local-authority exception set), and the
+// Kubernetes operator reconciles through the machine delivery wire, which is
+// already the client-local class. They stay in the enum so the registry can
+// say so in one place, and a row claiming either is a spec review event.
+var parityExceptionClasses = map[string]struct {
+	admits func(op api.Operation) bool
+	rule   string
+}{
+	"identity-protocol": {
+		admits: func(op api.Operation) bool {
+			return strings.HasPrefix(op.Path, "/api/v1/auth/") || strings.Contains(op.Path, "/scim/v2/")
+		},
+		rule: "protocol-shaped paths under /api/v1/auth/ or the SCIM wire under /scim/v2/",
+	},
+	"client-local-delivery": {
+		admits: func(op api.Operation) bool {
+			return op.AdmitsArtifact(api.ArtifactMachineCredential) && !op.AdmitsArtifact(api.ArtifactHumanSession)
+		},
+		rule: "machine-credential wire a human session cannot present",
+	},
+	"host-local-authority": {
+		admits: func(api.Operation) bool { return false },
+		rule:   "no HTTP endpoint by ADR; a member here is a spec review event",
+	},
+	"k8s-controller-reconciliation": {
+		admits: func(api.Operation) bool { return false },
+		rule:   "the operator speaks only the machine delivery wire; a member here is a spec review event",
+	},
+}
+
+type parityEntry struct {
+	WebUI     string   `yaml:"webui"`
+	Reach     string   `yaml:"reach"`
+	Via       []string `yaml:"via"`
+	Exception string   `yaml:"exception"`
+	Issue     int      `yaml:"issue"`
+	Note      string   `yaml:"note"`
+}
+
+type parityRegistry struct {
+	Operations map[string]parityEntry `yaml:"operations"`
+}
+
+func (e parityEntry) kind() string {
+	switch {
+	case e.WebUI != "":
+		return "webui"
+	case e.Exception != "":
+		return "exception"
+	case e.Issue != 0:
+		return "issue"
+	}
+	return ""
+}
+
+// direct reports whether the row claims the SPA calls this operation itself,
+// as opposed to delivering the same outcome through other operations.
+func (e parityEntry) direct() bool {
+	return e.WebUI != "" && len(e.Via) == 0
+}
+
+func loadParity(t *testing.T) parityRegistry {
+	t.Helper()
+	raw, err := os.ReadFile(parityPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", parityPath, err)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	var reg parityRegistry
+	if err := dec.Decode(&reg); err != nil {
+		t.Fatalf("decode %s: %v", parityPath, err)
+	}
+	if len(reg.Operations) == 0 {
+		t.Fatalf("%s declares no operations", parityPath)
+	}
+	return reg
+}
+
+func loadOperations(t *testing.T) map[string]api.Operation {
+	t.Helper()
+	ops, err := api.Operations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ops
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// generatedOperationName spells the `@hikyo/operations` export for an
+// operationId the way the generator does: words split at case boundaries,
+// acronyms folded to title case (`rotateDEK` becomes `rotateDekOp`,
+// `startCLIReauth` becomes `startCliReauthOp`). The rule is pinned against the
+// committed generated module below, so a generator change fails here rather
+// than silently emptying the evidence.
+func generatedOperationName(id string) string {
+	runes := []rune(id)
+	var words []string
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		prev, cur := runes[i-1], runes[i]
+		boundary := false
+		if unicode.IsUpper(cur) {
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) {
+				boundary = true
+			} else if unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
+				boundary = true
+			}
+		}
+		if boundary {
+			words = append(words, string(runes[start:i]))
+			start = i
+		}
+	}
+	words = append(words, string(runes[start:]))
+	var b strings.Builder
+	for i, w := range words {
+		lower := strings.ToLower(w)
+		if i == 0 {
+			b.WriteString(lower)
+			continue
+		}
+		b.WriteString(strings.ToUpper(lower[:1]))
+		b.WriteString(lower[1:])
+	}
+	b.WriteString("Op")
+	return b.String()
+}
+
+var identifierPattern = regexp.MustCompile(`[A-Za-z_$][A-Za-z0-9_$]*`)
+
+// spaSource is the browser application's runtime source: identifiers and
+// `/api/v1` path literals from every non-test module under web/src. Tests and
+// the test kit are excluded so a mock cannot count as browser reach.
+type spaSource struct {
+	identifiers map[string]bool
+	paths       map[string]bool
+}
+
+var (
+	apiPathLiteral   = regexp.MustCompile("/api/v1/[^'\"`\\s]*")
+	templateSegment  = regexp.MustCompile(`\$\{[^}]*\}`)
+	specPathTemplate = regexp.MustCompile(`\{[^}]*\}`)
+)
+
+func normalisePath(p string) string {
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	p = templateSegment.ReplaceAllString(p, "{}")
+	return specPathTemplate.ReplaceAllString(p, "{}")
+}
+
+func isSPARuntimeSource(path string, d fs.DirEntry) bool {
+	if d.IsDir() {
+		return false
+	}
+	name := d.Name()
+	if !strings.HasSuffix(name, ".ts") && !strings.HasSuffix(name, ".tsx") {
+		return false
+	}
+	if strings.Contains(name, ".test.") || strings.Contains(name, ".test-d.") {
+		return false
+	}
+	return true
+}
+
+func loadSPASource(t *testing.T) spaSource {
+	t.Helper()
+	src := spaSource{identifiers: map[string]bool{}, paths: map[string]bool{}}
+	files := 0
+	err := filepath.WalkDir(spaSourceRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && d.Name() == "testkit" {
+			return filepath.SkipDir
+		}
+		if !isSPARuntimeSource(path, d) {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files++
+		for _, id := range identifierPattern.FindAll(raw, -1) {
+			src.identifiers[string(id)] = true
+		}
+		for _, p := range apiPathLiteral.FindAll(raw, -1) {
+			src.paths[normalisePath(string(p))] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", spaSourceRoot, err)
+	}
+	if files == 0 {
+		t.Fatalf("no SPA source under %s", spaSourceRoot)
+	}
+	return src
+}
+
+var surfaceID = regexp.MustCompile(`id: '([^']+)'`)
+
+// loadSurfaces reads the router's closed surface list. It is the same list the
+// flow registry closes over, so a surface named here is one the build serves.
+func loadSurfaces(t *testing.T) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(spaNavigationSource)
+	if err != nil {
+		t.Fatalf("read %s: %v", spaNavigationSource, err)
+	}
+	const open = "export const SURFACES = defineSurfaceRegistry(["
+	start := strings.Index(string(raw), open)
+	if start < 0 {
+		t.Fatalf("%s: SURFACES block not found", spaNavigationSource)
+	}
+	body := string(raw)[start+len(open):]
+	end := strings.Index(body, "\n]);")
+	if end < 0 {
+		t.Fatalf("%s: SURFACES block is not closed", spaNavigationSource)
+	}
+	surfaces := map[string]bool{}
+	for _, m := range surfaceID.FindAllStringSubmatch(body[:end], -1) {
+		surfaces[m[1]] = true
+	}
+	if len(surfaces) == 0 {
+		t.Fatalf("%s: no surfaces parsed", spaNavigationSource)
+	}
+	return surfaces
+}
+
+func loadGeneratedExports(t *testing.T) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(generatedOperations)
+	if err != nil {
+		t.Fatalf("read %s: %v", generatedOperations, err)
+	}
+	exports := map[string]bool{}
+	for _, m := range regexp.MustCompile(`(?m)^export const ([A-Za-z0-9]+Op)\b`).FindAllStringSubmatch(string(raw), -1) {
+		exports[m[1]] = true
+	}
+	if len(exports) == 0 {
+		t.Fatalf("%s: no operation exports parsed", generatedOperations)
+	}
+	return exports
+}
+
+func TestParityRegistryCoversEveryOperationExactlyOnce(t *testing.T) {
+	reg := loadParity(t)
+	ops := loadOperations(t)
+
+	for _, id := range sortedKeys(ops) {
+		if _, ok := reg.Operations[id]; !ok {
+			t.Errorf("%s %s (%s) has no disposition in %s: add a webui surface, a closed exception, or an open issue", ops[id].Method, ops[id].Path, id, parityPath)
+		}
+	}
+	for _, id := range sortedKeys(reg.Operations) {
+		if _, ok := ops[id]; !ok {
+			t.Errorf("%s names %q, which is not an operationId in the contract", parityPath, id)
+		}
+	}
+}
+
+func TestParityDispositionsAreWellFormed(t *testing.T) {
+	reg := loadParity(t)
+
+	for _, id := range sortedKeys(reg.Operations) {
+		e := reg.Operations[id]
+		set := 0
+		for _, present := range []bool{e.WebUI != "", e.Exception != "", e.Issue != 0} {
+			if present {
+				set++
+			}
+		}
+		if set != 1 {
+			t.Errorf("%s: exactly one of webui, exception, issue must be set (got %d)", id, set)
+			continue
+		}
+		if e.WebUI == "" && (e.Reach != "" || len(e.Via) != 0) {
+			t.Errorf("%s: reach and via belong to a webui disposition only", id)
+		}
+		if e.Reach != "" && e.Reach != "path" {
+			t.Errorf("%s: reach %q is not a known evidence kind (only \"path\")", id, e.Reach)
+		}
+		if e.Reach != "" && len(e.Via) != 0 {
+			t.Errorf("%s: a via row delivers the outcome through other operations and carries no reach of its own", id)
+		}
+		if e.Issue < 0 {
+			t.Errorf("%s: issue %d is not an issue number", id, e.Issue)
+		}
+		for _, target := range e.Via {
+			other, ok := reg.Operations[target]
+			switch {
+			case !ok:
+				t.Errorf("%s: via names %q, which is not in the registry", id, target)
+			case target == id:
+				t.Errorf("%s: via names itself", id)
+			case !other.direct():
+				t.Errorf("%s: via target %q must itself be a direct webui row, not %s", id, target, describe(other))
+			}
+		}
+	}
+}
+
+func describe(e parityEntry) string {
+	switch e.kind() {
+	case "webui":
+		if len(e.Via) != 0 {
+			return fmt.Sprintf("webui %s via %v", e.WebUI, e.Via)
+		}
+		return "webui " + e.WebUI
+	case "exception":
+		return "exception " + e.Exception
+	case "issue":
+		return fmt.Sprintf("issue #%d", e.Issue)
+	}
+	return "an empty row"
+}
+
+func TestParityWebUIRowsNameServedSurfaces(t *testing.T) {
+	reg := loadParity(t)
+	surfaces := loadSurfaces(t)
+
+	for _, id := range sortedKeys(reg.Operations) {
+		e := reg.Operations[id]
+		if e.WebUI == "" {
+			continue
+		}
+		if !surfaces[e.WebUI] {
+			t.Errorf("%s: surface %q is not in the router's SURFACES list (%s)", id, e.WebUI, spaNavigationSource)
+		}
+	}
+}
+
+func TestParityGeneratedNameRuleMatchesTheClient(t *testing.T) {
+	ops := loadOperations(t)
+	exports := loadGeneratedExports(t)
+
+	// The generator skips a handful of protocol-only operations. Every other
+	// operation must resolve to an export under this test's spelling rule, or
+	// the evidence scan would be looking for names that do not exist.
+	missing := 0
+	for _, id := range sortedKeys(ops) {
+		if !exports[generatedOperationName(id)] {
+			missing++
+			if !parityExceptionClasses["identity-protocol"].admits(ops[id]) {
+				t.Errorf("%s: computed export %q is not in %s; the spelling rule or the generator changed", id, generatedOperationName(id), generatedOperations)
+			}
+		}
+	}
+	if missing > len(ops)/10 {
+		t.Errorf("%d of %d operations have no generated export; the spelling rule is broken", missing, len(ops))
+	}
+}
+
+func TestParityWebUIRowsAreReachedByTheSPA(t *testing.T) {
+	reg := loadParity(t)
+	ops := loadOperations(t)
+	src := loadSPASource(t)
+
+	for _, id := range sortedKeys(reg.Operations) {
+		e := reg.Operations[id]
+		op, ok := ops[id]
+		if !ok || !e.direct() {
+			continue
+		}
+		switch e.Reach {
+		case "":
+			if !src.identifiers[generatedOperationName(id)] {
+				t.Errorf("%s: claims surface %q but no runtime module under %s imports %s", id, e.WebUI, spaSourceRoot, generatedOperationName(id))
+			}
+		case "path":
+			if !src.paths[normalisePath(op.Path)] {
+				t.Errorf("%s: claims surface %q by path, but no runtime module under %s carries a %s literal", id, e.WebUI, spaSourceRoot, op.Path)
+			}
+		}
+	}
+}
+
+func TestParityRowsTheSPAReachesAreWebUIRows(t *testing.T) {
+	reg := loadParity(t)
+	ops := loadOperations(t)
+	src := loadSPASource(t)
+
+	for _, id := range sortedKeys(ops) {
+		e, ok := reg.Operations[id]
+		if !ok {
+			continue
+		}
+		if src.identifiers[generatedOperationName(id)] && !e.direct() {
+			t.Errorf("%s: the SPA imports %s, so the row must be a direct webui surface, not %s", id, generatedOperationName(id), describe(e))
+		}
+	}
+}
+
+func TestParityExceptionsAreClosedAndAdmitted(t *testing.T) {
+	reg := loadParity(t)
+	ops := loadOperations(t)
+
+	for _, id := range sortedKeys(reg.Operations) {
+		e := reg.Operations[id]
+		if e.Exception == "" {
+			continue
+		}
+		class, ok := parityExceptionClasses[e.Exception]
+		if !ok {
+			t.Errorf("%s: exception %q is not one of the closed classes %v", id, e.Exception, sortedKeys(parityExceptionClasses))
+			continue
+		}
+		op, ok := ops[id]
+		if !ok {
+			continue
+		}
+		if !class.admits(op) {
+			t.Errorf("%s (%s %s): does not qualify for %q: %s", id, op.Method, op.Path, e.Exception, class.rule)
+		}
+	}
+}
+
+func TestParityExceptionClassPredicatesAreDisjointOnTheContract(t *testing.T) {
+	// A row must have one honest home. If two admissible classes ever overlap
+	// on a real operation the registry author gets to choose, which is exactly
+	// the discretion the closed set is meant to remove.
+	ops := loadOperations(t)
+	classes := sortedKeys(parityExceptionClasses)
+	for _, id := range sortedKeys(ops) {
+		var admitted []string
+		for _, class := range classes {
+			if parityExceptionClasses[class].admits(ops[id]) {
+				admitted = append(admitted, class)
+			}
+		}
+		if len(admitted) > 1 {
+			t.Errorf("%s is admissible to more than one exception class: %v", id, admitted)
+		}
+	}
+}
+
+func TestParityGeneratedNameRuleSpellsAcronyms(t *testing.T) {
+	cases := map[string]string{
+		"whoami":                    "whoamiOp",
+		"rotateDEK":                 "rotateDekOp",
+		"startCLIReauth":            "startCliReauthOp",
+		"samlACS":                   "samlAcsOp",
+		"listScimDirectoryUsers":    "listScimDirectoryUsersOp",
+		"scimServiceProviderConfig": "scimServiceProviderConfigOp",
+	}
+	for in, want := range cases {
+		if got := generatedOperationName(in); got != want {
+			t.Errorf("generatedOperationName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := normalisePath("/api/v1/orgs/${encodeURIComponent(org)}/audit/export?x=1"); got != "/api/v1/orgs/{}/audit/export" {
+		t.Errorf("normalisePath does not fold template segments: %q", got)
+	}
+	if normalisePath("/api/v1/orgs/{org}/audit/export") != "/api/v1/orgs/{}/audit/export" {
+		t.Errorf("normalisePath does not fold contract parameters")
+	}
+}

--- a/docs/handoff/issue-490-webui-parity-registry.md
+++ b/docs/handoff/issue-490-webui-parity-registry.md
@@ -1,0 +1,80 @@
+# #490 WebUI parity registry: handoff
+
+Executable inventory of every public operation's browser disposition, with CI
+gates that fail when a new operation lands undispositioned, when the SPA and the
+registry disagree in either direction, or when a referenced implementation
+issue is closed without the surface landing.
+
+## What shipped
+
+| Piece | Where | Gate |
+| --- | --- | --- |
+| Registry | `api/parity.yaml` | one row per `operationId`, exactly one of `webui` / `exception` / `issue` |
+| Structural gate | `api/parity_test.go` | `go test ./api` (runs in `test`, and in `web-go` so web-only PRs pay it) |
+| Issue liveness | `scripts/ci/check-parity-issues.sh` (+ `_test.sh`) | `freeze-guard` job step, `github.token`, fails loud on a denied read |
+| Spec index | `docs/spec/README.md` | one document-map row |
+
+## How the gate decides
+
+- **Coverage:** registry keys equal the contract's operationIds, both ways.
+  Generator-skipped protocol operations (`scimBulk`, `scimMe`, `scimSearch*`)
+  are still contract operations, so they cannot slip past.
+- **Evidence for `webui`:** the generated `<operationId>Op` export is imported
+  by a runtime module under `web/src` (tests and `testkit` excluded), or with
+  `reach: path` a literal `/api/v1` path matching the operation's route. The
+  surface id must be in `SURFACES` in `web/src/app/navigation.ts`.
+- **Spelling rule:** the test computes the generated export name itself
+  (`rotateDEK` to `rotateDekOp`) and pins the rule against
+  `clients/ts/src/generated/operations.gen.ts`, so a generator change fails
+  here instead of emptying the evidence.
+- **Symmetry:** an operation the SPA imports must be a direct `webui` row. This
+  is what forces the adapter (#157), invite (#568), recovery (#571) and scoped
+  audit (#572) PRs to flip their rows when they land.
+- **Equivalent outcome vs mirroring:** `via: [ops]` records that the same user
+  outcome is delivered through other operations, which must themselves be
+  direct rows (no chains). Used for single `get`/`show` reads whose list
+  already shows the row, the batch value verbs the matrix edits cell by cell,
+  the definitions bundle verbs (the repository's path into the catalogue the
+  key-detail editor writes directly), and the instance directory.
+- **Closed exceptions:** `identity-protocol` (paths under `/api/v1/auth/` or
+  `/scim/v2/`), `client-local-delivery` (admits a machine credential and no
+  human session). `host-local-authority` and `k8s-controller-reconciliation`
+  are named in the enum with a predicate that admits nothing: the ADR gives
+  host-local verbs no HTTP endpoint, and the operator speaks only the delivery
+  wire. The predicates are also asserted pairwise disjoint over the contract.
+
+## Current dispositions (245 operations)
+
+| Disposition | Count | Notes |
+| --- | --- | --- |
+| `webui` direct | 175 | evidence: Op import (172) or path literal (3) |
+| `webui` via | 18 | equivalent outcomes, see file comments |
+| `exception: identity-protocol` | 24 | 5 auth legs + 19 SCIM wire |
+| `exception: client-local-delivery` | 2 | `fetchDelivery`, `reconcileOfflineRecords` |
+| `issue: 157` | 19 | adapters and adapter targets (browser AC is in #157) |
+| `issue: 568` | 2 | `establishCredential`, `resetCredential` |
+| `issue: 571` | 1 | `beginRecovery` (filed by this PR) |
+| `issue: 572` | 4 | project and environment audit query/export (filed by this PR) |
+
+Counts are from the file at merge time; the tests, not this table, are the
+source of truth.
+
+## Not in scope here
+
+- Proving each journey end to end from its surface (browser acceptance) is
+  #504. The registry proves reach and a served surface, and says so in its
+  header.
+- The api-cli-surface ADR is locked and was not amended. The registry header
+  cites it and the spellings document; the exception classes match the ADR's
+  amended text (identity-protocol restatement, parity principle).
+
+## Gotchas for the next person
+
+- The `freeze-guard` and `web-go` workflow edits are loaded from the base
+  branch on PRs (`pull_request_target`), so they first execute on the main push
+  after merge. The Go test itself ran on this PR through the `test` job.
+- `check-parity-issues.sh` extracts `issue: N` from non-comment lines with
+  grep; keep prose like that out of `note:` values or add the issue to the
+  stub in the fixture.
+- Flipping a row from `issue` to `webui` is the only registry change a surface
+  PR should need; the test names the exact row and the missing import.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -30,6 +30,7 @@ This is the build-ready specification set for Hikyo 1.0: a fully open-source, se
 | Deployment modules | [adr/deployment-adapter.md](../adr/deployment-adapter.md) (seam + Forgejo) · [adr/github-adapter.md](../adr/github-adapter.md) |
 | Import & migration | [adr/import-paths.md](../adr/import-paths.md) |
 | API & CLI spec | [adr/api-cli-surface.md](../adr/api-cli-surface.md) (skeleton) + [api-cli-spellings.md](./api-cli-spellings.md) (deferred spellings, discharged) |
+| WebUI parity registry | [api/parity.yaml](../../api/parity.yaml): one disposition per operation (surface, closed exception, or open issue), executable via `go test ./api` and `scripts/ci/check-parity-issues.sh` |
 | Multi-instance | [adr/multi-instance.md](../adr/multi-instance.md) |
 | Deployment & operations | [adr/ops-spec.md](../adr/ops-spec.md) + [ops-catalogue.md](./ops-catalogue.md) (deferred values, discharged) |
 | MVP scope & acceptance criteria | [adr/mvp-boundary.md](../adr/mvp-boundary.md) §1–§2, §6 + [self-hoster-checklist.md](./self-hoster-checklist.md) (passed) |

--- a/scripts/ci/check-parity-issues.sh
+++ b/scripts/ci/check-parity-issues.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+# WebUI parity registry: every `issue: N` disposition in api/parity.yaml must
+# name an OPEN issue. A closed issue with the row still pointing at it means a
+# surface was declared done without the registry flipping to `webui` (or the
+# issue was closed without the surface landing); either way the inventory is
+# lying and the build says so. The structural half of the registry (coverage,
+# evidence, closed exception classes) is `go test ./api`; this is the one check
+# that needs the network.
+#
+# Usage: check-parity-issues.sh [registry]
+# Environment: GH_TOKEN (read), GH_REPO (owner/name; defaults to gh's view of
+# the checkout).
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+registry=${1:-$script_dir/../../api/parity.yaml}
+
+if [ ! -f "$registry" ]; then
+	printf 'parity issues: registry %s not found\n' "$registry" >&2
+	exit 2
+fi
+
+# Comment lines are dropped first so prose never counts as a disposition.
+issues=$(grep -v '^[[:space:]]*#' "$registry" | grep -oE 'issue:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | sort -un || true)
+
+if [ -z "$issues" ]; then
+	printf 'parity issues: no issue dispositions in %s\n' "$registry"
+	exit 0
+fi
+
+repo=${GH_REPO:-}
+if [ -z "$repo" ]; then
+	if ! repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
+		printf 'parity issues: set GH_REPO=owner/name; the checkout has no resolvable GitHub remote\n' >&2
+		exit 2
+	fi
+fi
+
+failed=0
+for number in $issues; do
+	if ! answer=$(gh api "repos/$repo/issues/$number" --jq '[.state, (.pull_request != null | tostring)] | join(" ")' 2>&1); then
+		printf 'parity issues: cannot read %s#%s: %s\n' "$repo" "$number" "$answer" >&2
+		printf 'parity issues: the token needs read access to issues; this check never falls back to guessing\n' >&2
+		exit 1
+	fi
+	state=${answer%% *}
+	is_pull=${answer##* }
+	if [ "$is_pull" = "true" ]; then
+		printf 'parity issues: #%s is a pull request, not an implementation issue\n' "$number" >&2
+		failed=1
+		continue
+	fi
+	if [ "$state" != "open" ]; then
+		printf 'parity issues: #%s is %s but api/parity.yaml still lists operations under it; flip the rows to webui or reopen the issue\n' "$number" "$state" >&2
+		failed=1
+		continue
+	fi
+	printf 'parity issues: #%s open\n' "$number"
+done
+
+if [ "$failed" -ne 0 ]; then
+	exit 1
+fi
+printf 'parity issues: every referenced issue is open\n'

--- a/scripts/ci/check-parity-issues_test.sh
+++ b/scripts/ci/check-parity-issues_test.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+# Fixture for check-parity-issues.sh: a stub `gh` on PATH answers from
+# PARITY_STUB, a space-separated list of `number=state` (state `pr` marks a
+# pull request), and anything unlisted is an API error.
+
+script_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+checker="$script_dir/check-parity-issues.sh"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/hikyo-parity-fixture.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+mkdir "$work/bin"
+cat >"$work/bin/gh" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1" in
+api) ;;
+*) printf 'stub gh: unexpected subcommand %s\n' "$1" >&2; exit 64 ;;
+esac
+number=${2##*/}
+for pair in $PARITY_STUB; do
+	if [ "${pair%%=*}" = "$number" ]; then
+		case "${pair#*=}" in
+		pr) printf 'open true\n' ;;
+		*) printf '%s false\n' "${pair#*=}" ;;
+		esac
+		exit 0
+	fi
+done
+printf 'HTTP 404: Not Found\n' >&2
+exit 1
+EOF
+chmod +x "$work/bin/gh"
+PATH="$work/bin:$PATH"
+export PATH
+GH_REPO=fixture/repo
+export GH_REPO
+
+registry="$work/parity.yaml"
+cat >"$registry" <<'EOF'
+# a comment mentioning issue: 999 must not count
+operations:
+  alpha: {issue: 157}
+  beta:  {webui: matrix}
+  gamma: {issue: 568, note: "issue: 42 in prose is text, not a reference"}
+  delta: {issue: 157}
+EOF
+
+expect_pass() {
+	if ! out=$("$checker" "$registry" 2>&1); then
+		printf 'parity fixture failed: %s\n%s\n' "$1" "$out" >&2
+		exit 1
+	fi
+}
+
+expect_fail() {
+	if out=$("$checker" "$registry" 2>&1); then
+		printf 'parity fixture failed: %s\n%s\n' "$1" "$out" >&2
+		exit 1
+	fi
+	if ! printf '%s\n' "$out" | grep -F -- "$2" >/dev/null; then
+		printf 'parity fixture failed: %s: expected %s in\n%s\n' "$1" "$2" "$out" >&2
+		exit 1
+	fi
+}
+
+# The prose reference to 42 must be a reference too: it is inside a row, and
+# the extractor is deliberately simple. Feed it as open so the pass case holds.
+PARITY_STUB='157=open 568=open 42=open' expect_pass 'all open accepted'
+PARITY_STUB='157=open 568=closed 42=open' expect_fail 'closed issue refused' '#568 is closed'
+PARITY_STUB='157=pr 568=open 42=open' expect_fail 'pull request refused' '#157 is a pull request'
+PARITY_STUB='568=open 42=open' expect_fail 'unreadable issue refused' 'cannot read fixture/repo#157'
+
+printf 'operations: {}\n' >"$registry"
+PARITY_STUB='' expect_pass 'registry without issue rows accepted'
+
+if "$checker" "$work/missing.yaml" >/dev/null 2>&1; then
+	printf 'parity fixture failed: missing registry accepted\n' >&2
+	exit 1
+fi
+
+printf 'parity issues fixture: open accepted; closed, pull request, unreadable and missing refused\n'


### PR DESCRIPTION
Closes #490.

## What

Every operationId in `api/openapi.yaml` now has exactly one disposition in `api/parity.yaml`: a served browser surface (`webui`), one member of the closed exception set (`exception`), or an open implementation issue (`issue`). `go test ./api` makes the file executable:

- coverage both ways against the contract (new operation without a row fails; stale row fails);
- `webui` evidence is the SPA's own runtime source: the generated `<operationId>Op` import (tests and `testkit` excluded), or a literal `/api/v1` path for the three plain fetches; the surface must be in the router's `SURFACES` list;
- symmetry: an operation the SPA imports cannot sit under an exception or an issue, so landing a surface forces the row to flip;
- `via: [ops]` records equivalent user outcomes delivered through other (direct) operations, which is the line between outcome parity and literal CLI mirroring;
- exception classes are a closed enum admitted by predicates over the contract's metadata (`identity-protocol`: paths under `/api/v1/auth/` or `/scim/v2/`; `client-local-delivery`: machine-credential wire with no human session). `host-local-authority` and `k8s-controller-reconciliation` are named with predicates that admit nothing, per the ADR (no HTTP endpoint) and the operator's delivery-wire-only reach. Predicates are asserted pairwise disjoint.
- the export spelling rule is pinned against `clients/ts/src/generated/operations.gen.ts` so a generator change fails here rather than emptying the evidence.

Issue liveness (a referenced issue must still be open) is the one network check: `scripts/ci/check-parity-issues.sh`, run in `freeze-guard` with the workflow token, fail-loud on a denied read, covered by a stub-`gh` fixture in `supply-chain-checks`. `web-go` now also runs `./api/...` so a web-only PR that drops an import fails on its own plan.

## Contract and decisions

- No API change. No generated artifacts regenerated. The api-cli-surface ADR is locked and not amended; the registry header cites it and `docs/spec/api-cli-spellings.md`.
- Gaps with no open issue got one: #571 (recovery-code sign-in for `beginRecovery`) and #572 (project and environment audit pages for four operations). Adapters (19 ops) stay under #157, whose acceptance criteria already name the browser; `establishCredential` and `resetCredential` under #568.
- Dispositions: 175 direct webui, 18 via, 24 identity-protocol, 2 client-local-delivery, 26 under open issues. Handoff: `docs/handoff/issue-490-webui-parity-registry.md`.

## Validation

Scoped: `go test ./api/` green; nine registry mutations (dropped row, imported op under issue, unreached op as webui, unknown surface, host-local claim, non-protocol as identity-protocol, via chain, unknown field, path claim without literal) each fail with the row named. `shellcheck -s sh` clean; `check-parity-issues_test.sh` passes; live run against this repo reports all four issues open. `actionlint`, `check-trusted-ci-scripts_test.sh`, `check-required-jobs_test.sh`, `go test ./scripts/ci -run TestCIJobRegistry` green. `gofmt`, `go vet`, `go build ./...` clean.

Full: `go test ./api/... ./scripts/...` green. No web or Go runtime code changed, so the web typecheck/test/build and Playwright suites are unaffected by this diff; CI runs them as usual.

Note: the `ci.yml` step edits are loaded from the base branch on PRs, so they first execute on the main push after merge. The Go gate itself runs on this PR through the `test` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)