### PR TITLE
Dynamic secrets: provider and lease management WebUI #595

### DIFF
--- a/api/parity.yaml
+++ b/api/parity.yaml
@@ -385,13 +385,13 @@ operations:
   # dynamic secrets (#147 shipped API+CLI+read-only status; management WebUI #595)
   listLeases:                  {webui: machine-access}
   showLease:                   {webui: machine-access, via: [listLeases]}
-  listDynamicProviders:        {issue: 595}
-  createDynamicProvider:       {issue: 595}
-  showDynamicProvider:         {issue: 595}
-  deleteDynamicProvider:       {issue: 595}
-  setDynamicProviderCredential: {issue: 595}
-  revokeDynamicProviderCredential: {issue: 595}
-  mintLease:                   {issue: 595}
-  renewLease:                  {issue: 595}
-  revokeLease:                 {issue: 595}
-  settleLease:                 {issue: 595}
+  listDynamicProviders:        {webui: machine-access}
+  createDynamicProvider:       {webui: machine-access}
+  showDynamicProvider:         {webui: machine-access, via: [listDynamicProviders]}
+  deleteDynamicProvider:       {webui: machine-access}
+  setDynamicProviderCredential: {webui: machine-access}
+  revokeDynamicProviderCredential: {webui: machine-access}
+  mintLease:                   {webui: machine-access}
+  renewLease:                  {webui: machine-access}
+  revokeLease:                 {webui: machine-access}
+  settleLease:                 {webui: machine-access}

--- a/docs/handoff/147-dynamic-secrets.md
+++ b/docs/handoff/147-dynamic-secrets.md
@@ -197,6 +197,13 @@ mirroring how adapters (#157) ship CLI/API first with a tracked WebUI follow-up.
   `renewLease`, `revokeLease`, `settleLease`) -> `{issue: 595}` tracking the
   management WebUI (human mint keeps the reauth ceremony + display-once).
 
+**Resolved by #595** (`docs/handoff/595-dynamic-secrets-webui.md`): all ten rows
+above flipped to `{webui: machine-access}` — `showDynamicProvider` as
+`{webui: machine-access, via: [listDynamicProviders]}`. The `machine-access` page
+gained a **Providers** tab (provider CRUD + write-only credential set/revoke) and
+lease write actions on the **Leases** tab (display-once mint with the `mint`
+reauth ceremony, plus queued renew/revoke/settle). WebUI-only: no server change.
+
 ## CI wiring for the provider integration test (needs a workflow-scoped push)
 
 `scripts/ci/start-dynamic-pg.sh` is committed but the `ci.yml` step that invokes

