### PR TITLE
WebUI: project- and environment-scoped audit trail pages and exports (#572)

### DIFF
--- a/api/parity.yaml
+++ b/api/parity.yaml
@@ -345,10 +345,12 @@ operations:
   queryOrgAudit:               {webui: audit}
   # A plain same-origin download link; the browser streams the JSONL itself.
   exportOrgAudit:              {webui: audit, reach: path}
-  queryProjectAudit:           {issue: 572}
-  exportProjectAudit:          {issue: 572}
-  queryEnvAudit:               {issue: 572}
-  exportEnvAudit:              {issue: 572}
+  queryProjectAudit:           {webui: project-audit}
+  exportProjectAudit:          {webui: project-audit, reach: path}
+  queryEnvAudit:               {webui: project-audit}
+  # Environment scope is a filter on the project-audit page; both env operations
+  # are reached from it (the picker switches the query and the export link).
+  exportEnvAudit:              {webui: project-audit, reach: path}
 
   # instance
   rotateTokenKey:              {webui: instance-admin}

--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { expect, type Page } from '@playwright/test';
 import {
   zDefinitionsSettings,
@@ -14,6 +16,7 @@ import { z } from 'zod';
 import { expectPinnedAssertionSet, expectStatusIsTextAndAria } from '../fixtures/assertions.ts';
 import { BrowserApiError, browserApi } from '../fixtures/api.ts';
 import {
+  BASE_URL,
   establishSession,
   readSeed,
   STORAGE_STATE,
@@ -643,6 +646,224 @@ test.describe('project settings', () => {
     await expect(refusal).toBeVisible();
   });
 
+});
+
+/**
+ * Flow: project- and environment-scoped audit (registry surface `project-audit`,
+ * #572). It rides this file for the reason the registry spells out: the merge
+ * gate loads `ci.yml` from the base branch, so a spec a PR adds to a group never
+ * runs on that PR. settings.spec.ts is already in group 2 and is the
+ * project-scoped sibling surface, so the surface's pinned set runs from
+ * PR-checked-out content today. The bootstrap administrator holds `audit-read`
+ * (seeded break-glass at instance scope, inheriting down to this project), so
+ * the project and environment trails are readable.
+ */
+const PROJECT_AUDIT_PATH = `/orgs/${seed.org}/projects/${seed.project}/audit`;
+const PROJECT_AUDIT_SURFACES = surfacesForFlow('project-audit');
+
+test.describe('project audit trail', () => {
+  test.use({ storageState: STORAGE_STATE });
+
+  test('reads the project trail, scopes to an environment, and exports both', async ({ page }) => {
+    await page.goto(PROJECT_AUDIT_PATH);
+    await expect(page.getByRole('heading', { name: 'Audit', level: 1 })).toBeVisible();
+    await expect(page.getByText('Every recorded event in this project')).toBeVisible();
+
+    // The seed created this project's keys and published values, so the trail
+    // is not empty. A project-scoped holder reaches it without an org proof.
+    await expect(page.locator('.audit__row').first()).toBeVisible();
+
+    // The project export is a same-origin GET under the session cookie; the
+    // browser streams JSONL to disk.
+    const projectDownload = page.waitForEvent('download');
+    await page.getByRole('link', { name: 'Export JSONL' }).click();
+    const projectFile = await projectDownload;
+    expect(projectFile.suggestedFilename()).toMatch(/\.jsonl$/);
+    expect(readFileSync(await projectFile.path(), 'utf8').trim().length).toBeGreaterThan(0);
+
+    // Narrowing to an environment switches to the environment operations and
+    // carries the id in the URL, so a reload resolves the same environment.
+    await page.getByLabel('Environment').selectOption(seed.dev);
+    await expect(page).toHaveURL(new RegExp(`environment=${seed.dev}`));
+    await expect(page.getByText('Every recorded event in this environment')).toBeVisible();
+    await expect(page.locator('.audit__row').first()).toBeVisible();
+
+    // The export link now points at the environment operation's path.
+    const exportLink = page.getByRole('link', { name: 'Export JSONL' });
+    await expect(exportLink).toHaveAttribute(
+      'href',
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/environments/${seed.dev}/audit/export`,
+    );
+    const envDownload = page.waitForEvent('download');
+    await exportLink.click();
+    const envFile = await envDownload;
+    expect(envFile.suggestedFilename()).toMatch(/\.jsonl$/);
+  });
+
+  test('renders the scoped forbidden state instead of a blank table on 403', async ({ page }) => {
+    // A project holder who may NOT read this trail must see the refusal, never
+    // an empty table read as "no events".
+    const auditRead = new RegExp(
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/audit(\\?|$)`,
+    );
+    await page.route(auditRead, (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'forbidden', message: 'forbidden' } }),
+      }),
+    );
+    try {
+      await page.goto(PROJECT_AUDIT_PATH);
+      await expect(page.locator('.audit__empty[role="alert"]')).toContainText(
+        'This trail is not available, or you may not read it.',
+      );
+      await expect(page.locator('.audit__row')).toHaveCount(0);
+    } finally {
+      await page.unroute(auditRead);
+    }
+  });
+
+  test('keeps the trail and the scope escape when the environment list cannot be read', async ({
+    page,
+  }) => {
+    // The picker's list load is independent of the trail: a holder who cannot
+    // read the environment list still reads the project trail, and the picker
+    // stays usable so a deep link that pinned an environment is not a trap.
+    const envList = new RegExp(
+      `/api/v1/orgs/${seed.org}/projects/${seed.project}/environments(\\?|$)`,
+    );
+    await page.route(envList, (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'forbidden', message: 'forbidden' } }),
+      }),
+    );
+    try {
+      // Land already pinned to an environment: the list read fails, but the
+      // trail must still load and the "All environments" escape must remain.
+      await page.goto(`${PROJECT_AUDIT_PATH}?environment=${seed.dev}`);
+      const picker = page.getByLabel('Environment');
+      await expect(picker).toBeEnabled();
+      await expect(page.getByText('The environment list could not be read')).toBeVisible();
+      await expect(page.locator('.audit__row').first()).toBeVisible();
+
+      // Switching back to the project trail is reachable, so the deep link is
+      // recoverable rather than a dead end.
+      await picker.selectOption('');
+      await expect(page).not.toHaveURL(/environment=/);
+      await expect(page.getByText('Every recorded event in this project')).toBeVisible();
+      await expect(page.locator('.audit__row').first()).toBeVisible();
+    } finally {
+      await page.unroute(envList);
+    }
+  });
+
+  test('resets the open detail and filter when the project changes under the same surface', async ({
+    page,
+  }) => {
+    // `audit` and `project-audit` share one keyed element, so a sidebar hop
+    // between two projects reuses the component. An event or a filter from one
+    // project's trail must not carry into another's.
+    await page.goto(PROJECT_AUDIT_PATH);
+    await page.getByLabel('Operation').fill('settings.key_created');
+    await page.getByRole('button', { name: 'Apply filter' }).click();
+    await page.locator('.audit__row').first().click();
+    await expect(page.getByRole('complementary', { name: 'Event detail' })).toBeVisible();
+
+    // Client-side navigation to a DIFFERENT project's audit under the SAME
+    // keyed element (not a reload, which would remount and reset trivially):
+    // the component is reused, so the reset must come from the effect.
+    await page.evaluate((path) => {
+      history.pushState(null, '', path);
+      dispatchEvent(new PopStateEvent('popstate'));
+    }, `/orgs/${seed.org}/projects/${seed.history.project}/audit`);
+    await expect(page).toHaveURL(new RegExp(`${seed.history.project}/audit$`));
+    await expect(page.getByRole('complementary', { name: 'Event detail' })).toBeHidden();
+    await expect(page.getByLabel('Operation')).toHaveValue('');
+  });
+
+  test('closes the open detail when the environment scope changes by URL', async ({ page }) => {
+    // An environment scope switch can arrive by URL (a sidebar link clearing
+    // ?environment, or the back button), bypassing the picker's own path, so
+    // the open detail must still close: it belongs to the prior scope's trail.
+    await page.goto(`${PROJECT_AUDIT_PATH}?environment=${seed.dev}`);
+    await expect(page.getByText('Every recorded event in this environment')).toBeVisible();
+    await page.locator('.audit__row').first().click();
+    await expect(page.getByRole('complementary', { name: 'Event detail' })).toBeVisible();
+
+    // Clear ?environment by client-side navigation, not the picker: the reused
+    // component must still drop the detail from the environment trail.
+    await page.evaluate((path) => {
+      history.pushState(null, '', path);
+      dispatchEvent(new PopStateEvent('popstate'));
+    }, PROJECT_AUDIT_PATH);
+    await expect(page.getByText('Every recorded event in this project')).toBeVisible();
+    await expect(page.getByRole('complementary', { name: 'Event detail' })).toBeHidden();
+  });
+
+  test('refuses a malformed filter at the project boundary', async ({ page }) => {
+    const response = await page.request.get(
+      `${BASE_URL}/api/v1/orgs/${seed.org}/projects/${seed.project}/audit?outcome=not-an-outcome`,
+    );
+    expect(response.status()).toBe(400);
+  });
+
+  for (const scheme of ['dark', 'light'] as const) {
+    for (const surface of PROJECT_AUDIT_SURFACES) {
+      test(`meets the pinned assertion set on ${surface.label} (${scheme})`, async ({
+        page,
+      }, testInfo) => {
+        await page.emulateMedia({ colorScheme: scheme });
+        try {
+          await page.goto(PROJECT_AUDIT_PATH);
+          // Narrow before the sweep: the pinned set focuses, measures and
+          // contrast-checks EVERY interactive element, so a full page of rows
+          // would blow the per-test budget. `settings.key_created` is a small,
+          // always-present set: the seed created this project's keys (the audit
+          // event type, not the authz operation `key.create`).
+          await page.getByLabel('Operation').fill('settings.key_created');
+          await page.getByRole('button', { name: 'Apply filter' }).click();
+          await expect(page.locator('.audit__row').first()).toBeVisible();
+
+          const heading = page.getByRole('heading', { name: 'Audit', level: 1 });
+          // The project page carries a scope panel before the filter, so target
+          // the filter panel by name rather than "first panel".
+          const panel = page.locator('.audit__filter');
+          const op = page.locator('.audit__row-op').first();
+          const badge = page.locator('.chip').first();
+          const apply = page.getByRole('button', { name: 'Apply filter' });
+          const rowDensity = testInfo.project.name === 'mobile' ? '--touch' : '--row';
+
+          await expectPinnedAssertionSet(page, {
+            flow: 'project-audit',
+            surface: surface.id,
+            theme: scheme,
+            text: [heading, op],
+            radii: [
+              [panel, 'container'],
+              [apply, 'control'],
+              [badge, 'badge'],
+            ],
+            fonts: [
+              [heading, 'ui'],
+              [op, 'mono'],
+            ],
+            colours: [
+              [heading, 'color', '--tx'],
+              [panel, 'backgroundColor', '--bg-panel'],
+              [panel, 'borderTopColor', '--panel-line'],
+            ],
+            hairlines: [panel],
+            density: [[apply, rowDensity]],
+          });
+        } finally {
+          await page.emulateMedia({ colorScheme: null });
+        }
+      });
+    }
+  }
 });
 
 test.describe('settings flow visual contract', () => {

--- a/web/e2e/registry.ts
+++ b/web/e2e/registry.ts
@@ -78,6 +78,13 @@ export const FLOWS: readonly Flow[] = [
     spec: 'flows/instance-admin.spec.ts',
     surfaces: ['instance-admin', 'instance-members'],
   },
+  // Project- and environment-scoped audit (#572) is a new SURFACE, so S3
+  // closure demands a flow, but it cannot get its own spec FILE (the merge gate
+  // loads `ci.yml` from the base branch, so a spec a PR adds to a group never
+  // runs on that PR). It rides `settings.spec.ts`, already in group 2 and the
+  // project-scoped sibling surface, so the pinned set runs from PR-checked-out
+  // content today.
+  { id: 'project-audit', spec: 'flows/settings.spec.ts', surfaces: ['project-audit'] },
   { id: 'reveal', spec: 'flows/reveal.spec.ts', surfaces: ['values'] },
   { id: 'matrix', spec: 'flows/matrix.spec.ts', surfaces: ['matrix'] },
   // Secret-scanning warn dialog (#74, SS2/SS4 [UI]) rides the matrix editing

--- a/web/src/api/audit.test.ts
+++ b/web/src/api/audit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { auditExportUrl, emptyAuditFilter, type AuditScope } from './audit.ts';
+
+describe('auditExportUrl', () => {
+  const org: AuditScope = { kind: 'org', org: 'org_1' };
+  const project: AuditScope = { kind: 'project', org: 'org_1', project: 'prj_1' };
+  const env: AuditScope = { kind: 'env', org: 'org_1', project: 'prj_1', environment: 'env_1' };
+
+  it('names the export path of each scope', () => {
+    expect(auditExportUrl(org, emptyAuditFilter)).toBe('/api/v1/orgs/org_1/audit/export');
+    expect(auditExportUrl(project, emptyAuditFilter)).toBe(
+      '/api/v1/orgs/org_1/projects/prj_1/audit/export',
+    );
+    expect(auditExportUrl(env, emptyAuditFilter)).toBe(
+      '/api/v1/orgs/org_1/projects/prj_1/environments/env_1/audit/export',
+    );
+  });
+
+  it('drops empty filter fields and adds no query string when the filter is empty', () => {
+    expect(auditExportUrl(project, emptyAuditFilter)).not.toContain('?');
+    const url = auditExportUrl(project, { ...emptyAuditFilter, outcome: 'denied', actor: '' });
+    expect(url).toBe('/api/v1/orgs/org_1/projects/prj_1/audit/export?outcome=denied');
+  });
+
+  it('encodes scope identifiers so a slash cannot escape the path', () => {
+    const nasty: AuditScope = { kind: 'project', org: 'a/b', project: 'c d' };
+    expect(auditExportUrl(nasty, emptyAuditFilter)).toBe(
+      '/api/v1/orgs/a%2Fb/projects/c%20d/audit/export',
+    );
+  });
+});

--- a/web/src/api/audit.ts
+++ b/web/src/api/audit.ts
@@ -1,4 +1,4 @@
-import { queryOrgAuditOp } from '@hikyo/operations';
+import { queryEnvAuditOp, queryOrgAuditOp, queryProjectAuditOp } from '@hikyo/operations';
 import { zAuditPage } from '@hikyo/zod';
 import { useInfiniteQuery, type UseInfiniteQueryResult, type InfiniteData } from '@tanstack/react-query';
 import type { z } from 'zod';
@@ -7,6 +7,24 @@ import { parsed } from './client.ts';
 
 export type AuditPage = z.infer<typeof zAuditPage>;
 export type AuditEvent = AuditPage['items'][number];
+
+/**
+ * AuditScope is which trail is read. The three server operations share one
+ * query shape (#572); the scope is the only thing that differs, so every
+ * helper below closes over this union rather than duplicating the paging,
+ * the filter serialisation and the export link three times. A project holder
+ * with no org proof reads the project (and its environments') trail; the org
+ * holder reads the whole org trail, exactly as before.
+ */
+export type AuditScope =
+  | { readonly kind: 'org'; readonly org: string }
+  | { readonly kind: 'project'; readonly org: string; readonly project: string }
+  | {
+      readonly kind: 'env';
+      readonly org: string;
+      readonly project: string;
+      readonly environment: string;
+    };
 
 /**
  * The audit outcomes, in the closed order the contract's enum declares them.
@@ -114,23 +132,49 @@ function safeSeq(seq: bigint): number {
   return Number(seq);
 }
 
-export const auditPageKey = (org: string, filter: AuditFilter) =>
-  ['audit', org, filter] as const;
+export const auditPageKey = (scope: AuditScope, filter: AuditFilter) =>
+  ['audit', scope, filter] as const;
 
 /**
- * useAuditTrail pages the org trail. Each page SCANS up to the limit and RETURNS
- * the filtered subset; `getNextPageParam` follows `next_after_seq` and stops
- * only when the server reports the scan reached the trail's end. A sparse filter
- * therefore yields more pages with few or no items — deliberately: the caller
- * drives "load more" so the trail is never walked unbounded, and every page it
- * reads writes its own audit.query event.
+ * scopedPage runs one page of the trail against the operation the scope names.
+ * The three operations share a query shape, so the paging fields are built once
+ * and only the path (and thus the operation) differs. The switch keeps each
+ * branch's Data type concrete, so no cast is needed to reconcile the three.
+ */
+function scopedPage(
+  scope: AuditScope,
+  query: Record<string, string | number>,
+): Promise<AuditPage> {
+  switch (scope.kind) {
+    case 'org':
+      return parsed(queryOrgAuditOp, { path: { org: scope.org }, query });
+    case 'project':
+      return parsed(queryProjectAuditOp, {
+        path: { org: scope.org, project: scope.project },
+        query,
+      });
+    case 'env':
+      return parsed(queryEnvAuditOp, {
+        path: { org: scope.org, project: scope.project, environment: scope.environment },
+        query,
+      });
+  }
+}
+
+/**
+ * useAuditTrail pages the trail the scope names. Each page SCANS up to the limit
+ * and RETURNS the filtered subset; `getNextPageParam` follows `next_after_seq`
+ * and stops only when the server reports the scan reached the trail's end. A
+ * sparse filter therefore yields more pages with few or no items,
+ * deliberately: the caller drives "load more" so the trail is never walked
+ * unbounded, and every page it reads writes its own audit.query event.
  */
 export function useAuditTrail(
-  org: string,
+  scope: AuditScope,
   filter: AuditFilter,
 ): UseInfiniteQueryResult<InfiniteData<AuditPage>, unknown> {
   return useInfiniteQuery({
-    queryKey: auditPageKey(org, filter),
+    queryKey: auditPageKey(scope, filter),
     // The cursor is the trail's int64 seq (bigint end to end). The first page
     // carries no ceiling; the server pins one and returns it as upper_seq, which
     // every later page echoes as to_seq so paging is stable across concurrent
@@ -138,14 +182,11 @@ export function useAuditTrail(
     // cursor is narrowed — guarded — only at the call.
     initialPageParam: { after: 0n, ceiling: 0n } as AuditCursor,
     queryFn: ({ pageParam }) =>
-      parsed(queryOrgAuditOp, {
-        path: { org },
-        query: {
-          ...auditQuery(filter),
-          after_seq: safeSeq(pageParam.after),
-          limit: AUDIT_PAGE_LIMIT,
-          ...(pageParam.ceiling === 0n ? {} : { to_seq: safeSeq(pageParam.ceiling) }),
-        },
+      scopedPage(scope, {
+        ...auditQuery(filter),
+        after_seq: safeSeq(pageParam.after),
+        limit: AUDIT_PAGE_LIMIT,
+        ...(pageParam.ceiling === 0n ? {} : { to_seq: safeSeq(pageParam.ceiling) }),
       }),
     getNextPageParam: (last): AuditCursor | undefined =>
       last.exhausted ? undefined : { after: last.next_after_seq, ceiling: last.upper_seq },
@@ -154,14 +195,28 @@ export function useAuditTrail(
 }
 
 /**
- * auditExportUrl is the JSONL download URL for the current filter. It is a plain
- * same-origin GET so the browser streams the bytes to disk under the session
- * cookie — nothing is buffered in the SPA and no token rides the URL. Paging
- * fields are omitted: the export streams the whole filtered slice.
+ * auditExportUrl is the JSONL download URL for the current scope and filter. It
+ * is a plain same-origin GET so the browser streams the bytes to disk under the
+ * session cookie; nothing is buffered in the SPA and no token rides the URL.
+ * Paging fields are omitted: the export streams the whole filtered slice. Each
+ * scope writes its full path literal so the parity registry (api/parity.yaml)
+ * can prove the SPA reaches the export operation by path.
  */
-export function auditExportUrl(org: string, filter: AuditFilter): string {
+export function auditExportUrl(scope: AuditScope, filter: AuditFilter): string {
   const params = new URLSearchParams(auditQuery(filter));
   const query = params.toString();
-  const base = `/api/v1/orgs/${encodeURIComponent(org)}/audit/export`;
+  const org = encodeURIComponent(scope.org);
+  let base: string;
+  switch (scope.kind) {
+    case 'org':
+      base = `/api/v1/orgs/${org}/audit/export`;
+      break;
+    case 'project':
+      base = `/api/v1/orgs/${org}/projects/${encodeURIComponent(scope.project)}/audit/export`;
+      break;
+    case 'env':
+      base = `/api/v1/orgs/${org}/projects/${encodeURIComponent(scope.project)}/environments/${encodeURIComponent(scope.environment)}/audit/export`;
+      break;
+  }
   return query === '' ? base : `${base}?${query}`;
 }

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -70,7 +70,11 @@ const ELEMENTS: Record<SurfaceId, ReactElement> = {
   members: withRouteFallback(<Members key="members-org" scope={{ kind: 'org' }} />),
   'org-settings': withRouteFallback(<OrgSettings />),
   scim: withRouteFallback(<ScimProvisioning />),
-  audit: withRouteFallback(<Audit />),
+  // Keyed per scope like Members: `audit` and `project-audit` are siblings
+  // under the same Outlet, and React would otherwise carry an open detail, a
+  // draft filter and the environment picker from one scope into the other.
+  audit: withRouteFallback(<Audit key="audit-org" scope="org" />),
+  'project-audit': withRouteFallback(<Audit key="audit-project" scope="project" />),
   'project-settings': withRouteFallback(<ProjectSettings />),
   'change-approvals': withRouteFallback(<ChangeApprovals />),
   'instance-admin': withRouteFallback(<InstanceAdmin />),

--- a/web/src/app/navigation.test.ts
+++ b/web/src/app/navigation.test.ts
@@ -32,6 +32,7 @@ describe('the route policy registry', () => {
       'machine-access:authenticated:shell',
       'change-approvals:authenticated:shell',
       'adapters:authenticated:shell',
+      'project-audit:authenticated:shell',
       'project-settings:authenticated:shell',
       'cli-reauth:ceremony:none',
       'workspace-approve:ceremony:none',
@@ -56,6 +57,7 @@ describe('the route policy registry', () => {
       'machine-access',
       'change-approvals',
       'adapters',
+      'project-audit',
       'project-settings',
     ]);
     expect(sectionsFor('instance').map((s) => s.label)).toEqual([

--- a/web/src/app/navigation.ts
+++ b/web/src/app/navigation.ts
@@ -337,10 +337,26 @@ export const SURFACES = defineSurfaceRegistry([
     mode: 'authenticated',
     chrome: 'shell',
   },
+  // Project- and environment-scoped audit (#572). The org page (`audit`) reads
+  // the WHOLE org trail, so a project-only holder of `audit-read` cannot reach
+  // their trail from the browser through it. This page addresses ONE project,
+  // project-scoped like the matrix: the context block fills `:org`/`:project`
+  // from the route. Environment scope is a `?environment=<id>` filter on this
+  // same page, not a second surface: a reload and a shared link resolve the
+  // same environment, exactly as the matrix's per-key filter does. It sits
+  // beside project settings, the scope its capability addresses.
+  {
+    id: 'project-audit',
+    path: '/orgs/:org/projects/:project/audit',
+    label: 'Project audit',
+    section: 'project',
+    mode: 'authenticated',
+    chrome: 'shell',
+  },
   // Project settings addresses ONE project, exactly like the matrix, and is
   // project-scoped for the same reason (#567): the context block fills the
   // parameters from the route. Table order is sidebar order — matrix, machine
-  // access, deployment adapters, project settings.
+  // access, deployment adapters, project audit, project settings.
   {
     id: 'project-settings',
     path: '/orgs/:org/projects/:project/settings',

--- a/web/src/routes/Audit.tsx
+++ b/web/src/routes/Audit.tsx
@@ -1,5 +1,5 @@
-import { useState, type FormEvent } from 'react';
-import { useParams } from 'react-router';
+import { useEffect, useState, type FormEvent } from 'react';
+import { useParams, useSearchParams } from 'react-router';
 
 import {
   AUDIT_OUTCOMES,
@@ -8,8 +8,10 @@ import {
   useAuditTrail,
   type AuditEvent,
   type AuditFilter,
+  type AuditScope,
 } from '../api/audit.ts';
 import { ApiError } from '../api/client.ts';
+import { useEnvironments } from '../api/settings.ts';
 
 /** A stored UTC timestamp rendered in the operator's locale, or the raw value. */
 function when(value: string): string {
@@ -32,13 +34,58 @@ function refusalText(error: unknown): string {
   return 'The trail could not be read.';
 }
 
-export function Audit() {
+/**
+ * Audit renders one trail, org- or project-scoped (#572). The org page reads
+ * the whole org trail; the project page reads one project's, and an environment
+ * filter narrows it to one environment through the environment operations. The
+ * two are the SAME component with a `scope` prop rather than a copy, so the
+ * filter bar, paging, refusal handling and JSONL export are written once.
+ */
+export function Audit({ scope }: { readonly scope: 'org' | 'project' }) {
   const params = useParams();
   const org = params.org ?? '';
+  const project = params.project ?? '';
+  const [search, setSearch] = useSearchParams();
   const [draft, setDraft] = useState<AuditFilter>(emptyAuditFilter);
   const [applied, setApplied] = useState<AuditFilter>(emptyAuditFilter);
   const [selected, setSelected] = useState<AuditEvent | null>(null);
-  const trail = useAuditTrail(org, applied);
+
+  // The environment picker is a filter on the project page, carried in the URL
+  // (`?environment=<id>`) so a reload and a shared link resolve the same
+  // environment, and so a sidebar hop to another project cannot leave a stale
+  // environment id from the first behind. Its list load is INDEPENDENT of the
+  // trail: a project-only holder of `audit-read` may not read the environment
+  // list, and that must never blank the trail.
+  const isProject = scope === 'project';
+  const environments = useEnvironments(org, isProject ? project : '');
+  const environment = isProject ? search.get('environment') ?? '' : '';
+  const envItems = environments.data?.items ?? [];
+
+  // A scope switch changes :org/:project or ?environment without remounting
+  // this component: the element's key is fixed, so React reuses the instance.
+  // Close the open detail on ANY scope change, tenant or environment, because
+  // the selected event belongs to the trail that was showing — and the switch
+  // can arrive by URL (a sidebar link clearing ?environment, the back button)
+  // and so bypass the picker's own reset.
+  useEffect(() => {
+    setSelected(null);
+  }, [org, project, environment]);
+
+  // A tenant change also clears the filter, so one project's query does not
+  // silently narrow another's. An environment switch within a project keeps
+  // the filter: it is a refinement of the same project's view.
+  useEffect(() => {
+    setDraft(emptyAuditFilter);
+    setApplied(emptyAuditFilter);
+  }, [org, project]);
+
+  const auditScope: AuditScope = !isProject
+    ? { kind: 'org', org }
+    : environment === ''
+      ? { kind: 'project', org, project }
+      : { kind: 'env', org, project, environment };
+
+  const trail = useAuditTrail(auditScope, applied);
 
   const events = trail.data?.pages.flatMap((page) => page.items) ?? [];
   const scannedEnd = trail.hasNextPage !== true;
@@ -58,13 +105,57 @@ export function Audit() {
     setDraft((current) => ({ ...current, [key]: value }));
   }
 
+  function selectEnvironment(next: string) {
+    // The detail is closed by the scope-change effect above, so it is not
+    // cleared here: one source of truth for "scope changed, drop the detail".
+    const params = new URLSearchParams(search);
+    if (next === '') {
+      params.delete('environment');
+    } else {
+      params.set('environment', next);
+    }
+    setSearch(params, { replace: true });
+  }
+
+  const lede = !isProject
+    ? 'Every recorded event in this organisation, oldest first. Reading the trail is itself audited.'
+    : environment === ''
+      ? 'Every recorded event in this project, oldest first. Reading the trail is itself audited.'
+      : 'Every recorded event in this environment, oldest first. Reading the trail is itself audited.';
+
   return (
     <div className="page page--chrome page--audit">
       <h1>Audit</h1>
-      <p className="page__lede">
-        Every recorded event in this organisation, oldest first. Reading the trail is itself
-        audited.
-      </p>
+      <p className="page__lede">{lede}</p>
+
+      {isProject ? (
+        <div className="audit__scope panel">
+          <label className="field">
+            <span className="field__label">Environment</span>
+            {/* Never disabled: "All environments" is the only way back to the
+                project trail, so it must stay reachable even when the list read
+                fails while an environment is selected. When the list cannot be
+                read, the active environment still gets an option (by id) so the
+                current scope is honestly represented and can be switched away. */}
+            <select value={environment} onChange={(event) => selectEnvironment(event.target.value)}>
+              <option value="">All environments in this project</option>
+              {environment !== '' && !envItems.some((env) => env.id === environment) ? (
+                <option value={environment}>{environment}</option>
+              ) : null}
+              {envItems.map((env) => (
+                <option key={env.id} value={env.id}>
+                  {env.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {environments.isError ? (
+            <p className="audit__scope-note alert" role="alert">
+              The environment list could not be read.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
 
       <form className="audit__filter panel" onSubmit={onSubmit} aria-label="Filter the audit trail">
         <div className="audit__filter-grid">
@@ -148,7 +239,7 @@ export function Audit() {
           {/* A plain same-origin GET: the browser streams the JSONL to disk under
               the session cookie, so the SPA never holds the trail in memory and no
               token rides the URL. */}
-          <a className="btn" href={auditExportUrl(org, applied)} download>
+          <a className="btn" href={auditExportUrl(auditScope, applied)} download>
             Export JSONL
           </a>
         </div>

--- a/web/src/routes/sidebar-model.test.ts
+++ b/web/src/routes/sidebar-model.test.ts
@@ -50,6 +50,7 @@ describe('sidebarModel', () => {
       ['Machine access', '/orgs/org_1/projects/prj_1/machine-access'],
       ['Change approvals', '/orgs/org_1/projects/prj_1/change-approvals'],
       ['Deployment adapters', '/orgs/org_1/projects/prj_1/adapters'],
+      ['Project audit', '/orgs/org_1/projects/prj_1/audit'],
       ['Members', '/orgs/org_1/members?project=prj_1'],
       ['Project settings', '/orgs/org_1/projects/prj_1/settings'],
     ]);

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5309,10 +5309,26 @@ select {
    `.page--chrome .panel` supplies their fill, border colour and padding, but a
    bare `.panel` carries no border width or radius of its own (each surface
    states its panels' shape), so DESIGN.md's 6px container is set here. */
+.audit__scope,
 .audit__filter,
 .audit__detail {
   border: 1px solid var(--panel-line);
   border-radius: var(--radius-container);
+}
+
+/* The project page's environment picker (#572): a compact scope panel above
+   the filter. Layout only; it reuses `.field` and the panel base for its
+   tokens, so it holds the pinned assertion set without a second token source. */
+.audit__scope {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.audit__scope-note {
+  margin: 0;
 }
 
 .audit__filter {


### PR DESCRIPTION
Closes #572.

## What

The org audit page reads the whole org trail, so a project-only holder of `audit-read` could not read their trail from the browser at all. This adds a project-scoped audit surface under the project chrome (beside Project settings), with an environment picker that narrows the trail to one environment through the environment operations.

- `web/src/api/audit.ts` is extended by scope (`org | project | env`) rather than duplicated: one `AuditScope` union drives paging, filter serialisation and the JSONL export link. Each export path is a full literal so the parity registry proves reach by path.
- `Audit.tsx` is one component with a `scope` prop; the org and project surfaces render it keyed per scope. Environment lives in `?environment=` so a reload and a shared link resolve the same environment. Because the two surfaces share one keyed element, a scope change (tenant or environment, including URL-driven ones) closes the open detail; a tenant change also clears the filter. The picker's list load is independent of the trail: an environment-list refusal keeps the "All environments" escape reachable and never blanks the project trail. Same 403 forbidden state as the org page.
- `api/parity.yaml` flips the four operations from `issue` to `webui`.
- `project-audit` registered in navigation and the flow registry (rides `settings.spec.ts`, already in `ci.yml` group 2).

## Tests

New flow covers query, environment scoping, both exports, the 403 refusal, the 400 boundary, environment-list-failure resilience, cross-project + URL-driven state resets (soft navigation), and the pinned assertion set (axe on both schemes, mobile viewport). Verified locally: web unit 658/658, project-audit e2e 16/16 desktop+mobile, `go test ./api` green, typecheck clean.

## Review

Standards + Spec + cross-model (Codex `gpt-5.6-sol`, high effort). Cross-model ran three rounds (CHANGES → CHANGES → CLEAN); all blocking findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)