--- a/docs/handoff/595-dynamic-secrets-webui.md
+++ b/docs/handoff/595-dynamic-secrets-webui.md
@@ -1,0 +1,85 @@
+# Handoff: #595 Dynamic secrets — provider and lease management WebUI
+
+Issue: https://github.com/Hikyo-Org/Hikyo/issues/595 (follows #147, which shipped
+the API + CLI + read-only Leases tab).
+
+WebUI-only. No server, contract, migration, CLI or generated-code change — every
+operation already existed from #147 and is imported from the generated client.
+This ticket flips the ten `{issue: 595}` parity rows to `{webui: machine-access}`
+and gives the `machine-access` page the management surface behind them.
+
+## What landed
+
+**Providers tab** (`machine-access`, project-scoped):
+- Lists providers (kind, origin, grant role, credential presence + set date,
+  state). The admin credential is never listed.
+- `CreateProviderDialog` — kind is `postgres` (the closed enum), origin, grant
+  role, write-only credential. No passkey: configuring standing project
+  authority is `manage-identities`, not a per-environment disclosure (§#147 d1).
+  The server probes the origin with the credential before storing, so a success
+  means it was reachable and authenticated; the dialog says so.
+- `SetCredentialDialog` / `RevokeCredentialDialog` — the credential is write-only
+  (set/replace, never read back). Revoke states the fail-closed consequence:
+  existing leases stay minted at the provider but the worker can no longer
+  renew/revoke/expire them until a replacement is set.
+- `DeleteProviderDialog` — typed-**origin** confirmation (a provider has no
+  name). Refuses (409) with live leases unless the cascade is confirmed; the
+  dialog surfaces the live-lease count and requires the `revoke_all` tick when
+  there are any, and reports `revoked_lease_ids.length` in the success notice.
+  When the lease listing could not be read the count is unknown, so the tick is
+  offered and the server 409 is the honest fallback.
+
+**Leases tab** — write actions added to the existing read-only listing:
+- `LeaseMintDialog` — display-once mint. Reuses the shared mint lifecycle
+  (`useMintLifecycle`); a human mint runs one `mint`-purpose passkey ceremony
+  over the chosen environment, then the server discloses the **role name and
+  password exactly once**. The password lives only in the ephemeral lifecycle
+  result (`mintLease` is a plain async call, never a cached mutation — mirrors
+  `mintCredential`). Stored-confirmation gates dismiss; navigation/session/unmount
+  clear it. A mint whose response was lost is a live role whose password is gone
+  → the failure text says so and the listing is refreshed.
+- Per-row `renew` / `revoke` / `settle`, gated by the server's own state guards
+  (from `store.EnqueueTransition`): **renew** only from `active`, **revoke** from
+  any non-terminal state (the fail-safe teardown), **settle** only from
+  `unknown`. `unknown` renders as a loud alert row. All three are **queued**: the
+  copy says so, because the worker carries them out and the row moves when it does.
+
+## Reuse / refactor
+
+The display-once mint state machine (`mintLifecycle.ts`) was generalized over its
+request and result types with **defaults equal to the machine-credential types**,
+so the existing credential flow and its tests were unchanged (zero runtime diff).
+The wiring (state + sync ref + `moveMint`/`isSubmitting` + the three boundary
+clears) was extracted into `useMintLifecycle`, which now backs **both** the
+credential mint and the lease mint. One test annotation was needed
+(`transitionMintLifecycle<MintRequest, MintResult>` at the review step, where the
+result type is not otherwise inferable).
+
+## Parity
+
+`api/parity.yaml`: the ten rows flipped to `{webui: machine-access}`.
+`showDynamicProvider` stays a `via: [listDynamicProviders]` row — its `Op` symbol
+is deliberately **not** imported (the list row carries every field), and the
+parity checker requires a direct row for any imported `*Op`. The other nine
+`*Op`s are imported in `web/src/api/dynamic.ts`. `go test ./api/ -run Parity`
+green.
+
+## Gotchas for the next session
+
+- **`clients/ts` needs its own `pnpm install`** or `tsc`/build fail with TS2307
+  on `zod` (the generated sources resolve `zod` from `clients/ts/node_modules`);
+  the CI typecheck job does this explicitly.
+- **Node**: default shell Node breaks pnpm — `eval "$(fnm env)" && fnm use 24`.
+- **e2e has no PostgreSQL target**, so browser e2e covers the Providers empty
+  state, the create-provider client-side validation (empty fields refused before
+  any dial), the write-only password field, and the Mint-lease held-back state —
+  never a real mint (same boundary #147's e2e drew). Tests were added to
+  `machine-access.spec.ts` (already in a `ci.yml` group; the tab count moved 4→5).
+
+## Tests / gates
+
+- `web` typecheck + full vitest (668) green; `dynamic.test.ts` covers the
+  per-verb refusal mappers; the shared lifecycle tests cover the display-once
+  machine both mints run on.
+- `go test ./api/` (parity) green.
+- e2e: `machine-access.spec.ts` desktop + mobile.

--- a/web/e2e/flows/machine-access.spec.ts
+++ b/web/e2e/flows/machine-access.spec.ts
@@ -79,13 +79,14 @@ test.describe('machine access', () => {
     await expect(page.getByRole('heading', { name: 'Machine access', level: 1 })).toBeVisible();
   });
 
-  test('the inventory has four tabs, and every one of them says what it holds', async () => {
+  test('the inventory has five tabs, and every one of them says what it holds', async () => {
     const tabs = page.getByRole('tab');
-    await expect(tabs).toHaveCount(4);
+    await expect(tabs).toHaveCount(5);
     await expect(tabs.nth(0)).toHaveText(/Service accounts \(3\)/);
     await expect(tabs.nth(1)).toHaveText(/Federation \(1\)/);
     await expect(tabs.nth(2)).toHaveText(/Kubernetes targets \(0\)/);
-    await expect(tabs.nth(3)).toHaveText(/Leases \(0\)/);
+    await expect(tabs.nth(3)).toHaveText(/Providers \(0\)/);
+    await expect(tabs.nth(4)).toHaveText(/Leases \(0\)/);
 
     // The policy strip: the per-project opt-in is stated, not offered as a
     // control whose only outcome would be a refusal.
@@ -118,14 +119,55 @@ test.describe('machine access', () => {
     await expect(empty).toContainText('never that everything is healthy');
     await expectStatusIsTextAndAria(page, empty);
 
+    // The Providers tab is empty on a fresh project and says so.
+    await page.getByRole('tab', { name: 'Providers' }).click();
+    const providersEmpty = page
+      .getByRole('status')
+      .filter({ hasText: 'No dynamic-secret providers on this project yet' });
+    await expect(providersEmpty).toBeVisible();
+    await expectStatusIsTextAndAria(page, providersEmpty);
+    // Configuring a provider is offered, since a live session admits it.
+    await expect(page.getByRole('button', { name: 'Configure provider' })).toBeEnabled();
+
     // The Leases tab is status-only and empty on a fresh project; it never shows
-    // a secret and points mint/lifecycle at the CLI.
+    // a secret. With no provider yet, minting is held back and says why.
     await page.getByRole('tab', { name: 'Leases' }).click();
     const leasesEmpty = page
       .getByRole('status')
       .filter({ hasText: 'No dynamic-secret leases on this project yet' });
     await expect(leasesEmpty).toBeVisible();
     await expectStatusIsTextAndAria(page, leasesEmpty);
+    await expect(page.getByRole('button', { name: 'Mint lease' })).toBeDisabled();
+    await expect(
+      page.getByText('Configure a provider with a credential first', { exact: false }),
+    ).toBeVisible();
+  });
+
+  test('configuring a provider validates its inputs before it dials anything', async () => {
+    await page.getByRole('tab', { name: 'Providers' }).click();
+    await page.getByRole('button', { name: 'Configure provider' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(
+      dialog.getByRole('heading', { name: 'Configure dynamic-secret provider' }),
+    ).toBeVisible();
+
+    // Submitting with empty fields is refused CLIENT-side: no origin is dialled
+    // until the inputs are complete, so the operator meets a form refusal, not a
+    // probe failure.
+    await dialog.getByRole('button', { name: 'Configure provider' }).click();
+    await expect(
+      dialog.getByRole('alert').filter({ hasText: 'are all required' }),
+    ).toBeVisible();
+
+    // The admin credential is a write-only password field — never rendered back.
+    await expect(dialog.getByLabel('Admin credential (write-only)')).toHaveAttribute(
+      'type',
+      'password',
+    );
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
   });
 
   test('expanding a row shows credentials, bindings, targets and the journey below', async () => {

--- a/web/src/api/dynamic.test.ts
+++ b/web/src/api/dynamic.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from './client.ts';
+import {
+  createProviderRefusalText,
+  deleteProviderRefusalText,
+  leaseActionRefusalText,
+  leaseMintFailureText,
+  leaseMintRefusalText,
+  revokeCredentialRefusalText,
+  setCredentialRefusalText,
+} from './dynamic.ts';
+
+describe('createProviderRefusalText', () => {
+  it('reads a 400 as unreachable-or-refused and carries the safe detail', () => {
+    const text = createProviderRefusalText(
+      new ApiError(400, 'bad request', 'dynamic provider unreachable or credential refused'),
+    );
+    expect(text).toContain('could not be reached');
+    expect(text).toContain('(dynamic provider unreachable or credential refused)');
+    expect(text).toContain('Nothing was created.');
+  });
+
+  it('names manage-identities on a 403', () => {
+    expect(createProviderRefusalText(new ApiError(403, 'forbidden'))).toContain('manage-identities');
+  });
+});
+
+describe('setCredentialRefusalText', () => {
+  it('says the stored credential is unchanged on a 400', () => {
+    const text = setCredentialRefusalText(new ApiError(400, 'bad request'));
+    expect(text).toContain('unchanged');
+  });
+});
+
+describe('revokeCredentialRefusalText', () => {
+  it('names the manage-identities requirement on a 403', () => {
+    expect(revokeCredentialRefusalText(new ApiError(403, 'forbidden'))).toContain(
+      'manage-identities',
+    );
+  });
+});
+
+describe('deleteProviderRefusalText', () => {
+  it('reads a 409 as the live-leases cascade guard', () => {
+    const text = deleteProviderRefusalText(new ApiError(409, 'conflict'));
+    expect(text).toContain('live leases');
+    expect(text).toContain('cascade');
+  });
+});
+
+describe('leaseMintRefusalText', () => {
+  it('explains both the human and machine gates on a 403', () => {
+    const text = leaseMintRefusalText(new ApiError(403, 'forbidden'));
+    expect(text).toContain('reauthentication');
+    expect(text).toContain('machine-reveal');
+  });
+
+  it('reports a dismissed passkey without inventing a server cause', () => {
+    const dismissed = new Error('dismissed');
+    dismissed.name = 'NotAllowedError';
+    expect(leaseMintRefusalText(dismissed)).toContain('dismissed');
+  });
+});
+
+describe('leaseMintFailureText', () => {
+  it('stays plain for a pre-commit refusal (nothing was disclosed)', () => {
+    const text = leaseMintFailureText(new ApiError(409, 'conflict'));
+    expect(text).not.toContain('may still have been minted');
+  });
+
+  it('adds the may-have-minted honesty for an ambiguous outcome', () => {
+    const text = leaseMintFailureText(new ApiError(500, 'server error'));
+    expect(text).toContain('may still have been minted');
+    expect(text).toContain('not recoverable');
+  });
+});
+
+describe('leaseActionRefusalText', () => {
+  it('tells a renew 409 the lease is not active', () => {
+    expect(leaseActionRefusalText('renew', new ApiError(409, 'conflict'))).toContain(
+      'not active',
+    );
+  });
+
+  it('tells a settle 409 there is nothing to reconcile', () => {
+    expect(leaseActionRefusalText('settle', new ApiError(409, 'conflict'))).toContain(
+      'not awaiting reconcile',
+    );
+  });
+
+  it('names the read re-check on a renew 403', () => {
+    expect(leaseActionRefusalText('renew', new ApiError(403, 'forbidden'))).toContain('read');
+  });
+
+  it('conjugates the fallthrough verb correctly', () => {
+    expect(leaseActionRefusalText('settle', new ApiError(500, 'server error'))).toContain(
+      'settled',
+    );
+    expect(leaseActionRefusalText('revoke', new ApiError(500, 'server error'))).toContain(
+      'revoked',
+    );
+  });
+});

--- a/web/src/api/dynamic.ts
+++ b/web/src/api/dynamic.ts
@@ -1,12 +1,35 @@
-import { listLeasesOp } from '@hikyo/operations';
-import { zDynamicLease } from '@hikyo/zod';
-import { useQueries } from '@tanstack/react-query';
+import {
+  createDynamicProviderOp,
+  deleteDynamicProviderOp,
+  listDynamicProvidersOp,
+  listLeasesOp,
+  mintLeaseOp,
+  renewLeaseOp,
+  revokeDynamicProviderCredentialOp,
+  revokeLeaseOp,
+  setDynamicProviderCredentialOp,
+  settleLeaseOp,
+} from '@hikyo/operations';
+import { zDynamicLease, zDynamicProvider } from '@hikyo/zod';
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
 import type { z } from 'zod';
 
-import { parsed } from './client.ts';
+import { ApiError, ok, parsed, parsedPick } from './client.ts';
 import { useTransport } from './transport.tsx';
 
 export type DynamicLease = z.infer<typeof zDynamicLease>;
+
+/** DynamicProvider is a project-scoped provider row. Never carries a credential. */
+export type DynamicProvider = z.infer<typeof zDynamicProvider>;
+
+/** ProjectRef addresses one project. Providers are project-scoped. */
+export type ProjectRef = { readonly org: string; readonly project: string };
 
 /** A lease paired with the name of the environment it belongs to. */
 export type LeaseRow = { readonly environmentName: string; readonly lease: DynamicLease };
@@ -51,4 +74,436 @@ export function useLeases(
       isError: results.some((r) => r.isError),
     }),
   });
+}
+
+/**
+ * useRefreshLeases re-reads one environment's lease listing.
+ *
+ * It exists for the mint's no-`onSuccess` path: the mint is a plain async call
+ * (below), so a mint whose response was lost — but may have COMMITTED, leaving a
+ * live role whose password is gone forever — has to be able to invalidate the
+ * listing the operator will scan to find and revoke it.
+ */
+export function useRefreshLeases(p: ProjectRef): (environment: string) => void {
+  const queries = useQueryClient();
+  return (environment: string) => {
+    void queries.invalidateQueries({ queryKey: leasesKey(p.org, p.project, environment) });
+  };
+}
+
+// ---- Providers -----------------------------------------------------------
+
+const providersKey = (org: string, project: string) =>
+  ['dynamic-providers', org, project] as const;
+
+/** All lease listings for a project, whatever the environment. */
+const leasesForProjectKey = (org: string, project: string) =>
+  ['dynamic-leases', org, project] as const;
+
+/** useDynamicProviders lists a project's dynamic-secret providers. */
+export function useDynamicProviders(
+  p: ProjectRef,
+): UseQueryResult<{ items: readonly DynamicProvider[] }> {
+  const transport = useTransport();
+  return useQuery({
+    queryKey: providersKey(p.org, p.project),
+    queryFn: () =>
+      parsed(listDynamicProvidersOp, {
+        path: { org: p.org, project: p.project },
+        ...transport,
+      }),
+    enabled: p.org !== '' && p.project !== '',
+    retry: false,
+  });
+}
+
+/**
+ * useRefreshProviders re-reads the provider listing. It exists because the
+ * credential-bearing writes below are plain async calls (not mutations), so they
+ * have no `onSuccess` — and because a write whose response never arrived may
+ * still have COMMITTED, so the caller must be able to refresh on the failure path
+ * too.
+ */
+export function useRefreshProviders(p: ProjectRef): () => void {
+  const queries = useQueryClient();
+  return () => {
+    void queries.invalidateQueries({ queryKey: providersKey(p.org, p.project) });
+  };
+}
+
+/**
+ * createDynamicProvider configures a provider. The server PROBES the origin with
+ * the admin credential before it stores anything: a create that succeeds is a
+ * provider Hikyo could reach and authenticate against.
+ *
+ * Deliberately NOT a `useMutation`: TanStack retains a mutation's VARIABLES in
+ * its cache until garbage collection, and the request body carries the
+ * write-only admin credential in plaintext — a mutation would leave that secret
+ * reachable from the query client long after the dialog closed. A plain async
+ * call keeps it on the stack and nowhere else (mirrors `mintCredential`).
+ */
+export async function createDynamicProvider(
+  p: ProjectRef,
+  input: {
+    kind: DynamicProvider['kind'];
+    origin: string;
+    grant_role: string;
+    credential: string;
+  },
+): Promise<void> {
+  await parsed(createDynamicProviderOp, {
+    path: { org: p.org, project: p.project },
+    body: {
+      kind: input.kind,
+      origin: input.origin,
+      tls_mode: 'verify-full',
+      grant_role: input.grant_role,
+      credential: input.credential,
+    },
+  });
+}
+
+/**
+ * useDeleteDynamicProvider removes a provider. The server refuses (409) while
+ * the provider has live leases unless `revoke_all` is set, in which case it
+ * queues every one of them for revocation and returns their ids.
+ */
+export function useDeleteDynamicProvider(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { provider: string; revokeAll: boolean }) =>
+      parsed(deleteDynamicProviderOp, {
+        path: { org: p.org, project: p.project, provider: input.provider },
+        query: { revoke_all: input.revokeAll },
+      }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: providersKey(p.org, p.project) });
+      // A delete cascades to lease revocation across every environment, so the
+      // whole project's lease listings are stale — invalidate by the shared prefix.
+      void queries.invalidateQueries({ queryKey: leasesForProjectKey(p.org, p.project) });
+    },
+  });
+}
+
+/**
+ * setDynamicProviderCredential replaces the write-only admin credential. The
+ * credential is never read back; setting it re-probes the provider, so a success
+ * means the new credential authenticates.
+ *
+ * Plain async for the same reason as `createDynamicProvider`: the request body
+ * carries the plaintext credential, which a `useMutation` would cache in its
+ * variables. Refresh the provider listing through `useRefreshProviders`.
+ */
+export async function setDynamicProviderCredential(
+  p: ProjectRef,
+  input: { provider: string; credential: string },
+): Promise<void> {
+  await ok(setDynamicProviderCredentialOp, {
+    path: { org: p.org, project: p.project, provider: input.provider },
+    body: { credential: input.credential },
+  });
+}
+
+/**
+ * useRevokeDynamicProviderCredential clears the admin credential. It does NOT
+ * touch existing leases: their roles stay minted at the provider, but the worker
+ * can no longer renew, revoke or expire them until a replacement is set.
+ */
+export function useRevokeDynamicProviderCredential(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (provider: string) =>
+      ok(revokeDynamicProviderCredentialOp, {
+        path: { org: p.org, project: p.project, provider },
+      }),
+    onSuccess: () => {
+      void queries.invalidateQueries({ queryKey: providersKey(p.org, p.project) });
+    },
+  });
+}
+
+// ---- Lease write ops -----------------------------------------------------
+
+/**
+ * useRenewLease queues a renewal. The server flips the lease to `renewing` and
+ * the worker extends the role; the response reports the queued state, not a new
+ * expiry. Only an `active` lease may be renewed.
+ */
+export function useRenewLease(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      environment: string;
+      lease: string;
+      maxTtlSeconds: number | null;
+    }) =>
+      parsed(renewLeaseOp, {
+        path: { org: p.org, project: p.project, environment: input.environment, lease: input.lease },
+        body: { max_ttl_seconds: input.maxTtlSeconds },
+      }),
+    onSuccess: (_lease, input) => {
+      void queries.invalidateQueries({ queryKey: leasesKey(p.org, p.project, input.environment) });
+    },
+  });
+}
+
+/**
+ * useRevokeLease queues a revocation. The worker drops the role; the response
+ * reports the queued `revoking` state. Revoke is allowed from any non-terminal
+ * state so a compromised workload's lease can always be torn down.
+ */
+export function useRevokeLease(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environment: string; lease: string }) =>
+      parsed(revokeLeaseOp, {
+        path: { org: p.org, project: p.project, environment: input.environment, lease: input.lease },
+      }),
+    onSuccess: (_lease, input) => {
+      void queries.invalidateQueries({ queryKey: leasesKey(p.org, p.project, input.environment) });
+    },
+  });
+}
+
+/**
+ * useSettleLease re-triggers reconcile on an `unknown` lease — the only state it
+ * accepts. The worker re-probes the provider and settles the lease to its true
+ * terminal or active state.
+ */
+export function useSettleLease(p: ProjectRef) {
+  const queries = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { environment: string; lease: string }) =>
+      parsed(settleLeaseOp, {
+        path: { org: p.org, project: p.project, environment: input.environment, lease: input.lease },
+      }),
+    onSuccess: (_lease, input) => {
+      void queries.invalidateQueries({ queryKey: leasesKey(p.org, p.project, input.environment) });
+    },
+  });
+}
+
+/**
+ * zLeaseMinted narrows the mint result to what the caller may keep: the
+ * username and the display-once password, plus its expiry. Deliberately not the
+ * whole `lease` member — that is re-read from the listing a moment later, and
+ * parsing it here would let a drift in an unrelated field throw away the one
+ * value nothing in the system can ever return again.
+ */
+const zLeaseMinted = mintLeaseOp.response.pick({
+  username: true,
+  password: true,
+  expires_at: true,
+});
+
+export type LeaseMinted = z.infer<typeof zLeaseMinted>;
+
+/**
+ * mintLease is the display-once lease mint, and — like `mintCredential` — it is
+ * deliberately NOT a `useMutation`: TanStack keeps a mutation's result cached
+ * until garbage collection, and the password's whole contract is that it lives
+ * in exactly one place, the ephemeral dialog that renders it once.
+ */
+export async function mintLease(
+  p: { readonly org: string; readonly project: string; readonly environment: string },
+  req: { readonly providerId: string; readonly maxTtlSeconds: number },
+): Promise<LeaseMinted> {
+  return parsedPick(
+    mintLeaseOp,
+    {
+      path: { org: p.org, project: p.project, environment: p.environment },
+      body: { provider_id: req.providerId, max_ttl_seconds: req.maxTtlSeconds },
+    },
+    { username: true, password: true, expires_at: true },
+  );
+}
+
+// ---- Refusal text --------------------------------------------------------
+
+/** withDetail appends the server's safe detail sentence when it carried one. */
+function withDetail(base: string, error: unknown): string {
+  if (error instanceof ApiError && error.detail !== undefined && error.detail !== '') {
+    return `${base} (${error.detail})`;
+  }
+  return base;
+}
+
+/**
+ * createProviderRefusalText names a provider-create refusal in its own
+ * vocabulary. The load-bearing case is 400: the server probes the origin with
+ * the credential before storing anything, so a 400 is "malformed, unreachable,
+ * or the credential was refused" — the detail says which.
+ */
+export function createProviderRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return withDetail(
+          'The server refused the provider: its origin, grant role or credential was rejected, or PostgreSQL could not be reached and authenticated with them. Nothing was created.',
+          error,
+        );
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before configuring a provider.';
+      case 403:
+        return 'Configuring a provider needs manage-identities on this project. Nothing was created.';
+      case 404:
+        return 'This project is no longer here, or you may not administer its identities. Nothing was created.';
+      case 409:
+        return withDetail('The server refused that as a conflict. Nothing was created.', error);
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The provider could not be created (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The provider could not be created.';
+}
+
+/**
+ * setCredentialRefusalText names a credential-replace refusal. It re-probes, so
+ * 400 is the unreachable/refused-credential case, exactly as create.
+ */
+export function setCredentialRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return withDetail(
+          'The server refused the credential: PostgreSQL could not be reached and authenticated with it. The stored credential is unchanged.',
+          error,
+        );
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before replacing the credential.';
+      case 403:
+        return 'Replacing the credential needs manage-identities on this project.';
+      case 404:
+        return 'That provider is no longer here — someone may have deleted it.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The credential could not be set (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The credential could not be set.';
+}
+
+/** revokeCredentialRefusalText names a credential-revoke refusal. */
+export function revokeCredentialRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in first.';
+      case 403:
+        return 'Revoking the credential needs manage-identities on this project.';
+      case 404:
+        return 'That provider is no longer here — someone may have deleted it.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The credential could not be revoked (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The credential could not be revoked.';
+}
+
+/**
+ * deleteProviderRefusalText names a provider-delete refusal. A 409 is the
+ * live-leases guard: the operator must confirm the cascade to proceed.
+ */
+export function deleteProviderRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in before deleting a provider.';
+      case 403:
+        return 'Deleting a provider needs manage-identities on this project.';
+      case 404:
+        return 'That provider is no longer here — someone may have deleted it already.';
+      case 409:
+        return 'This provider still has live leases. Confirm the cascade to revoke them as part of the delete.';
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The provider could not be deleted (server error ${String(error.status)}).`;
+    }
+  }
+  return 'The provider could not be deleted.';
+}
+
+/**
+ * leaseMintRefusalText names a mint refusal BEFORE the request was issued (a
+ * dismissed passkey, a 403 for a missing disclosure capability). Once the mint
+ * request has left, use `leaseMintFailureText` instead: a lost response may have
+ * left a live role whose password is gone forever.
+ */
+export function leaseMintRefusalText(error: unknown): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 400:
+        return withDetail('The server refused that mint request as malformed.', error);
+      case 403:
+        return 'The server refused this mint. A human mint needs a disclosure capability over this environment and a fresh reauthentication; a machine mint needs the project machine-reveal opt-in.';
+      case 404:
+        return 'That provider or environment is no longer here.';
+      case 409:
+        return withDetail(
+          'The mint could not be completed: the provider refused it, or is not in a state that can mint. No credential was issued.',
+          error,
+        );
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The mint could not be completed (server error ${String(error.status)}).`;
+    }
+  }
+  if (error instanceof Error && error.name === 'NotAllowedError') {
+    return 'The passkey prompt was dismissed or timed out. Nothing was minted.';
+  }
+  return 'The mint could not be completed.';
+}
+
+/**
+ * leaseMintFailureText is the refusal for a mint request that WAS ISSUED. The
+ * pre-commit refusals (a malformed request, authorization, a provider conflict
+ * that discloses nothing, the budget) carry no ambiguity and stay the plain
+ * sentence. Anything else — a dropped response, a 5xx, an unparseable body — may
+ * have left a live role whose password is gone forever, so it says so.
+ */
+export function leaseMintFailureText(error: unknown): string {
+  const base = leaseMintRefusalText(error);
+  if (error instanceof ApiError && [400, 401, 403, 404, 409, 429].includes(error.status)) {
+    return base;
+  }
+  return `${base} A lease may still have been minted: its password is not recoverable, so check the leases below and revoke anything you did not expect.`;
+}
+
+/** leaseActionRefusalText names a renew/revoke/settle refusal by verb. */
+export function leaseActionRefusalText(
+  verb: 'renew' | 'revoke' | 'settle',
+  error: unknown,
+): string {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return 'The session could not be authenticated. Reload and sign in first.';
+      case 403:
+        return verb === 'renew'
+          ? 'The server refused the renewal. Renewing re-checks read over this environment — a principal that lost it cannot renew.'
+          : `The server refused to ${verb} this lease.`;
+      case 404:
+        return 'That lease is no longer here.';
+      case 409:
+        return {
+          renew: 'This lease is not active, so it cannot be renewed. Reload to see its current state.',
+          revoke:
+            'This lease is already terminal or being revoked. Reload to see its current state.',
+          settle:
+            'This lease is not awaiting reconcile, so there is nothing to settle. Reload to see its current state.',
+        }[verb];
+      case 429:
+        return 'Too many requests right now. Wait a moment and try again.';
+      default:
+        return `The lease could not be ${verb === 'settle' ? 'settled' : `${verb}d`} (server error ${String(error.status)}).`;
+    }
+  }
+  return `The lease could not be ${verb === 'settle' ? 'settled' : `${verb}d`}.`;
 }

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -55,18 +55,42 @@ import {
   type ServiceAccount,
 } from '../api/identities.ts';
 import { TypedNameConfirm } from './Sections.tsx';
-import { useLeases } from '../api/dynamic.ts';
+import { ApiError } from '../api/client.ts';
+import {
+  createDynamicProvider,
+  createProviderRefusalText,
+  deleteProviderRefusalText,
+  leaseActionRefusalText,
+  leaseMintFailureText,
+  leaseMintRefusalText,
+  mintLease,
+  revokeCredentialRefusalText,
+  setCredentialRefusalText,
+  setDynamicProviderCredential,
+  useDeleteDynamicProvider,
+  useDynamicProviders,
+  useLeases,
+  useRefreshLeases,
+  useRefreshProviders,
+  useRenewLease,
+  useRevokeDynamicProviderCredential,
+  useRevokeLease,
+  useSettleLease,
+  type DynamicLease,
+  type DynamicProvider,
+  type LeaseMinted,
+} from '../api/dynamic.ts';
 import { useMachineReveal, useSetMachineReveal } from '../api/machineReveal.ts';
 import { useAuth } from '../app/AuthProvider.tsx';
 import { writeClipboard } from '../app/clipboard.ts';
 import { runPasskeyCeremony, useEnvironments } from '../api/values.ts';
 import {
-  idleMintLifecycle,
-  mintLifecycleAtBoundary,
+  type IsMintSubmitting,
   type MintBoundary,
-  transitionMintLifecycle,
+  type MintBoundaryFields,
   type MintLifecycle,
-  type MintLifecycleEvent,
+  type MoveMint,
+  useMintLifecycle,
 } from './mintLifecycle.ts';
 import { useModalDialog } from './useModalDialog.ts';
 
@@ -96,26 +120,47 @@ import { useModalDialog } from './useModalDialog.ts';
  * rendered because it is real.
  */
 
-type Tab = 'accounts' | 'federation' | 'kubernetes' | 'leases';
+type Tab = 'accounts' | 'federation' | 'kubernetes' | 'providers' | 'leases';
 
 type Dialog =
   | { kind: 'binding'; account: ServiceAccount; replaces?: MachineCredential }
   | { kind: 'grant'; account: ServiceAccount }
   | { kind: 'create' }
-  | { kind: 'delete'; account: ServiceAccount };
+  | { kind: 'delete'; account: ServiceAccount }
+  | { kind: 'create-provider' }
+  | { kind: 'set-credential'; provider: DynamicProvider }
+  | { kind: 'revoke-credential'; provider: DynamicProvider }
+  | { kind: 'delete-provider'; provider: DynamicProvider };
 
-type MintTransitionResult = {
-  readonly state: MintLifecycle;
-  readonly accepted: boolean;
+/** A queued lease-lifecycle action awaiting confirmation. */
+type LeaseAction = {
+  readonly verb: 'renew' | 'revoke' | 'settle';
+  readonly environmentId: string;
+  readonly environmentName: string;
+  readonly lease: DynamicLease;
 };
 
-type MoveMint = (event: MintLifecycleEvent) => MintTransitionResult;
-type IsMintSubmitting = (requestId: number) => boolean;
+/** An environment as the lease-mint form addresses one. */
+type EnvOption = { readonly id: string; readonly name: string };
+
+/**
+ * The frozen inputs of a lease mint. Like MintRequest it carries only the
+ * addressed provider/environment and the labels the review panel shows — never a
+ * response field, so the disclosed password lives only in the lifecycle result.
+ */
+type LeaseMintRequest = MintBoundaryFields & {
+  readonly providerId: string;
+  readonly providerLabel: string;
+  readonly environmentId: string;
+  readonly environmentName: string;
+  readonly maxTtlSeconds: number;
+};
 
 const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: 'accounts', label: 'Service accounts' },
   { id: 'federation', label: 'Federation' },
   { id: 'kubernetes', label: 'Kubernetes targets' },
+  { id: 'providers', label: 'Providers' },
   { id: 'leases', label: 'Leases' },
 ];
 
@@ -140,6 +185,11 @@ export function MachineAccess() {
     [environmentsQuery.data],
   );
   const leases = useLeases(project, environments);
+  const providersQuery = useDynamicProviders(project);
+  const providers = useMemo(
+    () => providersQuery.data?.items ?? [],
+    [providersQuery.data],
+  );
   const grants = useMemo(() => grantsQuery.data?.items ?? [], [grantsQuery.data]);
   const credentials = useCredentials(project, accounts);
 
@@ -148,58 +198,22 @@ export function MachineAccess() {
   const [dialog, setDialog] = useState<Dialog | null>(null);
   const [refusal, setRefusal] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [mintLifecycle, setMintLifecycle] = useState<MintLifecycle>(idleMintLifecycle);
-  const mintLifecycleRef = useRef<MintLifecycle>(idleMintLifecycle);
+  const [leaseMintOpen, setLeaseMintOpen] = useState(false);
+  const [leaseAction, setLeaseAction] = useState<LeaseAction | null>(null);
   const mintBoundary: MintBoundary = {
     sessionId: liveSessionId,
     org: project.org,
     project: project.project,
   };
-  const mintBoundaryRef = useRef<MintBoundary>(mintBoundary);
-  mintBoundaryRef.current = mintBoundary;
-  const mintRequestId = useRef(0);
-
-  const moveMint = useCallback<MoveMint>((event) => {
-    const current = mintLifecycleRef.current;
-    const next = transitionMintLifecycle(current, event);
-    mintLifecycleRef.current = next;
-    if (next !== current) {
-      setMintLifecycle(next);
-    }
-    return { state: next, accepted: next !== current };
-  }, []);
-  const isMintSubmitting = useCallback<IsMintSubmitting>(
-    (requestId) => {
-      const current = mintLifecycleAtBoundary(
-        mintLifecycleRef.current,
-        mintBoundaryRef.current,
-      );
-      return current.kind === 'submitting' && current.request.id === requestId;
-    },
-    [],
-  );
-
-  // A project route is a new mint boundary. Clear before any completion from
-  // the old route can publish its display-once response into this one.
-  useEffect(() => {
-    moveMint({ type: 'clear', reason: 'navigation' });
-  }, [moveMint, project.org, project.project]);
-
-  // Session replacement is a harder boundary than navigation: even if the
-  // route remains mounted, no disclosure from the old browser session may
-  // survive into the new one.
-  useEffect(() => {
-    moveMint({ type: 'clear', reason: 'session-transition' });
-  }, [liveSessionId, moveMint]);
-
-  // Wipe the synchronous ref on unmount too, so an already-resolving promise
-  // sees idle and drops its late result.
-  useEffect(
-    () => () => {
-      mintLifecycleRef.current = idleMintLifecycle;
-    },
-    [],
-  );
+  // The display-once mint lifecycle, with its request-addressed completion and
+  // its navigation/session/unmount boundary clears (see useMintLifecycle).
+  const mint = useMintLifecycle(mintBoundary);
+  const moveMint: MoveMint = mint.moveMint;
+  const isMintSubmitting: IsMintSubmitting = mint.isSubmitting;
+  // A second, independent lifecycle for the dynamic-lease mint. It shares the
+  // same session/project boundary, so a route or session change clears the
+  // display-once lease password on exactly the same terms as a credential.
+  const leaseMint = useMintLifecycle<LeaseMintRequest, LeaseMinted>(mintBoundary);
 
   // A create, delete, binding or grant dialog carries a decision scoped to ONE
   // project and session. A boundary crossing — a route change, or a session
@@ -209,6 +223,8 @@ export function MachineAccess() {
   // this covers the setDialog-based dialogs.
   useEffect(() => {
     setDialog(null);
+    setLeaseMintOpen(false);
+    setLeaseAction(null);
   }, [project.org, project.project, liveSessionId]);
 
   const revoke = useRevokeCredential(project);
@@ -235,11 +251,10 @@ export function MachineAccess() {
       setRefusal('The current session could not be read. Reload before minting a credential.');
       return;
     }
-    mintRequestId.current += 1;
     moveMint({
       type: 'review',
       request: {
-        id: mintRequestId.current,
+        id: mint.nextRequestId(),
         sessionId: liveSessionId,
         org: project.org,
         project: project.project,
@@ -286,12 +301,30 @@ export function MachineAccess() {
    */
   const canAdminister = liveSessionId !== null && accountsQuery.isSuccess;
 
+  // Provider administration needs only a live session and a readable provider
+  // listing — the same lighter gate as create/delete above, for the same reason.
+  const canAdministerProviders = liveSessionId !== null && providersQuery.isSuccess;
+
+  // A lease can be minted only against a provider that is active AND holds a
+  // credential (the mint dials the provider), and only into an environment.
+  const mintableProviders = useMemo(
+    () => providers.filter((p) => p.state === 'active' && p.credential_present),
+    [providers],
+  );
+  const canMintLease =
+    liveSessionId !== null &&
+    providersQuery.isSuccess &&
+    environmentsQuery.isSuccess &&
+    mintableProviders.length > 0 &&
+    environments.length > 0;
+
   const tabCount: Record<Tab, string> = {
     accounts: accountsQuery.isSuccess ? String(accounts.length) : '—',
     // Unknown is rendered as unknown: "Federation (0)" on a failed listing
     // reads as "there are none", which is the one thing it does not know.
     federation: credentials.isPending || credentials.isError ? '—' : String(allBindings.length),
     kubernetes: '0',
+    providers: providersQuery.isSuccess ? String(providers.length) : '—',
     leases: leases.isPending || leases.isError ? '—' : String(leases.rows.length),
   };
 
@@ -309,7 +342,7 @@ export function MachineAccess() {
     );
   };
 
-  const activeMintLifecycle = mintLifecycleAtBoundary(mintLifecycle, mintBoundary);
+  const activeMintLifecycle = mint.active;
 
   return (
     <section className="card card--wide machine" aria-labelledby="machine-title">
@@ -575,13 +608,154 @@ export function MachineAccess() {
           </>
         ) : null}
 
+        {tab === 'providers' ? (
+          <>
+            <h2>Dynamic-secret providers</h2>
+            <p className="machine__lede">
+              Where Hikyo mints short-lived credentials. A provider is project-scoped, always
+              connects over <code>verify-full</code> TLS, and its admin credential is write-only —
+              set or replaced, never read back. Every minted lease role inherits the grant role.
+            </p>
+            <p className="machine__actions">
+              <button
+                className="btn btn--primary"
+                type="button"
+                disabled={!canAdministerProviders}
+                onClick={() => {
+                  setRefusal(null);
+                  setNotice(null);
+                  setDialog({ kind: 'create-provider' });
+                }}
+              >
+                Configure provider
+              </button>
+            </p>
+            <table className="values__table machine__table">
+              <caption className="visually-hidden">
+                The project&apos;s dynamic-secret providers. The admin credential is never listed.
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Kind</th>
+                  <th scope="col">Origin</th>
+                  <th scope="col" className="col-secondary">
+                    Grant role
+                  </th>
+                  <th scope="col">Credential</th>
+                  <th scope="col" className="col-secondary">
+                    State
+                  </th>
+                  <th scope="col">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {providers.map((provider) => (
+                  <tr key={provider.id}>
+                    <td>{provider.kind}</td>
+                    <td>
+                      <code>{provider.origin}</code>
+                    </td>
+                    <td className="col-secondary">
+                      <code>{provider.grant_role}</code>
+                    </td>
+                    <td>
+                      {provider.credential_present
+                        ? provider.credential_set_at === undefined ||
+                          provider.credential_set_at === null
+                          ? 'set'
+                          : `set ${isoDay(provider.credential_set_at)}`
+                        : 'none'}
+                    </td>
+                    <td className="col-secondary">{provider.state}</td>
+                    <td>
+                      {provider.state === 'active' ? (
+                        <span className="machine__row-actions">
+                          <button
+                            className="btn"
+                            type="button"
+                            disabled={!canAdministerProviders}
+                            onClick={() => {
+                              setRefusal(null);
+                              setNotice(null);
+                              setDialog({ kind: 'set-credential', provider });
+                            }}
+                          >
+                            {provider.credential_present
+                              ? 'Replace credential'
+                              : 'Set credential'}
+                          </button>
+                          {provider.credential_present ? (
+                            <button
+                              className="btn"
+                              type="button"
+                              disabled={!canAdministerProviders}
+                              onClick={() => {
+                                setRefusal(null);
+                                setNotice(null);
+                                setDialog({ kind: 'revoke-credential', provider });
+                              }}
+                            >
+                              Revoke credential
+                            </button>
+                          ) : null}
+                          <button
+                            className="btn"
+                            type="button"
+                            disabled={!canAdministerProviders}
+                            onClick={() => {
+                              setRefusal(null);
+                              setNotice(null);
+                              setDialog({ kind: 'delete-provider', provider });
+                            }}
+                          >
+                            Delete
+                          </button>
+                        </span>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {providersQuery.isError ? (
+              <p role="status">The providers could not be read.</p>
+            ) : providers.length === 0 && !providersQuery.isPending ? (
+              <p role="status">
+                No dynamic-secret providers on this project yet. Configure one to mint leased
+                credentials.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
         {tab === 'leases' ? (
           <>
             <h2>Dynamic-secret leases</h2>
             <p className="machine__lede">
               Short-lived credentials Hikyo minted at a provider. Status and metadata only — the
-              credential is disclosed once, at mint, and never shown again. Mint and lifecycle live
-              on the API and CLI (<code>hikyo lease</code>).
+              password is disclosed once, at mint, and never shown again. Renew, revoke and settle
+              are queued: the worker carries them out and the row moves when it does.
+            </p>
+            <p className="machine__actions">
+              <button
+                className="btn btn--primary"
+                type="button"
+                disabled={!canMintLease}
+                onClick={() => {
+                  setRefusal(null);
+                  setNotice(null);
+                  setLeaseMintOpen(true);
+                }}
+              >
+                Mint lease
+              </button>
+              {!canMintLease && providersQuery.isSuccess && mintableProviders.length === 0 ? (
+                <span className="machine__hint">
+                  Configure a provider with a credential first — a lease is minted against one.
+                </span>
+              ) : null}
             </p>
             <table className="values__table machine__table">
               <caption className="visually-hidden">
@@ -599,32 +773,90 @@ export function MachineAccess() {
                   <th scope="col" className="col-secondary">
                     Principal
                   </th>
+                  <th scope="col">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {leases.rows.map((row) => (
-                  <tr key={row.lease.id}>
-                    <td>{row.environmentName}</td>
-                    <td>
-                      <code>{row.lease.provider_handle}</code>
-                    </td>
-                    <td>{row.lease.state}</td>
-                    <td className="col-secondary">
-                      {row.lease.expires_at === undefined || row.lease.expires_at === null
-                        ? '—'
-                        : isoDay(row.lease.expires_at)}
-                    </td>
-                    <td className="col-secondary">{row.lease.principal_class}</td>
-                  </tr>
-                ))}
+                {leases.rows.map((row) => {
+                  const state = row.lease.state;
+                  const canRenew = state === 'active';
+                  const canRevoke = !['revoked', 'expired', 'failed', 'revoking'].includes(state);
+                  const canSettle = state === 'unknown';
+                  const openAction = (verb: LeaseAction['verb']) => {
+                    setRefusal(null);
+                    setNotice(null);
+                    setLeaseAction({
+                      verb,
+                      environmentId: row.lease.environment_id,
+                      environmentName: row.environmentName,
+                      lease: row.lease,
+                    });
+                  };
+                  return (
+                    <tr key={row.lease.id}>
+                      <td>{row.environmentName}</td>
+                      <td>
+                        <code>{row.lease.provider_handle}</code>
+                      </td>
+                      <td>
+                        {state === 'unknown' ? (
+                          <span className="alert" role="status">
+                            <span className="alert__glyph" aria-hidden="true">
+                              !
+                            </span>
+                            <span>unknown — awaiting reconcile</span>
+                          </span>
+                        ) : (
+                          state
+                        )}
+                      </td>
+                      <td className="col-secondary">
+                        {row.lease.expires_at === undefined || row.lease.expires_at === null
+                          ? '—'
+                          : isoDay(row.lease.expires_at)}
+                      </td>
+                      <td className="col-secondary">{row.lease.principal_class}</td>
+                      <td>
+                        {liveSessionId !== null && (canRenew || canRevoke || canSettle) ? (
+                          <span className="machine__row-actions">
+                            {canRenew ? (
+                              <button className="btn" type="button" onClick={() => openAction('renew')}>
+                                Renew
+                              </button>
+                            ) : null}
+                            {canSettle ? (
+                              <button
+                                className="btn"
+                                type="button"
+                                onClick={() => openAction('settle')}
+                              >
+                                Settle
+                              </button>
+                            ) : null}
+                            {canRevoke ? (
+                              <button
+                                className="btn"
+                                type="button"
+                                onClick={() => openAction('revoke')}
+                              >
+                                Revoke
+                              </button>
+                            ) : null}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
             {leases.isError ? (
               <p role="status">The leases could not be read for one or more environments.</p>
             ) : leases.rows.length === 0 && !leases.isPending ? (
               <p role="status">
-                No dynamic-secret leases on this project yet. Configure a provider and mint one with{' '}
-                <code>hikyo lease mint</code>.
+                No dynamic-secret leases on this project yet. Configure a provider and mint one.
               </p>
             ) : null}
           </>
@@ -705,6 +937,95 @@ export function MachineAccess() {
             setNotice(
               `Deleted ${name}. Every credential it held is revoked and every grant released — atomically, and this cannot be undone.`,
             );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'create-provider' ? (
+        <CreateProviderDialog
+          project={project}
+          onClose={() => setDialog(null)}
+          onCreated={(origin) => {
+            setDialog(null);
+            setNotice(
+              `Configured provider ${origin}. Hikyo reached it and authenticated — it can now mint leased credentials.`,
+            );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'set-credential' ? (
+        <SetCredentialDialog
+          project={project}
+          provider={dialog.provider}
+          onClose={() => setDialog(null)}
+          onSet={(origin) => {
+            setDialog(null);
+            setNotice(
+              `Replaced the admin credential for ${origin}. Hikyo re-probed the provider and authenticated with the new one.`,
+            );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'revoke-credential' ? (
+        <RevokeCredentialDialog
+          project={project}
+          provider={dialog.provider}
+          onClose={() => setDialog(null)}
+          onRevoked={(origin) => {
+            setDialog(null);
+            setNotice(
+              `Cleared the admin credential for ${origin}. Existing leases stay minted at the provider, but Hikyo cannot renew, revoke or expire them until a credential is set.`,
+            );
+          }}
+        />
+      ) : null}
+
+      {dialog?.kind === 'delete-provider' ? (
+        <DeleteProviderDialog
+          project={project}
+          provider={dialog.provider}
+          liveLeaseCount={leases.rows.filter(
+            (row) =>
+              row.lease.provider_id === dialog.provider.id &&
+              !['revoked', 'expired', 'failed'].includes(row.lease.state),
+          ).length}
+          leasesKnown={!leases.isPending && !leases.isError}
+          onClose={() => setDialog(null)}
+          onDeleted={(origin, revokedCount) => {
+            setDialog(null);
+            setNotice(
+              revokedCount === 0
+                ? `Deleted provider ${origin}.`
+                : `Deleted provider ${origin}. ${String(revokedCount)} live lease${revokedCount === 1 ? ' was' : 's were'} queued for revocation as part of the delete.`,
+            );
+          }}
+        />
+      ) : null}
+
+      {leaseMintOpen || leaseMint.active.kind !== 'idle' ? (
+        <LeaseMintDialog
+          project={project}
+          sessionId={liveSessionId}
+          providers={mintableProviders}
+          environments={environments}
+          lifecycle={leaseMint.active}
+          move={leaseMint.moveMint}
+          isSubmitting={leaseMint.isSubmitting}
+          nextRequestId={leaseMint.nextRequestId}
+          onClose={() => setLeaseMintOpen(false)}
+        />
+      ) : null}
+
+      {leaseAction !== null ? (
+        <LeaseActionDialog
+          project={project}
+          action={leaseAction}
+          onClose={() => setLeaseAction(null)}
+          onDone={(message) => {
+            setLeaseAction(null);
+            setNotice(message);
           }}
         />
       ) : null}
@@ -2540,5 +2861,980 @@ function DeleteAccountDialog({
 function blankClaims(preset: FederationPreset): Record<string, string> {
   return Object.fromEntries(
     preset.claims.map((field) => [field.claim, field.kind === 'event' ? 'push' : '']),
+  );
+}
+
+/**
+ * CreateProviderDialog configures a dynamic-secret provider.
+ *
+ * The server PROBES the origin with the admin credential before it stores
+ * anything, so a create that succeeds is a provider Hikyo could reach and
+ * authenticate against — the dialog says so rather than promising a store that
+ * might be unreachable. There is no passkey here: configuring standing project
+ * authority is `manage-identities`, not a per-environment disclosure.
+ */
+function CreateProviderDialog({
+  project,
+  onClose,
+  onCreated,
+}: {
+  project: ProjectRef;
+  onClose: () => void;
+  onCreated: (origin: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const refresh = useRefreshProviders(project);
+  const [origin, setOrigin] = useState('');
+  const [grantRole, setGrantRole] = useState('');
+  const [credential, setCredential] = useState('');
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    if (origin.trim() === '' || grantRole.trim() === '' || credential === '') {
+      setFailure('Origin, grant role and the admin credential are all required. Nothing was created.');
+      return;
+    }
+    setBusy(true);
+    setFailure(null);
+    try {
+      await createDynamicProvider(project, {
+        kind: 'postgres',
+        origin,
+        grant_role: grantRole,
+        credential,
+      });
+      refresh();
+      onCreated(origin);
+    } catch (error) {
+      // A create whose response was lost may still have committed; re-read the
+      // listing so a committed provider shows even when the dialog reports failure.
+      refresh();
+      setFailure(createProviderRefusalText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="create-provider-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="create-provider-title">
+        Configure dynamic-secret provider
+      </h2>
+      <p className="ceremony__lede">
+        PostgreSQL is the only provider kind. Hikyo connects over <code>verify-full</code> TLS and
+        mints each lease role <code>IN ROLE</code> the grant role, so the lease inherits exactly the
+        access you granted that parent. The admin credential is write-only: it is never returned, and
+        the server dials the origin with it before storing anything.
+      </p>
+
+      <fieldset className="machine__lock" disabled={busy}>
+        <div className="field">
+          <label htmlFor="create-provider-origin">Origin (host:port/dbname)</label>
+          <input
+            id="create-provider-origin"
+            className="mono"
+            value={origin}
+            autoComplete="off"
+            spellCheck={false}
+            maxLength={2048}
+            placeholder="db.internal:5432/app"
+            onChange={(event) => {
+              setOrigin(event.target.value);
+              setFailure(null);
+            }}
+          />
+        </div>
+
+        <div className="field">
+          <label htmlFor="create-provider-grant-role">Grant role</label>
+          <input
+            id="create-provider-grant-role"
+            className="mono"
+            value={grantRole}
+            autoComplete="off"
+            spellCheck={false}
+            maxLength={63}
+            onChange={(event) => {
+              setGrantRole(event.target.value);
+              setFailure(null);
+            }}
+          />
+        </div>
+
+        <div className="field">
+          <label htmlFor="create-provider-credential">Admin credential (write-only)</label>
+          <input
+            id="create-provider-credential"
+            className="mono"
+            type="password"
+            value={credential}
+            autoComplete="off"
+            spellCheck={false}
+            maxLength={4096}
+            onChange={(event) => {
+              setCredential(event.target.value);
+              setFailure(null);
+            }}
+          />
+        </div>
+      </fieldset>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => void submit()}
+        >
+          {busy ? 'Configuring…' : 'Configure provider'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * SetCredentialDialog replaces a provider's write-only admin credential. It
+ * re-probes on set, so a success means the new credential authenticates; the
+ * prior one is never shown and is overwritten, not archived.
+ */
+function SetCredentialDialog({
+  project,
+  provider,
+  onClose,
+  onSet,
+}: {
+  project: ProjectRef;
+  provider: DynamicProvider;
+  onClose: () => void;
+  onSet: (origin: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const refresh = useRefreshProviders(project);
+  const [credential, setCredential] = useState('');
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    if (credential === '') {
+      setFailure('The credential is required. The stored credential is unchanged.');
+      return;
+    }
+    setBusy(true);
+    setFailure(null);
+    try {
+      await setDynamicProviderCredential(project, { provider: provider.id, credential });
+      refresh();
+      onSet(provider.origin);
+    } catch (error) {
+      // A set whose response was lost may still have replaced the credential;
+      // re-read so the credential-set date reflects a write that may have landed.
+      refresh();
+      setFailure(setCredentialRefusalText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="set-credential-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="set-credential-title">
+        {`${provider.credential_present ? 'Replace' : 'Set'} admin credential · ${provider.origin}`}
+      </h2>
+      <p className="ceremony__lede">
+        Write-only: the credential is never read back. Hikyo dials the provider with it before
+        storing it, so a failure here leaves the current credential in place.
+      </p>
+
+      <fieldset className="machine__lock" disabled={busy}>
+        <div className="field">
+          <label htmlFor="set-credential-value">Admin credential</label>
+          <input
+            id="set-credential-value"
+            className="mono"
+            type="password"
+            value={credential}
+            autoComplete="off"
+            spellCheck={false}
+            maxLength={4096}
+            onChange={(event) => {
+              setCredential(event.target.value);
+              setFailure(null);
+            }}
+          />
+        </div>
+      </fieldset>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => void submit()}
+        >
+          {busy ? 'Saving…' : 'Save credential'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * RevokeCredentialDialog clears a provider's admin credential.
+ *
+ * It states the fail-closed consequence the ticket requires: existing leases are
+ * NOT torn down — their roles stay minted at the provider — but the worker can
+ * no longer renew, revoke or expire them until a replacement credential is set.
+ * A lease revocation that needs the credential will strand until then.
+ */
+function RevokeCredentialDialog({
+  project,
+  provider,
+  onClose,
+  onRevoked,
+}: {
+  project: ProjectRef;
+  provider: DynamicProvider;
+  onClose: () => void;
+  onRevoked: (origin: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const revoke = useRevokeDynamicProviderCredential(project);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    setBusy(true);
+    setFailure(null);
+    try {
+      await revoke.mutateAsync(provider.id);
+      onRevoked(provider.origin);
+    } catch (error) {
+      setFailure(revokeCredentialRefusalText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="revoke-credential-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="revoke-credential-title">
+        {`Revoke admin credential · ${provider.origin}`}
+      </h2>
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          This clears the stored credential. Existing leases stay minted at the provider, but Hikyo
+          can no longer renew, revoke or expire them — a revocation that needs the credential will
+          strand — until you set a replacement. New mints are refused while there is no credential.
+        </span>
+      </p>
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => void submit()}
+        >
+          {busy ? 'Revoking…' : 'Revoke credential'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * DeleteProviderDialog removes a provider behind a typed-origin confirmation.
+ *
+ * The server refuses while the provider has live leases unless the cascade is
+ * confirmed, in which case it queues every one of them for revocation. So the
+ * dialog states that truth — how many live leases go — and requires the cascade
+ * checkbox when there are any, rather than letting the operator meet the refusal
+ * as a 409.
+ */
+function DeleteProviderDialog({
+  project,
+  provider,
+  liveLeaseCount,
+  leasesKnown,
+  onClose,
+  onDeleted,
+}: {
+  project: ProjectRef;
+  provider: DynamicProvider;
+  liveLeaseCount: number;
+  leasesKnown: boolean;
+  onClose: () => void;
+  onDeleted: (origin: string, revokedCount: number) => void;
+}) {
+  const dialog = useModalDialog();
+  const remove = useDeleteDynamicProvider(project);
+  const [revokeAll, setRevokeAll] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  // A lease that appeared AFTER the cached count was read makes the server refuse
+  // with 409 even though this dialog thought there were none. Latch that so the
+  // cascade option appears and the operator can confirm and retry, rather than
+  // being stuck behind a hidden checkbox.
+  const [serverDemandsCascade, setServerDemandsCascade] = useState(false);
+
+  // With a known live-lease count the cascade is a required, explicit tick; when
+  // the lease listing could not be read the count is unknown, so the checkbox is
+  // offered; and a 409 from the server's own guard forces it on either way.
+  const cascadeRequired = (leasesKnown && liveLeaseCount > 0) || serverDemandsCascade;
+  const showCascade = cascadeRequired || !leasesKnown;
+  const confirmDisabled = busy || (cascadeRequired && !revokeAll);
+
+  const submit = async () => {
+    setBusy(true);
+    setFailure(null);
+    try {
+      const result = await remove.mutateAsync({ provider: provider.id, revokeAll });
+      onDeleted(provider.origin, result.revoked_lease_ids.length);
+    } catch (error) {
+      // The server's own live-leases guard (409) can fire on a lease that
+      // appeared after the cached count: reveal the cascade so a retry can carry it.
+      if (error instanceof ApiError && error.status === 409) {
+        setServerDemandsCascade(true);
+      }
+      setFailure(deleteProviderRefusalText(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useNavigationGuard(busy, () => {});
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="delete-provider-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="delete-provider-title">
+        {`Delete provider · ${provider.origin}`}
+      </h2>
+      <p className="ceremony__cap" role="status">
+        <span className="alert__glyph" aria-hidden="true">
+          !
+        </span>
+        <span>
+          {leasesKnown
+            ? liveLeaseCount === 0
+              ? 'This provider has no live leases. Deleting it removes its configuration and its stored credential. This cannot be undone.'
+              : `This provider has ${String(liveLeaseCount)} live lease${liveLeaseCount === 1 ? '' : 's'}. Deleting it queues ${liveLeaseCount === 1 ? 'that lease' : 'each of them'} for revocation, then removes the provider. This cannot be undone.`
+            : 'The lease listing could not be read, so the number of live leases is unknown. If any exist, confirm the cascade below or the delete will be refused.'}
+        </span>
+      </p>
+
+      {showCascade ? (
+        <div className="field chk">
+          <input
+            id="delete-provider-cascade"
+            type="checkbox"
+            checked={revokeAll}
+            disabled={busy}
+            onChange={(event) => {
+              setRevokeAll(event.target.checked);
+              setFailure(null);
+            }}
+          />
+          <label htmlFor="delete-provider-cascade">
+            Revoke every live lease of this provider as part of the delete.
+          </label>
+        </div>
+      ) : null}
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <TypedNameConfirm
+        label="Confirm the provider origin to delete it"
+        expect={provider.origin}
+        action="Delete provider"
+        hint={
+          <>
+            Type <span className="mono">{provider.origin}</span> to enable deletion.
+          </>
+        }
+        busy={confirmDisabled}
+        onConfirm={() => void submit()}
+      />
+
+      <div className="ceremony__actions">
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+/**
+ * LeaseMintDialog is the display-once lease mint.
+ *
+ * It reuses the mint lifecycle (request-addressed completion, stored-confirmation
+ * gate, boundary masking) that the credential mint runs on. A human mint takes a
+ * passkey reauthentication over the chosen environment, then the server discloses
+ * the role name and its password EXACTLY once — a retry is a new lease, never the
+ * old secret.
+ */
+function LeaseMintDialog({
+  project,
+  sessionId,
+  providers,
+  environments,
+  lifecycle,
+  move,
+  isSubmitting,
+  nextRequestId,
+  onClose,
+}: {
+  project: ProjectRef;
+  sessionId: string | null;
+  providers: readonly DynamicProvider[];
+  environments: readonly EnvOption[];
+  lifecycle: MintLifecycle<LeaseMintRequest, LeaseMinted>;
+  move: MoveMint<LeaseMintRequest, LeaseMinted>;
+  isSubmitting: IsMintSubmitting;
+  nextRequestId: () => number;
+  onClose: () => void;
+}) {
+  const dialog = useModalDialog();
+  const refreshLeases = useRefreshLeases(project);
+  const confirmation = useRef<HTMLInputElement>(null);
+  const [providerId, setProviderId] = useState(providers[0]?.id ?? '');
+  const [environmentId, setEnvironmentId] = useState(environments[0]?.id ?? '');
+  const [ttl, setTtl] = useState('3600');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const disclosed = lifecycle.kind === 'disclosed' ? lifecycle : null;
+  const disclosedValue = disclosed?.result.password ?? null;
+  const busy = lifecycle.kind === 'submitting';
+  const failure = lifecycle.kind === 'failed' ? lifecycle.error : null;
+
+  useEffect(() => {
+    if (disclosedValue !== null) {
+      confirmation.current?.focus();
+    }
+  }, [disclosedValue]);
+
+  const run = async () => {
+    if (sessionId === null) {
+      setFormError('The current session could not be read. Reload before minting a lease.');
+      return;
+    }
+    const provider = providers.find((p) => p.id === providerId);
+    const environment = environments.find((e) => e.id === environmentId);
+    if (provider === undefined || environment === undefined) {
+      setFormError('Choose a provider and an environment.');
+      return;
+    }
+    const seconds = Number(ttl);
+    if (!Number.isInteger(seconds) || seconds <= 0) {
+      setFormError('Enter the maximum lifetime as a whole number of seconds.');
+      return;
+    }
+    setFormError(null);
+    const request: LeaseMintRequest = {
+      id: nextRequestId(),
+      sessionId,
+      org: project.org,
+      project: project.project,
+      providerId: provider.id,
+      providerLabel: provider.origin,
+      environmentId: environment.id,
+      environmentName: environment.name,
+      maxTtlSeconds: seconds,
+    };
+    const reviewed = move({ type: 'review', request });
+    if (!reviewed.accepted || reviewed.state.kind !== 'reviewing') {
+      return;
+    }
+    const started = move({ type: 'submit' });
+    if (!started.accepted || started.state.kind !== 'submitting') {
+      return;
+    }
+    const active = started.state.request;
+    // `issued` is the difference between "nothing happened" and "a live role
+    // whose password is gone forever": once the mint request leaves, a failure
+    // says nothing about whether the server committed.
+    let issued = false;
+    try {
+      await runPasskeyCeremony({
+        operation: 'mint',
+        environmentId: active.environmentId,
+        keyIds: [],
+      });
+      if (!isSubmitting(active.id)) {
+        return;
+      }
+      issued = true;
+      const minted = await mintLease(
+        { org: active.org, project: active.project, environment: active.environmentId },
+        { providerId: active.providerId, maxTtlSeconds: active.maxTtlSeconds },
+      );
+      move({ type: 'succeeded', requestId: active.id, result: minted });
+      refreshLeases(active.environmentId);
+    } catch (error) {
+      if (issued) {
+        refreshLeases(active.environmentId);
+        move({ type: 'failed', requestId: active.id, error: leaseMintFailureText(error) });
+      } else {
+        move({ type: 'failed', requestId: active.id, error: leaseMintRefusalText(error) });
+      }
+    }
+  };
+
+  const dismiss = () => {
+    if (lifecycle.kind === 'idle') {
+      onClose();
+      return;
+    }
+    const result = move({ type: 'dismiss' });
+    if (result.state.kind === 'idle') {
+      onClose();
+    }
+  };
+
+  useNavigationGuard(busy || (disclosed !== null && !disclosed.stored), dismiss);
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="lease-mint-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        dismiss();
+      }}
+    >
+      {disclosed === null ? (
+        <>
+          <h2 className="ceremony__title" id="lease-mint-title">
+            Mint dynamic-secret lease
+          </h2>
+          <p className="ceremony__stepup">
+            <span className="alert__glyph" aria-hidden="true">
+              ⚿
+            </span>
+            <span>
+              <strong>Confirm it&apos;s you.</strong> The password is delivered display-once, to you.
+              A human mint takes a passkey reauthentication over the chosen environment and a
+              disclosure capability there.
+            </span>
+          </p>
+
+          <fieldset className="machine__lock" disabled={busy}>
+            <div className="field">
+              <label htmlFor="lease-mint-provider">Provider</label>
+              <select
+                id="lease-mint-provider"
+                value={providerId}
+                onChange={(event) => {
+                  setProviderId(event.target.value);
+                  setFormError(null);
+                }}
+              >
+                {providers.map((provider) => (
+                  <option key={provider.id} value={provider.id}>
+                    {provider.origin}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="field">
+              <label htmlFor="lease-mint-environment">Environment</label>
+              <select
+                id="lease-mint-environment"
+                value={environmentId}
+                onChange={(event) => {
+                  setEnvironmentId(event.target.value);
+                  setFormError(null);
+                }}
+              >
+                {environments.map((environment) => (
+                  <option key={environment.id} value={environment.id}>
+                    {environment.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="field">
+              <label htmlFor="lease-mint-ttl">Maximum lifetime (seconds)</label>
+              <input
+                id="lease-mint-ttl"
+                className="mono"
+                inputMode="numeric"
+                value={ttl}
+                onChange={(event) => {
+                  setTtl(event.target.value);
+                  setFormError(null);
+                }}
+              />
+            </div>
+          </fieldset>
+          <p className="ceremony__scope">
+            The provider clamps the lifetime to its own ceiling, and PostgreSQL enforces expiry with{' '}
+            <code>VALID UNTIL</code> even if Hikyo is down.
+          </p>
+
+          {formError !== null ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>{formError}</span>
+            </p>
+          ) : null}
+          {failure !== null ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>{failure}</span>
+            </p>
+          ) : null}
+
+          <div className="ceremony__actions">
+            <button
+              className="btn btn--primary"
+              type="button"
+              disabled={busy}
+              onClick={() => void run()}
+            >
+              {busy ? 'Minting…' : 'Use a passkey and mint'}
+            </button>
+            <button className="btn" type="button" onClick={dismiss} disabled={busy}>
+              Cancel
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <h2 className="ceremony__title" id="lease-mint-title">
+            Lease minted — shown exactly once
+          </h2>
+          <div className="field">
+            <label htmlFor="lease-mint-username">Role name</label>
+            <p className="mono machine__token" id="lease-mint-username">
+              {disclosed.result.username}
+            </p>
+          </div>
+          <div className="field">
+            <label htmlFor="lease-mint-password">Password</label>
+            <p className="mono machine__token" id="lease-mint-password">
+              {disclosed.result.password}
+            </p>
+          </div>
+          {disclosed.result.expires_at !== undefined && disclosed.result.expires_at !== null ? (
+            <p className="notice" role="status">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>{`This lease expires ${isoDay(disclosed.result.expires_at)}. The provider may have shortened the lifetime you asked for.`}</span>
+            </p>
+          ) : null}
+          <p className="ceremony__cap" role="status">
+            <span className="alert__glyph" aria-hidden="true">
+              !
+            </span>
+            <span>
+              This password is never retrievable again. The list shows metadata only, and a renewal
+              never returns it. Store it in the consuming workload now; if it is lost, revoke this
+              lease and mint a fresh one.
+            </span>
+          </p>
+          <button
+            className="btn"
+            type="button"
+            onClick={async () => {
+              const result = await writeClipboard(disclosed.result.password);
+              move({
+                type: 'copy-status',
+                requestId: disclosed.request.id,
+                message:
+                  result === 'ok'
+                    ? 'Copied. The clipboard is now the only copy outside its target system.'
+                    : 'This browser refused clipboard access, so nothing was copied.',
+              });
+            }}
+          >
+            Copy password
+          </button>
+          {disclosed.copyStatus === null ? null : (
+            <p className="notice" role="status">
+              <span className="alert__glyph" aria-hidden="true">
+                ⧉
+              </span>
+              <span>{disclosed.copyStatus}</span>
+            </p>
+          )}
+          <div className="field chk">
+            <input
+              id="lease-mint-stored"
+              type="checkbox"
+              ref={confirmation}
+              checked={disclosed.stored}
+              onChange={(event) => {
+                move({ type: 'confirm-stored', stored: event.target.checked });
+              }}
+            />
+            <label htmlFor="lease-mint-stored">
+              I have stored this password in its target workload.
+            </label>
+          </div>
+          {disclosed.heldBack ? (
+            <p className="alert" role="alert">
+              <span className="alert__glyph" aria-hidden="true">
+                !
+              </span>
+              <span>Confirm you have stored it — there is no second look at this password.</span>
+            </p>
+          ) : null}
+          <div className="ceremony__actions">
+            <button className="btn btn--primary" type="button" onClick={dismiss}>
+              Done
+            </button>
+          </div>
+        </>
+      )}
+    </dialog>
+  );
+}
+
+/**
+ * LeaseActionDialog confirms and queues a renew, revoke or settle. Each is
+ * QUEUED: the server records the intent and the worker carries it out, so the
+ * copy says "queued" rather than promising a done state the row does not yet
+ * show. Renew offers an optional new ceiling; revoke and settle are one-tap.
+ */
+function LeaseActionDialog({
+  project,
+  action,
+  onClose,
+  onDone,
+}: {
+  project: ProjectRef;
+  action: LeaseAction;
+  onClose: () => void;
+  onDone: (message: string) => void;
+}) {
+  const dialog = useModalDialog();
+  const renew = useRenewLease(project);
+  const revoke = useRevokeLease(project);
+  const settle = useSettleLease(project);
+  const [ttl, setTtl] = useState('');
+  const [failure, setFailure] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const handle = action.lease.provider_handle;
+
+  const submit = async () => {
+    setBusy(true);
+    setFailure(null);
+    try {
+      if (action.verb === 'renew') {
+        let seconds: number | null = null;
+        if (ttl.trim() !== '') {
+          const parsed = Number(ttl);
+          if (!Number.isInteger(parsed) || parsed <= 0) {
+            setFailure('Enter the new ceiling as a whole number of seconds, or leave it blank.');
+            setBusy(false);
+            return;
+          }
+          seconds = parsed;
+        }
+        await renew.mutateAsync({
+          environment: action.environmentId,
+          lease: action.lease.id,
+          maxTtlSeconds: seconds,
+        });
+        onDone(`Queued a renewal of ${handle}. The worker extends the role; the row moves when it does.`);
+      } else if (action.verb === 'revoke') {
+        await revoke.mutateAsync({ environment: action.environmentId, lease: action.lease.id });
+        onDone(`Queued the revocation of ${handle}. The worker drops the role; the row moves when it does.`);
+      } else {
+        await settle.mutateAsync({ environment: action.environmentId, lease: action.lease.id });
+        onDone(`Queued a reconcile of ${handle}. The worker re-probes the provider and settles the lease.`);
+      }
+    } catch (error) {
+      setFailure(leaseActionRefusalText(action.verb, error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useNavigationGuard(busy, () => {});
+
+  const title =
+    action.verb === 'renew'
+      ? `Renew lease · ${handle}`
+      : action.verb === 'revoke'
+        ? `Revoke lease · ${handle}`
+        : `Settle lease · ${handle}`;
+
+  const lede =
+    action.verb === 'renew'
+      ? 'Queues a renewal: the worker extends the role at the provider, never past the lease’s maximum TTL. Renewal re-checks read over this environment.'
+      : action.verb === 'revoke'
+        ? 'Queues a revocation: the worker drops the role at the provider. This is the fail-safe teardown — it succeeds even after the workload’s grants are gone.'
+        : 'This lease is in an ambiguous state. Settling re-triggers reconcile: the worker re-probes the provider and settles the lease to its true state.';
+
+  return (
+    <dialog
+      className="ceremony"
+      aria-labelledby="lease-action-title"
+      ref={dialog}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!busy) {
+          onClose();
+        }
+      }}
+    >
+      <h2 className="ceremony__title" id="lease-action-title">
+        {title}
+      </h2>
+      <p className="ceremony__lede">{lede}</p>
+
+      {action.verb === 'renew' ? (
+        <fieldset className="machine__lock" disabled={busy}>
+          <div className="field">
+            <label htmlFor="lease-action-ttl">New maximum lifetime (seconds, optional)</label>
+            <input
+              id="lease-action-ttl"
+              className="mono"
+              inputMode="numeric"
+              value={ttl}
+              placeholder="leave blank to keep the current ceiling"
+              onChange={(event) => {
+                setTtl(event.target.value);
+                setFailure(null);
+              }}
+            />
+          </div>
+        </fieldset>
+      ) : null}
+
+      {failure !== null ? (
+        <p className="alert" role="alert">
+          <span className="alert__glyph" aria-hidden="true">
+            !
+          </span>
+          <span>{failure}</span>
+        </p>
+      ) : null}
+
+      <div className="ceremony__actions">
+        <button
+          className="btn btn--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => void submit()}
+        >
+          {busy
+            ? 'Queuing…'
+            : action.verb === 'renew'
+              ? 'Queue renewal'
+              : action.verb === 'revoke'
+                ? 'Queue revocation'
+                : 'Queue reconcile'}
+        </button>
+        <button className="btn" type="button" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </dialog>
   );
 }

--- a/web/src/routes/mintLifecycle.test.ts
+++ b/web/src/routes/mintLifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   type MintLifecycle,
   type MintBoundary,
   type MintRequest,
+  type MintResult,
 } from './mintLifecycle.ts';
 
 const SENTINEL = 'hik_1_wl_SENTINEL_PLAINTEXT';
@@ -42,7 +43,10 @@ const request = (id: number, accountId = 'mch_first'): MintRequest => ({
 });
 
 function submitting(input: MintRequest): MintLifecycle {
-  const reviewing = transitionMintLifecycle(idleMintLifecycle, { type: 'review', request: input });
+  const reviewing = transitionMintLifecycle<MintRequest, MintResult>(idleMintLifecycle, {
+    type: 'review',
+    request: input,
+  });
   return transitionMintLifecycle(reviewing, { type: 'submit' });
 }
 

--- a/web/src/routes/mintLifecycle.ts
+++ b/web/src/routes/mintLifecycle.ts
@@ -1,3 +1,17 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * The fields every mint request carries so the lifecycle can address a response
+ * to the request that started it and mask it at a session/route boundary. A
+ * concrete request type (machine credential, dynamic lease) extends this.
+ */
+export type MintBoundaryFields = {
+  readonly id: number;
+  readonly sessionId: string;
+  readonly org: string;
+  readonly project: string;
+};
+
 /**
  * Non-secret inputs frozen when the operator opens mint review.
  *
@@ -5,11 +19,7 @@
  * addressed account, the review labels, and the disclosure environments. It
  * must not inherit unrelated query data or any credential response field.
  */
-export type MintRequest = {
-  readonly id: number;
-  readonly sessionId: string;
-  readonly org: string;
-  readonly project: string;
+export type MintRequest = MintBoundaryFields & {
   readonly accountId: string;
   readonly accountName: string;
   readonly rotating: boolean;
@@ -21,24 +31,32 @@ export type MintResult = {
   readonly clamped: boolean;
 };
 
-export type MintLifecycle =
+/**
+ * Closed display-once mint state machine, generic over the request it addresses
+ * and the disclosed result it carries. The machine-credential mint (`MintRequest`
+ * / `MintResult`) is the default instantiation; the dynamic-lease mint supplies
+ * its own request and result. The security-critical parts — request-addressed
+ * completion, the stored-confirmation gate, boundary masking — are identical for
+ * both, so they live here once.
+ */
+export type MintLifecycle<Req extends MintBoundaryFields = MintRequest, Res = MintResult> =
   | { readonly kind: 'idle' }
-  | { readonly kind: 'reviewing'; readonly request: MintRequest }
-  | { readonly kind: 'submitting'; readonly request: MintRequest }
-  | { readonly kind: 'failed'; readonly request: MintRequest; readonly error: string }
+  | { readonly kind: 'reviewing'; readonly request: Req }
+  | { readonly kind: 'submitting'; readonly request: Req }
+  | { readonly kind: 'failed'; readonly request: Req; readonly error: string }
   | {
       readonly kind: 'disclosed';
-      readonly request: MintRequest;
-      readonly result: MintResult;
+      readonly request: Req;
+      readonly result: Res;
       readonly stored: boolean;
       readonly heldBack: boolean;
       readonly copyStatus: string | null;
     };
 
-export type MintLifecycleEvent =
-  | { readonly type: 'review'; readonly request: MintRequest }
+export type MintLifecycleEvent<Req extends MintBoundaryFields = MintRequest, Res = MintResult> =
+  | { readonly type: 'review'; readonly request: Req }
   | { readonly type: 'submit' }
-  | { readonly type: 'succeeded'; readonly requestId: number; readonly result: MintResult }
+  | { readonly type: 'succeeded'; readonly requestId: number; readonly result: Res }
   | { readonly type: 'failed'; readonly requestId: number; readonly error: string }
   | { readonly type: 'confirm-stored'; readonly stored: boolean }
   | { readonly type: 'copy-status'; readonly requestId: number; readonly message: string }
@@ -48,7 +66,12 @@ export type MintLifecycleEvent =
       readonly reason: 'close' | 'navigation' | 'session-transition';
     };
 
-export const idleMintLifecycle: MintLifecycle = { kind: 'idle' };
+/**
+ * The idle state, typed as the bare `idle` variant so it is assignable to every
+ * `MintLifecycle` instantiation and never drives type-parameter inference when
+ * passed as the starting state.
+ */
+export const idleMintLifecycle: { readonly kind: 'idle' } = { kind: 'idle' };
 
 export type MintBoundary = {
   readonly sessionId: string | null;
@@ -57,10 +80,10 @@ export type MintBoundary = {
 };
 
 /** Mask lifecycle state synchronously when its route or session no longer owns it. */
-export function mintLifecycleAtBoundary(
-  state: MintLifecycle,
+export function mintLifecycleAtBoundary<Req extends MintBoundaryFields, Res>(
+  state: MintLifecycle<Req, Res>,
   boundary: MintBoundary,
-): MintLifecycle {
+): MintLifecycle<Req, Res> {
   if (state.kind === 'idle') {
     return state;
   }
@@ -68,7 +91,7 @@ export function mintLifecycleAtBoundary(
     state.request.org === boundary.org &&
     state.request.project === boundary.project
     ? state
-    : idleMintLifecycle;
+    : { kind: 'idle' };
 }
 
 /**
@@ -79,10 +102,10 @@ export function mintLifecycleAtBoundary(
  * submitting render. Async completion is request-addressed, so an old response
  * cannot put plaintext back after navigation, a new mint, or a session exit.
  */
-export function transitionMintLifecycle(
-  state: MintLifecycle,
-  event: MintLifecycleEvent,
-): MintLifecycle {
+export function transitionMintLifecycle<Req extends MintBoundaryFields, Res>(
+  state: MintLifecycle<Req, Res>,
+  event: MintLifecycleEvent<Req, Res>,
+): MintLifecycle<Req, Res> {
   switch (event.type) {
     case 'review':
       return { kind: 'reviewing', request: event.request };
@@ -120,8 +143,91 @@ export function transitionMintLifecycle(
       if (state.kind === 'disclosed' && !state.stored) {
         return { ...state, heldBack: true };
       }
-      return idleMintLifecycle;
+      return { kind: 'idle' };
     case 'clear':
-      return state.kind === 'idle' ? state : idleMintLifecycle;
+      return state.kind === 'idle' ? state : { kind: 'idle' };
   }
+}
+
+/** The result of applying an event: the next state and whether it changed. */
+export type MintTransitionResult<Req extends MintBoundaryFields, Res> = {
+  readonly state: MintLifecycle<Req, Res>;
+  readonly accepted: boolean;
+};
+
+export type MoveMint<Req extends MintBoundaryFields = MintRequest, Res = MintResult> = (
+  event: MintLifecycleEvent<Req, Res>,
+) => MintTransitionResult<Req, Res>;
+
+export type IsMintSubmitting = (requestId: number) => boolean;
+
+/**
+ * useMintLifecycle wires one display-once mint: the render state, a synchronous
+ * ref that async completions read (so a late response sees the current state,
+ * never a stale closure), and the three boundary clears — navigation, session
+ * replacement, unmount — that keep a disclosed value from surviving into a
+ * context that no longer owns it. Both the machine-credential mint and the
+ * dynamic-lease mint run on one of these.
+ */
+export function useMintLifecycle<Req extends MintBoundaryFields = MintRequest, Res = MintResult>(
+  boundary: MintBoundary,
+): {
+  readonly lifecycle: MintLifecycle<Req, Res>;
+  readonly active: MintLifecycle<Req, Res>;
+  readonly moveMint: MoveMint<Req, Res>;
+  readonly isSubmitting: IsMintSubmitting;
+  readonly nextRequestId: () => number;
+} {
+  const [lifecycle, setLifecycle] = useState<MintLifecycle<Req, Res>>({ kind: 'idle' });
+  const lifecycleRef = useRef<MintLifecycle<Req, Res>>(lifecycle);
+  const boundaryRef = useRef<MintBoundary>(boundary);
+  boundaryRef.current = boundary;
+  const requestId = useRef(0);
+
+  const moveMint = useCallback<MoveMint<Req, Res>>((event) => {
+    const current = lifecycleRef.current;
+    const next = transitionMintLifecycle(current, event);
+    lifecycleRef.current = next;
+    if (next !== current) {
+      setLifecycle(next);
+    }
+    return { state: next, accepted: next !== current };
+  }, []);
+
+  const isSubmitting = useCallback<IsMintSubmitting>((id) => {
+    const current = mintLifecycleAtBoundary(lifecycleRef.current, boundaryRef.current);
+    return current.kind === 'submitting' && current.request.id === id;
+  }, []);
+
+  // A project route is a new mint boundary. Clear before any completion from
+  // the old route can publish its display-once response into this one.
+  useEffect(() => {
+    moveMint({ type: 'clear', reason: 'navigation' });
+  }, [moveMint, boundary.org, boundary.project]);
+
+  // Session replacement is a harder boundary than navigation: even if the route
+  // remains mounted, no disclosure from the old browser session may survive.
+  useEffect(() => {
+    moveMint({ type: 'clear', reason: 'session-transition' });
+  }, [moveMint, boundary.sessionId]);
+
+  // Wipe the synchronous ref on unmount too, so an already-resolving promise
+  // sees idle and drops its late result.
+  useEffect(
+    () => () => {
+      lifecycleRef.current = { kind: 'idle' };
+    },
+    [],
+  );
+
+  return {
+    lifecycle,
+    active: mintLifecycleAtBoundary(lifecycle, boundary),
+    moveMint,
+    isSubmitting,
+    nextRequestId: () => {
+      requestId.current += 1;
+      return requestId.current;
+    },
+  };
 }


### PR DESCRIPTION
Closes #595. Follows #147, which shipped the dynamic-secrets server, API, CLI, audit, metrics, and a read-only Leases tab. **WebUI-only**: every operation already existed; no server, contract, migration, CLI, or generated-code change.

## What landed

**Providers tab** (`machine-access`, project-scoped)
- List providers (kind, origin, grant role, credential presence + set date, state). The admin credential is never listed.
- Configure a provider — `postgres` kind, origin, grant role, write-only credential. The server probes the origin with the credential before storing, so a create that succeeds is reachable and authenticated. No passkey: configuring standing project authority is `manage-identities`.
- Set/replace and revoke the write-only credential. Revoke states the fail-closed consequence: existing leases stay minted at the provider but the worker can no longer renew/revoke/expire them until a replacement is set.
- Delete behind a typed-**origin** confirm, with the live-lease cascade guard (`revoke_all`) surfaced and required when there are live leases.

**Leases tab** — write actions on the existing listing
- Display-once mint: a `mint`-purpose passkey reauthentication over the chosen environment, then the role name and password disclosed **exactly once** and never cached (`mintLease` is a plain async call, like `mintCredential`).
- Per-row renew / revoke / settle, gated by the server's own state guards (renew ← `active`; revoke ← any non-terminal; settle ← `unknown`), worded as **queued** transitions the worker carries out.

## Reuse

The display-once mint state machine (`mintLifecycle.ts`) was generalized over its request/result with **defaults equal to the machine-credential types** — zero runtime change to the shipped credential mint — and its wiring extracted into `useMintLifecycle`, now backing both mints.

## Parity

`api/parity.yaml`: the ten `{issue: 595}` rows → `{webui: machine-access}`. `showDynamicProvider` is a `via: [listDynamicProviders]` row (its `Op` is deliberately not imported; the list row carries every field).

## Tests / review

- Typecheck clean; full vitest (681) green, incl. new per-verb refusal-mapper tests; `go test ./api` (parity) green.
- e2e `machine-access.spec.ts` desktop + mobile (18 each) green, incl. pinned axe/contrast + 44px assertions; tab count 4→5.
- Blocking cross-model Codex review (high effort): R1 found and fixed a HIGH (credential-bearing writes cached the plaintext admin credential in TanStack mutation variables → converted to plain async) and a MEDIUM (delete dialog could not reveal the cascade after a concurrent-lease 409 → latch), R2 **CLEAN**.

Handoff: `docs/handoff/595-dynamic-secrets-webui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)